### PR TITLE
CGMES: preserve original switch type and use it for export; update alias type for terminals of DLs

### DIFF
--- a/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/CgmesConformity1ModifiedCatalog.java
+++ b/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/CgmesConformity1ModifiedCatalog.java
@@ -1483,6 +1483,19 @@ public final class CgmesConformity1ModifiedCatalog {
                 microGridBaseCaseBoundaries());
     }
 
+    public static GridModelReference microGridBaseCaseNLSwitchTypePreserved() {
+        String base = ENTSOE_CONFORMITY_1_MODIFIED
+                + "/MicroGrid/BaseCase/BC_NL_v2_switch_type_preserved/";
+        String baseOriginal = ENTSOE_CONFORMITY_1
+                + "/MicroGrid/BaseCase/CGMES_v2.4.15_MicroGridTestConfiguration_BC_NL_v2/";
+        return new GridModelReferenceResources(
+                "MicroGrid-BaseCase-NL-switch-type-preserved",
+                null,
+                new ResourceSet(base, MICRO_GRID_NL_EQ, MICRO_GRID_NL_SSH),
+                new ResourceSet(baseOriginal, MICRO_GRID_NL_TP),
+                microGridBaseCaseBoundaries());
+    }
+
     public static GridModelReference microGridBaseCaseBESingleFile() {
         String base = ENTSOE_CONFORMITY_1_MODIFIED
                 + "/MicroGrid/BaseCase/BC_BE_v2_single_file/";
@@ -1574,6 +1587,20 @@ public final class CgmesConformity1ModifiedCatalog {
                         MINI_GRID_EQ),
                 new ResourceSet(MINI_GRID_NODE_BREAKER_BASE,
                         MINI_GRID_SSH,
+                        MINI_GRID_SV,
+                        MINI_GRID_TP),
+                new ResourceSet(MINI_GRID_NODE_BREAKER_BD_BASE, MINI_GRID_BD_EQ,
+                        MINI_GRID_BD_TP));
+    }
+
+    public static GridModelReferenceResources miniGridNodeBreakerSwitchTypePreserved() {
+        String base = ENTSOE_CONFORMITY_1_MODIFIED
+                + "/MiniGrid/NodeBreaker/BaseCase_Complete_v3_switch_type_preserved/";
+        return new GridModelReferenceResources(
+                "MiniGrid-NodeBreaker-BaseCase-Complete-v3-switch-type-preserved",
+                null,
+                new ResourceSet(base, MINI_GRID_EQ, MINI_GRID_SSH),
+                new ResourceSet(MINI_GRID_NODE_BREAKER_BASE,
                         MINI_GRID_SV,
                         MINI_GRID_TP),
                 new ResourceSet(MINI_GRID_NODE_BREAKER_BD_BASE, MINI_GRID_BD_EQ,

--- a/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MicroGrid/BaseCase/BC_NL_v2_switch_type_preserved/MicroGridTestConfiguration_BC_NL_EQ_V2.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MicroGrid/BaseCase/BC_NL_v2_switch_type_preserved/MicroGridTestConfiguration_BC_NL_EQ_V2.xml
@@ -1,0 +1,1619 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF  xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<!-- Exported from CIMSpy EE/CIMdesk on Fri May 29 12:56:39.27. -->
+	<md:FullModel rdf:about="urn:uuid:77b55f87-fc1e-4046-9599-6c6b4f991a86">
+		<md:Model.created>2014-10-24T11:51:49</md:Model.created>
+		<md:Model.scenarioTime>2014-06-01T10:30:00</md:Model.scenarioTime>
+		<md:Model.version>2</md:Model.version>
+		<md:Model.DependentOn rdf:resource="urn:uuid:2399cbd0-9a39-11e0-aa80-0800200c9a66"/>
+		<md:Model.description>CGMES Conformity Assessment: &apos;MicroGridTestConfiguration....BC (MAS NL) Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+		<md:Model.modelingAuthoritySet>http://tennet.nl/CGMES/2.4.15</md:Model.modelingAuthoritySet>
+		<md:Model.profile>http://entsoe.eu/CIM/EquipmentCore/3/1</md:Model.profile>
+		<md:Model.profile>http://entsoe.eu/CIM/EquipmentShortCircuit/3/1</md:Model.profile>
+	</md:FullModel>
+	<cim:ACLineSegment rdf:ID="_7f43f508-2496-4b64-9146-0a40406cbe49">
+		<cim:IdentifiedObject.name>NL-Line_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_1</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000118</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:IdentifiedObject.description>10T-AT-DE-000118</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_72242f07-189e-4a06-9f7e-f7a2776ecfd9"/>
+		<cim:ACLineSegment.r>1.020000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>12.000000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0001413717</cim:ACLineSegment.bch>
+		<cim:Conductor.length>30.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0000300000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e"/>
+		<cim:ACLineSegment.r0>3.060000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>36.000000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0001500000</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0000300000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:ACLineSegment rdf:ID="_dad02278-bd25-476f-8f58-dbe44be72586">
+		<cim:IdentifiedObject.name>NL-Line_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>tie line BE-NL</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_00faa2b5-cb42-4c43-9c9a-2a09dd9c52f5"/>
+		<cim:ACLineSegment.r>2.320000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>20.240000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0000251327</cim:ACLineSegment.bch>
+		<cim:Conductor.length>40.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0000400000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e"/>
+		<cim:ACLineSegment.r0>0.696000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>6.072000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0000400000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:ACLineSegment rdf:ID="_a279a3dc-550b-426c-af3a-61b7be508dcc">
+		<cim:IdentifiedObject.name>NL-Line_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_3</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:IdentifiedObject.description>10T-AT-DE-00009W</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_644936cc-1ea0-46f3-93e6-eed0e0cc8bee"/>
+		<cim:ACLineSegment.r>5.060000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>69.000000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0000202319</cim:ACLineSegment.bch>
+		<cim:Conductor.length>23.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0000230000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+		<cim:ACLineSegment.r0>15.180000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>207.000000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0000455217</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0000230000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:ACLineSegment rdf:ID="_8fdc7abd-3746-481a-a65e-3df56acd8b13">
+		<cim:IdentifiedObject.name>NL-Line_4</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_4</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:IdentifiedObject.description>10T-AT-DE-00009W</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_f524d9fc-48be-4feb-9e77-a15696d4210a"/>
+		<cim:ACLineSegment.r>2.200000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>66.000000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0000898495</cim:ACLineSegment.bch>
+		<cim:Conductor.length>22.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0000242000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+		<cim:ACLineSegment.r0>6.600000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>198.000000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0000435425</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0000242000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:ACLineSegment rdf:ID="_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc">
+		<cim:IdentifiedObject.name>NL-Line_5</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_5</entsoe:IdentifiedObject.shortName>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000118</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:IdentifiedObject.description>10T-AT-DE-000118</cim:IdentifiedObject.description>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c7d37bc3-196c-4458-896b-614f810cea0f"/>
+		<cim:ACLineSegment.r>0.420000</cim:ACLineSegment.r>
+		<cim:ACLineSegment.x>6.300000</cim:ACLineSegment.x>
+		<cim:ACLineSegment.bch>0.0000648739</cim:ACLineSegment.bch>
+		<cim:Conductor.length>35.000000</cim:Conductor.length>
+		<cim:ACLineSegment.gch>0.0000350000</cim:ACLineSegment.gch>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e"/>
+		<cim:ACLineSegment.r0>1.260000</cim:ACLineSegment.r0>
+		<cim:ACLineSegment.x0>18.900000</cim:ACLineSegment.x0>
+		<cim:ACLineSegment.b0ch>0.0109955743</cim:ACLineSegment.b0ch>
+		<cim:ACLineSegment.g0ch>0.0000350000</cim:ACLineSegment.g0ch>
+		<cim:ACLineSegment.shortCircuitEndTemperature>160.0000000000</cim:ACLineSegment.shortCircuitEndTemperature>
+	</cim:ACLineSegment>
+	<cim:BaseVoltage rdf:ID="_c1d5bff18f8011e08e4d00247eb1f55e">
+		<cim:BaseVoltage.nominalVoltage>15.75</cim:BaseVoltage.nominalVoltage>
+		<cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+		<entsoe:IdentifiedObject.shortName>15.75</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.name>15.75 kV</cim:IdentifiedObject.name>
+	</cim:BaseVoltage>
+	<!-- changed from cim:Breaker to cim:Switch -->
+	<cim:Switch rdf:ID="_5f5d40ae-d52d-4631-9285-b3ceefff784c">
+		<cim:IdentifiedObject.name>B1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>B1</entsoe:IdentifiedObject.shortName>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+		<cim:Switch.retained>true</cim:Switch.retained>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c1d5bfea8f8011e08e4d00247eb1f55e"/>
+	</cim:Switch>
+	<cim:BusbarSection rdf:ID="_12733133-1f34-44f3-a020-f5b33cede919">
+		<cim:IdentifiedObject.name>N1230822396</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c1d5bfea8f8011e08e4d00247eb1f55e"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:BusbarSection rdf:ID="_143aa0b1-2cd4-4e58-98d4-b0438bd5a39a">
+		<cim:IdentifiedObject.name>NL-Busbar_2</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c1d5bfea8f8011e08e4d00247eb1f55e"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:BusbarSection rdf:ID="_53da4025-9d51-4eaf-b0d2-ce27fbe740d2">
+		<cim:IdentifiedObject.name>NL-Busbar_3</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_2a37dc57-2faf-464a-8175-bc415f9a635f"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:BusbarSection rdf:ID="_e6d49e32-b634-4b86-a8ca-15159f1497b5">
+		<cim:IdentifiedObject.name>NL-Busbar_5</cim:IdentifiedObject.name>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8"/>
+		<cim:BusbarSection.ipMax>0e+000</cim:BusbarSection.ipMax>
+	</cim:BusbarSection>
+	<cim:CurrentLimit rdf:ID="_a4b97f0b-39b8-452d-b51c-fd3b25fa1d9b1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1623.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2c3d48f-d768-4e1e-8841-6e9c4913f11f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_db8675aa-6a3d-47a8-b864-a3e474c5c8851">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1623.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b4d8f5e2-7b7a-45eb-b65a-252843d6acf4"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b4659169-38a4-494f-b3e2-aa83dc9a66701">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_37cc4210-71c0-4328-a86b-df0f65e76ef4"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_0388b680-3feb-45a2-bd56-5a620472107b1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1298.700000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_03943678-b63e-44d8-bc7d-9461da496268"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_317c3033-0409-4f57-9209-4baae4b5e1651">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_9a03e8ee-e832-43c8-b38e-0d43f8ef7355"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e29f4055-0267-4d9e-a889-8afc2326e8702">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1800.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_9a03e8ee-e832-43c8-b38e-0d43f8ef7355"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_a1cc9747-6819-429e-bd5f-23ffdb1d7376"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_62be08ea-2a9e-4284-9642-2947cb2c5f1b1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1062.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_14e9e317-a168-44a2-82ef-7c76190108a2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_22274f03-885c-4ea8-931d-862beec6edd12">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1800.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_14e9e317-a168-44a2-82ef-7c76190108a2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_a1cc9747-6819-429e-bd5f-23ffdb1d7376"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_1cd93631-5573-48db-8444-0e85a91aa6f11">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1103.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_13ee714f-6df4-4039-8519-5cf4e84ab20d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d73f50e0-00db-4f54-a087-b0d2204f229a1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1103.400000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7cf4108d-d355-48f5-8556-d42c37a8e2c8"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_45b85c9e-0788-4cbb-b71b-dc1d5de04e511">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1233.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_79a1fb3a-a66a-468c-8c78-c25714c73eba"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a228917a-44c9-4124-b7db-ea6408b3c5bb1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1233.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_125eeb58-1c45-41b2-a981-7d5993b40cda"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_150183f1-3144-4d18-b5ca-328efdead2571">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>415.710000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_83f719ad-2083-44ea-9ebc-9f456c114bdb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_89d45390-25dc-49a6-bb08-69b67f27cd391">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>755.820000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d47a27cc-9fad-40f2-a08c-37e545c268df"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fa85553d-9769-45fe-9b79-cecafa01c4ba1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>2975.940000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e7c1b1c7-aaeb-470a-9cb5-93a3ec269179"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_1a886514-5f7d-418a-99b7-02330ed01ca71">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>41569.200000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_261d13c4-1527-42a5-ad0d-a3b817971166"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_0c95b506-05a2-40d5-9f82-b9bf1e680a8d1">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>2975.940000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_fd472104-d68c-4536-ba4a-5fd9349c0a65"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_6a927421-36cd-487a-b6b7-61dd454704471">
+		<cim:IdentifiedObject.name>90</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>41569.200000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cf3e5341-6736-4b34-b4da-e4af2073765b"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_68cd26b8-d512-4104-a1d1-b2e8f9376ecc"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_2ddd3dac-4c0e-4355-b1eb-2e4bb45a2526">
+		<cim:IdentifiedObject.name>NL-Line_1 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_79a1fb3a-a66a-468c-8c78-c25714c73eba"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_802dd8b7-d55c-46bf-8a22-895e251fb8db">
+		<cim:IdentifiedObject.name>NL-Line_1 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_125eeb58-1c45-41b2-a981-7d5993b40cda"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3b9b581e-dd06-4be8-81b8-9abc72450c89">
+		<cim:IdentifiedObject.name>NL-Line_1 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1515.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_79a1fb3a-a66a-468c-8c78-c25714c73eba"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_5baace86-1d76-428b-9045-0d6b50024316">
+		<cim:IdentifiedObject.name>NL-Line_1 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1515.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_125eeb58-1c45-41b2-a981-7d5993b40cda"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_45b85c9e-0788-4cbb-b71b-dc1d5de04e51">
+		<cim:IdentifiedObject.name>NL-Line_1 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_79a1fb3a-a66a-468c-8c78-c25714c73eba"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a228917a-44c9-4124-b7db-ea6408b3c5bb">
+		<cim:IdentifiedObject.name>NL-Line_1 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_125eeb58-1c45-41b2-a981-7d5993b40cda"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_3341e4e1-b1f0-4832-854f-4254ddb7459b">
+		<cim:IdentifiedObject.name>NL-Line_2 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1299.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_13ee714f-6df4-4039-8519-5cf4e84ab20d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b5172307-8c71-4c82-92ec-b05592694ab1">
+		<cim:IdentifiedObject.name>NL-Line_2 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1299.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7cf4108d-d355-48f5-8556-d42c37a8e2c8"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_eaa17d90-1494-42b8-803c-0a6692c493a0">
+		<cim:IdentifiedObject.name>NL-Line_2 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_13ee714f-6df4-4039-8519-5cf4e84ab20d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_467f1c8f-fa42-45d5-88c1-9b8fea6f1cab">
+		<cim:IdentifiedObject.name>NL-Line_2 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1371.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7cf4108d-d355-48f5-8556-d42c37a8e2c8"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_1cd93631-5573-48db-8444-0e85a91aa6f1">
+		<cim:IdentifiedObject.name>NL-Line_2 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1226.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_13ee714f-6df4-4039-8519-5cf4e84ab20d"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d73f50e0-00db-4f54-a087-b0d2204f229a">
+		<cim:IdentifiedObject.name>NL-Line_2 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1226.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7cf4108d-d355-48f5-8556-d42c37a8e2c8"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_9dd40a3a-c6df-4f16-876c-bd11c538324b">
+		<cim:IdentifiedObject.name>NL-Line_3 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1312.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_9a03e8ee-e832-43c8-b38e-0d43f8ef7355"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_75caf931-a43f-4e4a-a831-fe9a729feb72">
+		<cim:IdentifiedObject.name>NL-Line_3 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1312.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_14e9e317-a168-44a2-82ef-7c76190108a2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_150d1dcb-f7b6-4fcd-bce9-e39c6ddf15aa">
+		<cim:IdentifiedObject.name>NL-Line_3 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_9a03e8ee-e832-43c8-b38e-0d43f8ef7355"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_bec4e785-5143-4ad4-b7b0-aea8e33be7e6">
+		<cim:IdentifiedObject.name>NL-Line_3 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_14e9e317-a168-44a2-82ef-7c76190108a2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_317c3033-0409-4f57-9209-4baae4b5e165">
+		<cim:IdentifiedObject.name>NL-Line_3 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_9a03e8ee-e832-43c8-b38e-0d43f8ef7355"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_62be08ea-2a9e-4284-9642-2947cb2c5f1b">
+		<cim:IdentifiedObject.name>NL-Line_3 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1180.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_14e9e317-a168-44a2-82ef-7c76190108a2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e29f4055-0267-4d9e-a889-8afc2326e870">
+		<cim:IdentifiedObject.name>NL-Line_3 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>2000.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_9a03e8ee-e832-43c8-b38e-0d43f8ef7355"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_dd9c5b59-0728-45ca-9930-0dff2a9fb390"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_22274f03-885c-4ea8-931d-862beec6edd1">
+		<cim:IdentifiedObject.name>NL-Line_3 - CL-3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>2000.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_14e9e317-a168-44a2-82ef-7c76190108a2"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_dd9c5b59-0728-45ca-9930-0dff2a9fb390"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fff80a22-3a4b-4c22-94d2-2901e8085df1">
+		<cim:IdentifiedObject.name>NL-Line_4 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1574.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_37cc4210-71c0-4328-a86b-df0f65e76ef4"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_4224b5aa-ef0b-4f31-b2a5-002c0c696721">
+		<cim:IdentifiedObject.name>NL-Line_4 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1574.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_03943678-b63e-44d8-bc7d-9461da496268"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_32ba352e-5877-4d42-b7e4-49a23b78297d">
+		<cim:IdentifiedObject.name>NL-Line_4 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1705.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_37cc4210-71c0-4328-a86b-df0f65e76ef4"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d6da4ddd-944f-48ab-bdb2-651883dc9dea">
+		<cim:IdentifiedObject.name>NL-Line_4 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1705.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_03943678-b63e-44d8-bc7d-9461da496268"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b4659169-38a4-494f-b3e2-aa83dc9a6670">
+		<cim:IdentifiedObject.name>NL-Line_4 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_37cc4210-71c0-4328-a86b-df0f65e76ef4"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_0388b680-3feb-45a2-bd56-5a620472107b">
+		<cim:IdentifiedObject.name>NL-Line_4 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_4 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1443.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_03943678-b63e-44d8-bc7d-9461da496268"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d4831248-07f3-4d9a-a06b-d39461cd16a2">
+		<cim:IdentifiedObject.name>NL-Line_5 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1876.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2c3d48f-d768-4e1e-8841-6e9c4913f11f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d3c7e111-afa0-4cc2-99d0-8c75e3d6fb91">
+		<cim:IdentifiedObject.name>NL-Line_5 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1876.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b4d8f5e2-7b7a-45eb-b65a-252843d6acf4"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b50d912a-8ce8-4962-a21b-f2d91dcc430e">
+		<cim:IdentifiedObject.name>NL-Line_5 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1948.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2c3d48f-d768-4e1e-8841-6e9c4913f11f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_c43551e9-eeee-415a-acf1-570fab88b426">
+		<cim:IdentifiedObject.name>NL-Line_5 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1948.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b4d8f5e2-7b7a-45eb-b65a-252843d6acf4"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_a4b97f0b-39b8-452d-b51c-fd3b25fa1d9b">
+		<cim:IdentifiedObject.name>NL-Line_5 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1804.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2c3d48f-d768-4e1e-8841-6e9c4913f11f"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_db8675aa-6a3d-47a8-b864-a3e474c5c885">
+		<cim:IdentifiedObject.name>NL-Line_5 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-Line_5 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>1804.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b4d8f5e2-7b7a-45eb-b65a-252843d6acf4"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_5e7f87db-9758-4098-b19e-4f365915721f">
+		<cim:IdentifiedObject.name>NL-TR2_1 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>481.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_83f719ad-2083-44ea-9ebc-9f456c114bdb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_bd6482bb-5e21-46df-a3c3-0e4a64d49f89">
+		<cim:IdentifiedObject.name>NL-TR2_1 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>849.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d47a27cc-9fad-40f2-a08c-37e545c268df"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_553477f0-ed39-499b-a07d-3c602bd8a13d">
+		<cim:IdentifiedObject.name>NL-TR2_1 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>491.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_83f719ad-2083-44ea-9ebc-9f456c114bdb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_8122651e-22ba-4320-9032-c59969020565">
+		<cim:IdentifiedObject.name>NL-TR2_1 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>859.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d47a27cc-9fad-40f2-a08c-37e545c268df"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_150183f1-3144-4d18-b5ca-328efdead257">
+		<cim:IdentifiedObject.name>NL-TR2_1 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>461.900000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_83f719ad-2083-44ea-9ebc-9f456c114bdb"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_89d45390-25dc-49a6-bb08-69b67f27cd39">
+		<cim:IdentifiedObject.name>NL-TR2_1 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL-TR2_1 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>839.800000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d47a27cc-9fad-40f2-a08c-37e545c268df"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e2153eed-fb1f-44e2-b116-d045c5e50e3b">
+		<cim:IdentifiedObject.name>NL_TR2_2 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3406.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e7c1b1c7-aaeb-470a-9cb5-93a3ec269179"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_2f71df7b-6118-4973-acea-7f65a563a979">
+		<cim:IdentifiedObject.name>NL_TR2_2 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>47188.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_261d13c4-1527-42a5-ad0d-a3b817971166"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_b4f373a0-1d09-4f4f-9f29-f72ff6b4f62f">
+		<cim:IdentifiedObject.name>NL_TR2_2 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3506.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e7c1b1c7-aaeb-470a-9cb5-93a3ec269179"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_176ae6ba-d38c-4f7c-8a60-038dc4980a39">
+		<cim:IdentifiedObject.name>NL_TR2_2 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>48188.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_261d13c4-1527-42a5-ad0d-a3b817971166"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_fa85553d-9769-45fe-9b79-cecafa01c4ba">
+		<cim:IdentifiedObject.name>NL_TR2_2 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3306.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e7c1b1c7-aaeb-470a-9cb5-93a3ec269179"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_1a886514-5f7d-418a-99b7-02330ed01ca7">
+		<cim:IdentifiedObject.name>NL_TR2_2 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_2 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>46188.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_261d13c4-1527-42a5-ad0d-a3b817971166"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_e2afb3a0-94ea-4f8f-b717-7b91c603d3dc">
+		<cim:IdentifiedObject.name>NL_TR2_3 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3506.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_fd472104-d68c-4536-ba4a-5fd9349c0a65"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_716e45d4-4092-4a1b-ba5f-c78e1da4f363">
+		<cim:IdentifiedObject.name>NL_TR2_3 - CL-0</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-0</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>47188.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cf3e5341-6736-4b34-b4da-e4af2073765b"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_250e948b-70ae-4139-971b-4f0053425b60"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_d4bc2ee3-43b8-46fb-9337-d82590af1c8b">
+		<cim:IdentifiedObject.name>NL_TR2_3 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3706.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_fd472104-d68c-4536-ba4a-5fd9349c0a65"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_23b11495-8c2c-47cc-a561-e215196afa2b">
+		<cim:IdentifiedObject.name>NL_TR2_3 - CL-1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>49188.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cf3e5341-6736-4b34-b4da-e4af2073765b"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_18c8d038-31ea-4d92-9e7e-4b8a397f30a5"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_0c95b506-05a2-40d5-9f82-b9bf1e680a8d">
+		<cim:IdentifiedObject.name>NL_TR2_3 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>3306.600000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_fd472104-d68c-4536-ba4a-5fd9349c0a65"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:CurrentLimit rdf:ID="_6a927421-36cd-487a-b6b7-61dd45470447">
+		<cim:IdentifiedObject.name>NL_TR2_3 - CL-2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>CL-2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Ratings for element NL_TR2_3 - Limit</cim:IdentifiedObject.description>
+		<cim:CurrentLimit.value>46188.000000</cim:CurrentLimit.value>
+		<cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cf3e5341-6736-4b34-b4da-e4af2073765b"/>
+		<cim:OperationalLimit.OperationalLimitType rdf:resource="#_1aee0921-7cbe-481c-9078-daf66ab2a950"/>
+	</cim:CurrentLimit>
+	<cim:EnergyConsumer rdf:ID="_69add5b4-70bd-4360-8a93-286256c0d38b">
+		<cim:IdentifiedObject.name>NL-Load_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Apple</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c1d5bfde8f8011e08e4d00247eb1f55e"/>
+	</cim:EnergyConsumer>
+	<cim:EnergyConsumer rdf:ID="_25ab1b5b-6803-47e2-805a-ab7b2072e034">
+		<cim:IdentifiedObject.name>NL-Load_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Electrabel</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>true</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c1d5bfde8f8011e08e4d00247eb1f55e"/>
+	</cim:EnergyConsumer>
+	<cim:EnergyConsumer rdf:ID="_b1e03a8f-6a11-4454-af58-4a4a680e857f">
+		<cim:IdentifiedObject.name>NL-Load_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Siemens</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c1d5bfea8f8011e08e4d00247eb1f55e"/>
+		<cim:EnergyConsumer.LoadResponse rdf:resource="#_7a797ed8-c370-47cf-83df-16c40f8fff69"/>
+	</cim:EnergyConsumer>
+	<cim:EquivalentInjection rdf:ID="_83bea592-913e-4473-8d17-969968ff83a2">
+		<cim:IdentifiedObject.name>NL-Inj-XCA_AL11</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-I-XCA_AL1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+		<cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+		<cim:EquivalentInjection.r>0e+000</cim:EquivalentInjection.r>
+		<cim:EquivalentInjection.x>0e+000</cim:EquivalentInjection.x>
+		<cim:EquivalentInjection.r2>0e+000</cim:EquivalentInjection.r2>
+		<cim:EquivalentInjection.x2>0e+000</cim:EquivalentInjection.x2>
+		<cim:EquivalentInjection.r0>0e+000</cim:EquivalentInjection.r0>
+		<cim:EquivalentInjection.x0>0e+000</cim:EquivalentInjection.x0>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e"/>
+	</cim:EquivalentInjection>
+	<cim:EquivalentInjection rdf:ID="_cab82e1c-1435-447b-bba0-74b592539eac">
+		<cim:IdentifiedObject.name>NL-Inj-XKA_MA11</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-I-XKA_MA1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+		<cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+		<cim:EquivalentInjection.r>0e+000</cim:EquivalentInjection.r>
+		<cim:EquivalentInjection.x>0e+000</cim:EquivalentInjection.x>
+		<cim:EquivalentInjection.r2>0e+000</cim:EquivalentInjection.r2>
+		<cim:EquivalentInjection.x2>0e+000</cim:EquivalentInjection.x2>
+		<cim:EquivalentInjection.r0>0e+000</cim:EquivalentInjection.r0>
+		<cim:EquivalentInjection.x0>0e+000</cim:EquivalentInjection.x0>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e"/>
+	</cim:EquivalentInjection>
+	<cim:EquivalentInjection rdf:ID="_b0442899-8dbe-48c1-a1fa-adb2a5929273">
+		<cim:IdentifiedObject.name>NL-Inj-XWI_GY11</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-I-XWI_GY1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+		<cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+		<cim:EquivalentInjection.r>0e+000</cim:EquivalentInjection.r>
+		<cim:EquivalentInjection.x>0e+000</cim:EquivalentInjection.x>
+		<cim:EquivalentInjection.r2>0e+000</cim:EquivalentInjection.r2>
+		<cim:EquivalentInjection.x2>0e+000</cim:EquivalentInjection.x2>
+		<cim:EquivalentInjection.r0>0e+000</cim:EquivalentInjection.r0>
+		<cim:EquivalentInjection.x0>0e+000</cim:EquivalentInjection.x0>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e"/>
+	</cim:EquivalentInjection>
+	<cim:EquivalentInjection rdf:ID="_12baa3f3-23b1-44e0-956f-d331e1527f37">
+		<cim:IdentifiedObject.name>NL-Inj-XZE_ST23</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-I-XZE_ST2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+		<cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+		<cim:EquivalentInjection.r>0e+000</cim:EquivalentInjection.r>
+		<cim:EquivalentInjection.x>0e+000</cim:EquivalentInjection.x>
+		<cim:EquivalentInjection.r2>0e+000</cim:EquivalentInjection.r2>
+		<cim:EquivalentInjection.x2>0e+000</cim:EquivalentInjection.x2>
+		<cim:EquivalentInjection.r0>0e+000</cim:EquivalentInjection.r0>
+		<cim:EquivalentInjection.x0>0e+000</cim:EquivalentInjection.x0>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+	</cim:EquivalentInjection>
+	<cim:EquivalentInjection rdf:ID="_820d95d7-26d4-4311-8b1f-026f8605b86d">
+		<cim:IdentifiedObject.name>NL-Inj-XZE_ST24</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-I-XZE_ST2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+		<cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+		<cim:EquivalentInjection.r>0e+000</cim:EquivalentInjection.r>
+		<cim:EquivalentInjection.x>0e+000</cim:EquivalentInjection.x>
+		<cim:EquivalentInjection.r2>0e+000</cim:EquivalentInjection.r2>
+		<cim:EquivalentInjection.x2>0e+000</cim:EquivalentInjection.x2>
+		<cim:EquivalentInjection.r0>0e+000</cim:EquivalentInjection.r0>
+		<cim:EquivalentInjection.x0>0e+000</cim:EquivalentInjection.x0>
+		<cim:ConductingEquipment.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+	</cim:EquivalentInjection>
+	<cim:GeneratingUnit rdf:ID="_b850063d-eae7-4675-bc98-4642d3076783">
+		<cim:IdentifiedObject.name>Gen-12908</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+		<cim:GeneratingUnit.initialP>150.000000</cim:GeneratingUnit.initialP>
+		<cim:GeneratingUnit.nominalP>225.000000</cim:GeneratingUnit.nominalP>
+		<cim:GeneratingUnit.maxOperatingP>250.000000</cim:GeneratingUnit.maxOperatingP>
+		<cim:GeneratingUnit.minOperatingP>130.000000</cim:GeneratingUnit.minOperatingP>
+		<cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource.offAGC"/>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c"/>
+	</cim:GeneratingUnit>
+	<cim:GeneratingUnit rdf:ID="_ca80ee09-3bed-4884-bc28-6dc89d067289">
+		<cim:IdentifiedObject.name>Gen-12910</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+		<cim:GeneratingUnit.initialP>140.000000</cim:GeneratingUnit.initialP>
+		<cim:GeneratingUnit.nominalP>225.000000</cim:GeneratingUnit.nominalP>
+		<cim:GeneratingUnit.maxOperatingP>250.000000</cim:GeneratingUnit.maxOperatingP>
+		<cim:GeneratingUnit.minOperatingP>130.000000</cim:GeneratingUnit.minOperatingP>
+		<cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource.offAGC"/>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c"/>
+	</cim:GeneratingUnit>
+	<cim:GeneratingUnit rdf:ID="_049438a6-780a-44fe-a788-ebe385d98e25">
+		<cim:IdentifiedObject.name>Gen-12923</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+		<cim:GeneratingUnit.initialP>600.492701</cim:GeneratingUnit.initialP>
+		<cim:GeneratingUnit.nominalP>990.000000</cim:GeneratingUnit.nominalP>
+		<cim:GeneratingUnit.maxOperatingP>1000.000000</cim:GeneratingUnit.maxOperatingP>
+		<cim:GeneratingUnit.minOperatingP>300.000000</cim:GeneratingUnit.minOperatingP>
+		<cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#GeneratorControlSource.offAGC"/>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c"/>
+	</cim:GeneratingUnit>
+	<cim:GeographicalRegion rdf:ID="_c1d5bfe28f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>NL</cim:IdentifiedObject.name>
+	</cim:GeographicalRegion>
+	<cim:Line rdf:ID="_72242f07-189e-4a06-9f7e-f7a2776ecfd9">
+		<cim:IdentifiedObject.name>container of NL-Line_1</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5bfe48f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_00faa2b5-cb42-4c43-9c9a-2a09dd9c52f5">
+		<cim:IdentifiedObject.name>container of NL-Line_2</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5bfe48f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_644936cc-1ea0-46f3-93e6-eed0e0cc8bee">
+		<cim:IdentifiedObject.name>container of NL-Line_3</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5bfe48f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_f524d9fc-48be-4feb-9e77-a15696d4210a">
+		<cim:IdentifiedObject.name>container of NL-Line_4</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5bfe48f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:Line rdf:ID="_c7d37bc3-196c-4458-896b-614f810cea0f">
+		<cim:IdentifiedObject.name>container of NL-Line_5</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_c1d5bfe48f8011e08e4d00247eb1f55e"/>
+	</cim:Line>
+	<cim:LinearShuntCompensator rdf:ID="_fbfed7e3-3dec-4829-a286-029e73535685">
+		<cim:IdentifiedObject.name>NL-S1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-S1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>shunt</cim:IdentifiedObject.description>
+		<cim:ShuntCompensator.normalSections>1</cim:ShuntCompensator.normalSections>
+		<cim:ShuntCompensator.maximumSections>1</cim:ShuntCompensator.maximumSections>
+		<cim:LinearShuntCompensator.bPerSection>0.000313</cim:LinearShuntCompensator.bPerSection>
+		<cim:LinearShuntCompensator.gPerSection>0e+000</cim:LinearShuntCompensator.gPerSection>
+		<cim:LinearShuntCompensator.b0PerSection>-0e+000</cim:LinearShuntCompensator.b0PerSection>
+		<cim:LinearShuntCompensator.g0PerSection>0e+000</cim:LinearShuntCompensator.g0PerSection>
+		<cim:ShuntCompensator.nomU>400.000000</cim:ShuntCompensator.nomU>
+		<cim:RegulatingCondEq.RegulatingControl rdf:resource="#_613dfeb3-0161-4cec-aaa9-ccddd885771b"/>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c1d5bfde8f8011e08e4d00247eb1f55e"/>
+	</cim:LinearShuntCompensator>
+	<cim:LoadResponseCharacteristic rdf:ID="_7a797ed8-c370-47cf-83df-16c40f8fff69">
+		<cim:IdentifiedObject.name>NL-Load_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_3</entsoe:IdentifiedObject.shortName>
+		<cim:LoadResponseCharacteristic.exponentModel>false</cim:LoadResponseCharacteristic.exponentModel>
+		<cim:LoadResponseCharacteristic.pConstantCurrent>0.200000</cim:LoadResponseCharacteristic.pConstantCurrent>
+		<cim:LoadResponseCharacteristic.pConstantImpedance>0e+000</cim:LoadResponseCharacteristic.pConstantImpedance>
+		<cim:LoadResponseCharacteristic.pConstantPower>0.800000</cim:LoadResponseCharacteristic.pConstantPower>
+		<cim:LoadResponseCharacteristic.pFrequencyExponent>0e+000</cim:LoadResponseCharacteristic.pFrequencyExponent>
+		<cim:LoadResponseCharacteristic.qConstantCurrent>0.300000</cim:LoadResponseCharacteristic.qConstantCurrent>
+		<cim:LoadResponseCharacteristic.qConstantImpedance>0e+000</cim:LoadResponseCharacteristic.qConstantImpedance>
+		<cim:LoadResponseCharacteristic.qConstantPower>0.700000</cim:LoadResponseCharacteristic.qConstantPower>
+		<cim:LoadResponseCharacteristic.pVoltageExponent>0e+000</cim:LoadResponseCharacteristic.pVoltageExponent>
+		<cim:LoadResponseCharacteristic.qFrequencyExponent>0e+000</cim:LoadResponseCharacteristic.qFrequencyExponent>
+		<cim:LoadResponseCharacteristic.qVoltageExponent>0e+000</cim:LoadResponseCharacteristic.qVoltageExponent>
+	</cim:LoadResponseCharacteristic>
+	<cim:OperationalLimitSet rdf:ID="_a2c3d48f-d768-4e1e-8841-6e9c4913f11f">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_5 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_757d4f50-707b-47a0-891c-cbaefd649631"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_37cc4210-71c0-4328-a86b-df0f65e76ef4">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_4 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_653bc4b8-518b-4adc-9d68-012fb641fb1d"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_9a03e8ee-e832-43c8-b38e-0d43f8ef7355">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_3 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_5dfee914-a4fd-4bde-a5b4-c4caa6378d10"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_13ee714f-6df4-4039-8519-5cf4e84ab20d">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_2 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_c557146e-dfc4-4020-9738-d592b188338b"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_79a1fb3a-a66a-468c-8c78-c25714c73eba">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_1 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_83f719ad-2083-44ea-9ebc-9f456c114bdb">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-TR2_1 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_e3e0c496-5837-4f0f-a596-cc421940f73f"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_e7c1b1c7-aaeb-470a-9cb5-93a3ec269179">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_2 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_1128e664-0653-448a-9068-e37f1a097c05"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_fd472104-d68c-4536-ba4a-5fd9349c0a65">
+		<cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_3 at Port 1</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_bd61b1f9-474d-424e-9709-42f75337c477"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_b4d8f5e2-7b7a-45eb-b65a-252843d6acf4">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_5 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_ae588863-b154-451d-978a-7ab08ac50fb6"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_03943678-b63e-44d8-bc7d-9461da496268">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_4 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_57979d14-d1d8-4311-ae53-aa8890423885"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_14e9e317-a168-44a2-82ef-7c76190108a2">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_3 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_6aecb9ba-5835-4b70-89bc-96d687e45779"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_7cf4108d-d355-48f5-8556-d42c37a8e2c8">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_2 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_8f308117-8bbd-4798-b145-4e78f7d049e7"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_125eeb58-1c45-41b2-a981-7d5993b40cda">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-Line_1 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_d47a27cc-9fad-40f2-a08c-37e545c268df">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL-TR2_1 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_261d13c4-1527-42a5-ad0d-a3b817971166">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_2 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_da232169-1c36-495a-8af6-a0d7d2b39f52"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitSet rdf:ID="_cf3e5341-6736-4b34-b4da-e4af2073765b">
+		<cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Limit-Ratings for branch NL_TR2_3 at Port 2</cim:IdentifiedObject.description>
+		<cim:OperationalLimitSet.Terminal rdf:resource="#_4f1c405f-07c9-4fb0-b64e-551896a29aa8"/>
+	</cim:OperationalLimitSet>
+	<cim:OperationalLimitType rdf:ID="_1aee0921-7cbe-481c-9078-daf66ab2a950">
+		<cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>patl</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.patl"/>
+	</cim:OperationalLimitType>
+	<cim:OperationalLimitType rdf:ID="_68cd26b8-d512-4104-a1d1-b2e8f9376ecc">
+		<cim:IdentifiedObject.name>PATLT</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>patlt</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.patlt"/>
+	</cim:OperationalLimitType>
+	<cim:OperationalLimitType rdf:ID="_18c8d038-31ea-4d92-9e7e-4b8a397f30a5">
+		<cim:IdentifiedObject.name>TATL10</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>tatl</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.tatl"/>
+		<cim:OperationalLimitType.acceptableDuration>10.000000</cim:OperationalLimitType.acceptableDuration>
+	</cim:OperationalLimitType>
+	<cim:OperationalLimitType rdf:ID="_250e948b-70ae-4139-971b-4f0053425b60">
+		<cim:IdentifiedObject.name>TATL20</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>tatl</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.tatl"/>
+		<cim:OperationalLimitType.acceptableDuration>20.000000</cim:OperationalLimitType.acceptableDuration>
+	</cim:OperationalLimitType>
+	<cim:OperationalLimitType rdf:ID="_dd9c5b59-0728-45ca-9930-0dff2a9fb390">
+		<cim:IdentifiedObject.name>TC</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>tc</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.tc"/>
+	</cim:OperationalLimitType>
+	<cim:OperationalLimitType rdf:ID="_a1cc9747-6819-429e-bd5f-23ffdb1d7376">
+		<cim:IdentifiedObject.name>TCT</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>tct</entsoe:IdentifiedObject.shortName>
+		<cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue"/>
+		<entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.tct"/>
+	</cim:OperationalLimitType>
+	<cim:PowerTransformer rdf:ID="_e8a7eaec-51d6-4571-b3d9-c36d52073c33">
+		<cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>new transformer in 2015</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c"/>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>
+		<cim:PowerTransformer.beforeShortCircuitAnglePf>0e+000</cim:PowerTransformer.beforeShortCircuitAnglePf>
+		<cim:PowerTransformer.highSideMinOperatingU>0e+000</cim:PowerTransformer.highSideMinOperatingU>
+		<cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+		<cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+	</cim:PowerTransformer>
+	<cim:PowerTransformer rdf:ID="_2184f365-8cd5-4b5d-8a28-9d68603bb6a4">
+		<cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>trafo</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c"/>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>
+		<cim:PowerTransformer.beforeShortCircuitAnglePf>0e+000</cim:PowerTransformer.beforeShortCircuitAnglePf>
+		<cim:PowerTransformer.highSideMinOperatingU>0e+000</cim:PowerTransformer.highSideMinOperatingU>
+		<cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+		<cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+	</cim:PowerTransformer>
+	<cim:PowerTransformer rdf:ID="_80016742-31b3-432a-b00a-300667a1e572">
+		<cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>out of service in 2020</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c"/>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>
+		<cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>0e+000</cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>
+		<cim:PowerTransformer.beforeShortCircuitAnglePf>0e+000</cim:PowerTransformer.beforeShortCircuitAnglePf>
+		<cim:PowerTransformer.highSideMinOperatingU>0e+000</cim:PowerTransformer.highSideMinOperatingU>
+		<cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+		<cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+	</cim:PowerTransformer>
+	<cim:PowerTransformerEnd rdf:ID="_c1d5c1448f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>1.350000</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>27.967436</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>-0.0000044445</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0000005625</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>1.350000</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>27.967436</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>320.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>400.000000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Yn"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_e3e0c496-5837-4f0f-a596-cc421940f73f"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_c1d5c14d8f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0e+000</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>0e+000</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>0.0</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0e+000</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>0e+000</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>320.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>220.000000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Yn"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_c1d5c1518f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_2</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0.069143</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>5.377333</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>-0.0001420227</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0000181818</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0.069143</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>5.377333</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>1260.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>220.000000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Yn"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_1128e664-0653-448a-9068-e37f1a097c05"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_c1d5c15a8f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_2</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0e+000</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>0e+000</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>0.0</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0e+000</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>0e+000</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>1260.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>15.750000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Yn"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_c1d5bff18f8011e08e4d00247eb1f55e"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_da232169-1c36-495a-8af6-a0d7d2b39f52"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_c1d5c15e8f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_3</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0.065302</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>5.377381</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>-0.0001420227</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0000181818</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0.069143</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>5.377333</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>1260.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>220.000000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Yn"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_bd61b1f9-474d-424e-9709-42f75337c477"/>
+	</cim:PowerTransformerEnd>
+	<cim:PowerTransformerEnd rdf:ID="_c1d5c1678f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_3</entsoe:IdentifiedObject.shortName>
+		<cim:PowerTransformerEnd.r>0e+000</cim:PowerTransformerEnd.r>
+		<cim:PowerTransformerEnd.x>0e+000</cim:PowerTransformerEnd.x>
+		<cim:PowerTransformerEnd.b>0.0</cim:PowerTransformerEnd.b>
+		<cim:PowerTransformerEnd.g>0.0</cim:PowerTransformerEnd.g>
+		<cim:PowerTransformerEnd.r0>0e+000</cim:PowerTransformerEnd.r0>
+		<cim:PowerTransformerEnd.x0>0e+000</cim:PowerTransformerEnd.x0>
+		<cim:PowerTransformerEnd.b0>0.0</cim:PowerTransformerEnd.b0>
+		<cim:PowerTransformerEnd.g0>0.0</cim:PowerTransformerEnd.g0>
+		<cim:TransformerEnd.rground>0e+000</cim:TransformerEnd.rground>
+		<cim:TransformerEnd.xground>0.0</cim:TransformerEnd.xground>
+		<cim:PowerTransformerEnd.ratedS>1260.000000</cim:PowerTransformerEnd.ratedS>
+		<cim:PowerTransformerEnd.ratedU>15.750000</cim:PowerTransformerEnd.ratedU>
+		<cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+		<cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+		<cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+		<cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Yn"/>
+		<cim:TransformerEnd.BaseVoltage rdf:resource="#_c1d5bff18f8011e08e4d00247eb1f55e"/>
+		<cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572"/>
+		<cim:TransformerEnd.Terminal rdf:resource="#_4f1c405f-07c9-4fb0-b64e-551896a29aa8"/>
+	</cim:PowerTransformerEnd>
+	<cim:RatioTapChanger rdf:ID="_c1d5c14b8f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:TapChanger.neutralU>400.000000</cim:TapChanger.neutralU>
+		<cim:TapChanger.lowStep>-20</cim:TapChanger.lowStep>
+		<cim:TapChanger.highStep>20</cim:TapChanger.highStep>
+		<cim:TapChanger.neutralStep>0</cim:TapChanger.neutralStep>
+		<cim:TapChanger.normalStep>-2</cim:TapChanger.normalStep>
+		<cim:RatioTapChanger.stepVoltageIncrement>0.800000</cim:RatioTapChanger.stepVoltageIncrement>
+		<cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+		<cim:TapChanger.TapChangerControl rdf:resource="#_1aaa0997-7715-4400-9435-ce74a8f67a24"/>
+		<cim:RatioTapChanger.tculControlMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerControlMode.volt"/>
+		<cim:RatioTapChanger.TransformerEnd rdf:resource="#_c1d5c1448f8011e08e4d00247eb1f55e"/>
+	</cim:RatioTapChanger>
+	<cim:RatioTapChanger rdf:ID="_c1d5c1588f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_2</entsoe:IdentifiedObject.shortName>
+		<cim:TapChanger.neutralU>220.000000</cim:TapChanger.neutralU>
+		<cim:TapChanger.lowStep>0</cim:TapChanger.lowStep>
+		<cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+		<cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+		<cim:TapChanger.normalStep>17</cim:TapChanger.normalStep>
+		<cim:RatioTapChanger.stepVoltageIncrement>0.625000</cim:RatioTapChanger.stepVoltageIncrement>
+		<cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+		<cim:TapChanger.TapChangerControl rdf:resource="#_aae0af33-62c8-4062-8364-885d3372f808"/>
+		<cim:RatioTapChanger.tculControlMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerControlMode.volt"/>
+		<cim:RatioTapChanger.TransformerEnd rdf:resource="#_c1d5c1518f8011e08e4d00247eb1f55e"/>
+	</cim:RatioTapChanger>
+	<cim:RatioTapChanger rdf:ID="_c1d5c1658f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_3</entsoe:IdentifiedObject.shortName>
+		<cim:TapChanger.neutralU>220.000000</cim:TapChanger.neutralU>
+		<cim:TapChanger.lowStep>-15</cim:TapChanger.lowStep>
+		<cim:TapChanger.highStep>15</cim:TapChanger.highStep>
+		<cim:TapChanger.neutralStep>0</cim:TapChanger.neutralStep>
+		<cim:TapChanger.normalStep>5</cim:TapChanger.normalStep>
+		<cim:RatioTapChanger.stepVoltageIncrement>0.625000</cim:RatioTapChanger.stepVoltageIncrement>
+		<cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+		<cim:TapChanger.TapChangerControl rdf:resource="#_76971b35-279e-4d3c-8873-76c6abde82c4"/>
+		<cim:RatioTapChanger.tculControlMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerControlMode.volt"/>
+		<cim:RatioTapChanger.TransformerEnd rdf:resource="#_c1d5c15e8f8011e08e4d00247eb1f55e"/>
+	</cim:RatioTapChanger>
+	<cim:RegulatingControl rdf:ID="_04f338d3-3c0d-433f-a77b-e36dd256f0f0">
+		<cim:IdentifiedObject.name>NL-G1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-G1</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_faab7959-f9bf-421b-bc3f-d364e0c1388b"/>
+	</cim:RegulatingControl>
+	<cim:RegulatingControl rdf:ID="_1b3c88f9-c2ca-4250-bd37-ae0efa2fb022">
+		<cim:IdentifiedObject.name>NL-G2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-G2</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_ae4b7cbe-349a-41c8-ace2-25ec26f14a64"/>
+	</cim:RegulatingControl>
+	<cim:RegulatingControl rdf:ID="_53e7a6c7-759b-4da2-898a-1c061d788670">
+		<cim:IdentifiedObject.name>NL-G3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-G3</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_f04ecab5-1a12-4cc0-ba56-b157ebf11a42"/>
+	</cim:RegulatingControl>
+	<cim:RegulatingControl rdf:ID="_613dfeb3-0161-4cec-aaa9-ccddd885771b">
+		<cim:IdentifiedObject.name>NL-S1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-S1</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_a015f692-3fc5-4ec3-8d1d-977c7b499e7c"/>
+	</cim:RegulatingControl>
+	<cim:SubGeographicalRegion rdf:ID="_c1d5bfe48f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>TENNET TSO B.V.</cim:IdentifiedObject.name>
+		<cim:SubGeographicalRegion.Region rdf:resource="#_c1d5bfe28f8011e08e4d00247eb1f55e"/>
+	</cim:SubGeographicalRegion>
+	<cim:Substation rdf:ID="_c49942d6-8b01-4b01-b5e8-f1180f84906c">
+		<cim:IdentifiedObject.name>PP_Amsterdam</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>PP_Amsterdam</entsoe:IdentifiedObject.shortName>
+		<cim:Substation.Region rdf:resource="#_c1d5bfe48f8011e08e4d00247eb1f55e"/>
+	</cim:Substation>
+	<cim:SynchronousMachine rdf:ID="_9c3b8f97-7972-477d-9dc8-87365cc0ad0e">
+		<cim:IdentifiedObject.name>NL-G1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-G1</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_8d8a82ba-b5b0-4e94-861a-192af055f2b8"/>
+		<cim:SynchronousMachine.qPercent>100.000000</cim:SynchronousMachine.qPercent>
+		<cim:SynchronousMachine.maxQ>600.000000</cim:SynchronousMachine.maxQ>
+		<cim:SynchronousMachine.minQ>0e+000</cim:SynchronousMachine.minQ>
+		<cim:RotatingMachine.ratedS>1100.000000</cim:RotatingMachine.ratedS>
+		<cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineKind.generator"/>
+		<cim:RegulatingCondEq.RegulatingControl rdf:resource="#_04f338d3-3c0d-433f-a77b-e36dd256f0f0"/>
+		<cim:RotatingMachine.GeneratingUnit rdf:resource="#_049438a6-780a-44fe-a788-ebe385d98e25"/>
+		<cim:RotatingMachine.ratedU>15.750000</cim:RotatingMachine.ratedU>
+		<cim:RotatingMachine.ratedPowerFactor>0.900000</cim:RotatingMachine.ratedPowerFactor>
+		<cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#ShortCircuitRotorKind.salientPole1"/>
+		<cim:SynchronousMachine.r0>0e+000</cim:SynchronousMachine.r0>
+		<cim:SynchronousMachine.r2>0e+000</cim:SynchronousMachine.r2>
+		<cim:SynchronousMachine.x0>0.110000</cim:SynchronousMachine.x0>
+		<cim:SynchronousMachine.x2>0.180000</cim:SynchronousMachine.x2>
+		<cim:SynchronousMachine.earthingStarPointR>0e+000</cim:SynchronousMachine.earthingStarPointR>
+		<cim:SynchronousMachine.earthingStarPointX>0e+000</cim:SynchronousMachine.earthingStarPointX>
+		<cim:SynchronousMachine.r>0e+000</cim:SynchronousMachine.r>
+		<cim:SynchronousMachine.satDirectSubtransX>0.210000</cim:SynchronousMachine.satDirectSubtransX>
+		<cim:SynchronousMachine.satDirectSyncX>1.900000</cim:SynchronousMachine.satDirectSyncX>
+		<cim:SynchronousMachine.satDirectTransX>0e+000</cim:SynchronousMachine.satDirectTransX>
+		<cim:SynchronousMachine.mu>0e+000</cim:SynchronousMachine.mu>
+		<cim:SynchronousMachine.ikk>0e+000</cim:SynchronousMachine.ikk>
+		<cim:SynchronousMachine.voltageRegulationRange>0e+000</cim:SynchronousMachine.voltageRegulationRange>
+		<cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+	</cim:SynchronousMachine>
+	<cim:SynchronousMachine rdf:ID="_2844585c-0d35-488d-a449-685bcd57afbf">
+		<cim:IdentifiedObject.name>NL-G2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-G2</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_2a37dc57-2faf-464a-8175-bc415f9a635f"/>
+		<cim:SynchronousMachine.qPercent>100.000000</cim:SynchronousMachine.qPercent>
+		<cim:SynchronousMachine.maxQ>200.000000</cim:SynchronousMachine.maxQ>
+		<cim:SynchronousMachine.minQ>0e+000</cim:SynchronousMachine.minQ>
+		<cim:RotatingMachine.ratedS>250.000000</cim:RotatingMachine.ratedS>
+		<cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineKind.generator"/>
+		<cim:RegulatingCondEq.RegulatingControl rdf:resource="#_1b3c88f9-c2ca-4250-bd37-ae0efa2fb022"/>
+		<cim:RotatingMachine.GeneratingUnit rdf:resource="#_ca80ee09-3bed-4884-bc28-6dc89d067289"/>
+		<cim:RotatingMachine.ratedU>15.750000</cim:RotatingMachine.ratedU>
+		<cim:RotatingMachine.ratedPowerFactor>0.900000</cim:RotatingMachine.ratedPowerFactor>
+		<cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#ShortCircuitRotorKind.salientPole1"/>
+		<cim:SynchronousMachine.r0>0e+000</cim:SynchronousMachine.r0>
+		<cim:SynchronousMachine.r2>0e+000</cim:SynchronousMachine.r2>
+		<cim:SynchronousMachine.x0>0.100000</cim:SynchronousMachine.x0>
+		<cim:SynchronousMachine.x2>0.160000</cim:SynchronousMachine.x2>
+		<cim:SynchronousMachine.earthingStarPointR>0e+000</cim:SynchronousMachine.earthingStarPointR>
+		<cim:SynchronousMachine.earthingStarPointX>0e+000</cim:SynchronousMachine.earthingStarPointX>
+		<cim:SynchronousMachine.r>0e+000</cim:SynchronousMachine.r>
+		<cim:SynchronousMachine.satDirectSubtransX>0.180000</cim:SynchronousMachine.satDirectSubtransX>
+		<cim:SynchronousMachine.satDirectSyncX>1.800000</cim:SynchronousMachine.satDirectSyncX>
+		<cim:SynchronousMachine.satDirectTransX>0e+000</cim:SynchronousMachine.satDirectTransX>
+		<cim:SynchronousMachine.mu>0e+000</cim:SynchronousMachine.mu>
+		<cim:SynchronousMachine.ikk>0e+000</cim:SynchronousMachine.ikk>
+		<cim:SynchronousMachine.voltageRegulationRange>0e+000</cim:SynchronousMachine.voltageRegulationRange>
+		<cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+	</cim:SynchronousMachine>
+	<cim:SynchronousMachine rdf:ID="_1dc9afba-23b5-41a0-8540-b479ed8baf4b">
+		<cim:IdentifiedObject.name>NL-G3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-G3</entsoe:IdentifiedObject.shortName>
+		<cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+		<cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+		<cim:Equipment.EquipmentContainer rdf:resource="#_2a37dc57-2faf-464a-8175-bc415f9a635f"/>
+		<cim:SynchronousMachine.qPercent>100.000000</cim:SynchronousMachine.qPercent>
+		<cim:SynchronousMachine.maxQ>200.000000</cim:SynchronousMachine.maxQ>
+		<cim:SynchronousMachine.minQ>0e+000</cim:SynchronousMachine.minQ>
+		<cim:RotatingMachine.ratedS>250.000000</cim:RotatingMachine.ratedS>
+		<cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineKind.generator"/>
+		<cim:RegulatingCondEq.RegulatingControl rdf:resource="#_53e7a6c7-759b-4da2-898a-1c061d788670"/>
+		<cim:RotatingMachine.GeneratingUnit rdf:resource="#_b850063d-eae7-4675-bc98-4642d3076783"/>
+		<cim:RotatingMachine.ratedU>15.750000</cim:RotatingMachine.ratedU>
+		<cim:RotatingMachine.ratedPowerFactor>0.900000</cim:RotatingMachine.ratedPowerFactor>
+		<cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#ShortCircuitRotorKind.turboSeries1"/>
+		<cim:SynchronousMachine.r0>0e+000</cim:SynchronousMachine.r0>
+		<cim:SynchronousMachine.r2>0e+000</cim:SynchronousMachine.r2>
+		<cim:SynchronousMachine.x0>0.130000</cim:SynchronousMachine.x0>
+		<cim:SynchronousMachine.x2>0.170000</cim:SynchronousMachine.x2>
+		<cim:SynchronousMachine.earthingStarPointR>0e+000</cim:SynchronousMachine.earthingStarPointR>
+		<cim:SynchronousMachine.earthingStarPointX>0e+000</cim:SynchronousMachine.earthingStarPointX>
+		<cim:SynchronousMachine.r>0e+000</cim:SynchronousMachine.r>
+		<cim:SynchronousMachine.satDirectSubtransX>0.200000</cim:SynchronousMachine.satDirectSubtransX>
+		<cim:SynchronousMachine.satDirectSyncX>1.900000</cim:SynchronousMachine.satDirectSyncX>
+		<cim:SynchronousMachine.satDirectTransX>0e+000</cim:SynchronousMachine.satDirectTransX>
+		<cim:SynchronousMachine.mu>0e+000</cim:SynchronousMachine.mu>
+		<cim:SynchronousMachine.ikk>0e+000</cim:SynchronousMachine.ikk>
+		<cim:SynchronousMachine.voltageRegulationRange>0e+000</cim:SynchronousMachine.voltageRegulationRange>
+		<cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+	</cim:SynchronousMachine>
+	<cim:TapChangerControl rdf:ID="_1aaa0997-7715-4400-9435-ce74a8f67a24">
+		<cim:IdentifiedObject.name>NL-TR2_1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_e3e0c496-5837-4f0f-a596-cc421940f73f"/>
+	</cim:TapChangerControl>
+	<cim:TapChangerControl rdf:ID="_aae0af33-62c8-4062-8364-885d3372f808">
+		<cim:IdentifiedObject.name>NL_TR2_2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_2</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_da232169-1c36-495a-8af6-a0d7d2b39f52"/>
+	</cim:TapChangerControl>
+	<cim:TapChangerControl rdf:ID="_76971b35-279e-4d3c-8873-76c6abde82c4">
+		<cim:IdentifiedObject.name>NL_TR2_3</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_3</entsoe:IdentifiedObject.shortName>
+		<cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage"/>
+		<cim:RegulatingControl.Terminal rdf:resource="#_4f1c405f-07c9-4fb0-b64e-551896a29aa8"/>
+	</cim:TapChangerControl>
+	<cim:Terminal rdf:ID="_8121d4c3-9cb2-47db-b40a-99678602bb2a">
+		<cim:IdentifiedObject.name>B1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>B1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_5f5d40ae-d52d-4631-9285-b3ceefff784c"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_5f40c3f7-9540-4e1b-aa97-6553d5524877">
+		<cim:IdentifiedObject.name>B1 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>B1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_5f5d40ae-d52d-4631-9285-b3ceefff784c"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_ecea10ff-e006-436b-a86a-beac4c2a30c1">
+		<cim:IdentifiedObject.name>N1230822396_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_12733133-1f34-44f3-a020-f5b33cede919"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_50f00b94-fe0f-48fd-887e-f0d4d59eee87">
+		<cim:IdentifiedObject.name>NL-Busbar_2_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_143aa0b1-2cd4-4e58-98d4-b0438bd5a39a"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_0f199d49-0093-4b51-b357-70371424d174">
+		<cim:IdentifiedObject.name>NL-Busbar_3_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_53da4025-9d51-4eaf-b0d2-ce27fbe740d2"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_42800bad-5e47-42e6-b9b0-1fb8fc5831aa">
+		<cim:IdentifiedObject.name>NL-Busbar_5_Busbar_Section</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>BB</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_e6d49e32-b634-4b86-a8ca-15159f1497b5"/>
+		<cim:IdentifiedObject.description>Busbar Section</cim:IdentifiedObject.description>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_faab7959-f9bf-421b-bc3f-d364e0c1388b">
+		<cim:IdentifiedObject.name>NL-G1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-G1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_ae4b7cbe-349a-41c8-ace2-25ec26f14a64">
+		<cim:IdentifiedObject.name>NL-G2 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-G2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_2844585c-0d35-488d-a449-685bcd57afbf"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_f04ecab5-1a12-4cc0-ba56-b157ebf11a42">
+		<cim:IdentifiedObject.name>NL-G3 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-G3</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_39d27c17-1e5b-4edc-a7ec-65a2d56542df">
+		<cim:IdentifiedObject.name>NL-Inj-XCA_AL11 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-I-XCA_AL1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_83bea592-913e-4473-8d17-969968ff83a2"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_f970233f-b573-49d9-9fc3-3a2a59ed3bbb">
+		<cim:IdentifiedObject.name>NL-Inj-XKA_MA11 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-I-XKA_MA1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_cab82e1c-1435-447b-bba0-74b592539eac"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_f48d48c7-e9f6-460c-898f-cc68a96efdeb">
+		<cim:IdentifiedObject.name>NL-Inj-XWI_GY11 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-I-XWI_GY1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_b0442899-8dbe-48c1-a1fa-adb2a5929273"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_24dd035c-0a8c-4351-aeb2-08d6622b42ae">
+		<cim:IdentifiedObject.name>NL-Inj-XZE_ST23 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-I-XZE_ST2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_12baa3f3-23b1-44e0-956f-d331e1527f37"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_26e50b4b-9a19-420d-98ce-bc4f11971cd7">
+		<cim:IdentifiedObject.name>NL-Inj-XZE_ST24 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-I-XZE_ST2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_820d95d7-26d4-4311-8b1f-026f8605b86d"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3">
+		<cim:IdentifiedObject.name>NL-Line_1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000118</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d">
+		<cim:IdentifiedObject.name>NL-Line_1 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_7f43f508-2496-4b64-9146-0a40406cbe49"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000118</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_c557146e-dfc4-4020-9738-d592b188338b">
+		<cim:IdentifiedObject.name>NL-Line_2 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_8f308117-8bbd-4798-b145-4e78f7d049e7">
+		<cim:IdentifiedObject.name>NL-Line_2 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_dad02278-bd25-476f-8f58-dbe44be72586"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_5dfee914-a4fd-4bde-a5b4-c4caa6378d10">
+		<cim:IdentifiedObject.name>NL-Line_3 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_3</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_6aecb9ba-5835-4b70-89bc-96d687e45779">
+		<cim:IdentifiedObject.name>NL-Line_3 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_3</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_a279a3dc-550b-426c-af3a-61b7be508dcc"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_653bc4b8-518b-4adc-9d68-012fb641fb1d">
+		<cim:IdentifiedObject.name>NL-Line_4 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_4</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_57979d14-d1d8-4311-ae53-aa8890423885">
+		<cim:IdentifiedObject.name>NL-Line_4 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_4</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_8fdc7abd-3746-481a-a65e-3df56acd8b13"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_757d4f50-707b-47a0-891c-cbaefd649631">
+		<cim:IdentifiedObject.name>NL-Line_5 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_5</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000118</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_ae588863-b154-451d-978a-7ab08ac50fb6">
+		<cim:IdentifiedObject.name>NL-Line_5 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_5</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_e8acf6b6-99cb-45ad-b8dc-16c7866a4ddc"/>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000118</entsoe:IdentifiedObject.energyIdentCodeEic>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_f461fd2d-1e41-4a3e-8213-7cc33c77a089">
+		<cim:IdentifiedObject.name>NL-Load_1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_69add5b4-70bd-4360-8a93-286256c0d38b"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_6dad1a97-6874-4206-a5a5-837e495325f8">
+		<cim:IdentifiedObject.name>NL-Load_2 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_25ab1b5b-6803-47e2-805a-ab7b2072e034"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0">
+		<cim:IdentifiedObject.name>NL-Load_3 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-L_3</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_b1e03a8f-6a11-4454-af58-4a4a680e857f"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_a015f692-3fc5-4ec3-8d1d-977c7b499e7c">
+		<cim:IdentifiedObject.name>NL-S1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-S1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_fbfed7e3-3dec-4829-a286-029e73535685"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_e3e0c496-5837-4f0f-a596-cc421940f73f">
+		<cim:IdentifiedObject.name>NL-TR2_1 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0">
+		<cim:IdentifiedObject.name>NL-TR2_1 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL-T_1</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_e8a7eaec-51d6-4571-b3d9-c36d52073c33"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_1128e664-0653-448a-9068-e37f1a097c05">
+		<cim:IdentifiedObject.name>NL_TR2_2 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_da232169-1c36-495a-8af6-a0d7d2b39f52">
+		<cim:IdentifiedObject.name>NL_TR2_2 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_2</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_2184f365-8cd5-4b5d-8a28-9d68603bb6a4"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_bd61b1f9-474d-424e-9709-42f75337c477">
+		<cim:IdentifiedObject.name>NL_TR2_3 - T1</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_3</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572"/>
+	</cim:Terminal>
+	<cim:Terminal rdf:ID="_4f1c405f-07c9-4fb0-b64e-551896a29aa8">
+		<cim:IdentifiedObject.name>NL_TR2_3 - T2</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.shortName>NL_T_3</entsoe:IdentifiedObject.shortName>
+		<cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+		<cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC"/>
+		<cim:Terminal.ConductingEquipment rdf:resource="#_80016742-31b3-432a-b00a-300667a1e572"/>
+	</cim:Terminal>
+	<cim:VoltageLevel rdf:ID="_2a37dc57-2faf-464a-8175-bc415f9a635f">
+		<cim:IdentifiedObject.name>15.8</cim:IdentifiedObject.name>
+		<cim:VoltageLevel.lowVoltageLimit>14.175000</cim:VoltageLevel.lowVoltageLimit>
+		<cim:VoltageLevel.highVoltageLimit>17.325000</cim:VoltageLevel.highVoltageLimit>
+		<cim:VoltageLevel.Substation rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c"/>
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_c1d5bff18f8011e08e4d00247eb1f55e"/>
+	</cim:VoltageLevel>
+	<cim:VoltageLevel rdf:ID="_8d8a82ba-b5b0-4e94-861a-192af055f2b8">
+		<cim:IdentifiedObject.name>15.8</cim:IdentifiedObject.name>
+		<cim:VoltageLevel.lowVoltageLimit>14.175000</cim:VoltageLevel.lowVoltageLimit>
+		<cim:VoltageLevel.highVoltageLimit>17.325000</cim:VoltageLevel.highVoltageLimit>
+		<cim:VoltageLevel.Substation rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c"/>
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_c1d5bff18f8011e08e4d00247eb1f55e"/>
+	</cim:VoltageLevel>
+	<cim:VoltageLevel rdf:ID="_c1d5bfea8f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>220.0</cim:IdentifiedObject.name>
+		<cim:VoltageLevel.lowVoltageLimit>198.000000</cim:VoltageLevel.lowVoltageLimit>
+		<cim:VoltageLevel.highVoltageLimit>242.000000</cim:VoltageLevel.highVoltageLimit>
+		<cim:VoltageLevel.Substation rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c"/>
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_7891a026ba2c42098556665efd13ba94"/>
+	</cim:VoltageLevel>
+	<cim:VoltageLevel rdf:ID="_c1d5bfde8f8011e08e4d00247eb1f55e">
+		<cim:IdentifiedObject.name>400.0</cim:IdentifiedObject.name>
+		<cim:VoltageLevel.lowVoltageLimit>360.000000</cim:VoltageLevel.lowVoltageLimit>
+		<cim:VoltageLevel.highVoltageLimit>440.000000</cim:VoltageLevel.highVoltageLimit>
+		<cim:VoltageLevel.Substation rdf:resource="#_c49942d6-8b01-4b01-b5e8-f1180f84906c"/>
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_65dd04e792584b3b912374e35dec032e"/>
+	</cim:VoltageLevel>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MicroGrid/BaseCase/BC_NL_v2_switch_type_preserved/MicroGridTestConfiguration_BC_NL_SSH_V2.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MicroGrid/BaseCase/BC_NL_v2_switch_type_preserved/MicroGridTestConfiguration_BC_NL_SSH_V2.xml
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#">
+  <md:FullModel rdf:about="urn:uuid:66085ffe-dddf-4fc8-805c-2c7aa2097b90">
+    <md:Model.created>2014-10-24T11:51:49</md:Model.created>
+    <md:Model.scenarioTime>2014-06-01T10:30:00</md:Model.scenarioTime>
+    <md:Model.version>2</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:77b55f87-fc1e-4046-9599-6c6b4f991a86"/>
+    <md:Model.description>CGMES Conformity Assessment: 'MicroGridTestConfiguration....BC (MAS NL) Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://tennet.nl/CGMES/2.4.15</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://entsoe.eu/CIM/SteadyStateHypothesis/1/1</md:Model.profile>
+  </md:FullModel>
+  <cim:Terminal rdf:about="#_757d4f50-707b-47a0-891c-cbaefd649631">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae588863-b154-451d-978a-7ab08ac50fb6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_653bc4b8-518b-4adc-9d68-012fb641fb1d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_57979d14-d1d8-4311-ae53-aa8890423885">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5dfee914-a4fd-4bde-a5b4-c4caa6378d10">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6aecb9ba-5835-4b70-89bc-96d687e45779">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c557146e-dfc4-4020-9738-d592b188338b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f308117-8bbd-4798-b145-4e78f7d049e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_357e3e14-c38e-4a7e-9c95-b3dbe158f5f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6b1cd30c-19ba-44e1-9447-d01db6b1ef9d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8121d4c3-9cb2-47db-b40a-99678602bb2a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f40c3f7-9540-4e1b-aa97-6553d5524877">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e3e0c496-5837-4f0f-a596-cc421940f73f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_baa7aef1-afcd-4981-97c0-ccec7b5ad4e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1128e664-0653-448a-9068-e37f1a097c05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_da232169-1c36-495a-8af6-a0d7d2b39f52">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_bd61b1f9-474d-424e-9709-42f75337c477">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4f1c405f-07c9-4fb0-b64e-551896a29aa8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ae4b7cbe-349a-41c8-ace2-25ec26f14a64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f04ecab5-1a12-4cc0-ba56-b157ebf11a42">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_faab7959-f9bf-421b-bc3f-d364e0c1388b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a015f692-3fc5-4ec3-8d1d-977c7b499e7c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f970233f-b573-49d9-9fc3-3a2a59ed3bbb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_24dd035c-0a8c-4351-aeb2-08d6622b42ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_26e50b4b-9a19-420d-98ce-bc4f11971cd7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f48d48c7-e9f6-460c-898f-cc68a96efdeb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_39d27c17-1e5b-4edc-a7ec-65a2d56542df">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fab54e9c-b12e-4e47-a9f2-fec4ef96c0c0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6dad1a97-6874-4206-a5a5-837e495325f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f461fd2d-1e41-4a3e-8213-7cc33c77a089">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ecea10ff-e006-436b-a86a-beac4c2a30c1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_42800bad-5e47-42e6-b9b0-1fb8fc5831aa">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0f199d49-0093-4b51-b357-70371424d174">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_50f00b94-fe0f-48fd-887e-f0d4d59eee87">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:EnergyConsumer rdf:about="#_b1e03a8f-6a11-4454-af58-4a4a680e857f">
+    <cim:EnergyConsumer.p>486.000000</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>230.000000</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_25ab1b5b-6803-47e2-805a-ab7b2072e034">
+    <cim:EnergyConsumer.p>10.000000</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>10.000000</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_69add5b4-70bd-4360-8a93-286256c0d38b">
+    <cim:EnergyConsumer.p>90.000000</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>280.000000</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:GeneratingUnit rdf:about="#_ca80ee09-3bed-4884-bc28-6dc89d067289">
+    <cim:GeneratingUnit.normalPF>0e+000</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_2844585c-0d35-488d-a449-685bcd57afbf">
+    <cim:RotatingMachine.p>-140.000000</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-77.743000</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator"/>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_b850063d-eae7-4675-bc98-4642d3076783">
+    <cim:GeneratingUnit.normalPF>0e+000</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_1dc9afba-23b5-41a0-8540-b479ed8baf4b">
+    <cim:RotatingMachine.p>-150.000000</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-83.296000</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator"/>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_049438a6-780a-44fe-a788-ebe385d98e25">
+    <cim:GeneratingUnit.normalPF>1.000000</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_9c3b8f97-7972-477d-9dc8-87365cc0ad0e">
+    <cim:RotatingMachine.p>-600.492701</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-386.922556</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator"/>
+    <cim:SynchronousMachine.referencePriority>1</cim:SynchronousMachine.referencePriority>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+  </cim:SynchronousMachine>
+  <cim:RatioTapChanger rdf:about="#_c1d5c14b8f8011e08e4d00247eb1f55e">
+    <cim:TapChanger.step>-2</cim:TapChanger.step>
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_c1d5c1588f8011e08e4d00247eb1f55e">
+    <cim:TapChanger.step>17</cim:TapChanger.step>
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_c1d5c1658f8011e08e4d00247eb1f55e">
+    <cim:TapChanger.step>5</cim:TapChanger.step>
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+  </cim:RatioTapChanger>
+  <cim:LinearShuntCompensator rdf:about="#_fbfed7e3-3dec-4829-a286-029e73535685">
+    <cim:ShuntCompensator.sections>1</cim:ShuntCompensator.sections>
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+  </cim:LinearShuntCompensator>
+  <!-- changed from cim:Breaker to cim:Switch -->
+  <cim:Switch rdf:about="#_5f5d40ae-d52d-4631-9285-b3ceefff784c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Switch>
+  <cim:EquivalentInjection rdf:about="#_cab82e1c-1435-447b-bba0-74b592539eac">
+    <cim:EquivalentInjection.p>43.687227</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-84.876604</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_12baa3f3-23b1-44e0-956f-d331e1527f37">
+    <cim:EquivalentInjection.p>27.365225</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-0.425626</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_820d95d7-26d4-4311-8b1f-026f8605b86d">
+    <cim:EquivalentInjection.p>26.805006</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-1.489867</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_b0442899-8dbe-48c1-a1fa-adb2a5929273">
+    <cim:EquivalentInjection.p>90.037005</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-148.603743</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_83bea592-913e-4473-8d17-969968ff83a2">
+    <cim:EquivalentInjection.p>46.816625</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>-79.193778</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:TapChangerControl rdf:about="#_1aaa0997-7715-4400-9435-ce74a8f67a24">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>0e+000</cim:RegulatingControl.targetValue>
+  </cim:TapChangerControl>
+  <cim:TapChangerControl rdf:about="#_aae0af33-62c8-4062-8364-885d3372f808">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>0e+000</cim:RegulatingControl.targetValue>
+  </cim:TapChangerControl>
+  <cim:TapChangerControl rdf:about="#_76971b35-279e-4d3c-8873-76c6abde82c4">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>0e+000</cim:RegulatingControl.targetValue>
+  </cim:TapChangerControl>
+  <cim:RegulatingControl rdf:about="#_1b3c88f9-c2ca-4250-bd37-ae0efa2fb022">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>16.017750</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:about="#_53e7a6c7-759b-4da2-898a-1c061d788670">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>16.017750</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:about="#_04f338d3-3c0d-433f-a77b-e36dd256f0f0">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>16.033500</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:about="#_613dfeb3-0161-4cec-aaa9-ccddd885771b">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>400.000000</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MiniGrid/NodeBreaker/BaseCase_Complete_v3_switch_type_preserved/MiniGridTestConfiguration_BC_EQ_v3.0.0.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MiniGrid/NodeBreaker/BaseCase_Complete_v3_switch_type_preserved/MiniGridTestConfiguration_BC_EQ_v3.0.0.xml
@@ -1,0 +1,4479 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:239ecbd2-9a39-11e0-aa80-0800200c9a66">
+    <md:Model.scenarioTime>2030-01-02T09:00:00</md:Model.scenarioTime>
+    <md:Model.created>2015-02-05T12:20:50.830</md:Model.created>
+    <md:Model.description>CGMES Conformity Assessment: Mini Grid Base Case Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E "as it is". To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.version>4</md:Model.version>
+    <md:Model.profile>http://entsoe.eu/CIM/EquipmentCore/3/1</md:Model.profile>
+    <md:Model.profile>http://entsoe.eu/CIM/EquipmentOperation/3/1</md:Model.profile>
+    <md:Model.profile>http://entsoe.eu/CIM/EquipmentShortCircuit/3/1</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://A1.de/Planning/ENTSOE/2</md:Model.modelingAuthoritySet>
+    <md:Model.Supersedes rdf:resource="urn:uuid:2399cbd2-9a39-11e0-aa80-0800200c9a66_EU" />
+	<md:Model.DependentOn rdf:resource="urn:uuid:2399cbd0-9a39-11e0-aa80-0800200c9a66" />
+  </md:FullModel>
+  <cim:Terminal rdf:ID="_8372a156-7579-4ea5-8793-24caf0d24603">
+    <cim:IdentifiedObject.name>L5_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d3de846d-5271-465e-8558-3e736fa120c4" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_1e7f52a9-21d0-4ebe-9a8a-b29281d5bfc9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_5042af3b-8c3a-4548-b2fa-a8d655f94402">
+    <cim:IdentifiedObject.name>L5_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_e2f8de8c-3191-4676-9ee7-f920e46f9085" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_1e7f52a9-21d0-4ebe-9a8a-b29281d5bfc9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_5492183a-1e6f-4dee-a506-f389c69f4c83">
+    <cim:IdentifiedObject.name>L6_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_8adb739f-8939-4e87-8d3e-c958aa49c187" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_56757c2b-550e-4843-886a-ed193f6eb21e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_3d6a6b41-0ff8-418a-9530-94c6752b2db0">
+    <cim:IdentifiedObject.name>L6_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1d9f1b8a-8d53-440a-b97d-71772e193e9f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_56757c2b-550e-4843-886a-ed193f6eb21e" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1a6456c6-fb39-42a0-b21d-089093ba7c49">
+    <cim:IdentifiedObject.name>L4_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_5de48674-41f7-4a17-8055-320eab5b638e" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e95a6228-ceac-4f0a-8b52-d35367b364dc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_d7f0a22b-afbc-41d2-b919-8fde5d1c5045">
+    <cim:IdentifiedObject.name>L4_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_064ae2ca-de5b-41a6-a3a4-86ddd1136880" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e95a6228-ceac-4f0a-8b52-d35367b364dc" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_933078aa-6687-4922-bb1f-4c1457f7c26f">
+    <cim:IdentifiedObject.name>L1_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_05c02066-7ded-48d7-b787-da1d2e77f81c" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d5d1cc4a-6297-4386-b6ce-16dc26f15feb" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_863647cc-d576-484a-bde3-e8998f9f021a">
+    <cim:IdentifiedObject.name>L1_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1925701d-9d85-4f19-86e4-cb7a75453f59" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d5d1cc4a-6297-4386-b6ce-16dc26f15feb" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_563c5f79-a51d-4ce8-a921-0e86dd984bb5">
+    <cim:IdentifiedObject.name>L2_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d09c63da-d5f4-4d89-a757-c7426a4b81d2" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_efdd7f46-67e6-46e3-9dcd-a3b6f8c613a4" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_706707e5-019e-4549-b981-a857f1dfa611">
+    <cim:IdentifiedObject.name>L2_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_473b9f45-3071-4fef-a90b-43a8c4eddeae" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_efdd7f46-67e6-46e3-9dcd-a3b6f8c613a4" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_0593fd2d-7e55-4a8d-8ddf-4f8a576cf26c">
+    <cim:IdentifiedObject.name>L3_a_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d9649b2e-0a9c-424e-b3b2-31dbd41bee4f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_35df6abe-3087-4c27-a90a-12b5065333f3" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_89df2b1b-9107-45a8-95ae-16afa04d99b3">
+    <cim:IdentifiedObject.name>L3_a_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cc81766a-a254-432f-b9a2-e22225f529f7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_35df6abe-3087-4c27-a90a-12b5065333f3" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_616ef15c-065f-4ca2-8367-d1aad079357e">
+    <cim:IdentifiedObject.name>L3_b_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b662305d-ac49-4c92-8a1d-ea3036616328" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_05597934-b248-491e-803a-68ce6290f502" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c39420a7-76ad-4bcc-afdf-da398485bf28">
+    <cim:IdentifiedObject.name>L3_b_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_edfce3cd-e2e1-49eb-9660-7fe920b96c57" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_05597934-b248-491e-803a-68ce6290f502" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_51ac3672-026d-4257-9c68-7c7f57a9b55e">
+    <cim:IdentifiedObject.name>T5_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_959b2f06-3e1d-454c-b756-7ec0271f9ff6" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ceb5d06a-a7ff-4102-a620-7f3ea5fb4a51" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_0fa430b4-d98c-43bd-9652-f61fb00e7340">
+    <cim:IdentifiedObject.name>T5_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_29c4f110-c71b-4baa-8bd1-dd193606b955" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ceb5d06a-a7ff-4102-a620-7f3ea5fb4a51" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_7145f995-b4a7-472e-9c58-2f8540ad3925">
+    <cim:IdentifiedObject.name>T6_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_71f091ea-9081-40c2-9e8c-49111b408dcf" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6c89588b-3df5-4120-88e5-26164afb43e9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_912cc25e-78d9-43a6-a77e-b2b7bb76688b">
+    <cim:IdentifiedObject.name>T6_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c575585e-bce8-4d2d-b211-a28f7ed6e07f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6c89588b-3df5-4120-88e5-26164afb43e9" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_a1158b5f-3b71-4c44-8b15-4150d983f73e">
+    <cim:IdentifiedObject.name>T2_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_74fb7acb-29d3-4402-8f1d-f393a0cade37" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f1e72854-ec35-46e9-b614-27db354e8dbb" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b2112f10-1057-4a28-a18d-a1952c791c4c">
+    <cim:IdentifiedObject.name>T2_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_2ad1f76e-e884-41d8-a50e-7f798b8e2df7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f1e72854-ec35-46e9-b614-27db354e8dbb" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_7fe566b9-6bac-4cd3-8b52-8f46e9ba237d">
+    <cim:IdentifiedObject.name>T1_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_7f102715-e610-4fe6-8557-ba49b1bb5be5" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_813365c3-5be7-4ef0-a0a7-abd1ae6dc174" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_82611054-72b9-4cb0-8621-e418b8962cb1">
+    <cim:IdentifiedObject.name>T1_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_de0ba159-8462-4173-8690-782b1c8887f7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_813365c3-5be7-4ef0-a0a7-abd1ae6dc174" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_eb8ed3e6-c0de-47e2-9dd5-52b321d51b70">
+    <cim:IdentifiedObject.name>T4_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0ded970c-cec5-45ac-90d6-eaafcb208874" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_411b5401-0a43-404a-acb4-05c3d7d0c95c" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_e59d3a8c-8382-413a-95ae-6354dfe85565">
+    <cim:IdentifiedObject.name>T4_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ccf6d0de-5af6-4b10-a11c-76f99fe18508" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_411b5401-0a43-404a-acb4-05c3d7d0c95c" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_5af3b857-165c-4f96-b415-0d6e2e9ca27f">
+    <cim:IdentifiedObject.name>T4_2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>3</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bddd7013-7e34-414c-87da-8e1178fdc256" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_411b5401-0a43-404a-acb4-05c3d7d0c95c" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1dfffea9-1fac-48f1-b466-1312643f3a47">
+    <cim:IdentifiedObject.name>T3_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f1fdcc78-2ff9-4118-8191-77e88dabfa22" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5d38b7ed-73fd-405a-9cdb-78425e003773" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_d5b02a21-e6f5-441c-81f2-4accb1a56ddd">
+    <cim:IdentifiedObject.name>T3_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_59c6d51f-4520-4b53-922e-14dec1fdeab4" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5d38b7ed-73fd-405a-9cdb-78425e003773" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_01a240e9-5607-4844-9d53-5c8b08b5c9a8">
+    <cim:IdentifiedObject.name>T3_2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>3</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0ccf291a-eadf-4010-a26c-f691a135118f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5d38b7ed-73fd-405a-9cdb-78425e003773" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_4dec53ca-3ea6-4bd0-a225-b559c8293e91">
+    <cim:IdentifiedObject.name>G2_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_a662bdaf-fbb3-4801-b12a-ace07d246e9f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2970a2b7-b840-4e9c-b405-0cb854cd2318" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_3434b50d-677d-4ad5-96d7-6c7d1be611e6">
+    <cim:IdentifiedObject.name>G1_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_7dbc4e44-5c8e-4b22-a80c-4269fdaa7581" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ca67be42-750e-4ebf-bfaa-24d446e59a22" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_9165ded7-ec43-469a-b006-554d388a63ec">
+    <cim:IdentifiedObject.name>G3_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ec8c3b42-d70c-41d6-89f4-f2df958817c8" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_392ea173-4f8e-48fa-b2a3-5c3721e93196" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_e3420c0c-d6fc-49ee-9447-74c8e1eba64e">
+    <cim:IdentifiedObject.name>M1_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f82294a-5cb0-4395-b79a-514c7de478bf" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_062ece1f-ade5-4d20-9c3a-fd8f12d12ec1" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_2e6ef544-c98e-44ec-a8de-8c44d2cccc33">
+    <cim:IdentifiedObject.name>M2_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f82294a-5cb0-4395-b79a-514c7de478bf" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ba62884d-8800-41a8-9c26-698297d7ebaa" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_6cd98e8c-ede7-46b1-aa01-7f9f7db26416">
+    <cim:IdentifiedObject.name>ASM-1229750300_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f82294a-5cb0-4395-b79a-514c7de478bf" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f184d87b-5565-45ee-89b4-29e8a42d3ad1" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_2fa56ee8-8afb-4db2-8fcf-89b9fa135bca">
+    <cim:IdentifiedObject.name>Q1_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4e34639c-5785-4ef6-811f-b0d237530ffb" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_089c1945-4101-487f-a557-66c013b748f6" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_07865469-d39d-4234-8cee-fa998fa49bed">
+    <cim:IdentifiedObject.name>Q2_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4cea32b-2ea1-4be3-9040-2a29cf7a48f1" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3de9e1ad-4562-44df-b268-70ed0517e9e7" />
+  </cim:Terminal>
+  <cim:BaseVoltage rdf:ID="_ed2bd589-b6d9-42bd-82fc-0b895e8707b1">
+    <cim:IdentifiedObject.name>380kV</cim:IdentifiedObject.name>
+    <cim:BaseVoltage.nominalVoltage>380</cim:BaseVoltage.nominalVoltage>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_e6b5f155-583d-46fa-90fc-0673d1afe1be">
+    <cim:IdentifiedObject.name>21kV</cim:IdentifiedObject.name>
+    <cim:BaseVoltage.nominalVoltage>21</cim:BaseVoltage.nominalVoltage>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_45b9413e-a116-4952-8cf8-aeb4b2e53348">
+    <cim:IdentifiedObject.name>10kV</cim:IdentifiedObject.name>
+    <cim:BaseVoltage.nominalVoltage>10</cim:BaseVoltage.nominalVoltage>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_a7363e0b-e9ed-424e-8984-6e74823307aa">
+    <cim:IdentifiedObject.name>110kV</cim:IdentifiedObject.name>
+    <cim:BaseVoltage.nominalVoltage>110</cim:BaseVoltage.nominalVoltage>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_b2a3e748-1772-409d-a61f-1d6da09564c9">
+    <cim:IdentifiedObject.name>30kV</cim:IdentifiedObject.name>
+    <cim:BaseVoltage.nominalVoltage>30</cim:BaseVoltage.nominalVoltage>
+  </cim:BaseVoltage>
+  <cim:VoltageLevel rdf:ID="_b2707f00-2554-41d2-bde2-7dd80a669e50">
+    <cim:IdentifiedObject.name>S2 10kV</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_3f64f4e2-adfe-4d12-b082-68e7fe4b11c9" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+  </cim:VoltageLevel>
+  <cim:VoltageLevel rdf:ID="_8d4a8238-5b31-4c16-8692-0265dae5e132">
+    <cim:IdentifiedObject.name>S5 10kV</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_b3e5b4de-b74d-43b4-8db9-784302a12acf" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+  </cim:VoltageLevel>
+  <cim:VoltageLevel rdf:ID="_0d68ac81-124d-4d21-afa8-6c503feef5b8">
+    <cim:IdentifiedObject.name>S4 10kV</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_d6056127-34f1-43a9-b029-23fddb913bd5" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+  </cim:VoltageLevel>
+  <cim:VoltageLevel rdf:ID="_6f8ef715-bc0a-47d7-a74e-27f17234f590">
+    <cim:IdentifiedObject.name>S3 21kV</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_974565b1-ac55-4901-9f48-afc7ef5486df" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_e6b5f155-583d-46fa-90fc-0673d1afe1be" />
+  </cim:VoltageLevel>
+  <cim:VoltageLevel rdf:ID="_347fb7af-642f-4c60-97d9-c03d440b6a82">
+    <cim:IdentifiedObject.name>S2 110kV</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_3f64f4e2-adfe-4d12-b082-68e7fe4b11c9" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+  </cim:VoltageLevel>
+  <cim:VoltageLevel rdf:ID="_051b93ae-9c15-4490-8cea-33395298f031">
+    <cim:IdentifiedObject.name>S3 110kV</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_974565b1-ac55-4901-9f48-afc7ef5486df" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+  </cim:VoltageLevel>
+  <cim:VoltageLevel rdf:ID="_5d9d9d87-ce6b-4213-b4ec-d50de9790a59">
+    <cim:IdentifiedObject.name>S1 380kV</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_af9a4ae3-ba2e-4c34-8e47-5af894ee20f4" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+  </cim:VoltageLevel>
+  <cim:VoltageLevel rdf:ID="_93778e52-3fd5-456d-8b10-987c3e6bc47e">
+    <cim:IdentifiedObject.name>S1 30kV</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_af9a4ae3-ba2e-4c34-8e47-5af894ee20f4" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_b2a3e748-1772-409d-a61f-1d6da09564c9" />
+  </cim:VoltageLevel>
+  <cim:VoltageLevel rdf:ID="_a43d15db-44a6-4fda-a525-2402ff43226f">
+    <cim:IdentifiedObject.name>S4 110kV</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_d6056127-34f1-43a9-b029-23fddb913bd5" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+  </cim:VoltageLevel>
+  <cim:VoltageLevel rdf:ID="_cd28a27e-8b17-4f23-b9f5-03b6de15203f">
+    <cim:IdentifiedObject.name>S1 110kV</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_af9a4ae3-ba2e-4c34-8e47-5af894ee20f4" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+  </cim:VoltageLevel>
+  <cim:Substation rdf:ID="_af9a4ae3-ba2e-4c34-8e47-5af894ee20f4">
+    <cim:IdentifiedObject.name>Sub1</cim:IdentifiedObject.name>
+    <cim:Substation.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Substation>
+  <cim:Substation rdf:ID="_3f64f4e2-adfe-4d12-b082-68e7fe4b11c9">
+    <cim:IdentifiedObject.name>Sub2</cim:IdentifiedObject.name>
+    <cim:Substation.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Substation>
+  <cim:Substation rdf:ID="_974565b1-ac55-4901-9f48-afc7ef5486df">
+    <cim:IdentifiedObject.name>Sub3</cim:IdentifiedObject.name>
+    <cim:Substation.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Substation>
+  <cim:Substation rdf:ID="_d6056127-34f1-43a9-b029-23fddb913bd5">
+    <cim:IdentifiedObject.name>Sub4</cim:IdentifiedObject.name>
+    <cim:Substation.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Substation>
+  <cim:Substation rdf:ID="_b3e5b4de-b74d-43b4-8db9-784302a12acf">
+    <cim:IdentifiedObject.name>Sub5</cim:IdentifiedObject.name>
+    <cim:Substation.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Substation>
+  <cim:GeographicalRegion rdf:ID="_11e42ac4-6168-4f6f-8da7-6f06616738eb">
+    <cim:IdentifiedObject.name>AA</cim:IdentifiedObject.name>
+  </cim:GeographicalRegion>
+  <cim:SubGeographicalRegion rdf:ID="_8f28794f-6030-4ec6-b17c-91ecb4321673">
+    <cim:IdentifiedObject.name>Z1</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_11e42ac4-6168-4f6f-8da7-6f06616738eb" />
+  </cim:SubGeographicalRegion>
+  <cim:OperationalLimitType rdf:ID="_0112c7f1-7523-4339-a285-d941a4a491ec">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimitType.acceptableDuration>45000</cim:OperationalLimitType.acceptableDuration>
+    <entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.patl" />
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue" />
+  </cim:OperationalLimitType>
+  <cim:OperationalLimitType rdf:ID="_92ad0fde-1e8d-46b5-83cf-8bcd39450e18">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimitType.acceptableDuration>900</cim:OperationalLimitType.acceptableDuration>
+    <entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.tatl" />
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue" />
+  </cim:OperationalLimitType>
+  <cim:OperationalLimitType rdf:ID="_ed7c9153-defb-4fff-aa25-85c175e80ca0">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimitType.acceptableDuration>60</cim:OperationalLimitType.acceptableDuration>
+    <entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.tatl" />
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue" />
+  </cim:OperationalLimitType>
+  <cim:ThermalGeneratingUnit rdf:ID="_93346fba-8a54-4969-a063-50e4a037e1f2">
+    <cim:IdentifiedObject.description>Gen-1</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>G2</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_3f64f4e2-adfe-4d12-b082-68e7fe4b11c9" />
+    <cim:GeneratingUnit.initialP>0</cim:GeneratingUnit.initialP>
+    <cim:GeneratingUnit.maxOperatingP>127.5</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>0</cim:GeneratingUnit.minOperatingP>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:ID="_2970a2b7-b840-4e9c-b405-0cb854cd2318">
+    <cim:IdentifiedObject.name>G2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b2707f00-2554-41d2-bde2-7dd80a669e50" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_10d33824-507a-4999-bd51-f73373e7509a" />
+    <cim:RotatingMachine.ratedPowerFactor>0.9</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>100</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>10.5</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_93346fba-8a54-4969-a063-50e4a037e1f2" />
+    <cim:SynchronousMachine.earthing>false</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.maxQ>43.6</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>-43.6</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0.004535</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.16</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>2</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>2</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#ShortCircuitRotorKind.turboSeries1" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.voltageRegulationRange>7.5</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.r>0.005</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.x0>0.1</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.16</cim:SynchronousMachine.x2>
+  </cim:SynchronousMachine>
+  <cim:ThermalGeneratingUnit rdf:ID="_a318334b-6a8d-40cd-9ce2-4526873d5504">
+    <cim:IdentifiedObject.description>Gen-2</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>G1</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_974565b1-ac55-4901-9f48-afc7ef5486df" />
+    <cim:GeneratingUnit.initialP>0</cim:GeneratingUnit.initialP>
+    <cim:GeneratingUnit.maxOperatingP>90</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>0</cim:GeneratingUnit.minOperatingP>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:ID="_ca67be42-750e-4ebf-bfaa-24d446e59a22">
+    <cim:IdentifiedObject.name>G1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_6f8ef715-bc0a-47d7-a74e-27f17234f590" />
+    <cim:RotatingMachine.ratedPowerFactor>0.85</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>150</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>21</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_a318334b-6a8d-40cd-9ce2-4526873d5504" />
+    <cim:SynchronousMachine.earthing>false</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.maxQ>79</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>-79</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0.00068</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.14</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>1.8</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>1.8</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#ShortCircuitRotorKind.turboSeries1" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.r>0.002</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.x0>0.1</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.14</cim:SynchronousMachine.x2>
+  </cim:SynchronousMachine>
+  <cim:ThermalGeneratingUnit rdf:ID="_f1001dea-bb33-4f34-9508-d492af527d35">
+    <cim:IdentifiedObject.description>Gen-3</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>G3</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_d6056127-34f1-43a9-b029-23fddb913bd5" />
+    <cim:GeneratingUnit.initialP>0</cim:GeneratingUnit.initialP>
+    <cim:GeneratingUnit.maxOperatingP>8</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>0</cim:GeneratingUnit.minOperatingP>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:ID="_392ea173-4f8e-48fa-b2a3-5c3721e93196">
+    <cim:IdentifiedObject.name>G3</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_0d68ac81-124d-4d21-afa8-6c503feef5b8" />
+    <cim:RotatingMachine.ratedPowerFactor>0.8</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>10</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>10.5</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_f1001dea-bb33-4f34-9508-d492af527d35" />
+    <cim:SynchronousMachine.earthing>false</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.maxQ>6</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>-6</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0.00163</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.1</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>1.8</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>1.8</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#ShortCircuitRotorKind.turboSeries1" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.r>0.018</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.x0>0.08</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.1</cim:SynchronousMachine.x2>
+  </cim:SynchronousMachine>
+  <cim:AsynchronousMachine rdf:ID="_062ece1f-ade5-4d20-9c3a-fd8f12d12ec1">
+    <cim:IdentifiedObject.name>M3</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d4a8238-5b31-4c16-8692-0265dae5e132" />
+    <cim:RotatingMachine.ratedPowerFactor>0.88</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>5.828</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>10</cim:RotatingMachine.ratedU>
+    <cim:AsynchronousMachine.converterFedDrive>false</cim:AsynchronousMachine.converterFedDrive>
+    <cim:AsynchronousMachine.efficiency>97.5</cim:AsynchronousMachine.efficiency>
+    <cim:AsynchronousMachine.iaIrRatio>5</cim:AsynchronousMachine.iaIrRatio>
+    <cim:AsynchronousMachine.polePairNumber>1</cim:AsynchronousMachine.polePairNumber>
+    <cim:AsynchronousMachine.ratedMechanicalPower>5</cim:AsynchronousMachine.ratedMechanicalPower>
+    <cim:AsynchronousMachine.reversible>false</cim:AsynchronousMachine.reversible>
+    <cim:AsynchronousMachine.rxLockedRotorRatio>0.1</cim:AsynchronousMachine.rxLockedRotorRatio>
+  </cim:AsynchronousMachine>
+  <cim:AsynchronousMachine rdf:ID="_ba62884d-8800-41a8-9c26-698297d7ebaa">
+    <cim:IdentifiedObject.name>M2a</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d4a8238-5b31-4c16-8692-0265dae5e132" />
+    <cim:RotatingMachine.ratedPowerFactor>0.89</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>2.321</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>10</cim:RotatingMachine.ratedU>
+    <cim:AsynchronousMachine.converterFedDrive>false</cim:AsynchronousMachine.converterFedDrive>
+    <cim:AsynchronousMachine.efficiency>96.8</cim:AsynchronousMachine.efficiency>
+    <cim:AsynchronousMachine.iaIrRatio>5.2</cim:AsynchronousMachine.iaIrRatio>
+    <cim:AsynchronousMachine.polePairNumber>2</cim:AsynchronousMachine.polePairNumber>
+    <cim:AsynchronousMachine.ratedMechanicalPower>2</cim:AsynchronousMachine.ratedMechanicalPower>
+    <cim:AsynchronousMachine.reversible>false</cim:AsynchronousMachine.reversible>
+    <cim:AsynchronousMachine.rxLockedRotorRatio>0.1</cim:AsynchronousMachine.rxLockedRotorRatio>
+  </cim:AsynchronousMachine>
+  <cim:AsynchronousMachine rdf:ID="_f184d87b-5565-45ee-89b4-29e8a42d3ad1">
+    <cim:IdentifiedObject.name>M2b</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d4a8238-5b31-4c16-8692-0265dae5e132" />
+    <cim:RotatingMachine.ratedPowerFactor>0.89</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>2.321</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>10</cim:RotatingMachine.ratedU>
+    <cim:AsynchronousMachine.converterFedDrive>false</cim:AsynchronousMachine.converterFedDrive>
+    <cim:AsynchronousMachine.efficiency>96.8</cim:AsynchronousMachine.efficiency>
+    <cim:AsynchronousMachine.iaIrRatio>5.2</cim:AsynchronousMachine.iaIrRatio>
+    <cim:AsynchronousMachine.polePairNumber>2</cim:AsynchronousMachine.polePairNumber>
+    <cim:AsynchronousMachine.ratedMechanicalPower>2</cim:AsynchronousMachine.ratedMechanicalPower>
+    <cim:AsynchronousMachine.reversible>false</cim:AsynchronousMachine.reversible>
+    <cim:AsynchronousMachine.rxLockedRotorRatio>0.1</cim:AsynchronousMachine.rxLockedRotorRatio>
+  </cim:AsynchronousMachine>
+  <cim:ExternalNetworkInjection rdf:ID="_089c1945-4101-487f-a557-66c013b748f6">
+    <cim:IdentifiedObject.name>Q1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_5d9d9d87-ce6b-4213-b4ec-d50de9790a59" />
+    <cim:ExternalNetworkInjection.governorSCD>0</cim:ExternalNetworkInjection.governorSCD>
+    <cim:ExternalNetworkInjection.ikSecond>true</cim:ExternalNetworkInjection.ikSecond>
+    <cim:ExternalNetworkInjection.maxInitialSymShCCurrent>38000</cim:ExternalNetworkInjection.maxInitialSymShCCurrent>
+    <cim:ExternalNetworkInjection.maxP>800</cim:ExternalNetworkInjection.maxP>
+    <cim:ExternalNetworkInjection.maxQ>600</cim:ExternalNetworkInjection.maxQ>
+    <cim:ExternalNetworkInjection.maxR0ToX0Ratio>0.15</cim:ExternalNetworkInjection.maxR0ToX0Ratio>
+    <cim:ExternalNetworkInjection.maxR1ToX1Ratio>0.1</cim:ExternalNetworkInjection.maxR1ToX1Ratio>
+    <cim:ExternalNetworkInjection.maxZ0ToZ1Ratio>3.029</cim:ExternalNetworkInjection.maxZ0ToZ1Ratio>
+    <cim:ExternalNetworkInjection.minInitialSymShCCurrent>0</cim:ExternalNetworkInjection.minInitialSymShCCurrent>
+    <cim:ExternalNetworkInjection.minP>-800</cim:ExternalNetworkInjection.minP>
+    <cim:ExternalNetworkInjection.minQ>-600</cim:ExternalNetworkInjection.minQ>
+    <cim:ExternalNetworkInjection.minR0ToX0Ratio>0.1</cim:ExternalNetworkInjection.minR0ToX0Ratio>
+    <cim:ExternalNetworkInjection.minR1ToX1Ratio>0.1</cim:ExternalNetworkInjection.minR1ToX1Ratio>
+    <cim:ExternalNetworkInjection.minZ0ToZ1Ratio>1</cim:ExternalNetworkInjection.minZ0ToZ1Ratio>
+    <cim:ExternalNetworkInjection.voltageFactor>1.1</cim:ExternalNetworkInjection.voltageFactor>
+  </cim:ExternalNetworkInjection>
+  <cim:ExternalNetworkInjection rdf:ID="_3de9e1ad-4562-44df-b268-70ed0517e9e7">
+    <cim:IdentifiedObject.name>Q2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_a43d15db-44a6-4fda-a525-2402ff43226f" />
+    <cim:ExternalNetworkInjection.governorSCD>0</cim:ExternalNetworkInjection.governorSCD>
+    <cim:ExternalNetworkInjection.ikSecond>true</cim:ExternalNetworkInjection.ikSecond>
+    <cim:ExternalNetworkInjection.maxInitialSymShCCurrent>16000</cim:ExternalNetworkInjection.maxInitialSymShCCurrent>
+    <cim:ExternalNetworkInjection.maxP>88</cim:ExternalNetworkInjection.maxP>
+    <cim:ExternalNetworkInjection.maxQ>66</cim:ExternalNetworkInjection.maxQ>
+    <cim:ExternalNetworkInjection.maxR0ToX0Ratio>0.2</cim:ExternalNetworkInjection.maxR0ToX0Ratio>
+    <cim:ExternalNetworkInjection.maxR1ToX1Ratio>0.1</cim:ExternalNetworkInjection.maxR1ToX1Ratio>
+    <cim:ExternalNetworkInjection.maxZ0ToZ1Ratio>3.34865</cim:ExternalNetworkInjection.maxZ0ToZ1Ratio>
+    <cim:ExternalNetworkInjection.minInitialSymShCCurrent>0</cim:ExternalNetworkInjection.minInitialSymShCCurrent>
+    <cim:ExternalNetworkInjection.minP>-88</cim:ExternalNetworkInjection.minP>
+    <cim:ExternalNetworkInjection.minQ>-66</cim:ExternalNetworkInjection.minQ>
+    <cim:ExternalNetworkInjection.minR0ToX0Ratio>0</cim:ExternalNetworkInjection.minR0ToX0Ratio>
+    <cim:ExternalNetworkInjection.minR1ToX1Ratio>0</cim:ExternalNetworkInjection.minR1ToX1Ratio>
+    <cim:ExternalNetworkInjection.minZ0ToZ1Ratio>0</cim:ExternalNetworkInjection.minZ0ToZ1Ratio>
+    <cim:ExternalNetworkInjection.voltageFactor>1.1</cim:ExternalNetworkInjection.voltageFactor>
+  </cim:ExternalNetworkInjection>
+  <cim:ACLineSegment rdf:ID="_1e7f52a9-21d0-4ebe-9a8a-b29281d5bfc9">
+    <cim:IdentifiedObject.description>Line-7</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>L5</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c2091d24-3470-4bde-b020-8618e9e352a6" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Conductor.length>15</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>1.8</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>3.3</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>80</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>5.79</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>16.5</cim:ACLineSegment.x0>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_b3e74f7e-f257-44f1-a558-39d2476dbc54">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_8372a156-7579-4ea5-8793-24caf0d24603" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_c158c7c6-05a8-431c-951a-3b5641afbba5">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b3e74f7e-f257-44f1-a558-39d2476dbc54" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_10be2112-5068-4819-b82a-a640e4df11a6">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b3e74f7e-f257-44f1-a558-39d2476dbc54" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>604</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_5b545c73-df9c-4d25-bca2-62a57dd0b01b">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b3e74f7e-f257-44f1-a558-39d2476dbc54" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>735</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_56757c2b-550e-4843-886a-ed193f6eb21e">
+    <cim:IdentifiedObject.description>Line-4</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>L6</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_18235722-b718-4b01-bdeb-68ac9b8b9977" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Conductor.length>1</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.082</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>0.082</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>80</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>0.086</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>0.086</cim:ACLineSegment.x0>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_bb6e6a25-5f04-44ad-a89f-3f3a77285db6">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_5492183a-1e6f-4dee-a506-f389c69f4c83" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_5aab6f38-8337-4c05-921c-afb639bfee4e">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_bb6e6a25-5f04-44ad-a89f-3f3a77285db6" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>1155</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_cc310538-02b9-42cf-8438-8ae55caa5780">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_bb6e6a25-5f04-44ad-a89f-3f3a77285db6" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>1328</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_1ad2d2cf-4c58-4709-ab69-6e3fd948b3b1">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_bb6e6a25-5f04-44ad-a89f-3f3a77285db6" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>1617</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_e95a6228-ceac-4f0a-8b52-d35367b364dc">
+    <cim:IdentifiedObject.description>Line-5</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>L4</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_9d3fb3a7-ab7b-4126-b3b6-9678584e37ab" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Conductor.length>10</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.96</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>2.2</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>80</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>3.88</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>11</cim:ACLineSegment.x0>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_cf69da25-f6ac-4176-9089-444a1bb2bc47">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_1a6456c6-fb39-42a0-b21d-089093ba7c49" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_50ef4486-e407-4efb-906a-259e124b975b">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cf69da25-f6ac-4176-9089-444a1bb2bc47" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_03f63965-4a6c-48c1-b859-b1247a48a49f">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cf69da25-f6ac-4176-9089-444a1bb2bc47" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>604</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_c6e13965-aa0f-43a4-9ab2-293253cb421b">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cf69da25-f6ac-4176-9089-444a1bb2bc47" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>735</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_d5d1cc4a-6297-4386-b6ce-16dc26f15feb">
+    <cim:IdentifiedObject.description>Line-1</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>L1</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8dec4794-709f-4aa0-9872-5a4f94e9f714" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Conductor.length>20</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>2.4</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>6.4</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>80</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>7.8</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>25.2</cim:ACLineSegment.x0>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_c4e84cc6-5ec5-4633-8837-ce49ccf34393">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_933078aa-6687-4922-bb1f-4c1457f7c26f" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_40823ca5-dc1c-42ee-8b0b-83c7de4a3104">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_c4e84cc6-5ec5-4633-8837-ce49ccf34393" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_13f165da-ae31-466a-826e-4012f2eac2cd">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_c4e84cc6-5ec5-4633-8837-ce49ccf34393" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>604</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_ea167db4-754b-4848-93a5-be269cfe4644">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_c4e84cc6-5ec5-4633-8837-ce49ccf34393" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>735</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_efdd7f46-67e6-46e3-9dcd-a3b6f8c613a4">
+    <cim:IdentifiedObject.description>Line-6</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>L2</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_1c19c2b3-8095-4f82-b0b1-692868bd15f4" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Conductor.length>10</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>1.2</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>3.2</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>80</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>3.9</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>12.6</cim:ACLineSegment.x0>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_23e70872-1757-4736-8b48-64926fabf973">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_563c5f79-a51d-4ce8-a921-0e86dd984bb5" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_94530374-3c11-4ffb-ad0f-59e38e3a7891">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_23e70872-1757-4736-8b48-64926fabf973" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_c7b03b9e-a4f8-443d-8595-ba7152d45c65">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_23e70872-1757-4736-8b48-64926fabf973" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>604</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_b43a0fbc-5a9c-44ac-a9a0-7885d5efbd93">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_23e70872-1757-4736-8b48-64926fabf973" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>735</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_35df6abe-3087-4c27-a90a-12b5065333f3">
+    <cim:IdentifiedObject.description>Line-2</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>L3_a</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_f01dd6de-a7a1-4485-94db-7c7a392b946f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Conductor.length>5</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.6</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>2.6</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>80</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>1.95</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>9.3</cim:ACLineSegment.x0>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_e0ad214e-cf92-4212-95dd-7c1895eaa91e">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_0593fd2d-7e55-4a8d-8ddf-4f8a576cf26c" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_c3161303-d82f-4ede-b270-d7c2b7822f27">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e0ad214e-cf92-4212-95dd-7c1895eaa91e" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_512568f1-b159-4158-8b32-4edc95d784bb">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e0ad214e-cf92-4212-95dd-7c1895eaa91e" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>604</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_25eae7ae-45b2-4485-8721-b9e9e2284ab7">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e0ad214e-cf92-4212-95dd-7c1895eaa91e" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>735</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_05597934-b248-491e-803a-68ce6290f502">
+    <cim:IdentifiedObject.description>Line-3</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>L3_b</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_42cb5e94-d05b-45ae-a620-bc7a7343f5de" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Conductor.length>5</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.6</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>2.6</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>80</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>1.95</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>9.3</cim:ACLineSegment.x0>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_5ed6f9f8-c080-4eef-a6d0-020ca76af7e9">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_616ef15c-065f-4ca2-8367-d1aad079357e" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_3e21a1e3-c6a7-4e12-8fa9-20eac1e20dcc">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_5ed6f9f8-c080-4eef-a6d0-020ca76af7e9" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_62f48d08-8ac8-4e9a-9430-67ac0f5aab59">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_5ed6f9f8-c080-4eef-a6d0-020ca76af7e9" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>604</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_799cc174-c824-4015-8889-121bde37245d">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_5ed6f9f8-c080-4eef-a6d0-020ca76af7e9" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>735</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_ceb5d06a-a7ff-4102-a620-7f3ea5fb4a51">
+    <cim:IdentifiedObject.description>Trafo-1</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>T5</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_d6056127-34f1-43a9-b029-23fddb913bd5" />
+    <cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>158.14</cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>
+    <cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>121.095</cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>
+    <cim:PowerTransformer.beforeShortCircuitAnglePf>36.86</cim:PowerTransformer.beforeShortCircuitAnglePf>
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_d2e671db-1ed5-4f8d-bbbf-54554b175428">
+    <cim:IdentifiedObject.name>T5</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_51ac3672-026d-4257-9c68-7c7f57a9b55e" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>31.5</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>115</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>2.099206</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>2.099206</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>50.3372</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>50.3372</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_ceb5d06a-a7ff-4102-a620-7f3ea5fb4a51" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_e5badf8e-cfbd-48f0-b248-adfa0eb9a884">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_51ac3672-026d-4257-9c68-7c7f57a9b55e" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_a94a2227-8925-41a7-ae14-739cab0a36b2">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e5badf8e-cfbd-48f0-b248-adfa0eb9a884" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>158</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_5864da77-5083-45eb-962f-349a6e5a1063">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e5badf8e-cfbd-48f0-b248-adfa0eb9a884" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>182</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_c46c0958-4b79-4184-91a1-188c7a5959ce">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e5badf8e-cfbd-48f0-b248-adfa0eb9a884" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>222</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformerEnd rdf:ID="_59ef0c3b-5e98-4771-8e07-0544bdc64c4a">
+    <cim:IdentifiedObject.name>T5</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_0fa430b4-d98c-43bd-9652-f61fb00e7340" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>31.5</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>10.5</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_ceb5d06a-a7ff-4102-a620-7f3ea5fb4a51" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_db22b997-1134-4ef1-a4ce-3d599b44de6a">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_0fa430b4-d98c-43bd-9652-f61fb00e7340" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2b7585e3-85ea-496e-b6ed-76349fa65841">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_db22b997-1134-4ef1-a4ce-3d599b44de6a" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>1732</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_18dac733-f9c1-485c-a62d-f90e9958cd99">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_db22b997-1134-4ef1-a4ce-3d599b44de6a" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>1992</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_411da062-b032-4029-8a40-3ff07ad69818">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_db22b997-1134-4ef1-a4ce-3d599b44de6a" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>2425</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_6c89588b-3df5-4120-88e5-26164afb43e9">
+    <cim:IdentifiedObject.description>Trafo-2</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>T6</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_d6056127-34f1-43a9-b029-23fddb913bd5" />
+    <cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>158.14</cim:PowerTransformer.beforeShCircuitHighestOperatingCurrent>
+    <cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>121.095</cim:PowerTransformer.beforeShCircuitHighestOperatingVoltage>
+    <cim:PowerTransformer.beforeShortCircuitAnglePf>36.86</cim:PowerTransformer.beforeShortCircuitAnglePf>
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_fe6b71c8-5a63-4a10-a699-a6bf376e2e2f">
+    <cim:IdentifiedObject.name>T6</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_7145f995-b4a7-472e-9c58-2f8540ad3925" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>31.5</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>115</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>2.099206</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>2.099206</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>50.3372</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>50.3372</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_6c89588b-3df5-4120-88e5-26164afb43e9" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_82efa96c-b6da-48d1-9a01-964f3da06e49">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_7145f995-b4a7-472e-9c58-2f8540ad3925" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_65bc1d48-d43b-453c-b507-acb0966f8d2d">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_82efa96c-b6da-48d1-9a01-964f3da06e49" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>158</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_62224afb-e38e-40f3-8af8-8df8e1f2fd95">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_82efa96c-b6da-48d1-9a01-964f3da06e49" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>182</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_388327a4-d5da-477f-b9dd-a45edaa5b2f0">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_82efa96c-b6da-48d1-9a01-964f3da06e49" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>222</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformerEnd rdf:ID="_d99ae781-8809-4e59-b167-fc0106934b25">
+    <cim:IdentifiedObject.name>T6</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.xground>100</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_912cc25e-78d9-43a6-a77e-b2b7bb76688b" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>31.5</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>10.5</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_6c89588b-3df5-4120-88e5-26164afb43e9" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_4de221e3-af50-46de-b0d2-d096fc6bb7fc">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_912cc25e-78d9-43a6-a77e-b2b7bb76688b" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_63551f30-7dda-4ddb-8f27-999f18779da4">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4de221e3-af50-46de-b0d2-d096fc6bb7fc" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>1732</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_e2220586-2422-4a05-a34f-d932cce7567c">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4de221e3-af50-46de-b0d2-d096fc6bb7fc" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>1992</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_35b531f8-d134-4a3f-a176-7759bde52ece">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4de221e3-af50-46de-b0d2-d096fc6bb7fc" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>2425</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_f1e72854-ec35-46e9-b614-27db354e8dbb">
+    <cim:IdentifiedObject.description>Trafo-3</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>T2</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_3f64f4e2-adfe-4d12-b082-68e7fe4b11c9" />
+    <cim:PowerTransformer.highSideMinOperatingU>115</cim:PowerTransformer.highSideMinOperatingU>
+    <cim:PowerTransformer.isPartOfGeneratorUnit>true</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_063fef99-e19b-4ebe-92a9-1e8927fdca2a">
+    <cim:IdentifiedObject.name>T2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_a1158b5f-3b71-4c44-8b15-4150d983f73e" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>100</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>120</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0.72</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.72</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>17.2649937</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>17.2649937</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_f1e72854-ec35-46e9-b614-27db354e8dbb" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_2f6fd787-0059-4264-af1f-10de7bf1d250">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_a1158b5f-3b71-4c44-8b15-4150d983f73e" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_b378a9d1-836e-41db-9e27-515aab8e516d">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_2f6fd787-0059-4264-af1f-10de7bf1d250" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>481</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_84c02220-11c1-4198-b81a-d58c41873fb1">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_2f6fd787-0059-4264-af1f-10de7bf1d250" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>553</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_af422211-ccbf-483c-97c9-2bbbd48f78f9">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_2f6fd787-0059-4264-af1f-10de7bf1d250" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>673</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformerEnd rdf:ID="_6e5fd46a-a8d2-4f85-baa2-b6efac1ad5fd">
+    <cim:IdentifiedObject.name>T2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_b2112f10-1057-4a28-a18d-a1952c791c4c" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.D" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>5</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>100</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>10.5</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_f1e72854-ec35-46e9-b614-27db354e8dbb" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_7bee47c1-98f3-4edc-9904-2d701043e59c">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_b2112f10-1057-4a28-a18d-a1952c791c4c" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_7dd09c51-89c1-4391-a4f0-842c95f23f4e">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7bee47c1-98f3-4edc-9904-2d701043e59c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>5498</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_c63497a5-89c2-4940-a40f-ef6ececc073d">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7bee47c1-98f3-4edc-9904-2d701043e59c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>6323</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_1162b24f-783f-4fe9-afce-24bac9cb061a">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7bee47c1-98f3-4edc-9904-2d701043e59c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>7698</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_813365c3-5be7-4ef0-a0a7-abd1ae6dc174">
+    <cim:IdentifiedObject.description>Trafo-4</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>T1</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_974565b1-ac55-4901-9f48-afc7ef5486df" />
+    <cim:PowerTransformer.highSideMinOperatingU>115</cim:PowerTransformer.highSideMinOperatingU>
+    <cim:PowerTransformer.isPartOfGeneratorUnit>true</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_0a33f633-7415-4f95-b3c2-f3ddbee92644">
+    <cim:IdentifiedObject.name>T1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_7fe566b9-6bac-4cd3-8b52-8f46e9ba237d" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_e6b5f155-583d-46fa-90fc-0673d1afe1be" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.D" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>5</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>150</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>21</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0.0147</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.0147</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>0.47017</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0.446662</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_813365c3-5be7-4ef0-a0a7-abd1ae6dc174" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_69d76b84-9655-451f-9101-54b151eb01d3">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_7fe566b9-6bac-4cd3-8b52-8f46e9ba237d" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_7a187956-2f45-43bf-b548-464f76810cc1">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_69d76b84-9655-451f-9101-54b151eb01d3" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>4123</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_2087197f-6dad-4625-a751-7d1df6b6ca80">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_69d76b84-9655-451f-9101-54b151eb01d3" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>4742</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_5b8bbc1e-6e73-43a2-af19-cefabdc56b54">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_69d76b84-9655-451f-9101-54b151eb01d3" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>5773</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:RatioTapChanger rdf:ID="_0522ca48-e644-4d3a-9721-22bb0abd1c8b">
+    <cim:IdentifiedObject.name>T1</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>25</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>13</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>21</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>13</cim:TapChanger.normalStep>
+    <cim:RatioTapChanger.tculControlMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerControlMode.volt" />
+    <cim:RatioTapChanger.stepVoltageIncrement>1</cim:RatioTapChanger.stepVoltageIncrement>
+    <cim:RatioTapChanger.TransformerEnd rdf:resource="#_0a33f633-7415-4f95-b3c2-f3ddbee92644" />
+  </cim:RatioTapChanger>
+  <cim:PowerTransformerEnd rdf:ID="_4864d0c6-f4ca-477a-b944-9927edb37fa6">
+    <cim:IdentifiedObject.name>T1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.xground>22</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_82611054-72b9-4cb0-8621-e418b8962cb1" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>150</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>115</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_813365c3-5be7-4ef0-a0a7-abd1ae6dc174" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_3a070392-4564-4fc8-8b94-34328a589fab">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_82611054-72b9-4cb0-8621-e418b8962cb1" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_9607451a-b19f-4841-93aa-e6757f277b9a">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_3a070392-4564-4fc8-8b94-34328a589fab" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>753</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_fafc5f7d-b49f-497c-a4a4-d15df5eb8040">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_3a070392-4564-4fc8-8b94-34328a589fab" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>866</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_f60bb615-492a-4942-9f93-2c67749d642e">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_3a070392-4564-4fc8-8b94-34328a589fab" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>1054</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_411b5401-0a43-404a-acb4-05c3d7d0c95c">
+    <cim:IdentifiedObject.name>T4</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_af9a4ae3-ba2e-4c34-8e47-5af894ee20f4" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_8f183bc1-d883-5b72-1918-ebb9fbe4b3e7">
+    <cim:IdentifiedObject.name>T4</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>3</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_eb8ed3e6-c0de-47e2-9dd5-52b321d51b70" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_b2a3e748-1772-409d-a61f-1d6da09564c9" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.D" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>5</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>50</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>30</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0.0254571438</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.0254571438</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>1.259741</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>1.176919</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_411b5401-0a43-404a-acb4-05c3d7d0c95c" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_f1fe0842-8784-4ca4-bbbe-674f96804c1d">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_eb8ed3e6-c0de-47e2-9dd5-52b321d51b70" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_339876d4-a3b4-49f7-8969-c29d7e222897">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f1fe0842-8784-4ca4-bbbe-674f96804c1d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>962</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_2fff858a-1bab-41e0-bbbf-7f20d3f38cf1">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f1fe0842-8784-4ca4-bbbe-674f96804c1d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>1106</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_b9b7509a-b3a1-4dbd-aaab-4db17394f383">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f1fe0842-8784-4ca4-bbbe-674f96804c1d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>1347</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformerEnd rdf:ID="_c98e36e1-a53a-384c-357e-ab34d9335d77">
+    <cim:IdentifiedObject.name>T4</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_e59d3a8c-8382-413a-95ae-6354dfe85565" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>350</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>120</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0.05348571429</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.05348571429</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>-0.001121283618</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>-0.6881</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_411b5401-0a43-404a-acb4-05c3d7d0c95c" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_8973d7f9-bacb-4996-bc68-176b405a8d7c">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_e59d3a8c-8382-413a-95ae-6354dfe85565" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_febfc21c-435b-47a8-851c-c1b8e2400fa6">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_8973d7f9-bacb-4996-bc68-176b405a8d7c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>1683</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_7a5635e4-ea6d-491c-9cdc-73a1db69c3e0">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_8973d7f9-bacb-4996-bc68-176b405a8d7c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>1936</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_6b58bc5d-b2b2-4fda-ac1a-f715f9827d17">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_8973d7f9-bacb-4996-bc68-176b405a8d7c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>2357</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformerEnd rdf:ID="_a2ea9c4e-6793-6d52-a476-3dbb1da389cf">
+    <cim:IdentifiedObject.name>T4</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_5af3b857-165c-4f96-b415-0d6e2e9ca27f" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>350</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>400</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0.5942857143</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.5942857143</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>96.0051006</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>95.05666</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_411b5401-0a43-404a-acb4-05c3d7d0c95c" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_95ffb82a-4e2e-4ca4-baba-6e253a0cdb17">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_5af3b857-165c-4f96-b415-0d6e2e9ca27f" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_503ef306-11a4-451a-83eb-4b256f6698b2">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_95ffb82a-4e2e-4ca4-baba-6e253a0cdb17" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>505</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_b9ac6108-d047-49da-a4e7-7fef4fc87baa">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_95ffb82a-4e2e-4ca4-baba-6e253a0cdb17" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>580</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_afef4cb4-b859-415e-af9a-f2cdfd1d7876">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_95ffb82a-4e2e-4ca4-baba-6e253a0cdb17" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>707</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_5d38b7ed-73fd-405a-9cdb-78425e003773">
+    <cim:IdentifiedObject.description>Trafo-5</cim:IdentifiedObject.description>
+    <cim:IdentifiedObject.name>T3</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_af9a4ae3-ba2e-4c34-8e47-5af894ee20f4" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_03916530-aaea-41c2-b0a2-770d44470839">
+    <cim:IdentifiedObject.name>T3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>true</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_1dfffea9-1fac-48f1-b466-1312643f3a47" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Yn" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>350</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>400</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0.5942857143</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.5942857143</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>96.0051006</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>95.05666</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_5d38b7ed-73fd-405a-9cdb-78425e003773" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_938affe6-43f5-4729-a3c7-7543ef4eb20e">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_1dfffea9-1fac-48f1-b466-1312643f3a47" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_e906b8f2-2da9-4975-bf67-66bec9865ea9">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_938affe6-43f5-4729-a3c7-7543ef4eb20e" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>505</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_91716cae-f695-473a-9586-82daed44ebf7">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_938affe6-43f5-4729-a3c7-7543ef4eb20e" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>580</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_96f4092e-628e-4649-8b06-7a96bcc1b989">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_938affe6-43f5-4729-a3c7-7543ef4eb20e" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>707</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:RatioTapChanger rdf:ID="_8de2d157-15d1-42c7-b376-a8ae5b6c0e77">
+    <cim:IdentifiedObject.name>T3</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>400</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>17</cim:TapChanger.normalStep>
+    <cim:RatioTapChanger.tculControlMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerControlMode.volt" />
+    <cim:RatioTapChanger.stepVoltageIncrement>1</cim:RatioTapChanger.stepVoltageIncrement>
+    <cim:RatioTapChanger.TransformerEnd rdf:resource="#_03916530-aaea-41c2-b0a2-770d44470839" />
+  </cim:RatioTapChanger>
+  <cim:PowerTransformerEnd rdf:ID="_4c7533e8-0c50-443e-8a8a-12574f04daf5">
+    <cim:IdentifiedObject.name>T3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_d5b02a21-e6f5-441c-81f2-4accb1a56ddd" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>350</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>120</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0.05348571429</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.05348571429</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>-0.001121283618</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>-0.6881</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_5d38b7ed-73fd-405a-9cdb-78425e003773" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_86b8024b-e6dd-4e33-903f-87bb436f5843">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_d5b02a21-e6f5-441c-81f2-4accb1a56ddd" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_1279ed2c-6ab6-46d8-af8c-d32d133f3589">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_86b8024b-e6dd-4e33-903f-87bb436f5843" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>1683</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_46e3ac62-4de9-4a04-8f8f-dc6ce15a125e">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_86b8024b-e6dd-4e33-903f-87bb436f5843" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>1936</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_2b650521-4b6f-450f-a5f8-afccbccd9260">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_86b8024b-e6dd-4e33-903f-87bb436f5843" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>2357</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:PowerTransformerEnd rdf:ID="_3b446af6-630a-46ee-bc76-d5543509b355">
+    <cim:IdentifiedObject.name>T3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>3</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_01a240e9-5607-4844-9d53-5c8b08b5c9a8" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_b2a3e748-1772-409d-a61f-1d6da09564c9" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#WindingConnection.D" />
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.phaseAngleClock>5</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.ratedS>50</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.ratedU>30</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.r>0.02545714286</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.02545714286</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.x>1.259740894</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>1.176919</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_5d38b7ed-73fd-405a-9cdb-78425e003773" />
+  </cim:PowerTransformerEnd>
+  <cim:OperationalLimitSet rdf:ID="_df1c9d1f-8177-4758-ab9f-0dabf6a989b8">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_01a240e9-5607-4844-9d53-5c8b08b5c9a8" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_b3ea9d58-113b-4cbb-887b-9af0de3280ac">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_df1c9d1f-8177-4758-ab9f-0dabf6a989b8" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>962</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_5d2a6568-5610-4f15-ae82-d9b6ad5778b7">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_df1c9d1f-8177-4758-ab9f-0dabf6a989b8" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>1106</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_d64b670b-240d-42bb-9222-49ab6c131bdd">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_df1c9d1f-8177-4758-ab9f-0dabf6a989b8" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>1347</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:RatioTapChanger rdf:ID="_4a8a5456-91ac-4bc9-b8e2-64eeeef78a1a">
+    <cim:IdentifiedObject.name>T4</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>400</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>17</cim:TapChanger.normalStep>
+    <cim:RatioTapChanger.tculControlMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#TransformerControlMode.volt" />
+    <cim:RatioTapChanger.stepVoltageIncrement>1</cim:RatioTapChanger.stepVoltageIncrement>
+    <cim:RatioTapChanger.TransformerEnd rdf:resource="#_a2ea9c4e-6793-6d52-a476-3dbb1da389cf" />
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:ID="_04684742-c766-11e0-1111-005056c00008">
+    <cim:IdentifiedObject.name>68-116_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_a60c40a3-2ef6-41b7-8ca2-08594f75eb63" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5150a037-e241-421f-98b2-fe60e5c90303" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_04684742-c766-11e1-1111-005056c00008">
+    <cim:IdentifiedObject.name>68-116_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_183d126d-2522-4ff2-a8cd-c5016cf09c1b" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5150a037-e241-421f-98b2-fe60e5c90303" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_04684742-c766-11e2-1111-005056c00008">
+    <cim:IdentifiedObject.name>Injection_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_183d126d-2522-4ff2-a8cd-c5016cf09c1b" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cc268d3b-fe87-42ee-b48a-9e9d625a8650" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_04684742-c766-11e0-2222-005056c00008">
+    <cim:IdentifiedObject.name>71-73_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_8a5d6181-9f2e-4818-b3d6-dcca06db5e5e" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f32baf36-7ea3-4b6a-9452-71e7f18779f8" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_04684742-c766-11e1-2222-005056c00008">
+    <cim:IdentifiedObject.name>71-73_1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_49831d24-33e9-4233-8424-3f88186a924e" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f32baf36-7ea3-4b6a-9452-71e7f18779f8" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_04684742-c766-11e2-2222-005056c00008">
+    <cim:IdentifiedObject.name>Injection_0</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_49831d24-33e9-4233-8424-3f88186a924e" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a5a2acc5-c3cd-406c-b061-83a06bcef2f4" />
+  </cim:Terminal>
+  <cim:ACLineSegment rdf:ID="_5150a037-e241-421f-98b2-fe60e5c90303">
+    <cim:IdentifiedObject.name>XQ1-N1</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_41d4fafe-e4ce-4ca3-86d9-f181ae3f8ea3" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:Conductor.length>1</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>0</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>80</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>0.05</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>0</cim:ACLineSegment.x0>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_897ba3f2-36c2-4c61-b540-e44d027a5bdc">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_04684742-c766-11e0-1111-005056c00008" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_96f545a9-d779-43ba-b3c6-6c506b830cd0">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_897ba3f2-36c2-4c61-b540-e44d027a5bdc" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>1000</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_5915064d-0ee3-441d-b160-21acc094008b">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_897ba3f2-36c2-4c61-b540-e44d027a5bdc" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>1150</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_b87b8f1b-b972-4800-88b1-69171f052ffb">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_897ba3f2-36c2-4c61-b540-e44d027a5bdc" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>1400</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_f32baf36-7ea3-4b6a-9452-71e7f18779f8">
+    <cim:IdentifiedObject.name>XQ2-N5</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c3f46fe5-0cd1-4a1c-b722-e967b9ab21e2" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Conductor.length>1</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>0</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>80</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>0.05</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>0</cim:ACLineSegment.x0>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_57c14dc8-1249-4a1c-8a58-b741b7bd8ae5">
+    <cim:IdentifiedObject.name>Ratings</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_04684742-c766-11e0-2222-005056c00008" />
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_f7db6e6d-a44e-4df1-b9ec-8b0711e96763">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_57c14dc8-1249-4a1c-8a58-b741b7bd8ae5" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_0112c7f1-7523-4339-a285-d941a4a491ec" />
+    <cim:CurrentLimit.value>1000</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_6cb3ee02-4526-40a3-9c95-1d17d524aae7">
+    <cim:IdentifiedObject.name>ShortTerm</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_57c14dc8-1249-4a1c-8a58-b741b7bd8ae5" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_92ad0fde-1e8d-46b5-83cf-8bcd39450e18" />
+    <cim:CurrentLimit.value>1150</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_2b31b2eb-93d0-4642-8d7f-eb353722cea1">
+    <cim:IdentifiedObject.name>Emergency</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_57c14dc8-1249-4a1c-8a58-b741b7bd8ae5" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_ed7c9153-defb-4fff-aa25-85c175e80ca0" />
+    <cim:CurrentLimit.value>1400</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:EquivalentInjection rdf:ID="_cc268d3b-fe87-42ee-b48a-9e9d625a8650">
+    <cim:IdentifiedObject.name>Injection1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_41d4fafe-e4ce-4ca3-86d9-f181ae3f8ea3" />
+	<cim:ConductingEquipment.BaseVoltage rdf:resource="#_e9277658-07e5-4e84-aef8-a891d14e7c54" />
+    <cim:EquivalentInjection.r>0.63185</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>2.85315</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0.63185</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>6.3185</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>19.021</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>6.3185</cim:EquivalentInjection.x2>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_a5a2acc5-c3cd-406c-b061-83a06bcef2f4">
+    <cim:IdentifiedObject.name>Injection2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c3f46fe5-0cd1-4a1c-b722-e967b9ab21e2" />
+	<cim:ConductingEquipment.BaseVoltage rdf:resource="#_fe97b80b-3e0e-4a2c-964b-bc29b0dda632" />
+    <cim:EquivalentInjection.r>0.43445</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>2.86738</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0.43445</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>4.3445</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>14.3369</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>4.3445</cim:EquivalentInjection.x2>
+  </cim:EquivalentInjection>
+  <cim:ConnectivityNode rdf:ID="_c4cea32b-2ea1-4be3-9040-2a29cf7a48f1">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE1</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_a43d15db-44a6-4fda-a525-2402ff43226f" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_1a89e8aa-04e8-4640-adf2-bcb07b18045d">
+    <cim:IdentifiedObject.name>BUSBAR1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_a43d15db-44a6-4fda-a525-2402ff43226f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_ba98fd7b-b3e5-4b37-b218-df5f1e08ead5">
+    <cim:IdentifiedObject.name>L5_0_BUSBAR</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4cea32b-2ea1-4be3-9040-2a29cf7a48f1" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_1a89e8aa-04e8-4640-adf2-bcb07b18045d" />
+  </cim:Terminal>
+  <cim:Bay rdf:ID="_77f210d9-fbab-4fb3-bda1-950df09b9776">
+    <cim:IdentifiedObject.name>BAY_L5_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_a43d15db-44a6-4fda-a525-2402ff43226f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_1d058982-f5ff-4bcc-abf4-e0037ff511bf">
+    <cim:IdentifiedObject.name>L5_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_e118faef-acce-8f60-1e5b-f224e12eccbe" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4cea32b-2ea1-4be3-9040-2a29cf7a48f1" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5938ea51-0cfb-4c6c-8d6f-c2bf3254c94a" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_5938ea51-0cfb-4c6c-8d6f-c2bf3254c94a">
+    <cim:IdentifiedObject.name>DISCONNECTOR1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_77f210d9-fbab-4fb3-bda1-950df09b9776" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_2a864763-0d92-428b-a813-c665e878dec4">
+    <cim:IdentifiedObject.name>L5_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9232947a-f81f-472a-ac61-fa1b3f22b740" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5938ea51-0cfb-4c6c-8d6f-c2bf3254c94a" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_9232947a-f81f-472a-ac61-fa1b3f22b740">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE2</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_77f210d9-fbab-4fb3-bda1-950df09b9776" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_ba0cc755-9201-4d57-8206-3fa57b147583">
+    <cim:IdentifiedObject.name>L5_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9232947a-f81f-472a-ac61-fa1b3f22b740" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5e9f0079-647e-46da-b0ee-f5f24e127602" />
+  </cim:Terminal>
+  <!-- changed from Breaker to ProtectedSwitch -->
+  <cim:ProtectedSwitch rdf:ID="_5e9f0079-647e-46da-b0ee-f5f24e127602">
+    <cim:IdentifiedObject.name>PROTECTEDSWITCH1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_77f210d9-fbab-4fb3-bda1-950df09b9776" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:ProtectedSwitch>
+  <cim:Terminal rdf:ID="_43f700ce-3882-4906-b41f-b7c4eb2e74e0">
+    <cim:IdentifiedObject.name>L5_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ddc31fd5-e9be-481b-a426-f3970c0b51e2" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5e9f0079-647e-46da-b0ee-f5f24e127602" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_ddc31fd5-e9be-481b-a426-f3970c0b51e2">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE3</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_77f210d9-fbab-4fb3-bda1-950df09b9776" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_dbede101-7eec-40b8-9f22-b9cc9109bbd6">
+    <cim:IdentifiedObject.name>L5_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ddc31fd5-e9be-481b-a426-f3970c0b51e2" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_4580fb7b-c31b-4b84-ad1d-1ca4d50f4fc5" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_4580fb7b-c31b-4b84-ad1d-1ca4d50f4fc5">
+    <cim:IdentifiedObject.name>DISCONNECTOR2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_77f210d9-fbab-4fb3-bda1-950df09b9776" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_2fadea4c-9336-4247-a3ea-a621c79cb544">
+    <cim:IdentifiedObject.name>L5_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d3de846d-5271-465e-8558-3e736fa120c4" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_4580fb7b-c31b-4b84-ad1d-1ca4d50f4fc5" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_d3de846d-5271-465e-8558-3e736fa120c4">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE4</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_77f210d9-fbab-4fb3-bda1-950df09b9776" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_9e585839-b83e-4f53-95f7-2fe60dea9e67">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE5</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_051b93ae-9c15-4490-8cea-33395298f031" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_da8e9cec-96f8-4048-b31a-a56f5ef53c31">
+    <cim:IdentifiedObject.name>BUSBAR2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_051b93ae-9c15-4490-8cea-33395298f031" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_0cc10ecd-426c-4aa9-8a40-541c79204113">
+    <cim:IdentifiedObject.name>L5_1_BUSBAR</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9e585839-b83e-4f53-95f7-2fe60dea9e67" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_da8e9cec-96f8-4048-b31a-a56f5ef53c31" />
+  </cim:Terminal>
+  <cim:Bay rdf:ID="_7d394f47-4ec8-4176-94cb-b32e54a6487d">
+    <cim:IdentifiedObject.name>BAY_L5_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_051b93ae-9c15-4490-8cea-33395298f031" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_9ce03e95-44ba-487b-9cf3-04d968077ff9">
+    <cim:IdentifiedObject.name>L5_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_cc1c62da-ae58-7198-7eb5-2971feb99ae3" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9e585839-b83e-4f53-95f7-2fe60dea9e67" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3006c97d-d51e-4e7b-92b1-a9a321f585ce" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_3006c97d-d51e-4e7b-92b1-a9a321f585ce">
+    <cim:IdentifiedObject.name>DISCONNECTOR3</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_7d394f47-4ec8-4176-94cb-b32e54a6487d" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_01f33c90-d1ca-448f-9d62-13677c5c7a5f">
+    <cim:IdentifiedObject.name>L5_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_67581d4c-d6b7-4679-a655-33c9cef2cb1b" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3006c97d-d51e-4e7b-92b1-a9a321f585ce" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_67581d4c-d6b7-4679-a655-33c9cef2cb1b">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE6</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_7d394f47-4ec8-4176-94cb-b32e54a6487d" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_56ffd36b-6acc-409b-ba46-7ad7ed7b9702">
+    <cim:IdentifiedObject.name>L5_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_67581d4c-d6b7-4679-a655-33c9cef2cb1b" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_622a9aff-f9d4-49c7-8f29-fd88009c5df0" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_622a9aff-f9d4-49c7-8f29-fd88009c5df0">
+    <cim:IdentifiedObject.name>BREAKER2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_7d394f47-4ec8-4176-94cb-b32e54a6487d" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_19a1b3be-397a-4c6f-ad6e-57b6db72e65b">
+    <cim:IdentifiedObject.name>L5_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_2d51a1ee-8a92-4c14-8f13-586427c86626" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_622a9aff-f9d4-49c7-8f29-fd88009c5df0" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_2d51a1ee-8a92-4c14-8f13-586427c86626">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE7</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_7d394f47-4ec8-4176-94cb-b32e54a6487d" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_2f11bc44-be19-4a25-8ac0-c0d7fc4816f3">
+    <cim:IdentifiedObject.name>L5_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_2d51a1ee-8a92-4c14-8f13-586427c86626" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f5335138-f3b9-400b-abf1-e9b559c887b2" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_f5335138-f3b9-400b-abf1-e9b559c887b2">
+    <cim:IdentifiedObject.name>DISCONNECTOR4</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_7d394f47-4ec8-4176-94cb-b32e54a6487d" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_21b69381-c805-4fc1-968a-7969c3bc451a">
+    <cim:IdentifiedObject.name>L5_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_e2f8de8c-3191-4676-9ee7-f920e46f9085" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f5335138-f3b9-400b-abf1-e9b559c887b2" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_e2f8de8c-3191-4676-9ee7-f920e46f9085">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE8</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_7d394f47-4ec8-4176-94cb-b32e54a6487d" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_ec8c3b42-d70c-41d6-89f4-f2df958817c8">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE9</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_0d68ac81-124d-4d21-afa8-6c503feef5b8" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_84a0d591-e69e-407d-991d-54b3c6394d09">
+    <cim:IdentifiedObject.name>BUSBAR3</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_0d68ac81-124d-4d21-afa8-6c503feef5b8" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_138c9c5b-9472-4831-ad22-f1b7b319b0a3">
+    <cim:IdentifiedObject.name>L6_0_BUSBAR</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ec8c3b42-d70c-41d6-89f4-f2df958817c8" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84a0d591-e69e-407d-991d-54b3c6394d09" />
+  </cim:Terminal>
+  <cim:Bay rdf:ID="_d2e2fbab-d0a3-405b-b896-660c32bfa280">
+    <cim:IdentifiedObject.name>BAY_L6_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_0d68ac81-124d-4d21-afa8-6c503feef5b8" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_1b32b063-7f09-4eb5-8071-58501c5d296c">
+    <cim:IdentifiedObject.name>L6_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_928cbae7-e9d0-b980-8af2-63e9c1aeede3" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ec8c3b42-d70c-41d6-89f4-f2df958817c8" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_7d655d91-394a-4f47-8f83-7f1de3baa056" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_7d655d91-394a-4f47-8f83-7f1de3baa056">
+    <cim:IdentifiedObject.name>DISCONNECTOR5</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_d2e2fbab-d0a3-405b-b896-660c32bfa280" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_a02cfa66-d32c-45f7-9a4d-ae1e02efcb6a">
+    <cim:IdentifiedObject.name>L6_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_add7e168-c993-4dfa-b58e-7da15280f6f9" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_7d655d91-394a-4f47-8f83-7f1de3baa056" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_add7e168-c993-4dfa-b58e-7da15280f6f9">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE10</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_d2e2fbab-d0a3-405b-b896-660c32bfa280" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_1750b98e-7a97-4951-bfc0-f090eafd1b79">
+    <cim:IdentifiedObject.name>L6_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_add7e168-c993-4dfa-b58e-7da15280f6f9" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_4c49cfd1-4758-476e-95ce-5cd2c56e3165" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_4c49cfd1-4758-476e-95ce-5cd2c56e3165">
+    <cim:IdentifiedObject.name>BREAKER3</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_d2e2fbab-d0a3-405b-b896-660c32bfa280" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_c1b14884-b320-4989-b362-de40b5245072">
+    <cim:IdentifiedObject.name>L6_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_08d61cd0-994d-4ff9-89fe-3cd6ee25b71c" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_4c49cfd1-4758-476e-95ce-5cd2c56e3165" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_08d61cd0-994d-4ff9-89fe-3cd6ee25b71c">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE11</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_d2e2fbab-d0a3-405b-b896-660c32bfa280" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_3a845e4b-a2d0-45ab-a557-428ffdaee5ed">
+    <cim:IdentifiedObject.name>L6_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_08d61cd0-994d-4ff9-89fe-3cd6ee25b71c" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_dcba20ce-b619-471a-8ab0-2371d4d090b0" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_dcba20ce-b619-471a-8ab0-2371d4d090b0">
+    <cim:IdentifiedObject.name>DISCONNECTOR6</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_d2e2fbab-d0a3-405b-b896-660c32bfa280" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_449bd7ff-89c2-42bf-8f2f-374766f5998d">
+    <cim:IdentifiedObject.name>L6_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_8adb739f-8939-4e87-8d3e-c958aa49c187" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_dcba20ce-b619-471a-8ab0-2371d4d090b0" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_8adb739f-8939-4e87-8d3e-c958aa49c187">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE12</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_d2e2fbab-d0a3-405b-b896-660c32bfa280" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_0f82294a-5cb0-4395-b79a-514c7de478bf">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE13</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_8d4a8238-5b31-4c16-8692-0265dae5e132" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_4171593e-40e0-4937-8c04-2276c3c16d68">
+    <cim:IdentifiedObject.name>BUSBAR4</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8d4a8238-5b31-4c16-8692-0265dae5e132" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_368c0e1a-6dff-4929-81db-19d77f04b242">
+    <cim:IdentifiedObject.name>L6_1_BUSBAR</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f82294a-5cb0-4395-b79a-514c7de478bf" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_4171593e-40e0-4937-8c04-2276c3c16d68" />
+  </cim:Terminal>
+  <cim:Bay rdf:ID="_19c4a380-115c-4f79-a952-342f05b6b088">
+    <cim:IdentifiedObject.name>BAY_L6_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_8d4a8238-5b31-4c16-8692-0265dae5e132" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_f161d809-ed9e-40ad-bc58-e8a746f8afcb">
+    <cim:IdentifiedObject.name>L6_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_d9461afa-08ca-19d4-f44b-27073a817ea5" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f82294a-5cb0-4395-b79a-514c7de478bf" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3a783d1d-1113-414d-ab67-34b139781196" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_3a783d1d-1113-414d-ab67-34b139781196">
+    <cim:IdentifiedObject.name>DISCONNECTOR7</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_19c4a380-115c-4f79-a952-342f05b6b088" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_b58d9a22-7735-418e-b046-8b72c2f65ae9">
+    <cim:IdentifiedObject.name>L6_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_69e9878c-fce1-4ce3-8535-0c4337e9fd0a" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3a783d1d-1113-414d-ab67-34b139781196" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_69e9878c-fce1-4ce3-8535-0c4337e9fd0a">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE14</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_19c4a380-115c-4f79-a952-342f05b6b088" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_2bff438e-6dfd-4ff6-91fc-d94f5cb5441f">
+    <cim:IdentifiedObject.name>L6_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_69e9878c-fce1-4ce3-8535-0c4337e9fd0a" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fbdcf00d-8a07-4c62-9e39-86f459bea2be" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_fbdcf00d-8a07-4c62-9e39-86f459bea2be">
+    <cim:IdentifiedObject.name>BREAKER4</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_19c4a380-115c-4f79-a952-342f05b6b088" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_6d733695-7db0-46fb-b940-e220b2272f57">
+    <cim:IdentifiedObject.name>L6_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_528967db-59db-4208-b580-f184fe9d32c1" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fbdcf00d-8a07-4c62-9e39-86f459bea2be" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_528967db-59db-4208-b580-f184fe9d32c1">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE15</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_19c4a380-115c-4f79-a952-342f05b6b088" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_dd7aaa6c-3b38-4ad7-b7e0-61f0fe0c2ce9">
+    <cim:IdentifiedObject.name>L6_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_528967db-59db-4208-b580-f184fe9d32c1" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_83317cbd-8326-44b8-a9fb-f69b6ba5a1cb" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_83317cbd-8326-44b8-a9fb-f69b6ba5a1cb">
+    <cim:IdentifiedObject.name>DISCONNECTOR8</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_19c4a380-115c-4f79-a952-342f05b6b088" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_734b0038-78d2-4373-82d6-e7ee819fcaf5">
+    <cim:IdentifiedObject.name>L6_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1d9f1b8a-8d53-440a-b97d-71772e193e9f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_83317cbd-8326-44b8-a9fb-f69b6ba5a1cb" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_1d9f1b8a-8d53-440a-b97d-71772e193e9f">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE16</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_19c4a380-115c-4f79-a952-342f05b6b088" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_758394a7-f24e-41c4-9cb2-f7497324141a">
+    <cim:IdentifiedObject.name>BAY_L4_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_a43d15db-44a6-4fda-a525-2402ff43226f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_f2255df3-1730-467c-b42b-77e6e8c919bc">
+    <cim:IdentifiedObject.name>L4_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_e118faef-acce-8f60-1e5b-f224e12eccbe" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4cea32b-2ea1-4be3-9040-2a29cf7a48f1" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fe1384c9-f1c1-4026-9f5d-10a3b22208b9" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_fe1384c9-f1c1-4026-9f5d-10a3b22208b9">
+    <cim:IdentifiedObject.name>DISCONNECTOR9</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_758394a7-f24e-41c4-9cb2-f7497324141a" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_52cb56c2-0251-431b-b2ab-70de47ceace1">
+    <cim:IdentifiedObject.name>L4_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_567fee6b-56e6-4cee-b2a3-28098764bdcb" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fe1384c9-f1c1-4026-9f5d-10a3b22208b9" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_567fee6b-56e6-4cee-b2a3-28098764bdcb">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE17</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_758394a7-f24e-41c4-9cb2-f7497324141a" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_840b6263-d00b-49c4-8b65-84f4c0ae2a0a">
+    <cim:IdentifiedObject.name>L4_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_567fee6b-56e6-4cee-b2a3-28098764bdcb" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2ed632f6-36a3-4937-8d5d-ad105c57c071" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_2ed632f6-36a3-4937-8d5d-ad105c57c071">
+    <cim:IdentifiedObject.name>BREAKER5</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_758394a7-f24e-41c4-9cb2-f7497324141a" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_b3c8d494-0a24-49fe-94fe-adcb64af5f2c">
+    <cim:IdentifiedObject.name>L4_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b15dabdc-4466-4ce6-a546-4b3579a079f8" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2ed632f6-36a3-4937-8d5d-ad105c57c071" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_b15dabdc-4466-4ce6-a546-4b3579a079f8">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE18</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_758394a7-f24e-41c4-9cb2-f7497324141a" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_ab273d2b-0715-4fbe-91fb-f1113e15759f">
+    <cim:IdentifiedObject.name>L4_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b15dabdc-4466-4ce6-a546-4b3579a079f8" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_154f3756-4e07-4f06-9147-ed83de84e265" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_154f3756-4e07-4f06-9147-ed83de84e265">
+    <cim:IdentifiedObject.name>DISCONNECTOR10</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_758394a7-f24e-41c4-9cb2-f7497324141a" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_284c13ce-0b59-4e75-868a-9db150506504">
+    <cim:IdentifiedObject.name>L4_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_5de48674-41f7-4a17-8055-320eab5b638e" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_154f3756-4e07-4f06-9147-ed83de84e265" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_5de48674-41f7-4a17-8055-320eab5b638e">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE19</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_758394a7-f24e-41c4-9cb2-f7497324141a" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_cc636acd-3f39-4641-829e-dc401eb03569">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE20</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_347fb7af-642f-4c60-97d9-c03d440b6a82" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_78f2ae0e-da25-483a-8a71-76f709389894">
+    <cim:IdentifiedObject.name>BUSBAR5</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_347fb7af-642f-4c60-97d9-c03d440b6a82" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_6ea87619-9cd4-4d25-8876-e39ffb092138">
+    <cim:IdentifiedObject.name>L4_1_BUSBAR</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cc636acd-3f39-4641-829e-dc401eb03569" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_78f2ae0e-da25-483a-8a71-76f709389894" />
+  </cim:Terminal>
+  <cim:Bay rdf:ID="_624814c5-e56c-470a-8f4a-a59fca4b34bb">
+    <cim:IdentifiedObject.name>BAY_L4_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_347fb7af-642f-4c60-97d9-c03d440b6a82" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_1d68fb97-30d7-4c37-8d2e-31324a274ffb">
+    <cim:IdentifiedObject.name>L4_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_472651ab-53d8-8160-2fb1-156d83d6259a" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cc636acd-3f39-4641-829e-dc401eb03569" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_15d6eb77-36d6-48d0-a227-25d29e839517" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_15d6eb77-36d6-48d0-a227-25d29e839517">
+    <cim:IdentifiedObject.name>DISCONNECTOR11</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_624814c5-e56c-470a-8f4a-a59fca4b34bb" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_3fb40e0a-bb4a-4967-8ba3-3e94b8153554">
+    <cim:IdentifiedObject.name>L4_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c099d321-32a7-4cf9-8680-00d2f7d5eabf" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_15d6eb77-36d6-48d0-a227-25d29e839517" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_c099d321-32a7-4cf9-8680-00d2f7d5eabf">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE21</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_624814c5-e56c-470a-8f4a-a59fca4b34bb" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_ca0088fa-c27d-466a-ab97-e2f0029baed7">
+    <cim:IdentifiedObject.name>L4_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c099d321-32a7-4cf9-8680-00d2f7d5eabf" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a9b68255-188c-408d-8362-5f3b0a1e730f" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_a9b68255-188c-408d-8362-5f3b0a1e730f">
+    <cim:IdentifiedObject.name>BREAKER6</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_624814c5-e56c-470a-8f4a-a59fca4b34bb" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_bb2136b7-d699-4b34-9b30-d9047d534974">
+    <cim:IdentifiedObject.name>L4_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_955134c9-51cb-4e7c-a960-587c16111331" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a9b68255-188c-408d-8362-5f3b0a1e730f" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_955134c9-51cb-4e7c-a960-587c16111331">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE22</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_624814c5-e56c-470a-8f4a-a59fca4b34bb" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_239cc8c7-6c51-4c18-b9ac-b0c88ad3b38c">
+    <cim:IdentifiedObject.name>L4_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_955134c9-51cb-4e7c-a960-587c16111331" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84970563-073f-4316-a175-060b544640e0" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_84970563-073f-4316-a175-060b544640e0">
+    <cim:IdentifiedObject.name>DISCONNECTOR12</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_624814c5-e56c-470a-8f4a-a59fca4b34bb" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_8793d235-8e5d-4706-81ed-b569289f5565">
+    <cim:IdentifiedObject.name>L4_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_064ae2ca-de5b-41a6-a3a4-86ddd1136880" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84970563-073f-4316-a175-060b544640e0" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_064ae2ca-de5b-41a6-a3a4-86ddd1136880">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE23</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_624814c5-e56c-470a-8f4a-a59fca4b34bb" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_c4e14a0e-16c4-4b46-8d2d-b45ff7585057">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE24</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_cd28a27e-8b17-4f23-b9f5-03b6de15203f" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_bbbfc5c0-45ee-49fd-9dec-17c90af3f42b">
+    <cim:IdentifiedObject.name>BUSBAR6</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_cd28a27e-8b17-4f23-b9f5-03b6de15203f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_9bab684d-c68a-4d54-8884-5b36faf7fcbe">
+    <cim:IdentifiedObject.name>L1_0_BUSBAR</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4e14a0e-16c4-4b46-8d2d-b45ff7585057" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_bbbfc5c0-45ee-49fd-9dec-17c90af3f42b" />
+  </cim:Terminal>
+  <cim:Bay rdf:ID="_480e9627-dea4-4042-b286-daab933077c3">
+    <cim:IdentifiedObject.name>BAY_L1_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_cd28a27e-8b17-4f23-b9f5-03b6de15203f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_ac3f7dcd-3ed3-423b-baa8-bdaccbc93834">
+    <cim:IdentifiedObject.name>L1_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_4ce5f804-c3b0-fa8a-4fa7-71df511c0b08" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4e14a0e-16c4-4b46-8d2d-b45ff7585057" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ea5a6982-018c-4ce6-85f6-78b5ab5dbfc1" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_ea5a6982-018c-4ce6-85f6-78b5ab5dbfc1">
+    <cim:IdentifiedObject.name>DISCONNECTOR13</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_480e9627-dea4-4042-b286-daab933077c3" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_07a28042-960a-4fe9-9d8e-9abcd70078c5">
+    <cim:IdentifiedObject.name>L1_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_e4fa17b2-d2a2-4a57-a74e-a382c8092187" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ea5a6982-018c-4ce6-85f6-78b5ab5dbfc1" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_e4fa17b2-d2a2-4a57-a74e-a382c8092187">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE25</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_480e9627-dea4-4042-b286-daab933077c3" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_c086e4b7-3b1b-4a1f-9c89-58ccd10f4491">
+    <cim:IdentifiedObject.name>L1_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_e4fa17b2-d2a2-4a57-a74e-a382c8092187" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_62156fd8-595d-4ab0-af53-0de3b8056a6e" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_62156fd8-595d-4ab0-af53-0de3b8056a6e">
+    <cim:IdentifiedObject.name>BREAKER7</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_480e9627-dea4-4042-b286-daab933077c3" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_7cfa863e-28f0-4f89-9d1e-1460f0856d80">
+    <cim:IdentifiedObject.name>L1_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1cf8ec46-dde1-454e-9e98-38aeb059a1c5" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_62156fd8-595d-4ab0-af53-0de3b8056a6e" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_1cf8ec46-dde1-454e-9e98-38aeb059a1c5">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE26</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_480e9627-dea4-4042-b286-daab933077c3" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_fee53b4a-5459-4c52-9a84-c4c8c5af6c44">
+    <cim:IdentifiedObject.name>L1_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1cf8ec46-dde1-454e-9e98-38aeb059a1c5" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f88b1d2b-2f06-44ff-bfe5-8f1156e13092" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_f88b1d2b-2f06-44ff-bfe5-8f1156e13092">
+    <cim:IdentifiedObject.name>DISCONNECTOR14</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_480e9627-dea4-4042-b286-daab933077c3" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_bf748e1d-94a2-40e1-a1bf-a3a8d88abcd8">
+    <cim:IdentifiedObject.name>L1_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_05c02066-7ded-48d7-b787-da1d2e77f81c" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f88b1d2b-2f06-44ff-bfe5-8f1156e13092" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_05c02066-7ded-48d7-b787-da1d2e77f81c">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE27</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_480e9627-dea4-4042-b286-daab933077c3" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_6aeb4473-531f-45f0-9ac9-e86bb9cf22c8">
+    <cim:IdentifiedObject.name>BAY_L1_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_347fb7af-642f-4c60-97d9-c03d440b6a82" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_7cf9455b-5c62-4a22-bbde-fe8c6d7275e0">
+    <cim:IdentifiedObject.name>L1_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_472651ab-53d8-8160-2fb1-156d83d6259a" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cc636acd-3f39-4641-829e-dc401eb03569" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_faf75564-a154-4528-9428-913e6501a21f" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_faf75564-a154-4528-9428-913e6501a21f">
+    <cim:IdentifiedObject.name>DISCONNECTOR15</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_6aeb4473-531f-45f0-9ac9-e86bb9cf22c8" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_c124c099-9921-4276-b070-3961632dca63">
+    <cim:IdentifiedObject.name>L1_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_86e78ed5-cbc9-4c9a-b929-da282b4f6f72" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_faf75564-a154-4528-9428-913e6501a21f" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_86e78ed5-cbc9-4c9a-b929-da282b4f6f72">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE28</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_6aeb4473-531f-45f0-9ac9-e86bb9cf22c8" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_6346b12f-326a-4648-bf6e-7bac1bcc49ee">
+    <cim:IdentifiedObject.name>L1_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_86e78ed5-cbc9-4c9a-b929-da282b4f6f72" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_285ccb1e-a867-4efc-880e-e871c1929376" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_285ccb1e-a867-4efc-880e-e871c1929376">
+    <cim:IdentifiedObject.name>BREAKER8</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_6aeb4473-531f-45f0-9ac9-e86bb9cf22c8" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_824db363-9d54-481d-9012-4cb5ae3f0a25">
+    <cim:IdentifiedObject.name>L1_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f2f0151f-d02a-4ff6-bf16-b8fd2f7738f7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_285ccb1e-a867-4efc-880e-e871c1929376" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_f2f0151f-d02a-4ff6-bf16-b8fd2f7738f7">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE29</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_6aeb4473-531f-45f0-9ac9-e86bb9cf22c8" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_297eac16-1730-41af-911d-ba0c6d64b9bd">
+    <cim:IdentifiedObject.name>L1_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f2f0151f-d02a-4ff6-bf16-b8fd2f7738f7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_22e27c40-eb38-4f04-aebd-7ef543798211" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_22e27c40-eb38-4f04-aebd-7ef543798211">
+    <cim:IdentifiedObject.name>DISCONNECTOR16</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_6aeb4473-531f-45f0-9ac9-e86bb9cf22c8" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_12373941-f783-4b0a-a24d-904c0b7a4d2e">
+    <cim:IdentifiedObject.name>L1_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1925701d-9d85-4f19-86e4-cb7a75453f59" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_22e27c40-eb38-4f04-aebd-7ef543798211" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_1925701d-9d85-4f19-86e4-cb7a75453f59">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE30</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_6aeb4473-531f-45f0-9ac9-e86bb9cf22c8" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_f7e579df-31e0-449a-add1-34543de0c4d4">
+    <cim:IdentifiedObject.name>BAY_L2_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_347fb7af-642f-4c60-97d9-c03d440b6a82" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_6038e540-8447-4790-b307-742767d48f15">
+    <cim:IdentifiedObject.name>L2_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_472651ab-53d8-8160-2fb1-156d83d6259a" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cc636acd-3f39-4641-829e-dc401eb03569" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9313f8a4-159d-48c8-92f1-36b1d16ee7c9" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_9313f8a4-159d-48c8-92f1-36b1d16ee7c9">
+    <cim:IdentifiedObject.name>DISCONNECTOR17</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_f7e579df-31e0-449a-add1-34543de0c4d4" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_9dca17f5-274f-4716-b0a9-0d0eef5fa400">
+    <cim:IdentifiedObject.name>L2_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_efdda81c-b0f4-4be2-85fb-45c6be439789" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9313f8a4-159d-48c8-92f1-36b1d16ee7c9" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_efdda81c-b0f4-4be2-85fb-45c6be439789">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE31</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_f7e579df-31e0-449a-add1-34543de0c4d4" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_ac5bfe2f-7f34-46ec-9c20-93a034af23d4">
+    <cim:IdentifiedObject.name>L2_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_efdda81c-b0f4-4be2-85fb-45c6be439789" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_8e57f735-6869-463e-959e-b517b15a5ec5" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_8e57f735-6869-463e-959e-b517b15a5ec5">
+    <cim:IdentifiedObject.name>BREAKER9</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_f7e579df-31e0-449a-add1-34543de0c4d4" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_eed80693-c239-446f-b83e-a566c96f4b12">
+    <cim:IdentifiedObject.name>L2_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d74ef9c4-2df3-4ee6-a3b0-47de684c6852" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_8e57f735-6869-463e-959e-b517b15a5ec5" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_d74ef9c4-2df3-4ee6-a3b0-47de684c6852">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE32</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_f7e579df-31e0-449a-add1-34543de0c4d4" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_3df2cd7a-edb6-4fab-ac4c-5619d7d6c30a">
+    <cim:IdentifiedObject.name>L2_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d74ef9c4-2df3-4ee6-a3b0-47de684c6852" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_869b6ad5-3975-49ae-81fe-01547a229a25" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_869b6ad5-3975-49ae-81fe-01547a229a25">
+    <cim:IdentifiedObject.name>DISCONNECTOR18</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_f7e579df-31e0-449a-add1-34543de0c4d4" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_6c1b3247-5c23-4080-854d-96af3af219c7">
+    <cim:IdentifiedObject.name>L2_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d09c63da-d5f4-4d89-a757-c7426a4b81d2" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_869b6ad5-3975-49ae-81fe-01547a229a25" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_d09c63da-d5f4-4d89-a757-c7426a4b81d2">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE33</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_f7e579df-31e0-449a-add1-34543de0c4d4" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_aafc7b02-73a6-4bc4-9aca-9791c844e260">
+    <cim:IdentifiedObject.name>BAY_L2_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_051b93ae-9c15-4490-8cea-33395298f031" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_ea74068d-472d-458c-9abc-cdd5437616c9">
+    <cim:IdentifiedObject.name>L2_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_cc1c62da-ae58-7198-7eb5-2971feb99ae3" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9e585839-b83e-4f53-95f7-2fe60dea9e67" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_8fa214d6-5b7f-4d04-8de7-e5609d9f9deb" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_8fa214d6-5b7f-4d04-8de7-e5609d9f9deb">
+    <cim:IdentifiedObject.name>DISCONNECTOR19</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_aafc7b02-73a6-4bc4-9aca-9791c844e260" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_5d820300-529c-4622-ab38-cc4374bd081c">
+    <cim:IdentifiedObject.name>L2_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ccb7c358-3422-42b1-808b-b46c0201fdd7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_8fa214d6-5b7f-4d04-8de7-e5609d9f9deb" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_ccb7c358-3422-42b1-808b-b46c0201fdd7">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE34</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_aafc7b02-73a6-4bc4-9aca-9791c844e260" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_4c355eec-daf6-4639-8af6-1c397eb1c061">
+    <cim:IdentifiedObject.name>L2_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ccb7c358-3422-42b1-808b-b46c0201fdd7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_eb33e134-698f-4258-8361-4b5fa4c2f9de" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_eb33e134-698f-4258-8361-4b5fa4c2f9de">
+    <cim:IdentifiedObject.name>BREAKER10</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_aafc7b02-73a6-4bc4-9aca-9791c844e260" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_f48c1439-dd5c-4045-ad78-760321438b23">
+    <cim:IdentifiedObject.name>L2_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9b8c8eea-fa50-4e84-96eb-cfc03a3fc5b6" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_eb33e134-698f-4258-8361-4b5fa4c2f9de" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_9b8c8eea-fa50-4e84-96eb-cfc03a3fc5b6">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE35</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_aafc7b02-73a6-4bc4-9aca-9791c844e260" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_2731a0ed-82af-4e6a-bf8f-65bfb89a2d99">
+    <cim:IdentifiedObject.name>L2_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9b8c8eea-fa50-4e84-96eb-cfc03a3fc5b6" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9e8afc23-52fc-40e6-ab85-3d0328a228f2" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_9e8afc23-52fc-40e6-ab85-3d0328a228f2">
+    <cim:IdentifiedObject.name>DISCONNECTOR20</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_aafc7b02-73a6-4bc4-9aca-9791c844e260" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_5c7f2182-6d27-491a-b1e8-5e48c2bced16">
+    <cim:IdentifiedObject.name>L2_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_473b9f45-3071-4fef-a90b-43a8c4eddeae" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9e8afc23-52fc-40e6-ab85-3d0328a228f2" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_473b9f45-3071-4fef-a90b-43a8c4eddeae">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE36</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_aafc7b02-73a6-4bc4-9aca-9791c844e260" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_bc32ba43-4e85-444f-adec-b773e1e1254c">
+    <cim:IdentifiedObject.name>BAY_L3_a_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_cd28a27e-8b17-4f23-b9f5-03b6de15203f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_a9aff7a4-f0a1-4745-8e16-9c80aecc38be">
+    <cim:IdentifiedObject.name>L3_a_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_4ce5f804-c3b0-fa8a-4fa7-71df511c0b08" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4e14a0e-16c4-4b46-8d2d-b45ff7585057" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_90e1b509-e6d1-4a3b-8dcc-587f8b362bd3" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_90e1b509-e6d1-4a3b-8dcc-587f8b362bd3">
+    <cim:IdentifiedObject.name>DISCONNECTOR21</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_bc32ba43-4e85-444f-adec-b773e1e1254c" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_8e922bca-b992-472f-9cce-322c669d50d1">
+    <cim:IdentifiedObject.name>L3_a_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_a2f94dfc-c3c3-4dbf-95b8-8435ca5eaf74" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_90e1b509-e6d1-4a3b-8dcc-587f8b362bd3" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_a2f94dfc-c3c3-4dbf-95b8-8435ca5eaf74">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE37</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_bc32ba43-4e85-444f-adec-b773e1e1254c" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_d2a672b4-28a4-47fa-9102-c1100bc4dc49">
+    <cim:IdentifiedObject.name>L3_a_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_a2f94dfc-c3c3-4dbf-95b8-8435ca5eaf74" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_788bb5ff-f36e-406b-b6a6-ea1b7268ba03" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_788bb5ff-f36e-406b-b6a6-ea1b7268ba03">
+    <cim:IdentifiedObject.name>BREAKER11</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_bc32ba43-4e85-444f-adec-b773e1e1254c" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_cb8687b7-c25e-427f-841f-7d1380a2e274">
+    <cim:IdentifiedObject.name>L3_a_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_40bb040b-2375-471e-84b5-b8f177e897d7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_788bb5ff-f36e-406b-b6a6-ea1b7268ba03" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_40bb040b-2375-471e-84b5-b8f177e897d7">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE38</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_bc32ba43-4e85-444f-adec-b773e1e1254c" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_d72b6257-6b28-47d2-ba37-61630d9d9647">
+    <cim:IdentifiedObject.name>L3_a_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_40bb040b-2375-471e-84b5-b8f177e897d7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ef2f27d9-acde-4aad-a920-d61c98682f4d" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_ef2f27d9-acde-4aad-a920-d61c98682f4d">
+    <cim:IdentifiedObject.name>DISCONNECTOR22</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_bc32ba43-4e85-444f-adec-b773e1e1254c" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_a9d77a71-a9b4-44cb-9c4f-e52492b37980">
+    <cim:IdentifiedObject.name>L3_a_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d9649b2e-0a9c-424e-b3b2-31dbd41bee4f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ef2f27d9-acde-4aad-a920-d61c98682f4d" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_d9649b2e-0a9c-424e-b3b2-31dbd41bee4f">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE39</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_bc32ba43-4e85-444f-adec-b773e1e1254c" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_af9eb1f6-f0af-4546-bfb8-83e81635802f">
+    <cim:IdentifiedObject.name>BAY_L3_a_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_a43d15db-44a6-4fda-a525-2402ff43226f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_e7daaf22-0533-4753-a9ef-7f11979a0d59">
+    <cim:IdentifiedObject.name>L3_a_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_e118faef-acce-8f60-1e5b-f224e12eccbe" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4cea32b-2ea1-4be3-9040-2a29cf7a48f1" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b68ac335-9806-4609-812c-1f47f8738bde" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_b68ac335-9806-4609-812c-1f47f8738bde">
+    <cim:IdentifiedObject.name>DISCONNECTOR23</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_af9eb1f6-f0af-4546-bfb8-83e81635802f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_0e0a7e38-7c23-436c-973f-76d23ab89027">
+    <cim:IdentifiedObject.name>L3_a_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_583e0eed-a939-4d54-bebe-0d133bdf3c42" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b68ac335-9806-4609-812c-1f47f8738bde" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_583e0eed-a939-4d54-bebe-0d133bdf3c42">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE40</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_af9eb1f6-f0af-4546-bfb8-83e81635802f" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_0787d496-6606-4dc2-a363-3a7b4ab437fc">
+    <cim:IdentifiedObject.name>L3_a_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_583e0eed-a939-4d54-bebe-0d133bdf3c42" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a5a962a6-2f47-4ef1-960f-e29131bcba36" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_a5a962a6-2f47-4ef1-960f-e29131bcba36">
+    <cim:IdentifiedObject.name>BREAKER12</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_af9eb1f6-f0af-4546-bfb8-83e81635802f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_baa12311-4df0-4662-964a-701b03f31b73">
+    <cim:IdentifiedObject.name>L3_a_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_858bc635-8899-4f15-aacd-7ed65ed24696" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a5a962a6-2f47-4ef1-960f-e29131bcba36" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_858bc635-8899-4f15-aacd-7ed65ed24696">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE41</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_af9eb1f6-f0af-4546-bfb8-83e81635802f" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_60de37d6-c659-40e1-bf7b-2ab7d59b5d0f">
+    <cim:IdentifiedObject.name>L3_a_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_858bc635-8899-4f15-aacd-7ed65ed24696" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b0677acc-df2e-4730-9516-fab2403103d0" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_b0677acc-df2e-4730-9516-fab2403103d0">
+    <cim:IdentifiedObject.name>DISCONNECTOR24</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_af9eb1f6-f0af-4546-bfb8-83e81635802f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_952e500f-4609-412d-a368-5a4d74ec78d9">
+    <cim:IdentifiedObject.name>L3_a_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cc81766a-a254-432f-b9a2-e22225f529f7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b0677acc-df2e-4730-9516-fab2403103d0" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_cc81766a-a254-432f-b9a2-e22225f529f7">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE42</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_af9eb1f6-f0af-4546-bfb8-83e81635802f" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_20dd33bf-3927-4360-a689-810b16d0efde">
+    <cim:IdentifiedObject.name>BAY_L3_b_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_cd28a27e-8b17-4f23-b9f5-03b6de15203f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_654343eb-a916-4b23-8f63-2dbb93f8c60b">
+    <cim:IdentifiedObject.name>L3_b_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_4ce5f804-c3b0-fa8a-4fa7-71df511c0b08" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4e14a0e-16c4-4b46-8d2d-b45ff7585057" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b81c76fd-24fb-4888-a52e-5a9d0177df1d" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_b81c76fd-24fb-4888-a52e-5a9d0177df1d">
+    <cim:IdentifiedObject.name>DISCONNECTOR25</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_20dd33bf-3927-4360-a689-810b16d0efde" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_0fd8256c-1eb8-4ff8-88c6-5b14842e3c00">
+    <cim:IdentifiedObject.name>L3_b_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_2025cf6e-0135-4085-ac63-3d232ea808cf" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b81c76fd-24fb-4888-a52e-5a9d0177df1d" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_2025cf6e-0135-4085-ac63-3d232ea808cf">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE43</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_20dd33bf-3927-4360-a689-810b16d0efde" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_37fb1b60-4171-4977-a82f-ce6c160b52b2">
+    <cim:IdentifiedObject.name>L3_b_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_2025cf6e-0135-4085-ac63-3d232ea808cf" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f58f46ea-b73b-421e-9fea-a86126a95b10" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_f58f46ea-b73b-421e-9fea-a86126a95b10">
+    <cim:IdentifiedObject.name>BREAKER13</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_20dd33bf-3927-4360-a689-810b16d0efde" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_77e5f07e-b2a4-44f1-a321-68726d99ee04">
+    <cim:IdentifiedObject.name>L3_b_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_289cda9a-53df-441b-a05a-fa90cdd44d94" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f58f46ea-b73b-421e-9fea-a86126a95b10" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_289cda9a-53df-441b-a05a-fa90cdd44d94">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE44</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_20dd33bf-3927-4360-a689-810b16d0efde" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_7b7d05e5-8d78-46e2-8065-958e57258ceb">
+    <cim:IdentifiedObject.name>L3_b_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_289cda9a-53df-441b-a05a-fa90cdd44d94" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_06917aa0-6cc2-4d46-b37b-6ed9fec32ccd" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_06917aa0-6cc2-4d46-b37b-6ed9fec32ccd">
+    <cim:IdentifiedObject.name>DISCONNECTOR26</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_20dd33bf-3927-4360-a689-810b16d0efde" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_ea3b457b-9508-4f84-8715-b7df2019068b">
+    <cim:IdentifiedObject.name>L3_b_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b662305d-ac49-4c92-8a1d-ea3036616328" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_06917aa0-6cc2-4d46-b37b-6ed9fec32ccd" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_b662305d-ac49-4c92-8a1d-ea3036616328">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE45</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_20dd33bf-3927-4360-a689-810b16d0efde" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_03c4341a-bbde-40b7-9543-57fa61266b6f">
+    <cim:IdentifiedObject.name>BAY_L3_b_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_a43d15db-44a6-4fda-a525-2402ff43226f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_ac754d2e-5ed9-4466-a351-aa861198e255">
+    <cim:IdentifiedObject.name>L3_b_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_e118faef-acce-8f60-1e5b-f224e12eccbe" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4cea32b-2ea1-4be3-9040-2a29cf7a48f1" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c6727598-4dae-4226-a542-166766d2f702" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_c6727598-4dae-4226-a542-166766d2f702">
+    <cim:IdentifiedObject.name>DISCONNECTOR27</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_03c4341a-bbde-40b7-9543-57fa61266b6f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_1621a8f0-f63d-4869-b42a-db0d9364db22">
+    <cim:IdentifiedObject.name>L3_b_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_189fdb29-586a-4bda-a2d0-ce4a1e11a892" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c6727598-4dae-4226-a542-166766d2f702" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_189fdb29-586a-4bda-a2d0-ce4a1e11a892">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE46</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_03c4341a-bbde-40b7-9543-57fa61266b6f" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_e562be25-b44e-4f1f-834e-ec46dbfb689e">
+    <cim:IdentifiedObject.name>L3_b_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_189fdb29-586a-4bda-a2d0-ce4a1e11a892" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c217742e-f713-44b7-a0b2-7c78aebc165d" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_c217742e-f713-44b7-a0b2-7c78aebc165d">
+    <cim:IdentifiedObject.name>BREAKER14</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_03c4341a-bbde-40b7-9543-57fa61266b6f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_e87a69d3-296b-4497-8dc5-5ae782fdb184">
+    <cim:IdentifiedObject.name>L3_b_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_364f4b8f-8a34-477a-8b25-fd3a8666ae59" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c217742e-f713-44b7-a0b2-7c78aebc165d" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_364f4b8f-8a34-477a-8b25-fd3a8666ae59">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE47</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_03c4341a-bbde-40b7-9543-57fa61266b6f" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_a01745f7-1965-4c49-b53d-0f3180aa9e17">
+    <cim:IdentifiedObject.name>L3_b_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_364f4b8f-8a34-477a-8b25-fd3a8666ae59" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6f28743a-c690-4569-b229-977566414a16" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_6f28743a-c690-4569-b229-977566414a16">
+    <cim:IdentifiedObject.name>DISCONNECTOR28</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_03c4341a-bbde-40b7-9543-57fa61266b6f" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_37ed18b5-9040-4b03-9622-9c5481e36d05">
+    <cim:IdentifiedObject.name>L3_b_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_edfce3cd-e2e1-49eb-9660-7fe920b96c57" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6f28743a-c690-4569-b229-977566414a16" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_edfce3cd-e2e1-49eb-9660-7fe920b96c57">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE48</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_03c4341a-bbde-40b7-9543-57fa61266b6f" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_ba11103d-1cef-4e99-a236-be82b85dd7e9">
+    <cim:IdentifiedObject.name>BAY_T5_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_a43d15db-44a6-4fda-a525-2402ff43226f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_2ca5c7d4-9b73-44fd-b9f1-e8353ed93d9b">
+    <cim:IdentifiedObject.name>T5_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_e118faef-acce-8f60-1e5b-f224e12eccbe" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4cea32b-2ea1-4be3-9040-2a29cf7a48f1" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_79341979-e66c-4b08-8053-6d97216e0777" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_79341979-e66c-4b08-8053-6d97216e0777">
+    <cim:IdentifiedObject.name>DISCONNECTOR29</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_ba11103d-1cef-4e99-a236-be82b85dd7e9" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_25af8438-9b28-446c-bb2c-e9d64aae2111">
+    <cim:IdentifiedObject.name>T5_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_18e79ca1-d405-4df2-baab-056c46c503d9" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_79341979-e66c-4b08-8053-6d97216e0777" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_18e79ca1-d405-4df2-baab-056c46c503d9">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE49</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_ba11103d-1cef-4e99-a236-be82b85dd7e9" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_563df48e-ea91-4aa6-9e7d-0beb477b4df8">
+    <cim:IdentifiedObject.name>T5_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_18e79ca1-d405-4df2-baab-056c46c503d9" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a772f653-51f9-498c-afc9-c37b2a49cf32" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_a772f653-51f9-498c-afc9-c37b2a49cf32">
+    <cim:IdentifiedObject.name>BREAKER15</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_ba11103d-1cef-4e99-a236-be82b85dd7e9" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_85d4137e-4559-4915-985c-0571e218e19c">
+    <cim:IdentifiedObject.name>T5_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_08fb7cc1-82f4-4b13-b3ed-a46da751fd17" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a772f653-51f9-498c-afc9-c37b2a49cf32" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_08fb7cc1-82f4-4b13-b3ed-a46da751fd17">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE50</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_ba11103d-1cef-4e99-a236-be82b85dd7e9" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_fda2c67c-d8c4-475b-a791-4ab5f6422da1">
+    <cim:IdentifiedObject.name>T5_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_08fb7cc1-82f4-4b13-b3ed-a46da751fd17" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_74534b01-b13b-49a2-b0d7-d0feb1348ef5" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_74534b01-b13b-49a2-b0d7-d0feb1348ef5">
+    <cim:IdentifiedObject.name>DISCONNECTOR30</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_ba11103d-1cef-4e99-a236-be82b85dd7e9" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_fdec908f-fe51-492d-a385-4db764d5f58b">
+    <cim:IdentifiedObject.name>T5_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_959b2f06-3e1d-454c-b756-7ec0271f9ff6" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_74534b01-b13b-49a2-b0d7-d0feb1348ef5" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_959b2f06-3e1d-454c-b756-7ec0271f9ff6">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE51</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_ba11103d-1cef-4e99-a236-be82b85dd7e9" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_fd1ed2b0-edda-4e9a-8990-25db7ae515be">
+    <cim:IdentifiedObject.name>BAY_T5_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_0d68ac81-124d-4d21-afa8-6c503feef5b8" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_c239382f-9dd0-4d7c-ba5c-a4064dd94fca">
+    <cim:IdentifiedObject.name>T5_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_928cbae7-e9d0-b980-8af2-63e9c1aeede3" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ec8c3b42-d70c-41d6-89f4-f2df958817c8" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c7f7f032-1e4d-494a-9352-bad1a3056e3f" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_c7f7f032-1e4d-494a-9352-bad1a3056e3f">
+    <cim:IdentifiedObject.name>DISCONNECTOR31</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_fd1ed2b0-edda-4e9a-8990-25db7ae515be" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_e29ee98e-b807-415d-be0c-9126a3e39b92">
+    <cim:IdentifiedObject.name>T5_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c2000fc5-2a1a-4f5a-9569-aa209ee018cb" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c7f7f032-1e4d-494a-9352-bad1a3056e3f" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_c2000fc5-2a1a-4f5a-9569-aa209ee018cb">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE52</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_fd1ed2b0-edda-4e9a-8990-25db7ae515be" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_890ab3df-c021-4f4d-9333-22b01240c9e1">
+    <cim:IdentifiedObject.name>T5_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c2000fc5-2a1a-4f5a-9569-aa209ee018cb" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c1e02075-4fdf-41e1-b5e4-925bb2396011" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_c1e02075-4fdf-41e1-b5e4-925bb2396011">
+    <cim:IdentifiedObject.name>BREAKER16</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_fd1ed2b0-edda-4e9a-8990-25db7ae515be" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_01df618d-a8cd-493e-ad4a-793ae42c427f">
+    <cim:IdentifiedObject.name>T5_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_aa1c1321-a0f2-4f06-b84a-b9da17f10459" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c1e02075-4fdf-41e1-b5e4-925bb2396011" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_aa1c1321-a0f2-4f06-b84a-b9da17f10459">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE53</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_fd1ed2b0-edda-4e9a-8990-25db7ae515be" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_c4a0c1fc-1d63-4dd9-846b-090626d8584f">
+    <cim:IdentifiedObject.name>T5_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_aa1c1321-a0f2-4f06-b84a-b9da17f10459" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2ec6cb16-7516-46f9-8cd8-2a52eea85bb5" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_2ec6cb16-7516-46f9-8cd8-2a52eea85bb5">
+    <cim:IdentifiedObject.name>DISCONNECTOR32</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_fd1ed2b0-edda-4e9a-8990-25db7ae515be" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_e7128a94-8515-4934-949e-8e86ff612c74">
+    <cim:IdentifiedObject.name>T5_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_29c4f110-c71b-4baa-8bd1-dd193606b955" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2ec6cb16-7516-46f9-8cd8-2a52eea85bb5" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_29c4f110-c71b-4baa-8bd1-dd193606b955">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE54</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_fd1ed2b0-edda-4e9a-8990-25db7ae515be" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_c3bfac6d-6894-498a-8381-7fffe3f0c831">
+    <cim:IdentifiedObject.name>BAY_T6_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_a43d15db-44a6-4fda-a525-2402ff43226f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_fe962374-f78f-4ed9-becd-f320150fc65f">
+    <cim:IdentifiedObject.name>T6_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_e118faef-acce-8f60-1e5b-f224e12eccbe" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4cea32b-2ea1-4be3-9040-2a29cf7a48f1" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c803aa12-a8c7-4491-8163-1a1c6ea60db8" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_c803aa12-a8c7-4491-8163-1a1c6ea60db8">
+    <cim:IdentifiedObject.name>DISCONNECTOR33</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c3bfac6d-6894-498a-8381-7fffe3f0c831" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_8f4a8d13-3695-4115-b765-c93eafb155ee">
+    <cim:IdentifiedObject.name>T6_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_41c16bf5-7747-424e-812e-06ab372aec9d" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c803aa12-a8c7-4491-8163-1a1c6ea60db8" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_41c16bf5-7747-424e-812e-06ab372aec9d">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE55</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_c3bfac6d-6894-498a-8381-7fffe3f0c831" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_9c535ea3-28f2-4029-bc08-60282cec3213">
+    <cim:IdentifiedObject.name>T6_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_41c16bf5-7747-424e-812e-06ab372aec9d" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6557ecb5-b9a7-4089-aa70-58d4d11f503b" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_6557ecb5-b9a7-4089-aa70-58d4d11f503b">
+    <cim:IdentifiedObject.name>BREAKER17</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c3bfac6d-6894-498a-8381-7fffe3f0c831" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_02820aae-8266-4c45-96de-5640eff65320">
+    <cim:IdentifiedObject.name>T6_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ac6c4351-848e-43c1-aac9-8eab63bd6347" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6557ecb5-b9a7-4089-aa70-58d4d11f503b" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_ac6c4351-848e-43c1-aac9-8eab63bd6347">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE56</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_c3bfac6d-6894-498a-8381-7fffe3f0c831" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_58bca65d-d7b1-4c05-b433-f39e10a916b6">
+    <cim:IdentifiedObject.name>T6_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ac6c4351-848e-43c1-aac9-8eab63bd6347" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ac85d2fb-2417-4a86-9c63-d389e6ffae47" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_ac85d2fb-2417-4a86-9c63-d389e6ffae47">
+    <cim:IdentifiedObject.name>DISCONNECTOR34</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c3bfac6d-6894-498a-8381-7fffe3f0c831" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_55ee67e4-02df-4acd-8117-c43987a52ff0">
+    <cim:IdentifiedObject.name>T6_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_71f091ea-9081-40c2-9e8c-49111b408dcf" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ac85d2fb-2417-4a86-9c63-d389e6ffae47" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_71f091ea-9081-40c2-9e8c-49111b408dcf">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE57</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_c3bfac6d-6894-498a-8381-7fffe3f0c831" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_0b7b4c92-ce4e-4b08-a91d-95a75e57c3f7">
+    <cim:IdentifiedObject.name>BAY_T6_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_0d68ac81-124d-4d21-afa8-6c503feef5b8" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_e4b01a0e-fd58-41d0-ae5a-583ecadf6b43">
+    <cim:IdentifiedObject.name>T6_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_928cbae7-e9d0-b980-8af2-63e9c1aeede3" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ec8c3b42-d70c-41d6-89f4-f2df958817c8" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2c03a3cf-4890-4092-9fe3-c6d139677882" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_2c03a3cf-4890-4092-9fe3-c6d139677882">
+    <cim:IdentifiedObject.name>DISCONNECTOR35</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_0b7b4c92-ce4e-4b08-a91d-95a75e57c3f7" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_faf9bfb2-81b7-4dc5-a9b5-3d7cc05c6aeb">
+    <cim:IdentifiedObject.name>T6_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_463aee41-aaef-4a6e-bea6-a67f5a0fcbdd" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2c03a3cf-4890-4092-9fe3-c6d139677882" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_463aee41-aaef-4a6e-bea6-a67f5a0fcbdd">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE58</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_0b7b4c92-ce4e-4b08-a91d-95a75e57c3f7" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_ee0315f9-835c-4b1f-91e6-df688fa5cea0">
+    <cim:IdentifiedObject.name>T6_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_463aee41-aaef-4a6e-bea6-a67f5a0fcbdd" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d0119330-220f-4ed3-ad3c-f893ad0534fb" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_d0119330-220f-4ed3-ad3c-f893ad0534fb">
+    <cim:IdentifiedObject.name>BREAKER18</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_0b7b4c92-ce4e-4b08-a91d-95a75e57c3f7" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_fe141bda-142c-4438-83d0-dae0d0ae199a">
+    <cim:IdentifiedObject.name>T6_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_461cffe9-5b6d-4726-bbae-eb8f7abb4b3c" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d0119330-220f-4ed3-ad3c-f893ad0534fb" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_461cffe9-5b6d-4726-bbae-eb8f7abb4b3c">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE59</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_0b7b4c92-ce4e-4b08-a91d-95a75e57c3f7" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_c394efef-2d00-4236-becd-b9a99545e7b9">
+    <cim:IdentifiedObject.name>T6_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_461cffe9-5b6d-4726-bbae-eb8f7abb4b3c" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_64b4c3d3-0116-4477-af5f-76fe482a4347" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_64b4c3d3-0116-4477-af5f-76fe482a4347">
+    <cim:IdentifiedObject.name>DISCONNECTOR36</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_0b7b4c92-ce4e-4b08-a91d-95a75e57c3f7" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_a48cca94-4d2d-4e8e-97e7-52f5635b5a3e">
+    <cim:IdentifiedObject.name>T6_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c575585e-bce8-4d2d-b211-a28f7ed6e07f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_64b4c3d3-0116-4477-af5f-76fe482a4347" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_c575585e-bce8-4d2d-b211-a28f7ed6e07f">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE60</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_0b7b4c92-ce4e-4b08-a91d-95a75e57c3f7" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_c474cf16-2087-4245-90b9-cd35296d54dd">
+    <cim:IdentifiedObject.name>BAY_T2_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_347fb7af-642f-4c60-97d9-c03d440b6a82" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_5f5082df-e28b-4a83-85f4-37b18687ba6b">
+    <cim:IdentifiedObject.name>T2_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_472651ab-53d8-8160-2fb1-156d83d6259a" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cc636acd-3f39-4641-829e-dc401eb03569" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9dc3bedf-0d30-4a56-ba5c-f2e69d7997ee" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_9dc3bedf-0d30-4a56-ba5c-f2e69d7997ee">
+    <cim:IdentifiedObject.name>DISCONNECTOR37</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c474cf16-2087-4245-90b9-cd35296d54dd" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_ac39e330-965f-4a05-bd93-2e338aa1e7ce">
+    <cim:IdentifiedObject.name>T2_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_5781553c-c3c7-48af-9835-8ccdd12a34af" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9dc3bedf-0d30-4a56-ba5c-f2e69d7997ee" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_5781553c-c3c7-48af-9835-8ccdd12a34af">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE61</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_c474cf16-2087-4245-90b9-cd35296d54dd" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_16918aef-e2ae-421f-bfa4-7d3c1e749bb7">
+    <cim:IdentifiedObject.name>T2_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_5781553c-c3c7-48af-9835-8ccdd12a34af" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d6665f59-851b-4183-81b0-59c53e1baa6a" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_d6665f59-851b-4183-81b0-59c53e1baa6a">
+    <cim:IdentifiedObject.name>BREAKER19</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c474cf16-2087-4245-90b9-cd35296d54dd" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_9c86faec-f24c-4cbf-a1e6-9c9e1288de24">
+    <cim:IdentifiedObject.name>T2_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_17933347-a362-481d-abd6-9ea6bd8aae8f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d6665f59-851b-4183-81b0-59c53e1baa6a" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_17933347-a362-481d-abd6-9ea6bd8aae8f">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE62</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_c474cf16-2087-4245-90b9-cd35296d54dd" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_e661d283-0a97-43df-825f-6ed99a267448">
+    <cim:IdentifiedObject.name>T2_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_17933347-a362-481d-abd6-9ea6bd8aae8f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b8924fbf-6513-4385-b032-21045c0a5b8f" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_b8924fbf-6513-4385-b032-21045c0a5b8f">
+    <cim:IdentifiedObject.name>DISCONNECTOR38</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c474cf16-2087-4245-90b9-cd35296d54dd" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_b1597fc9-786b-4142-a321-2f80bdc61ced">
+    <cim:IdentifiedObject.name>T2_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_74fb7acb-29d3-4402-8f1d-f393a0cade37" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b8924fbf-6513-4385-b032-21045c0a5b8f" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_74fb7acb-29d3-4402-8f1d-f393a0cade37">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE63</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_c474cf16-2087-4245-90b9-cd35296d54dd" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_a662bdaf-fbb3-4801-b12a-ace07d246e9f">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE64</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_b2707f00-2554-41d2-bde2-7dd80a669e50" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_25781dc3-bf27-4b5d-b920-e71f246bcde6">
+    <cim:IdentifiedObject.name>BUSBAR7</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b2707f00-2554-41d2-bde2-7dd80a669e50" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_c347ba7b-5eca-4de0-8487-3489436ec008">
+    <cim:IdentifiedObject.name>T2_1_BUSBAR</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_a662bdaf-fbb3-4801-b12a-ace07d246e9f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_25781dc3-bf27-4b5d-b920-e71f246bcde6" />
+  </cim:Terminal>
+  <cim:Bay rdf:ID="_06479be3-30eb-433b-b414-10cb275fdb55">
+    <cim:IdentifiedObject.name>BAY_T2_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_b2707f00-2554-41d2-bde2-7dd80a669e50" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_adcc04eb-c3c4-47c2-9004-09b2a43b1dee">
+    <cim:IdentifiedObject.name>T2_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_bbca3066-6714-61e7-688f-876b7fb58093" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_a662bdaf-fbb3-4801-b12a-ace07d246e9f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cd8813aa-3213-4d9a-994d-4a4513e458b4" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_cd8813aa-3213-4d9a-994d-4a4513e458b4">
+    <cim:IdentifiedObject.name>DISCONNECTOR39</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_06479be3-30eb-433b-b414-10cb275fdb55" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_f4f76784-0aaa-48ba-98b7-d8f363e4b833">
+    <cim:IdentifiedObject.name>T2_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_a9d648ce-5c97-40cf-8a48-c26b1bd2987f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cd8813aa-3213-4d9a-994d-4a4513e458b4" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_a9d648ce-5c97-40cf-8a48-c26b1bd2987f">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE65</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_06479be3-30eb-433b-b414-10cb275fdb55" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_ff096281-10e6-44c9-af78-8e2829cff084">
+    <cim:IdentifiedObject.name>T2_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_a9d648ce-5c97-40cf-8a48-c26b1bd2987f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_1287758d-606d-44c9-9e93-2f465ebf54b7" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_1287758d-606d-44c9-9e93-2f465ebf54b7">
+    <cim:IdentifiedObject.name>BREAKER20</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_06479be3-30eb-433b-b414-10cb275fdb55" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_33b68bdf-f081-4428-972f-7f5f0dd33b8c">
+    <cim:IdentifiedObject.name>T2_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c8dfe7f5-344f-45fe-89bf-91c30ef3f780" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_1287758d-606d-44c9-9e93-2f465ebf54b7" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_c8dfe7f5-344f-45fe-89bf-91c30ef3f780">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE66</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_06479be3-30eb-433b-b414-10cb275fdb55" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_4915762d-133e-4209-8545-2822d095d7cd">
+    <cim:IdentifiedObject.name>T2_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c8dfe7f5-344f-45fe-89bf-91c30ef3f780" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_8e56ead3-f4d3-4cd9-a34f-c7340ff7384d" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_8e56ead3-f4d3-4cd9-a34f-c7340ff7384d">
+    <cim:IdentifiedObject.name>DISCONNECTOR40</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_06479be3-30eb-433b-b414-10cb275fdb55" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_45b9413e-a116-4952-8cf8-aeb4b2e53348" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_eb6825bf-0004-4845-88f2-6e4ba54eab89">
+    <cim:IdentifiedObject.name>T2_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_2ad1f76e-e884-41d8-a50e-7f798b8e2df7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_8e56ead3-f4d3-4cd9-a34f-c7340ff7384d" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_2ad1f76e-e884-41d8-a50e-7f798b8e2df7">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE67</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_06479be3-30eb-433b-b414-10cb275fdb55" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_7dbc4e44-5c8e-4b22-a80c-4269fdaa7581">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE68</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_6f8ef715-bc0a-47d7-a74e-27f17234f590" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_a43ab51f-ba09-4224-8437-63a9ab30ea50">
+    <cim:IdentifiedObject.name>BUSBAR8</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_6f8ef715-bc0a-47d7-a74e-27f17234f590" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_e6b5f155-583d-46fa-90fc-0673d1afe1be" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_7a6a78cb-5c02-4706-a5ba-020d7d5369d5">
+    <cim:IdentifiedObject.name>T1_0_BUSBAR</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_7dbc4e44-5c8e-4b22-a80c-4269fdaa7581" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a43ab51f-ba09-4224-8437-63a9ab30ea50" />
+  </cim:Terminal>
+  <cim:Bay rdf:ID="_cede97c1-c13f-4f1a-8c37-cf13499cc780">
+    <cim:IdentifiedObject.name>BAY_T1_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_6f8ef715-bc0a-47d7-a74e-27f17234f590" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_171b75ea-d84d-4884-9780-5212780d4154">
+    <cim:IdentifiedObject.name>T1_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_aac4d021-1255-bbdc-c668-59dd6b55f07b" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_7dbc4e44-5c8e-4b22-a80c-4269fdaa7581" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b7e79b65-8d3e-4ee9-bf05-12bf2250b12d" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_b7e79b65-8d3e-4ee9-bf05-12bf2250b12d">
+    <cim:IdentifiedObject.name>DISCONNECTOR41</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_cede97c1-c13f-4f1a-8c37-cf13499cc780" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_e6b5f155-583d-46fa-90fc-0673d1afe1be" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_3fc6a85d-1528-46f2-a3a0-502a1adc2da6">
+    <cim:IdentifiedObject.name>T1_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_6b3b2259-cac2-4b68-9ed0-2c8c4f769984" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b7e79b65-8d3e-4ee9-bf05-12bf2250b12d" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_6b3b2259-cac2-4b68-9ed0-2c8c4f769984">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE69</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_cede97c1-c13f-4f1a-8c37-cf13499cc780" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_08514e88-e6b6-4a2f-ad85-1021568dcece">
+    <cim:IdentifiedObject.name>T1_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_6b3b2259-cac2-4b68-9ed0-2c8c4f769984" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_052682ba-a4e5-41d5-9728-0fa4e2e01011" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_052682ba-a4e5-41d5-9728-0fa4e2e01011">
+    <cim:IdentifiedObject.name>BREAKER21</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_cede97c1-c13f-4f1a-8c37-cf13499cc780" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_e6b5f155-583d-46fa-90fc-0673d1afe1be" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_23ab327a-2d61-4fee-ac8d-ab1f570f9c77">
+    <cim:IdentifiedObject.name>T1_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_3155f5d4-637d-470d-bbdb-c25bd1d24355" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_052682ba-a4e5-41d5-9728-0fa4e2e01011" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_3155f5d4-637d-470d-bbdb-c25bd1d24355">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE70</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_cede97c1-c13f-4f1a-8c37-cf13499cc780" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_11f4f138-5e43-4a82-88bf-7c57d50813dd">
+    <cim:IdentifiedObject.name>T1_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_3155f5d4-637d-470d-bbdb-c25bd1d24355" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2af10fbd-4763-4940-b11d-00dcd7627016" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_2af10fbd-4763-4940-b11d-00dcd7627016">
+    <cim:IdentifiedObject.name>DISCONNECTOR42</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_cede97c1-c13f-4f1a-8c37-cf13499cc780" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_e6b5f155-583d-46fa-90fc-0673d1afe1be" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_64050cf7-60b8-4d43-a471-55e2386fcdbd">
+    <cim:IdentifiedObject.name>T1_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_7f102715-e610-4fe6-8557-ba49b1bb5be5" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2af10fbd-4763-4940-b11d-00dcd7627016" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_7f102715-e610-4fe6-8557-ba49b1bb5be5">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE71</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_cede97c1-c13f-4f1a-8c37-cf13499cc780" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_90d51a9b-bc1e-4446-ad52-7f1422cf0b54">
+    <cim:IdentifiedObject.name>BAY_T1_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_051b93ae-9c15-4490-8cea-33395298f031" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_c833199a-0d18-415d-afa2-86e007434894">
+    <cim:IdentifiedObject.name>T1_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_cc1c62da-ae58-7198-7eb5-2971feb99ae3" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9e585839-b83e-4f53-95f7-2fe60dea9e67" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_27cb23c0-ad7b-4019-8cdf-205e240f742a" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_27cb23c0-ad7b-4019-8cdf-205e240f742a">
+    <cim:IdentifiedObject.name>DISCONNECTOR43</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_90d51a9b-bc1e-4446-ad52-7f1422cf0b54" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_7ad619e2-6d13-44cc-9ebe-cb674fb137ae">
+    <cim:IdentifiedObject.name>T1_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_eaa17022-1f42-46ca-b431-12b3f8008a6b" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_27cb23c0-ad7b-4019-8cdf-205e240f742a" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_eaa17022-1f42-46ca-b431-12b3f8008a6b">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE72</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_90d51a9b-bc1e-4446-ad52-7f1422cf0b54" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_23c7d2cf-57aa-46d3-bfe6-571211b901ca">
+    <cim:IdentifiedObject.name>T1_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_eaa17022-1f42-46ca-b431-12b3f8008a6b" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fdf5cfbe-9bf5-406a-8d04-fafe47afe31d" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_fdf5cfbe-9bf5-406a-8d04-fafe47afe31d">
+    <cim:IdentifiedObject.name>BREAKER22</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_90d51a9b-bc1e-4446-ad52-7f1422cf0b54" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_224f7bbc-4253-4642-a886-eb9b45154612">
+    <cim:IdentifiedObject.name>T1_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_47e5b82b-8879-4619-aa11-aea30583af34" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fdf5cfbe-9bf5-406a-8d04-fafe47afe31d" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_47e5b82b-8879-4619-aa11-aea30583af34">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE73</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_90d51a9b-bc1e-4446-ad52-7f1422cf0b54" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_10af2a5e-765c-4e4c-8c7c-f1e589be90de">
+    <cim:IdentifiedObject.name>T1_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_47e5b82b-8879-4619-aa11-aea30583af34" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2791a96c-c66c-44e7-a5dc-8331a8996c76" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_2791a96c-c66c-44e7-a5dc-8331a8996c76">
+    <cim:IdentifiedObject.name>DISCONNECTOR44</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_90d51a9b-bc1e-4446-ad52-7f1422cf0b54" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_daa62f13-06fb-470d-a027-8f09ecfc85d6">
+    <cim:IdentifiedObject.name>T1_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_de0ba159-8462-4173-8690-782b1c8887f7" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2791a96c-c66c-44e7-a5dc-8331a8996c76" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_de0ba159-8462-4173-8690-782b1c8887f7">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE74</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_90d51a9b-bc1e-4446-ad52-7f1422cf0b54" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_4506d630-5c09-449c-b3a1-8c3899b6a83e">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE75</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_93778e52-3fd5-456d-8b10-987c3e6bc47e" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_0e851b9d-f638-40ff-b77a-b381698dc9a3">
+    <cim:IdentifiedObject.name>BUSBAR9</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_93778e52-3fd5-456d-8b10-987c3e6bc47e" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b2a3e748-1772-409d-a61f-1d6da09564c9" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_c83f924b-18d1-4cb9-a91d-616e8b347ac2">
+    <cim:IdentifiedObject.name>T4_0_BUSBAR</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4506d630-5c09-449c-b3a1-8c3899b6a83e" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_0e851b9d-f638-40ff-b77a-b381698dc9a3" />
+  </cim:Terminal>
+  <cim:Bay rdf:ID="_7990d389-6be8-4141-8baa-25169522b92b">
+    <cim:IdentifiedObject.name>BAY_T4_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_93778e52-3fd5-456d-8b10-987c3e6bc47e" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_1425f9f4-9037-4086-9c0f-9b1f007eca48">
+    <cim:IdentifiedObject.name>T4_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_42b42397-38f5-05e8-da3a-21314ea193af" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4506d630-5c09-449c-b3a1-8c3899b6a83e" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c8b06b9b-8876-4fb5-9279-5a396e3db63d" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_c8b06b9b-8876-4fb5-9279-5a396e3db63d">
+    <cim:IdentifiedObject.name>DISCONNECTOR45</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_7990d389-6be8-4141-8baa-25169522b92b" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b2a3e748-1772-409d-a61f-1d6da09564c9" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_bbf95af6-337a-4307-b305-6733a9fd28f8">
+    <cim:IdentifiedObject.name>T4_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ba946d59-902f-403c-a4c2-5ebd4e1a5028" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c8b06b9b-8876-4fb5-9279-5a396e3db63d" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_ba946d59-902f-403c-a4c2-5ebd4e1a5028">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE76</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_7990d389-6be8-4141-8baa-25169522b92b" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_9f666788-e66c-4cfc-827f-de5ccba9fd2d">
+    <cim:IdentifiedObject.name>T4_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ba946d59-902f-403c-a4c2-5ebd4e1a5028" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_47143596-5947-430d-b14b-e00ac796985a" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_47143596-5947-430d-b14b-e00ac796985a">
+    <cim:IdentifiedObject.name>BREAKER23</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_7990d389-6be8-4141-8baa-25169522b92b" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b2a3e748-1772-409d-a61f-1d6da09564c9" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_40a6d6e8-9175-445c-977c-b0daab3c7f0d">
+    <cim:IdentifiedObject.name>T4_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_2e7c2f66-84ec-42d9-a05f-f49338e0e602" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_47143596-5947-430d-b14b-e00ac796985a" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_2e7c2f66-84ec-42d9-a05f-f49338e0e602">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE77</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_7990d389-6be8-4141-8baa-25169522b92b" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_6a16e43b-81d7-4acc-ba40-cb0e4f099d8a">
+    <cim:IdentifiedObject.name>T4_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_2e7c2f66-84ec-42d9-a05f-f49338e0e602" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cf48defa-93b9-4723-8e41-8dab315ceee0" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_cf48defa-93b9-4723-8e41-8dab315ceee0">
+    <cim:IdentifiedObject.name>DISCONNECTOR46</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_7990d389-6be8-4141-8baa-25169522b92b" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b2a3e748-1772-409d-a61f-1d6da09564c9" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_187a1ad0-2749-4bd6-8664-a6258e7decc1">
+    <cim:IdentifiedObject.name>T4_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0ded970c-cec5-45ac-90d6-eaafcb208874" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cf48defa-93b9-4723-8e41-8dab315ceee0" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_0ded970c-cec5-45ac-90d6-eaafcb208874">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE78</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_7990d389-6be8-4141-8baa-25169522b92b" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_c10ede4e-ed73-4e06-bb38-f049b5c658c6">
+    <cim:IdentifiedObject.name>BAY_T4_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_cd28a27e-8b17-4f23-b9f5-03b6de15203f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_cb18d1c1-2835-4d6f-b98b-3ca2f28c2fa2">
+    <cim:IdentifiedObject.name>T4_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_4ce5f804-c3b0-fa8a-4fa7-71df511c0b08" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4e14a0e-16c4-4b46-8d2d-b45ff7585057" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cb5d0327-ad13-4b40-a74c-3d9888823205" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_cb5d0327-ad13-4b40-a74c-3d9888823205">
+    <cim:IdentifiedObject.name>DISCONNECTOR47</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c10ede4e-ed73-4e06-bb38-f049b5c658c6" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_72e34044-2af0-4b04-9ee9-e69aaadc0807">
+    <cim:IdentifiedObject.name>T4_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c6879353-6561-4464-a4c2-46e7f208bb4a" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cb5d0327-ad13-4b40-a74c-3d9888823205" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_c6879353-6561-4464-a4c2-46e7f208bb4a">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE79</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_c10ede4e-ed73-4e06-bb38-f049b5c658c6" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_e2854830-a0c3-46ef-92a7-70e7fd1c783b">
+    <cim:IdentifiedObject.name>T4_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c6879353-6561-4464-a4c2-46e7f208bb4a" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d08c1582-0b3e-46ec-9e97-d70c423eefe1" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_d08c1582-0b3e-46ec-9e97-d70c423eefe1">
+    <cim:IdentifiedObject.name>BREAKER24</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c10ede4e-ed73-4e06-bb38-f049b5c658c6" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_ded03fef-e28a-43f4-8e06-7330708e0f81">
+    <cim:IdentifiedObject.name>T4_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cd4cf95a-19cc-4636-a300-59d3f000bced" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d08c1582-0b3e-46ec-9e97-d70c423eefe1" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_cd4cf95a-19cc-4636-a300-59d3f000bced">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE80</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_c10ede4e-ed73-4e06-bb38-f049b5c658c6" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_cd41ef76-36d6-44e0-80c5-d8b8c77eea5a">
+    <cim:IdentifiedObject.name>T4_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_cd4cf95a-19cc-4636-a300-59d3f000bced" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ba645318-e12c-4f6a-b5e9-5dfe595ae477" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_ba645318-e12c-4f6a-b5e9-5dfe595ae477">
+    <cim:IdentifiedObject.name>DISCONNECTOR48</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_c10ede4e-ed73-4e06-bb38-f049b5c658c6" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_fb51a5d5-4917-492c-9d66-24aeb6f38b41">
+    <cim:IdentifiedObject.name>T4_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ccf6d0de-5af6-4b10-a11c-76f99fe18508" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ba645318-e12c-4f6a-b5e9-5dfe595ae477" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_ccf6d0de-5af6-4b10-a11c-76f99fe18508">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE81</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_c10ede4e-ed73-4e06-bb38-f049b5c658c6" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_4e34639c-5785-4ef6-811f-b0d237530ffb">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE82</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_5d9d9d87-ce6b-4213-b4ec-d50de9790a59" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_839c01c8-f8b8-45c0-aa2a-ba0a1a4b7504">
+    <cim:IdentifiedObject.name>BUSBAR10</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_5d9d9d87-ce6b-4213-b4ec-d50de9790a59" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_5abad0fd-8229-4c16-867c-7cc6b31a91d1">
+    <cim:IdentifiedObject.name>T4_2_BUSBAR</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>3</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4e34639c-5785-4ef6-811f-b0d237530ffb" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_839c01c8-f8b8-45c0-aa2a-ba0a1a4b7504" />
+  </cim:Terminal>
+  <cim:Bay rdf:ID="_7d8f2c9f-3c3f-4547-a323-9809f36bddb1">
+    <cim:IdentifiedObject.name>BAY_T4_2</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_5d9d9d87-ce6b-4213-b4ec-d50de9790a59" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_9fff761f-9fa8-40ed-a802-48bbd0632769">
+    <cim:IdentifiedObject.name>T4_2_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_5b9532e2-cd9b-652f-7ad3-42c1c84322fb" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4e34639c-5785-4ef6-811f-b0d237530ffb" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_aecb59fa-9af0-4d30-a865-009c2b35f9cb" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_aecb59fa-9af0-4d30-a865-009c2b35f9cb">
+    <cim:IdentifiedObject.name>DISCONNECTOR49</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_7d8f2c9f-3c3f-4547-a323-9809f36bddb1" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_1dd51f56-f284-42e8-a7d4-3084da9312bc">
+    <cim:IdentifiedObject.name>T4_2_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_767d214f-4170-404f-b49a-5d979e90010e" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_aecb59fa-9af0-4d30-a865-009c2b35f9cb" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_767d214f-4170-404f-b49a-5d979e90010e">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE83</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_7d8f2c9f-3c3f-4547-a323-9809f36bddb1" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_55f3f6b2-fcef-4cca-9ccb-e729b36231e7">
+    <cim:IdentifiedObject.name>T4_2_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_767d214f-4170-404f-b49a-5d979e90010e" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2b97cb41-b132-4359-ba18-6520d52acd72" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_2b97cb41-b132-4359-ba18-6520d52acd72">
+    <cim:IdentifiedObject.name>BREAKER25</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_7d8f2c9f-3c3f-4547-a323-9809f36bddb1" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_ee65527d-b472-4dca-82b2-46fda4781ca4">
+    <cim:IdentifiedObject.name>T4_2_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_7d8eae2a-2efb-41d1-8bb3-20a267f28461" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2b97cb41-b132-4359-ba18-6520d52acd72" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_7d8eae2a-2efb-41d1-8bb3-20a267f28461">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE84</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_7d8f2c9f-3c3f-4547-a323-9809f36bddb1" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_81449772-3530-4973-be76-dc0cc7590229">
+    <cim:IdentifiedObject.name>T4_2_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_7d8eae2a-2efb-41d1-8bb3-20a267f28461" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_0bc3b6a5-091e-4b8f-b9d9-a34d327473d0" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_0bc3b6a5-091e-4b8f-b9d9-a34d327473d0">
+    <cim:IdentifiedObject.name>DISCONNECTOR50</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_7d8f2c9f-3c3f-4547-a323-9809f36bddb1" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_04596a73-8298-499d-81d5-2bd97b90bc94">
+    <cim:IdentifiedObject.name>T4_2_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bddd7013-7e34-414c-87da-8e1178fdc256" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_0bc3b6a5-091e-4b8f-b9d9-a34d327473d0" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_bddd7013-7e34-414c-87da-8e1178fdc256">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE85</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_7d8f2c9f-3c3f-4547-a323-9809f36bddb1" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_cd9de198-e977-4cfc-8d57-4c2410b41ad4">
+    <cim:IdentifiedObject.name>BAY_T3_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_5d9d9d87-ce6b-4213-b4ec-d50de9790a59" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_beb46906-7d88-4689-9a95-65d87344cfe0">
+    <cim:IdentifiedObject.name>T3_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_5b9532e2-cd9b-652f-7ad3-42c1c84322fb" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4e34639c-5785-4ef6-811f-b0d237530ffb" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e1e0da2d-79f4-4ca9-8ca2-62532a91edef" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_e1e0da2d-79f4-4ca9-8ca2-62532a91edef">
+    <cim:IdentifiedObject.name>DISCONNECTOR51</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_cd9de198-e977-4cfc-8d57-4c2410b41ad4" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_8bdafc99-ed74-4569-a175-3b69eb0f592c">
+    <cim:IdentifiedObject.name>T3_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_20c8c63c-73fb-4613-a9cb-8f4ab940aa5d" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e1e0da2d-79f4-4ca9-8ca2-62532a91edef" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_20c8c63c-73fb-4613-a9cb-8f4ab940aa5d">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE86</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_cd9de198-e977-4cfc-8d57-4c2410b41ad4" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_d8b520f2-938b-4cad-ab26-a339b1908f64">
+    <cim:IdentifiedObject.name>T3_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_20c8c63c-73fb-4613-a9cb-8f4ab940aa5d" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3eae0be8-9a2f-4355-89d6-865b340c2ec9" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_3eae0be8-9a2f-4355-89d6-865b340c2ec9">
+    <cim:IdentifiedObject.name>BREAKER26</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_cd9de198-e977-4cfc-8d57-4c2410b41ad4" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_fecfd76e-409a-42f1-bc4a-eb538bf07b8f">
+    <cim:IdentifiedObject.name>T3_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_e68b682a-53a1-47d3-9d6e-eb4197b52c73" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3eae0be8-9a2f-4355-89d6-865b340c2ec9" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_e68b682a-53a1-47d3-9d6e-eb4197b52c73">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE87</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_cd9de198-e977-4cfc-8d57-4c2410b41ad4" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_2f6359c5-2e17-40e4-9daf-3a8c0e51a680">
+    <cim:IdentifiedObject.name>T3_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_e68b682a-53a1-47d3-9d6e-eb4197b52c73" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c5bac804-64da-4b3a-8bdc-4c199a9d39ac" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_c5bac804-64da-4b3a-8bdc-4c199a9d39ac">
+    <cim:IdentifiedObject.name>DISCONNECTOR52</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_cd9de198-e977-4cfc-8d57-4c2410b41ad4" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_3d4a821e-3c82-4501-a982-a40a58b99d7e">
+    <cim:IdentifiedObject.name>T3_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f1fdcc78-2ff9-4118-8191-77e88dabfa22" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c5bac804-64da-4b3a-8bdc-4c199a9d39ac" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_f1fdcc78-2ff9-4118-8191-77e88dabfa22">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE88</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_cd9de198-e977-4cfc-8d57-4c2410b41ad4" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_0803aaa8-219e-4a2b-9d09-369249853fef">
+    <cim:IdentifiedObject.name>BAY_T3_1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_cd28a27e-8b17-4f23-b9f5-03b6de15203f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_917c8eea-f432-4a03-b9b6-03479fd7bc6f">
+    <cim:IdentifiedObject.name>T3_1_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_4ce5f804-c3b0-fa8a-4fa7-71df511c0b08" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4e14a0e-16c4-4b46-8d2d-b45ff7585057" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6b7dc761-737d-4452-9d3f-de9e14a7c801" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_6b7dc761-737d-4452-9d3f-de9e14a7c801">
+    <cim:IdentifiedObject.name>DISCONNECTOR53</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_0803aaa8-219e-4a2b-9d09-369249853fef" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_39242d8e-e722-413a-814b-0aabad87cf6e">
+    <cim:IdentifiedObject.name>T3_1_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_7b5a5ef4-1e93-4f6d-be70-5357373e07ff" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6b7dc761-737d-4452-9d3f-de9e14a7c801" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_7b5a5ef4-1e93-4f6d-be70-5357373e07ff">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE89</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_0803aaa8-219e-4a2b-9d09-369249853fef" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_9c54c0f9-ffa9-41e1-8d96-e9ccec4ca73e">
+    <cim:IdentifiedObject.name>T3_1_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_7b5a5ef4-1e93-4f6d-be70-5357373e07ff" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_0f02c390-e5bc-4e8f-9936-2d269b8847ad" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_0f02c390-e5bc-4e8f-9936-2d269b8847ad">
+    <cim:IdentifiedObject.name>BREAKER27</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_0803aaa8-219e-4a2b-9d09-369249853fef" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_4eaf0e87-ff3b-490f-a9d9-f4b176526d64">
+    <cim:IdentifiedObject.name>T3_1_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf1b9dd9-a46d-4479-894d-6fee84283c8f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_0f02c390-e5bc-4e8f-9936-2d269b8847ad" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_bf1b9dd9-a46d-4479-894d-6fee84283c8f">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE90</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_0803aaa8-219e-4a2b-9d09-369249853fef" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_fc90d1be-938f-4d95-8416-e1516f9bcccc">
+    <cim:IdentifiedObject.name>T3_1_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf1b9dd9-a46d-4479-894d-6fee84283c8f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_315a9d60-b7ef-4652-bc3b-2b8c5d334dcf" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_315a9d60-b7ef-4652-bc3b-2b8c5d334dcf">
+    <cim:IdentifiedObject.name>DISCONNECTOR54</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_0803aaa8-219e-4a2b-9d09-369249853fef" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_3ee6718d-4e99-4c27-aa05-b9f4c08df9ed">
+    <cim:IdentifiedObject.name>T3_1_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_59c6d51f-4520-4b53-922e-14dec1fdeab4" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_315a9d60-b7ef-4652-bc3b-2b8c5d334dcf" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_59c6d51f-4520-4b53-922e-14dec1fdeab4">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE91</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_0803aaa8-219e-4a2b-9d09-369249853fef" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_9e981bec-a029-4692-a205-66aec553ed46">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE92</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_93778e52-3fd5-456d-8b10-987c3e6bc47e" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_d9f23c01-d924-4040-ab48-d5c36ccdf1a3">
+    <cim:IdentifiedObject.name>BUSBAR11</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_93778e52-3fd5-456d-8b10-987c3e6bc47e" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b2a3e748-1772-409d-a61f-1d6da09564c9" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_5cc19236-ff11-44e9-a321-dc932b96ec2f">
+    <cim:IdentifiedObject.name>T3_2_BUSBAR</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>3</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9e981bec-a029-4692-a205-66aec553ed46" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d9f23c01-d924-4040-ab48-d5c36ccdf1a3" />
+  </cim:Terminal>
+  <cim:Bay rdf:ID="_3d253748-fb0c-4664-800a-a0a1f3980829">
+    <cim:IdentifiedObject.name>BAY_T3_2</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_93778e52-3fd5-456d-8b10-987c3e6bc47e" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_51780311-f1c8-4757-90d3-970f749bad9b">
+    <cim:IdentifiedObject.name>T3_2_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_78c24a17-ce65-aa59-6754-536706ac68dd" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9e981bec-a029-4692-a205-66aec553ed46" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_35ec1a87-3d57-4274-b9c2-ecb120180fab" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_35ec1a87-3d57-4274-b9c2-ecb120180fab">
+    <cim:IdentifiedObject.name>DISCONNECTOR55</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_3d253748-fb0c-4664-800a-a0a1f3980829" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b2a3e748-1772-409d-a61f-1d6da09564c9" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_83489ba7-933a-47c9-bb14-9a9a53ec3000">
+    <cim:IdentifiedObject.name>T3_2_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_17ccac3a-66be-4ac4-98e8-0ead95b0ed11" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_35ec1a87-3d57-4274-b9c2-ecb120180fab" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_17ccac3a-66be-4ac4-98e8-0ead95b0ed11">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE93</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_3d253748-fb0c-4664-800a-a0a1f3980829" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_e6115f33-a5e0-44c3-a300-af9ce4d7614b">
+    <cim:IdentifiedObject.name>T3_2_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_17ccac3a-66be-4ac4-98e8-0ead95b0ed11" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_81ee8901-1cb8-4c51-ae32-d2adc6ad9077" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_81ee8901-1cb8-4c51-ae32-d2adc6ad9077">
+    <cim:IdentifiedObject.name>BREAKER28</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_3d253748-fb0c-4664-800a-a0a1f3980829" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b2a3e748-1772-409d-a61f-1d6da09564c9" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_11e5ac40-a08b-4246-8aa2-a4735171ed44">
+    <cim:IdentifiedObject.name>T3_2_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9e865f24-441f-4e2f-b46d-94e0b37a547d" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_81ee8901-1cb8-4c51-ae32-d2adc6ad9077" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_9e865f24-441f-4e2f-b46d-94e0b37a547d">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE94</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_3d253748-fb0c-4664-800a-a0a1f3980829" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_58a19099-c22b-421c-bf57-9a7098fdcada">
+    <cim:IdentifiedObject.name>T3_2_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_9e865f24-441f-4e2f-b46d-94e0b37a547d" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f48344b0-09df-498d-9517-3c51ca3ce8e6" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_f48344b0-09df-498d-9517-3c51ca3ce8e6">
+    <cim:IdentifiedObject.name>DISCONNECTOR56</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_3d253748-fb0c-4664-800a-a0a1f3980829" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b2a3e748-1772-409d-a61f-1d6da09564c9" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_9bcf9e20-557c-4d96-8226-e4a56014c3ef">
+    <cim:IdentifiedObject.name>T3_2_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0ccf291a-eadf-4010-a26c-f691a135118f" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f48344b0-09df-498d-9517-3c51ca3ce8e6" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_0ccf291a-eadf-4010-a26c-f691a135118f">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE95</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_3d253748-fb0c-4664-800a-a0a1f3980829" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_4f6b14be-0718-4eb5-84f2-4842c939e83e">
+    <cim:IdentifiedObject.name>BAY_68-116_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_5d9d9d87-ce6b-4213-b4ec-d50de9790a59" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_0c19b22d-e00e-4223-b1c0-1ef70038795b">
+    <cim:IdentifiedObject.name>68-116_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_5b9532e2-cd9b-652f-7ad3-42c1c84322fb" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4e34639c-5785-4ef6-811f-b0d237530ffb" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ddb70bc6-7ec9-4042-9816-b7f5a601064e" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_ddb70bc6-7ec9-4042-9816-b7f5a601064e">
+    <cim:IdentifiedObject.name>DISCONNECTOR57</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_4f6b14be-0718-4eb5-84f2-4842c939e83e" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_95c8dbad-f5ce-4e51-834e-8da51351dd49">
+    <cim:IdentifiedObject.name>68-116_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_24fea3e7-7042-48f9-9a60-59d4b4cc3771" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ddb70bc6-7ec9-4042-9816-b7f5a601064e" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_24fea3e7-7042-48f9-9a60-59d4b4cc3771">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE96</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_4f6b14be-0718-4eb5-84f2-4842c939e83e" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_779905a2-f53f-4a01-b39f-70654cd83b37">
+    <cim:IdentifiedObject.name>68-116_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_24fea3e7-7042-48f9-9a60-59d4b4cc3771" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_575ed362-86e6-4753-a05c-e0015504a9d1" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_575ed362-86e6-4753-a05c-e0015504a9d1">
+    <cim:IdentifiedObject.name>BREAKER29</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_4f6b14be-0718-4eb5-84f2-4842c939e83e" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_17b8d4b2-20a5-4486-8590-95b32b6aaa21">
+    <cim:IdentifiedObject.name>68-116_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_28c3b78e-8a19-44ce-9a4e-e932fcf67a51" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_575ed362-86e6-4753-a05c-e0015504a9d1" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_28c3b78e-8a19-44ce-9a4e-e932fcf67a51">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE97</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_4f6b14be-0718-4eb5-84f2-4842c939e83e" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_47c7eebe-1623-42a9-999d-3fc362b6da45">
+    <cim:IdentifiedObject.name>68-116_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_28c3b78e-8a19-44ce-9a4e-e932fcf67a51" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9c0bdbb8-034f-4a0e-838e-5cdde5c91e9b" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_9c0bdbb8-034f-4a0e-838e-5cdde5c91e9b">
+    <cim:IdentifiedObject.name>DISCONNECTOR58</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_4f6b14be-0718-4eb5-84f2-4842c939e83e" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_ed2bd589-b6d9-42bd-82fc-0b895e8707b1" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_4b71493f-425b-4f1d-ab96-f087d6d79d7e">
+    <cim:IdentifiedObject.name>68-116_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_a60c40a3-2ef6-41b7-8ca2-08594f75eb63" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9c0bdbb8-034f-4a0e-838e-5cdde5c91e9b" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_a60c40a3-2ef6-41b7-8ca2-08594f75eb63">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE98</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_4f6b14be-0718-4eb5-84f2-4842c939e83e" />
+  </cim:ConnectivityNode>
+  <cim:Bay rdf:ID="_39f34620-4d8d-4854-a643-a4117fe2665b">
+    <cim:IdentifiedObject.name>BAY_71-73_0</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_a43d15db-44a6-4fda-a525-2402ff43226f" />
+  </cim:Bay>
+  <cim:Terminal rdf:ID="_0f0cd299-c8ad-49b9-9c6f-40b7c90caef9">
+    <cim:IdentifiedObject.name>71-73_0_ADD_DSC11</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:ACDCTerminal.BusNameMarker rdf:resource="#_e118faef-acce-8f60-1e5b-f224e12eccbe" />
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c4cea32b-2ea1-4be3-9040-2a29cf7a48f1" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_20a4b1b1-5307-471e-85cb-f2b1e059dd4c" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_20a4b1b1-5307-471e-85cb-f2b1e059dd4c">
+    <cim:IdentifiedObject.name>DISCONNECTOR59</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_39f34620-4d8d-4854-a643-a4117fe2665b" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_d8ddf8a1-e5e1-471e-b6bc-e54368130390">
+    <cim:IdentifiedObject.name>71-73_0_ADD_DSC12</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_87c33625-a21c-46df-8723-ce0c4e26ca15" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_20a4b1b1-5307-471e-85cb-f2b1e059dd4c" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_87c33625-a21c-46df-8723-ce0c4e26ca15">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE100</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_39f34620-4d8d-4854-a643-a4117fe2665b" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_fc2c3298-0a43-4e6c-adb0-24740392b456">
+    <cim:IdentifiedObject.name>71-73_0_ADDB1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_87c33625-a21c-46df-8723-ce0c4e26ca15" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9bde615c-44c1-4a7f-8801-72545a4e6c59" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_9bde615c-44c1-4a7f-8801-72545a4e6c59">
+    <cim:IdentifiedObject.name>BREAKER30</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_39f34620-4d8d-4854-a643-a4117fe2665b" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_b38253aa-c786-4532-8776-09088beb0a0c">
+    <cim:IdentifiedObject.name>71-73_0_ADDB2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0a5ec602-62ef-48ff-bb40-4bf99dd5e7d0" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_9bde615c-44c1-4a7f-8801-72545a4e6c59" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_0a5ec602-62ef-48ff-bb40-4bf99dd5e7d0">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE101</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_39f34620-4d8d-4854-a643-a4117fe2665b" />
+  </cim:ConnectivityNode>
+  <cim:Terminal rdf:ID="_b542f80e-eefe-4771-8eb2-f63529d26ede">
+    <cim:IdentifiedObject.name>71-73_0_ADD_DSC21</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0a5ec602-62ef-48ff-bb40-4bf99dd5e7d0" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_535445e8-b782-49a6-87e7-55946e1bbba1" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_535445e8-b782-49a6-87e7-55946e1bbba1">
+    <cim:IdentifiedObject.name>DISCONNECTOR60</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_39f34620-4d8d-4854-a643-a4117fe2665b" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7363e0b-e9ed-424e-8984-6e74823307aa" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_ac72ebd7-9315-405f-9c62-cef2078ca70d">
+    <cim:IdentifiedObject.name>71-73_0_ADD_DSC22</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#PhaseCode.ABC" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_8a5d6181-9f2e-4818-b3d6-dcca06db5e5e" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_535445e8-b782-49a6-87e7-55946e1bbba1" />
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_8a5d6181-9f2e-4818-b3d6-dcca06db5e5e">
+    <cim:IdentifiedObject.name>CONNECTIVITY_NODE102</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_39f34620-4d8d-4854-a643-a4117fe2665b" />
+  </cim:ConnectivityNode>
+  <cim:ControlAreaGeneratingUnit rdf:ID="_a661b188-2945-40e1-9880-2014908ea354">
+    <cim:IdentifiedObject.name>GEN_A1</cim:IdentifiedObject.name>
+    <cim:ControlAreaGeneratingUnit.ControlArea rdf:resource="#_1f9ecd81-e069-4040-bd64-f34b0fac3a60" />
+    <cim:ControlAreaGeneratingUnit.GeneratingUnit rdf:resource="#_93346fba-8a54-4969-a063-50e4a037e1f2" />
+  </cim:ControlAreaGeneratingUnit>
+  <cim:ControlArea rdf:ID="_1f9ecd81-e069-4040-bd64-f34b0fac3a60">
+    <cim:IdentifiedObject.name>_CA_A1</cim:IdentifiedObject.name>
+    <cim:ControlArea.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaTypeKind.Interchange" />
+  </cim:ControlArea>
+  <cim:BusNameMarker rdf:ID="_e118faef-acce-8f60-1e5b-f224e12eccbe">
+    <cim:IdentifiedObject.name>5</cim:IdentifiedObject.name>
+    <cim:BusNameMarker.priority>1</cim:BusNameMarker.priority>
+  </cim:BusNameMarker>
+  <cim:BusNameMarker rdf:ID="_cc1c62da-ae58-7198-7eb5-2971feb99ae3">
+    <cim:IdentifiedObject.name>4</cim:IdentifiedObject.name>
+    <cim:BusNameMarker.priority>1</cim:BusNameMarker.priority>
+  </cim:BusNameMarker>
+  <cim:BusNameMarker rdf:ID="_928cbae7-e9d0-b980-8af2-63e9c1aeede3">
+    <cim:IdentifiedObject.name>6</cim:IdentifiedObject.name>
+    <cim:BusNameMarker.priority>1</cim:BusNameMarker.priority>
+  </cim:BusNameMarker>
+  <cim:BusNameMarker rdf:ID="_d9461afa-08ca-19d4-f44b-27073a817ea5">
+    <cim:IdentifiedObject.name>7</cim:IdentifiedObject.name>
+    <cim:BusNameMarker.priority>1</cim:BusNameMarker.priority>
+  </cim:BusNameMarker>
+  <cim:BusNameMarker rdf:ID="_472651ab-53d8-8160-2fb1-156d83d6259a">
+    <cim:IdentifiedObject.name>3</cim:IdentifiedObject.name>
+    <cim:BusNameMarker.priority>1</cim:BusNameMarker.priority>
+  </cim:BusNameMarker>
+  <cim:BusNameMarker rdf:ID="_4ce5f804-c3b0-fa8a-4fa7-71df511c0b08">
+    <cim:IdentifiedObject.name>2</cim:IdentifiedObject.name>
+    <cim:BusNameMarker.priority>1</cim:BusNameMarker.priority>
+  </cim:BusNameMarker>
+  <cim:BusNameMarker rdf:ID="_bbca3066-6714-61e7-688f-876b7fb58093">
+    <cim:IdentifiedObject.name>HG2</cim:IdentifiedObject.name>
+    <cim:BusNameMarker.priority>1</cim:BusNameMarker.priority>
+  </cim:BusNameMarker>
+  <cim:BusNameMarker rdf:ID="_aac4d021-1255-bbdc-c668-59dd6b55f07b">
+    <cim:IdentifiedObject.name>HG1</cim:IdentifiedObject.name>
+    <cim:BusNameMarker.priority>1</cim:BusNameMarker.priority>
+  </cim:BusNameMarker>
+  <cim:BusNameMarker rdf:ID="_42b42397-38f5-05e8-da3a-21314ea193af">
+    <cim:IdentifiedObject.name>H</cim:IdentifiedObject.name>
+    <cim:BusNameMarker.priority>1</cim:BusNameMarker.priority>
+  </cim:BusNameMarker>
+  <cim:BusNameMarker rdf:ID="_5b9532e2-cd9b-652f-7ad3-42c1c84322fb">
+    <cim:IdentifiedObject.name>1</cim:IdentifiedObject.name>
+    <cim:BusNameMarker.priority>1</cim:BusNameMarker.priority>
+  </cim:BusNameMarker>
+  <cim:BusNameMarker rdf:ID="_78c24a17-ce65-aa59-6754-536706ac68dd">
+    <cim:IdentifiedObject.name>8</cim:IdentifiedObject.name>
+    <cim:BusNameMarker.priority>1</cim:BusNameMarker.priority>
+  </cim:BusNameMarker>
+  <cim:Line rdf:ID="_c2091d24-3470-4bde-b020-8618e9e352a6">
+    <cim:IdentifiedObject.name>Container for Line-7</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Line>
+  <cim:Line rdf:ID="_18235722-b718-4b01-bdeb-68ac9b8b9977">
+    <cim:IdentifiedObject.name>Container for Line-4</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Line>
+  <cim:Line rdf:ID="_9d3fb3a7-ab7b-4126-b3b6-9678584e37ab">
+    <cim:IdentifiedObject.name>Container for Line-5</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Line>
+  <cim:Line rdf:ID="_8dec4794-709f-4aa0-9872-5a4f94e9f714">
+    <cim:IdentifiedObject.name>Container for Line-1</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Line>
+  <cim:Line rdf:ID="_1c19c2b3-8095-4f82-b0b1-692868bd15f4">
+    <cim:IdentifiedObject.name>Container for Line-6</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Line>
+  <cim:Line rdf:ID="_f01dd6de-a7a1-4485-94db-7c7a392b946f">
+    <cim:IdentifiedObject.name>Container for Line-2</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Line>
+  <cim:Line rdf:ID="_42cb5e94-d05b-45ae-a620-bc7a7343f5de">
+    <cim:IdentifiedObject.name>Container for Line-3</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_8f28794f-6030-4ec6-b17c-91ecb4321673" />
+  </cim:Line>
+  <cim:RegulatingControl rdf:ID="_10d33824-507a-4999-bd51-f73373e7509a">
+    <cim:IdentifiedObject.name>TwinBrch SM</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_4dec53ca-3ea6-4bd0-a225-b559c8293e91" />
+  </cim:RegulatingControl>
+  <cim:OperationalLimitType rdf:ID="_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12">
+    <cim:IdentifiedObject.name>PATLT</cim:IdentifiedObject.name>
+    <cim:OperationalLimitType.acceptableDuration>4000</cim:OperationalLimitType.acceptableDuration>
+    <entsoe:OperationalLimitType.limitType rdf:resource="http://entsoe.eu/CIM/SchemaExtension/3/1#LimitTypeKind.patlt" />
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#OperationalLimitDirectionKind.absoluteValue" />
+  </cim:OperationalLimitType>
+  <cim:CurrentLimit rdf:ID="_44b184ba-0034-4f10-acd9-5fe976632461">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b3e74f7e-f257-44f1-a558-39d2476dbc54" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_3e684ef9-64c7-407e-8e9a-44720b63efac">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_bb6e6a25-5f04-44ad-a89f-3f3a77285db6" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>1155</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_d6ceab86-06b7-4bb3-91a7-c52e5e3c7557">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cf69da25-f6ac-4176-9089-444a1bb2bc47" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_c73928d1-3ec0-4aa3-ab2b-35df61b2e18b">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_c4e84cc6-5ec5-4633-8837-ce49ccf34393" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_4b476a28-d0f0-4aa0-8aa7-293840fa64ac">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_23e70872-1757-4736-8b48-64926fabf973" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_c5d40744-0e35-4d38-86a9-614261483a99">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e0ad214e-cf92-4212-95dd-7c1895eaa91e" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_b5d817a9-1d98-4609-93fe-74da3d295ccf">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_5ed6f9f8-c080-4eef-a6d0-020ca76af7e9" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>525</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_b5092424-435b-4e9b-9ac2-9a68c710a987">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e5badf8e-cfbd-48f0-b248-adfa0eb9a884" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>158</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_76ca5aef-b793-42e7-9f3b-6f0db50631d9">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_db22b997-1134-4ef1-a4ce-3d599b44de6a" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>1732</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_4e4fd255-4795-4c56-ac86-2e139e02e799">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_82efa96c-b6da-48d1-9a01-964f3da06e49" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>158</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_088eb5f2-e13b-4edf-a30a-ff48b7a8ae41">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4de221e3-af50-46de-b0d2-d096fc6bb7fc" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>1732</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_b2937835-f761-493b-a52c-b0df96831f5f">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_2f6fd787-0059-4264-af1f-10de7bf1d250" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>481</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_3b71d2e4-8be2-4821-9b04-1c3450aea420">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7bee47c1-98f3-4edc-9904-2d701043e59c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>5498</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_c936d958-7948-4d0c-bdf2-0377047aae44">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_69d76b84-9655-451f-9101-54b151eb01d3" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>4123</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_1ea781c3-c283-414b-8f9b-32007d3552a5">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_3a070392-4564-4fc8-8b94-34328a589fab" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>753</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_427b3d77-d05c-4299-9a39-54b0de217dbb">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f1fe0842-8784-4ca4-bbbe-674f96804c1d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>962</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_3d101345-5841-44af-bbab-88ed4f251baf">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_8973d7f9-bacb-4996-bc68-176b405a8d7c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>1683</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_f6223efc-90c1-4d6b-8c83-f10c861d80d3">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_95ffb82a-4e2e-4ca4-baba-6e253a0cdb17" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>505</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_ba76dd94-af4b-4dca-bb06-60fcb8ef56a2">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_938affe6-43f5-4729-a3c7-7543ef4eb20e" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>505</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_d1f82a75-6043-4eff-a40b-f6cfc608f190">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_86b8024b-e6dd-4e33-903f-87bb436f5843" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>1683</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_b49709a1-3039-48d5-9f81-efa5a42ea3da">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_df1c9d1f-8177-4758-ab9f-0dabf6a989b8" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>962</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_e6887eaa-9704-4d02-ac77-1cbbe04cf063">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_897ba3f2-36c2-4c61-b540-e44d027a5bdc" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>1000</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_cd839287-33a5-482c-b848-1e62283f6a1a">
+    <cim:IdentifiedObject.name>Normal</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_57c14dc8-1249-4a1c-8a58-b741b7bd8ae5" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_c3b2d0b0-8b1d-4b36-92c9-165d03bc5e12" />
+    <cim:CurrentLimit.value>1000</cim:CurrentLimit.value>
+  </cim:CurrentLimit>
+</rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MiniGrid/NodeBreaker/BaseCase_Complete_v3_switch_type_preserved/MiniGridTestConfiguration_BC_SSH_v3.0.0.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MiniGrid/NodeBreaker/BaseCase_Complete_v3_switch_type_preserved/MiniGridTestConfiguration_BC_SSH_v3.0.0.xml
@@ -1,0 +1,1077 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:239scbd7-9a39-11e0-aa80-0800200c9a66">
+    <md:Model.scenarioTime>2030-01-02T09:00:00</md:Model.scenarioTime>
+    <md:Model.created>2014-10-22T09:01:25.830</md:Model.created>
+    <md:Model.description>CGMES Conformity Assessment: Mini Grid Base Case Test Configuration. The model is owned by ENTSO-E and is provided by ENTSO-E "as it is". To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.version>4</md:Model.version>
+    <md:Model.profile>http://entsoe.eu/CIM/SteadyStateHypothesis/1/1</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://A1.de/Planning/ENTSOE/2</md:Model.modelingAuthoritySet>
+    <md:Model.Supersedes rdf:resource="urn:uuid:2399cbd7-9a39-11e0-aa80-0800200c9a66_EU" />
+    <md:Model.DependentOn rdf:resource="urn:uuid:239ecbd2-9a39-11e0-aa80-0800200c9a66" />
+  </md:FullModel>
+  <cim:Terminal rdf:about="#_8372a156-7579-4ea5-8793-24caf0d24603">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5042af3b-8c3a-4548-b2fa-a8d655f94402">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5492183a-1e6f-4dee-a506-f389c69f4c83">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3d6a6b41-0ff8-418a-9530-94c6752b2db0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1a6456c6-fb39-42a0-b21d-089093ba7c49">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d7f0a22b-afbc-41d2-b919-8fde5d1c5045">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_933078aa-6687-4922-bb1f-4c1457f7c26f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_863647cc-d576-484a-bde3-e8998f9f021a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_563c5f79-a51d-4ce8-a921-0e86dd984bb5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_706707e5-019e-4549-b981-a857f1dfa611">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0593fd2d-7e55-4a8d-8ddf-4f8a576cf26c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_89df2b1b-9107-45a8-95ae-16afa04d99b3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_616ef15c-065f-4ca2-8367-d1aad079357e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c39420a7-76ad-4bcc-afdf-da398485bf28">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_51ac3672-026d-4257-9c68-7c7f57a9b55e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0fa430b4-d98c-43bd-9652-f61fb00e7340">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7145f995-b4a7-472e-9c58-2f8540ad3925">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_912cc25e-78d9-43a6-a77e-b2b7bb76688b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1158b5f-3b71-4c44-8b15-4150d983f73e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b2112f10-1057-4a28-a18d-a1952c791c4c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7fe566b9-6bac-4cd3-8b52-8f46e9ba237d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_82611054-72b9-4cb0-8621-e418b8962cb1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_eb8ed3e6-c0de-47e2-9dd5-52b321d51b70">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e59d3a8c-8382-413a-95ae-6354dfe85565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5af3b857-165c-4f96-b415-0d6e2e9ca27f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1dfffea9-1fac-48f1-b466-1312643f3a47">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5b02a21-e6f5-441c-81f2-4accb1a56ddd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_01a240e9-5607-4844-9d53-5c8b08b5c9a8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4dec53ca-3ea6-4bd0-a225-b559c8293e91">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3434b50d-677d-4ad5-96d7-6c7d1be611e6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9165ded7-ec43-469a-b006-554d388a63ec">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e3420c0c-d6fc-49ee-9447-74c8e1eba64e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2e6ef544-c98e-44ec-a8de-8c44d2cccc33">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6cd98e8c-ede7-46b1-aa01-7f9f7db26416">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2fa56ee8-8afb-4db2-8fcf-89b9fa135bca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_07865469-d39d-4234-8cee-fa998fa49bed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:ThermalGeneratingUnit rdf:about="#_93346fba-8a54-4969-a063-50e4a037e1f2">
+    <cim:GeneratingUnit.normalPF>1</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_2970a2b7-b840-4e9c-b405-0cb854cd2318">
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-0</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-0</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>1</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:ThermalGeneratingUnit rdf:about="#_a318334b-6a8d-40cd-9ce2-4526873d5504">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_ca67be42-750e-4ebf-bfaa-24d446e59a22">
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-5</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-2</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:ThermalGeneratingUnit rdf:about="#_f1001dea-bb33-4f34-9508-d492af527d35">
+    <cim:GeneratingUnit.normalPF>0</cim:GeneratingUnit.normalPF>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_392ea173-4f8e-48fa-b2a3-5c3721e93196">
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-4</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-3</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+  <cim:AsynchronousMachine rdf:about="#_062ece1f-ade5-4d20-9c3a-fd8f12d12ec1">
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>5</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>3</cim:RotatingMachine.q>
+    <cim:AsynchronousMachine.asynchronousMachineType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#AsynchronousMachineKind.motor" />
+  </cim:AsynchronousMachine>
+  <cim:AsynchronousMachine rdf:about="#_ba62884d-8800-41a8-9c26-698297d7ebaa">
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>2</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>1</cim:RotatingMachine.q>
+    <cim:AsynchronousMachine.asynchronousMachineType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#AsynchronousMachineKind.motor" />
+  </cim:AsynchronousMachine>
+  <cim:AsynchronousMachine rdf:about="#_f184d87b-5565-45ee-89b4-29e8a42d3ad1">
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>2</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>1</cim:RotatingMachine.q>
+    <cim:AsynchronousMachine.asynchronousMachineType rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#AsynchronousMachineKind.motor" />
+  </cim:AsynchronousMachine>
+  <cim:ExternalNetworkInjection rdf:about="#_089c1945-4101-487f-a557-66c013b748f6">
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:ExternalNetworkInjection.referencePriority>0</cim:ExternalNetworkInjection.referencePriority>
+    <cim:ExternalNetworkInjection.p>0</cim:ExternalNetworkInjection.p>
+    <cim:ExternalNetworkInjection.q>0</cim:ExternalNetworkInjection.q>
+  </cim:ExternalNetworkInjection>
+  <cim:ExternalNetworkInjection rdf:about="#_3de9e1ad-4562-44df-b268-70ed0517e9e7">
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:ExternalNetworkInjection.referencePriority>0</cim:ExternalNetworkInjection.referencePriority>
+    <cim:ExternalNetworkInjection.p>0</cim:ExternalNetworkInjection.p>
+    <cim:ExternalNetworkInjection.q>0</cim:ExternalNetworkInjection.q>
+  </cim:ExternalNetworkInjection>
+  <cim:RatioTapChanger rdf:about="#_0522ca48-e644-4d3a-9721-22bb0abd1c8b">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>13</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_8de2d157-15d1-42c7-b376-a8ae5b6c0e77">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>17</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:RatioTapChanger rdf:about="#_4a8a5456-91ac-4bc9-b8e2-64eeeef78a1a">
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+    <cim:TapChanger.step>17</cim:TapChanger.step>
+  </cim:RatioTapChanger>
+  <cim:Terminal rdf:about="#_04684742-c766-11e0-1111-005056c00008">
+    <cim:ACDCTerminal.connected>false</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684742-c766-11e1-1111-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684742-c766-11e2-1111-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684742-c766-11e0-2222-005056c00008">
+    <cim:ACDCTerminal.connected>false</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684742-c766-11e1-2222-005056c00008">
+    <cim:ACDCTerminal.connected>false</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_04684742-c766-11e2-2222-005056c00008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:EquivalentInjection rdf:about="#_cc268d3b-fe87-42ee-b48a-9e9d625a8650">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>0</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_a5a2acc5-c3cd-406c-b061-83a06bcef2f4">
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0</cim:EquivalentInjection.regulationTarget>
+    <cim:EquivalentInjection.p>0</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0</cim:EquivalentInjection.q>
+  </cim:EquivalentInjection>
+  <cim:Terminal rdf:about="#_ba98fd7b-b3e5-4b37-b218-df5f1e08ead5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d058982-f5ff-4bcc-abf4-e0037ff511bf">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_5938ea51-0cfb-4c6c-8d6f-c2bf3254c94a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2a864763-0d92-428b-a813-c665e878dec4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ba0cc755-9201-4d57-8206-3fa57b147583">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <!-- changd from Breaker to ProtectedSwitch -->
+  <cim:ProtectedSwitch rdf:about="#_5e9f0079-647e-46da-b0ee-f5f24e127602">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:ProtectedSwitch>
+  <cim:Terminal rdf:about="#_43f700ce-3882-4906-b41f-b7c4eb2e74e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dbede101-7eec-40b8-9f22-b9cc9109bbd6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_4580fb7b-c31b-4b84-ad1d-1ca4d50f4fc5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_2fadea4c-9336-4247-a3ea-a621c79cb544">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0cc10ecd-426c-4aa9-8a40-541c79204113">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9ce03e95-44ba-487b-9cf3-04d968077ff9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3006c97d-d51e-4e7b-92b1-a9a321f585ce">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_01f33c90-d1ca-448f-9d62-13677c5c7a5f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_56ffd36b-6acc-409b-ba46-7ad7ed7b9702">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_622a9aff-f9d4-49c7-8f29-fd88009c5df0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_19a1b3be-397a-4c6f-ad6e-57b6db72e65b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f11bc44-be19-4a25-8ac0-c0d7fc4816f3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f5335138-f3b9-400b-abf1-e9b559c887b2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_21b69381-c805-4fc1-968a-7969c3bc451a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_138c9c5b-9472-4831-ad22-f1b7b319b0a3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1b32b063-7f09-4eb5-8071-58501c5d296c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_7d655d91-394a-4f47-8f83-7f1de3baa056">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a02cfa66-d32c-45f7-9a4d-ae1e02efcb6a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1750b98e-7a97-4951-bfc0-f090eafd1b79">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_4c49cfd1-4758-476e-95ce-5cd2c56e3165">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_c1b14884-b320-4989-b362-de40b5245072">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3a845e4b-a2d0-45ab-a557-428ffdaee5ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_dcba20ce-b619-471a-8ab0-2371d4d090b0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_449bd7ff-89c2-42bf-8f2f-374766f5998d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_368c0e1a-6dff-4929-81db-19d77f04b242">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f161d809-ed9e-40ad-bc58-e8a746f8afcb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_3a783d1d-1113-414d-ab67-34b139781196">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b58d9a22-7735-418e-b046-8b72c2f65ae9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2bff438e-6dfd-4ff6-91fc-d94f5cb5441f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fbdcf00d-8a07-4c62-9e39-86f459bea2be">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_6d733695-7db0-46fb-b940-e220b2272f57">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_dd7aaa6c-3b38-4ad7-b7e0-61f0fe0c2ce9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_83317cbd-8326-44b8-a9fb-f69b6ba5a1cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_734b0038-78d2-4373-82d6-e7ee819fcaf5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f2255df3-1730-467c-b42b-77e6e8c919bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_fe1384c9-f1c1-4026-9f5d-10a3b22208b9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_52cb56c2-0251-431b-b2ab-70de47ceace1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_840b6263-d00b-49c4-8b65-84f4c0ae2a0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2ed632f6-36a3-4937-8d5d-ad105c57c071">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b3c8d494-0a24-49fe-94fe-adcb64af5f2c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ab273d2b-0715-4fbe-91fb-f1113e15759f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_154f3756-4e07-4f06-9147-ed83de84e265">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_284c13ce-0b59-4e75-868a-9db150506504">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6ea87619-9cd4-4d25-8876-e39ffb092138">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1d68fb97-30d7-4c37-8d2e-31324a274ffb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_15d6eb77-36d6-48d0-a227-25d29e839517">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fb40e0a-bb4a-4967-8ba3-3e94b8153554">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca0088fa-c27d-466a-ab97-e2f0029baed7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a9b68255-188c-408d-8362-5f3b0a1e730f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_bb2136b7-d699-4b34-9b30-d9047d534974">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_239cc8c7-6c51-4c18-b9ac-b0c88ad3b38c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_84970563-073f-4316-a175-060b544640e0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8793d235-8e5d-4706-81ed-b569289f5565">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9bab684d-c68a-4d54-8884-5b36faf7fcbe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac3f7dcd-3ed3-423b-baa8-bdaccbc93834">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ea5a6982-018c-4ce6-85f6-78b5ab5dbfc1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_07a28042-960a-4fe9-9d8e-9abcd70078c5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c086e4b7-3b1b-4a1f-9c89-58ccd10f4491">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_62156fd8-595d-4ab0-af53-0de3b8056a6e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_7cfa863e-28f0-4f89-9d1e-1460f0856d80">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fee53b4a-5459-4c52-9a84-c4c8c5af6c44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f88b1d2b-2f06-44ff-bfe5-8f1156e13092">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bf748e1d-94a2-40e1-a1bf-a3a8d88abcd8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7cf9455b-5c62-4a22-bbde-fe8c6d7275e0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_faf75564-a154-4528-9428-913e6501a21f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_c124c099-9921-4276-b070-3961632dca63">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6346b12f-326a-4648-bf6e-7bac1bcc49ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_285ccb1e-a867-4efc-880e-e871c1929376">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_824db363-9d54-481d-9012-4cb5ae3f0a25">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_297eac16-1730-41af-911d-ba0c6d64b9bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_22e27c40-eb38-4f04-aebd-7ef543798211">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_12373941-f783-4b0a-a24d-904c0b7a4d2e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6038e540-8447-4790-b307-742767d48f15">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9313f8a4-159d-48c8-92f1-36b1d16ee7c9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9dca17f5-274f-4716-b0a9-0d0eef5fa400">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac5bfe2f-7f34-46ec-9c20-93a034af23d4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_8e57f735-6869-463e-959e-b517b15a5ec5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_eed80693-c239-446f-b83e-a566c96f4b12">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3df2cd7a-edb6-4fab-ac4c-5619d7d6c30a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_869b6ad5-3975-49ae-81fe-01547a229a25">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_6c1b3247-5c23-4080-854d-96af3af219c7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ea74068d-472d-458c-9abc-cdd5437616c9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8fa214d6-5b7f-4d04-8de7-e5609d9f9deb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5d820300-529c-4622-ab38-cc4374bd081c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c355eec-daf6-4639-8af6-1c397eb1c061">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_eb33e134-698f-4258-8361-4b5fa4c2f9de">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_f48c1439-dd5c-4045-ad78-760321438b23">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2731a0ed-82af-4e6a-bf8f-65bfb89a2d99">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9e8afc23-52fc-40e6-ab85-3d0328a228f2">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_5c7f2182-6d27-491a-b1e8-5e48c2bced16">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a9aff7a4-f0a1-4745-8e16-9c80aecc38be">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_90e1b509-e6d1-4a3b-8dcc-587f8b362bd3">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8e922bca-b992-472f-9cce-322c669d50d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d2a672b4-28a4-47fa-9102-c1100bc4dc49">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_788bb5ff-f36e-406b-b6a6-ea1b7268ba03">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_cb8687b7-c25e-427f-841f-7d1380a2e274">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d72b6257-6b28-47d2-ba37-61630d9d9647">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ef2f27d9-acde-4aad-a920-d61c98682f4d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a9d77a71-a9b4-44cb-9c4f-e52492b37980">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e7daaf22-0533-4753-a9ef-7f11979a0d59">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b68ac335-9806-4609-812c-1f47f8738bde">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0e0a7e38-7c23-436c-973f-76d23ab89027">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0787d496-6606-4dc2-a363-3a7b4ab437fc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a5a962a6-2f47-4ef1-960f-e29131bcba36">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_baa12311-4df0-4662-964a-701b03f31b73">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_60de37d6-c659-40e1-bf7b-2ab7d59b5d0f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b0677acc-df2e-4730-9516-fab2403103d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_952e500f-4609-412d-a368-5a4d74ec78d9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_654343eb-a916-4b23-8f63-2dbb93f8c60b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b81c76fd-24fb-4888-a52e-5a9d0177df1d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_0fd8256c-1eb8-4ff8-88c6-5b14842e3c00">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_37fb1b60-4171-4977-a82f-ce6c160b52b2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_f58f46ea-b73b-421e-9fea-a86126a95b10">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_77e5f07e-b2a4-44f1-a321-68726d99ee04">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7b7d05e5-8d78-46e2-8065-958e57258ceb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_06917aa0-6cc2-4d46-b37b-6ed9fec32ccd">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ea3b457b-9508-4f84-8715-b7df2019068b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ac754d2e-5ed9-4466-a351-aa861198e255">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c6727598-4dae-4226-a542-166766d2f702">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1621a8f0-f63d-4869-b42a-db0d9364db22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e562be25-b44e-4f1f-834e-ec46dbfb689e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c217742e-f713-44b7-a0b2-7c78aebc165d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_e87a69d3-296b-4497-8dc5-5ae782fdb184">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a01745f7-1965-4c49-b53d-0f3180aa9e17">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6f28743a-c690-4569-b229-977566414a16">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_37ed18b5-9040-4b03-9622-9c5481e36d05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2ca5c7d4-9b73-44fd-b9f1-e8353ed93d9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_79341979-e66c-4b08-8053-6d97216e0777">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_25af8438-9b28-446c-bb2c-e9d64aae2111">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_563df48e-ea91-4aa6-9e7d-0beb477b4df8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_a772f653-51f9-498c-afc9-c37b2a49cf32">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_85d4137e-4559-4915-985c-0571e218e19c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fda2c67c-d8c4-475b-a791-4ab5f6422da1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_74534b01-b13b-49a2-b0d7-d0feb1348ef5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fdec908f-fe51-492d-a385-4db764d5f58b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c239382f-9dd0-4d7c-ba5c-a4064dd94fca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c7f7f032-1e4d-494a-9352-bad1a3056e3f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e29ee98e-b807-415d-be0c-9126a3e39b92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_890ab3df-c021-4f4d-9333-22b01240c9e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_c1e02075-4fdf-41e1-b5e4-925bb2396011">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_01df618d-a8cd-493e-ad4a-793ae42c427f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c4a0c1fc-1d63-4dd9-846b-090626d8584f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2ec6cb16-7516-46f9-8cd8-2a52eea85bb5">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_e7128a94-8515-4934-949e-8e86ff612c74">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fe962374-f78f-4ed9-becd-f320150fc65f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c803aa12-a8c7-4491-8163-1a1c6ea60db8">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8f4a8d13-3695-4115-b765-c93eafb155ee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c535ea3-28f2-4029-bc08-60282cec3213">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_6557ecb5-b9a7-4089-aa70-58d4d11f503b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_02820aae-8266-4c45-96de-5640eff65320">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_58bca65d-d7b1-4c05-b433-f39e10a916b6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ac85d2fb-2417-4a86-9c63-d389e6ffae47">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_55ee67e4-02df-4acd-8117-c43987a52ff0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e4b01a0e-fd58-41d0-ae5a-583ecadf6b43">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2c03a3cf-4890-4092-9fe3-c6d139677882">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_faf9bfb2-81b7-4dc5-a9b5-3d7cc05c6aeb">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ee0315f9-835c-4b1f-91e6-df688fa5cea0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d0119330-220f-4ed3-ad3c-f893ad0534fb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fe141bda-142c-4438-83d0-dae0d0ae199a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c394efef-2d00-4236-becd-b9a99545e7b9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_64b4c3d3-0116-4477-af5f-76fe482a4347">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_a48cca94-4d2d-4e8e-97e7-52f5635b5a3e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5f5082df-e28b-4a83-85f4-37b18687ba6b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9dc3bedf-0d30-4a56-ba5c-f2e69d7997ee">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac39e330-965f-4a05-bd93-2e338aa1e7ce">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_16918aef-e2ae-421f-bfa4-7d3c1e749bb7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d6665f59-851b-4183-81b0-59c53e1baa6a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_9c86faec-f24c-4cbf-a1e6-9c9e1288de24">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e661d283-0a97-43df-825f-6ed99a267448">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b8924fbf-6513-4385-b032-21045c0a5b8f">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_b1597fc9-786b-4142-a321-2f80bdc61ced">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c347ba7b-5eca-4de0-8487-3489436ec008">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_adcc04eb-c3c4-47c2-9004-09b2a43b1dee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cd8813aa-3213-4d9a-994d-4a4513e458b4">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_f4f76784-0aaa-48ba-98b7-d8f363e4b833">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ff096281-10e6-44c9-af78-8e2829cff084">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_1287758d-606d-44c9-9e93-2f465ebf54b7">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_33b68bdf-f081-4428-972f-7f5f0dd33b8c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4915762d-133e-4209-8545-2822d095d7cd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_8e56ead3-f4d3-4cd9-a34f-c7340ff7384d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_eb6825bf-0004-4845-88f2-6e4ba54eab89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_7a6a78cb-5c02-4706-a5ba-020d7d5369d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_171b75ea-d84d-4884-9780-5212780d4154">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_b7e79b65-8d3e-4ee9-bf05-12bf2250b12d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3fc6a85d-1528-46f2-a3a0-502a1adc2da6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_08514e88-e6b6-4a2f-ad85-1021568dcece">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_052682ba-a4e5-41d5-9728-0fa4e2e01011">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_23ab327a-2d61-4fee-ac8d-ab1f570f9c77">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_11f4f138-5e43-4a82-88bf-7c57d50813dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2af10fbd-4763-4940-b11d-00dcd7627016">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_64050cf7-60b8-4d43-a471-55e2386fcdbd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c833199a-0d18-415d-afa2-86e007434894">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_27cb23c0-ad7b-4019-8cdf-205e240f742a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_7ad619e2-6d13-44cc-9ebe-cb674fb137ae">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_23c7d2cf-57aa-46d3-bfe6-571211b901ca">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_fdf5cfbe-9bf5-406a-8d04-fafe47afe31d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_224f7bbc-4253-4642-a886-eb9b45154612">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_10af2a5e-765c-4e4c-8c7c-f1e589be90de">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_2791a96c-c66c-44e7-a5dc-8331a8996c76">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_daa62f13-06fb-470d-a027-8f09ecfc85d6">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c83f924b-18d1-4cb9-a91d-616e8b347ac2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1425f9f4-9037-4086-9c0f-9b1f007eca48">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c8b06b9b-8876-4fb5-9279-5a396e3db63d">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_bbf95af6-337a-4307-b305-6733a9fd28f8">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9f666788-e66c-4cfc-827f-de5ccba9fd2d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_47143596-5947-430d-b14b-e00ac796985a">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_40a6d6e8-9175-445c-977c-b0daab3c7f0d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_6a16e43b-81d7-4acc-ba40-cb0e4f099d8a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cf48defa-93b9-4723-8e41-8dab315ceee0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_187a1ad0-2749-4bd6-8664-a6258e7decc1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cb18d1c1-2835-4d6f-b98b-3ca2f28c2fa2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_cb5d0327-ad13-4b40-a74c-3d9888823205">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_72e34044-2af0-4b04-9ee9-e69aaadc0807">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e2854830-a0c3-46ef-92a7-70e7fd1c783b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_d08c1582-0b3e-46ec-9e97-d70c423eefe1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ded03fef-e28a-43f4-8e06-7330708e0f81">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cd41ef76-36d6-44e0-80c5-d8b8c77eea5a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ba645318-e12c-4f6a-b5e9-5dfe595ae477">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_fb51a5d5-4917-492c-9d66-24aeb6f38b41">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5abad0fd-8229-4c16-867c-7cc6b31a91d1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9fff761f-9fa8-40ed-a802-48bbd0632769">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_aecb59fa-9af0-4d30-a865-009c2b35f9cb">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_1dd51f56-f284-42e8-a7d4-3084da9312bc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_55f3f6b2-fcef-4cca-9ccb-e729b36231e7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_2b97cb41-b132-4359-ba18-6520d52acd72">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_ee65527d-b472-4dca-82b2-46fda4781ca4">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_81449772-3530-4973-be76-dc0cc7590229">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_0bc3b6a5-091e-4b8f-b9d9-a34d327473d0">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_04596a73-8298-499d-81d5-2bd97b90bc94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beb46906-7d88-4689-9a95-65d87344cfe0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_e1e0da2d-79f4-4ca9-8ca2-62532a91edef">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_8bdafc99-ed74-4569-a175-3b69eb0f592c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d8b520f2-938b-4cad-ab26-a339b1908f64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_3eae0be8-9a2f-4355-89d6-865b340c2ec9">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_fecfd76e-409a-42f1-bc4a-eb538bf07b8f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2f6359c5-2e17-40e4-9daf-3a8c0e51a680">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_c5bac804-64da-4b3a-8bdc-4c199a9d39ac">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3d4a821e-3c82-4501-a982-a40a58b99d7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_917c8eea-f432-4a03-b9b6-03479fd7bc6f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_6b7dc761-737d-4452-9d3f-de9e14a7c801">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_39242d8e-e722-413a-814b-0aabad87cf6e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_9c54c0f9-ffa9-41e1-8d96-e9ccec4ca73e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_0f02c390-e5bc-4e8f-9936-2d269b8847ad">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_4eaf0e87-ff3b-490f-a9d9-f4b176526d64">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc90d1be-938f-4d95-8416-e1516f9bcccc">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_315a9d60-b7ef-4652-bc3b-2b8c5d334dcf">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_3ee6718d-4e99-4c27-aa05-b9f4c08df9ed">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5cc19236-ff11-44e9-a321-dc932b96ec2f">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_51780311-f1c8-4757-90d3-970f749bad9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_35ec1a87-3d57-4274-b9c2-ecb120180fab">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_83489ba7-933a-47c9-bb14-9a9a53ec3000">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_e6115f33-a5e0-44c3-a300-af9ce4d7614b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_81ee8901-1cb8-4c51-ae32-d2adc6ad9077">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_11e5ac40-a08b-4246-8aa2-a4735171ed44">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_58a19099-c22b-421c-bf57-9a7098fdcada">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_f48344b0-09df-498d-9517-3c51ca3ce8e6">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_9bcf9e20-557c-4d96-8226-e4a56014c3ef">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0c19b22d-e00e-4223-b1c0-1ef70038795b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_ddb70bc6-7ec9-4042-9816-b7f5a601064e">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_95c8dbad-f5ce-4e51-834e-8da51351dd49">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_779905a2-f53f-4a01-b39f-70654cd83b37">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_575ed362-86e6-4753-a05c-e0015504a9d1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_17b8d4b2-20a5-4486-8590-95b32b6aaa21">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_47c7eebe-1623-42a9-999d-3fc362b6da45">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_9c0bdbb8-034f-4a0e-838e-5cdde5c91e9b">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_4b71493f-425b-4f1d-ab96-f087d6d79d7e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_0f0cd299-c8ad-49b9-9c6f-40b7c90caef9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_20a4b1b1-5307-471e-85cb-f2b1e059dd4c">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_d8ddf8a1-e5e1-471e-b6bc-e54368130390">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fc2c3298-0a43-4e6c-adb0-24740392b456">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_9bde615c-44c1-4a7f-8801-72545a4e6c59">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Terminal rdf:about="#_b38253aa-c786-4532-8776-09088beb0a0c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b542f80e-eefe-4771-8eb2-f63529d26ede">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Disconnector rdf:about="#_535445e8-b782-49a6-87e7-55946e1bbba1">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Terminal rdf:about="#_ac72ebd7-9315-405f-9c62-cef2078ca70d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:ControlArea rdf:about="#_1f9ecd81-e069-4040-bd64-f34b0fac3a60">
+    <cim:ControlArea.netInterchange>0</cim:ControlArea.netInterchange>
+  </cim:ControlArea>
+  <cim:RegulatingControl rdf:about="#_10d33824-507a-4999-bd51-f73373e7509a">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetDeadband>0</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValue>10.0</cim:RegulatingControl.targetValue>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k" />
+  </cim:RegulatingControl>
+</rdf:RDF>

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
@@ -7,6 +7,7 @@
 
 package com.powsybl.cgmes.conversion.elements;
 
+import com.powsybl.cgmes.conversion.Conversion;
 import com.powsybl.iidm.network.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,11 +79,16 @@ public class SwitchConversion extends AbstractConductingEquipmentConversion impl
             boolean retained = p.asBoolean("retained", false);
             adder.setRetained(retained);
             s = adder.add();
+            if (!kindHasDirectMapToIiidm()) {
+                addTypeAsProperty(s);
+            }
         } else {
             VoltageLevel.BusBreakerView.SwitchAdder adder = voltageLevel().getBusBreakerView().newSwitch();
             identify(adder);
             connect(adder, open);
             s = adder.add();
+            // Always preserve the original type, because all switches at bus/breaker view will be of kind "breaker"
+            addTypeAsProperty(s);
         }
         addAliasesAndProperties(s);
         return s;
@@ -107,6 +113,15 @@ public class SwitchConversion extends AbstractConductingEquipmentConversion impl
             return SwitchKind.LOAD_BREAK_SWITCH;
         }
         return SwitchKind.BREAKER;
+    }
+
+    private boolean kindHasDirectMapToIiidm() {
+        String type = p.getLocal("type").toLowerCase();
+        return type.contains("breaker") || type.contains("disconnector") || type.contains("loadbreak");
+    }
+
+    private void addTypeAsProperty(Switch s) {
+        s.setProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "switchType", p.getLocal("type"));
     }
 
     private void warnDanglingLineCreated() {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
@@ -468,7 +468,14 @@ public class CgmesExportContext {
         if (c instanceof DanglingLine) {
             String terminalId = c.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TERMINAL1).orElse(null);
             if (terminalId == null) {
-                terminalId = CgmesExportUtil.getUniqueId();
+                // Legacy: in previous versions, dangling line terminals were recorded in a different alias
+                // read it, remove it and store in the standard alias for equipment terminal (Terminal1)
+                terminalId = c.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TERMINAL).orElse(null);
+                if (terminalId != null) {
+                    c.removeAlias(terminalId);
+                } else {
+                    terminalId = CgmesExportUtil.getUniqueId();
+                }
                 c.addAlias(terminalId, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TERMINAL1);
             }
             String boundaryId = c.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + TERMINAL_BOUNDARY).orElse(null);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -213,6 +213,20 @@ public final class CgmesExportUtil {
         return CgmesNames.ENERGY_CONSUMER;
     }
 
+    public static String switchClassname(SwitchKind kind) {
+        switch (kind) {
+            case BREAKER:
+                return "Breaker";
+            case DISCONNECTOR:
+                return "Disconnector";
+            case LOAD_BREAK_SWITCH:
+                return "LoadBreakSwitch";
+        }
+        LOG.warn("It is not possible to determine the type of switch from kind {}", kind);
+        return "Switch";
+    }
+
+
     /**
      * @deprecated Use {@link #getTerminalSequenceNumber(Terminal)} instead
      */

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -180,7 +180,8 @@ public final class EquipmentExport {
         for (Switch sw : network.getSwitches()) {
             if (context.isExportedEquipment(sw)) {
                 VoltageLevel vl = sw.getVoltageLevel();
-                SwitchEq.write(context.getNamingStrategy().getCgmesId(sw), sw.getNameOrId(), sw.getKind(), context.getNamingStrategy().getCgmesId(vl), sw.isOpen(), sw.isRetained(), cimNamespace, writer, context);
+                String switchType = sw.getProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "switchType"); // may be null
+                SwitchEq.write(context.getNamingStrategy().getCgmesId(sw), sw.getNameOrId(), switchType, sw.getKind(), context.getNamingStrategy().getCgmesId(vl), sw.isOpen(), sw.isRetained(), cimNamespace, writer, context);
             }
         }
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
@@ -295,8 +295,7 @@ public final class StateVariablesExport {
             String cgmesTerminalId = context.getNamingStrategy().getCgmesIdFromAlias(c, aliasTypeForTerminalId);
             writePowerFlow(cgmesTerminalId, p, q, cimNamespace, writer, context);
         } else {
-            // TODO(LUMA) Review for IOP, EMF. We previously returned silently if no terminal was found
-            throw new PowsyblException("Exporting CGMES SvPowerFlow. Missing alias for " + c.getType() + " " + c.getId() + ": " + aliasTypeForTerminalId);
+            LOG.error("Exporting CGMES SvPowerFlow. Missing alias for {} {}: {}", c.getType(), c.getId(), aliasTypeForTerminalId);
         }
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
@@ -499,26 +499,15 @@ public final class SteadyStateHypothesisExport {
 
     private static void writeSwitch(Switch sw, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) {
         try {
-            CgmesExportUtil.writeStartAbout(switchClassname(sw.getKind()), context.getNamingStrategy().getCgmesId(sw), cimNamespace, writer, context);
+            String switchType = sw.getProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "switchType");
+            String className = switchType != null ? switchType : CgmesExportUtil.switchClassname(sw.getKind());
+            CgmesExportUtil.writeStartAbout(className, context.getNamingStrategy().getCgmesId(sw), cimNamespace, writer, context);
             writer.writeStartElement(cimNamespace, "Switch.open");
             writer.writeCharacters(Boolean.toString(sw.isOpen()));
             writer.writeEndElement();
             writer.writeEndElement();
         } catch (XMLStreamException e) {
             throw new UncheckedXmlStreamException(e);
-        }
-    }
-
-    private static String switchClassname(SwitchKind kind) {
-        switch (kind) {
-            case BREAKER:
-                return "Breaker";
-            case DISCONNECTOR:
-                return "Disconnector";
-            case LOAD_BREAK_SWITCH:
-                return "LoadBreakSwitch";
-            default:
-                throw new IllegalStateException("Unexpected switch king " + kind);
         }
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/elements/SwitchEq.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/elements/SwitchEq.java
@@ -18,8 +18,9 @@ import javax.xml.stream.XMLStreamWriter;
  */
 public final class SwitchEq {
 
-    public static void write(String id, String switchName, SwitchKind switchKind, String equipmentContainer, boolean open, boolean retained, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
-        CgmesExportUtil.writeStartIdName(switchClassname(switchKind), id, switchName, cimNamespace, writer, context);
+    public static void write(String id, String switchName, String switchType, SwitchKind switchKind, String equipmentContainer, boolean open, boolean retained, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
+        String className = switchType != null ? switchType : CgmesExportUtil.switchClassname(switchKind);
+        CgmesExportUtil.writeStartIdName(className, id, switchName, cimNamespace, writer, context);
         CgmesExportUtil.writeReference("Equipment.EquipmentContainer", equipmentContainer, cimNamespace, writer, context);
         writer.writeStartElement(cimNamespace, "Switch.normalOpen");
         writer.writeCharacters(CgmesExportUtil.format(open));
@@ -28,18 +29,6 @@ public final class SwitchEq {
         writer.writeCharacters(CgmesExportUtil.format(retained));
         writer.writeEndElement();
         writer.writeEndElement();
-    }
-
-    private static String switchClassname(SwitchKind switchKind) {
-        switch (switchKind) {
-            case BREAKER:
-                return "Breaker";
-            case DISCONNECTOR:
-                return "Disconnector";
-            case LOAD_BREAK_SWITCH:
-                return "LoadBreakSwitch";
-        }
-        return "Switch";
     }
 
     private SwitchEq() {

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/issues/SwitchExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/issues/SwitchExportTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.test.export.issues;
+
+import com.powsybl.cgmes.conformity.CgmesConformity1ModifiedCatalog;
+import com.powsybl.cgmes.model.CgmesNamespace;
+import com.powsybl.commons.test.AbstractConverterTest;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.SwitchKind;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.stream.*;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
+class SwitchExportTest extends AbstractConverterTest {
+
+    @Test
+    void testSwitchTypePreservedBusBranch() {
+        // Load a bus/branch network containing a generic "Switch", not a breaker
+        Network network = Network.read(CgmesConformity1ModifiedCatalog.microGridBaseCaseNLSwitchTypePreserved().dataSource());
+        String basename = "micro-nl";
+        network.write("CGMES", null, tmpDir.resolve(basename));
+
+        // In IIDM the switch has been created of kind "Breaker"
+        String switchId = "5f5d40ae-d52d-4631-9285-b3ceefff784c";
+        assertEquals(SwitchKind.BREAKER, network.getSwitch(switchId).getKind());
+
+        // Check that the "Switch" type has been preserved in EQ and SSH when we export
+        String switchIdEq = readId("Switch", "ID", tmpDir.resolve(basename + "_EQ.xml"));
+        String switchIdSsh = readId("Switch", "about", tmpDir.resolve(basename + "_SSH.xml"));
+        assertEquals("_" + switchId, switchIdEq);
+        assertEquals("#_" + switchId, switchIdSsh);
+    }
+
+    @Test
+    void testSwitchTypePreservedNodeBreaker() {
+        // Load a node/branch network containing a "ProtectedSwitch"
+        Network network = Network.read(CgmesConformity1ModifiedCatalog.miniGridNodeBreakerSwitchTypePreserved().dataSource());
+        String basename = "mini";
+        network.write("CGMES", null, tmpDir.resolve(basename));
+
+        // In IIDM the switch has been created of kind "Breaker", the default when the type read is not supported
+        String switchId = "5e9f0079-647e-46da-b0ee-f5f24e127602";
+        assertEquals(SwitchKind.BREAKER, network.getSwitch(switchId).getKind());
+
+        // Check that the "ProtectedSwitch" type has been preserved in EQ and SSH when we export
+        String switchIdEq = readId("ProtectedSwitch", "ID", tmpDir.resolve(basename + "_EQ.xml"));
+        String switchIdSsh = readId("ProtectedSwitch", "about", tmpDir.resolve(basename + "_SSH.xml"));
+        assertEquals("_" + switchId, switchIdEq);
+        assertEquals("#_" + switchId, switchIdSsh);
+    }
+
+    private static String readId(String elementName, String rdfIdAttrName, Path ssh) {
+        String id;
+        try (InputStream is = Files.newInputStream(ssh)) {
+            XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(is);
+            while (reader.hasNext()) {
+                int next = reader.next();
+                if (next == XMLStreamConstants.START_ELEMENT) {
+                    if (reader.getLocalName().equals(elementName)) {
+                        id = reader.getAttributeValue(CgmesNamespace.RDF_NAMESPACE, rdfIdAttrName);
+                        reader.close();
+                        return id;
+                    }
+                }
+            }
+            reader.close();
+        } catch (XMLStreamException | IOException e) {
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+}

--- a/cgmes/cgmes-model/src/main/resources/CIM14.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM14.sparql
@@ -157,6 +157,7 @@ WHERE {
         a cim:Switch ;
         cim:IdentifiedObject.name ?name ;
         cim:Equipment.MemberOf_EquipmentContainer ?EquipmentContainer .
+    BIND ( "Switch" AS ?type )
     ?Terminal1
         a cim:Terminal ;
         cim:Terminal.ConductingEquipment ?Switch .


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Switch types with no direct mapping to IIDM kinds are exported back using the generic `Switch` class.

XIIDM files saved with previous versions used the alias type "Terminal" for recording the dangling line network terminal (paired dangling lines were not saved, only their tie lines). Now all dangling lines are saved in the XIIIDM file, with the tie lines referring to them. To have uniform treatment of aliases all equipment, including dangling lines, save their first terminal in the alias "Terminal1". The terminal reference read from old XIIDM files was lost. 

**What is the new behavior (if this is a feature change)?**
Original type (class name) is kept as a property and used in export of EQ and SSH files.

Dangling lines network terminal from old XIIDM files is read from alias "Terminal" if not found under alias "Terminal1" and aliases are updated ("Terminal" removed, "Terminal1" saved).

**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
