### PR TITLE
Proposal for handling UpDown scalable get steady state power instead of throwing exception

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/DanglingLineScalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/DanglingLineScalable.java
@@ -166,7 +166,7 @@ public class DanglingLineScalable extends AbstractInjectionScalable {
     }
 
     @Override
-    public double getSteadyStatePower(Network network, ScalingConvention scalingConvention) {
+    public double getSteadyStatePower(Network network, double asked, ScalingConvention scalingConvention) {
         DanglingLine line = network.getDanglingLine(id);
         if (line == null) {
             LOGGER.warn("DanglingLine {} not found", id);

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/GeneratorScalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/GeneratorScalable.java
@@ -186,7 +186,7 @@ class GeneratorScalable extends AbstractInjectionScalable {
     }
 
     @Override
-    public double getSteadyStatePower(Network network, ScalingConvention scalingConvention) {
+    public double getSteadyStatePower(Network network, double asked, ScalingConvention scalingConvention) {
         Generator generator = network.getGenerator(id);
         if (generator == null) {
             LOGGER.warn("Generator {} not found", id);

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/LoadScalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/LoadScalable.java
@@ -160,7 +160,7 @@ class LoadScalable extends AbstractInjectionScalable {
     }
 
     @Override
-    public double getSteadyStatePower(Network network, ScalingConvention scalingConvention) {
+    public double getSteadyStatePower(Network network, double asked, ScalingConvention scalingConvention) {
         Load load = network.getLoad(id);
         if (load == null) {
             LOGGER.warn("Load {} not found", id);

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/ProportionalScalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/ProportionalScalable.java
@@ -258,7 +258,7 @@ public class ProportionalScalable extends AbstractCompoundScalable {
         Objects.requireNonNull(parameters);
 
         // Compute the current power value
-        double currentGlobalPower = getSteadyStatePower(n, parameters.getScalingConvention());
+        double currentGlobalPower = getSteadyStatePower(n, asked, parameters.getScalingConvention());
 
         // Variation asked
         double variationAsked = Scalable.getVariationAsked(parameters, asked, currentGlobalPower);
@@ -308,8 +308,8 @@ public class ProportionalScalable extends AbstractCompoundScalable {
     }
 
     @Override
-    public double getSteadyStatePower(Network network, ScalingConvention scalingConvention) {
-        return scalablePercentageList.stream().mapToDouble(scalablePercentage -> scalablePercentage.getScalable().getSteadyStatePower(network, scalingConvention)).sum();
+    public double getSteadyStatePower(Network network, double asked, ScalingConvention scalingConvention) {
+        return scalablePercentageList.stream().mapToDouble(scalablePercentage -> scalablePercentage.getScalable().getSteadyStatePower(network, asked, scalingConvention)).sum();
     }
 
 }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/Scalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/Scalable.java
@@ -262,5 +262,5 @@ public interface Scalable {
      * @param network Network in which the injections are defined
      * @return the current power value
      */
-    double getSteadyStatePower(Network network, ScalingConvention scalingConvention);
+    double getSteadyStatePower(Network network, double asked, ScalingConvention scalingConvention);
 }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/ScalableAdapter.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/ScalableAdapter.java
@@ -91,7 +91,7 @@ class ScalableAdapter extends AbstractScalable {
     }
 
     @Override
-    public double getSteadyStatePower(Network network, ScalingConvention scalingConvention) {
-        return getScalable(network).getSteadyStatePower(network, scalingConvention);
+    public double getSteadyStatePower(Network network, double asked, ScalingConvention scalingConvention) {
+        return getScalable(network).getSteadyStatePower(network, asked, scalingConvention);
     }
 }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/StackScalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/StackScalable.java
@@ -39,7 +39,7 @@ class StackScalable extends AbstractCompoundScalable {
         Objects.requireNonNull(n);
 
         // Compute the current power value
-        double currentGlobalPower = getSteadyStatePower(n, parameters.getScalingConvention());
+        double currentGlobalPower = getSteadyStatePower(n, asked, parameters.getScalingConvention());
 
         // Variation asked
         double variationAsked = Scalable.getVariationAsked(parameters, asked, currentGlobalPower);
@@ -57,7 +57,7 @@ class StackScalable extends AbstractCompoundScalable {
     }
 
     @Override
-    public double getSteadyStatePower(Network network, ScalingConvention scalingConvention) {
-        return scalables.stream().mapToDouble(scalable -> scalable.getSteadyStatePower(network, scalingConvention)).sum();
+    public double getSteadyStatePower(Network network, double asked, ScalingConvention scalingConvention) {
+        return scalables.stream().mapToDouble(scalable -> scalable.getSteadyStatePower(network, asked, scalingConvention)).sum();
     }
 }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/UpDownScalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/UpDownScalable.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm.modification.scalable;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Injection;
 import com.powsybl.iidm.network.Network;
 
@@ -66,7 +65,7 @@ class UpDownScalable extends AbstractScalable {
     }
 
     @Override
-    public double getSteadyStatePower(Network network, ScalingConvention scalingConvention) {
-        throw new PowsyblException("getCurrentPower should not be used on UpDownScalable, only on other types of Scalable");
+    public double getSteadyStatePower(Network network, double asked, ScalingConvention scalingConvention) {
+        return asked > 0 ? upScalable.getSteadyStatePower(network, asked, scalingConvention) : downScalable.getSteadyStatePower(network, asked, scalingConvention);
     }
 }

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/scalable/UpDownScalableTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/scalable/UpDownScalableTest.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.iidm.modification.scalable;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Injection;
 import com.powsybl.iidm.network.Network;
 import org.junit.jupiter.api.Test;
@@ -90,8 +89,14 @@ class UpDownScalableTest {
         Scalable downScalable = Scalable.onLoad("l1", 50, 200);
         Scalable upDownScalable = Scalable.upDown(upScalable, downScalable);
 
-        // Error raised
-        PowsyblException e0 = assertThrows(PowsyblException.class, () -> upDownScalable.getSteadyStatePower(testNetwork, Scalable.ScalingConvention.LOAD));
-        assertEquals("getCurrentPower should not be used on UpDownScalable, only on other types of Scalable", e0.getMessage());
+        testNetwork.getGenerator("g2").setTargetP(32);
+        double asked = 1;
+        assertEquals(-32, upDownScalable.getSteadyStatePower(testNetwork, asked, Scalable.ScalingConvention.LOAD));
+        assertEquals(32, upDownScalable.getSteadyStatePower(testNetwork, asked, Scalable.ScalingConvention.GENERATOR));
+
+        testNetwork.getLoad("l1").setP0(42);
+        asked = -1;
+        assertEquals(42, upDownScalable.getSteadyStatePower(testNetwork, asked, Scalable.ScalingConvention.LOAD));
+        assertEquals(-42, upDownScalable.getSteadyStatePower(testNetwork, asked, Scalable.ScalingConvention.GENERATOR));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->
`UpDownScalable` throws an exception in method `getSteadyStatePower`.
GSLK module in powsybl-entsoe creates up/down scalables. Some of the features in GSLK fail if we do not allow scaling on these objects.



**What is the new behavior (if this is a feature change)?**
Because `UpDownScalable` delegates in its `upScalable` or `downScalable` inner objects to perform the scaling, it seems to make sense to delegate also the `getSteadyStatePower` method to the proper sub-object. The sub-object is selected depending on the `asked` parameter of the scaling, so to do the proper delegation we must pass it around also in `getSteadyStatePower`.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
