### PR TITLE
CGMES option to force import of node/breaker as bus/breaker

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -271,7 +271,13 @@ public class CgmesImport implements Importer {
                                 getFormat(),
                                 p,
                                 CREATE_FICTITIOUS_SWITCHES_FOR_DISCONNECTED_TERMINALS_MODE_PARAMETER,
-                                defaultValueConfig)));
+                                defaultValueConfig)))
+                .setImportNodeBreakerAsBusBreaker(
+                        Parameter.readBoolean(
+                                getFormat(),
+                                p,
+                                IMPORT_NODE_BREAKER_AS_BUS_BREAKER_PARAMETER,
+                                defaultValueConfig));
         String namingStrategy = Parameter.readString(getFormat(), p, NAMING_STRATEGY_PARAMETER, defaultValueConfig);
         String idMappingFilePath = Parameter.readString(getFormat(), p, ID_MAPPING_FILE_PATH_PARAMETER, defaultValueConfig);
         if (idMappingFilePath == null) {
@@ -343,6 +349,7 @@ public class CgmesImport implements Importer {
     public static final String SOURCE_FOR_IIDM_ID = "iidm.import.cgmes.source-for-iidm-id";
     public static final String STORE_CGMES_MODEL_AS_NETWORK_EXTENSION = "iidm.import.cgmes.store-cgmes-model-as-network-extension";
     public static final String STORE_CGMES_CONVERSION_CONTEXT_AS_NETWORK_EXTENSION = "iidm.import.cgmes.store-cgmes-conversion-context-as-network-extension";
+    public static final String IMPORT_NODE_BREAKER_AS_BUS_BREAKER = "iidm.import.cgmes.import-node-breaker-as-bus-breaker";
 
     public static final String SOURCE_FOR_IIDM_ID_MRID = "mRID";
     public static final String SOURCE_FOR_IIDM_ID_RDFID = "rdfID";
@@ -447,6 +454,11 @@ public class CgmesImport implements Importer {
             ParameterType.BOOLEAN,
             "Decode escaped special characters in IDs",
             Boolean.TRUE);
+    public static final Parameter IMPORT_NODE_BREAKER_AS_BUS_BREAKER_PARAMETER = new Parameter(
+            IMPORT_NODE_BREAKER_AS_BUS_BREAKER,
+            ParameterType.BOOLEAN,
+            "Force import of CGMES node/breaker models as bus/breaker",
+            Boolean.FALSE);
 
     private static final List<Parameter> STATIC_PARAMETERS = List.of(
             ALLOW_UNSUPPORTED_TAP_CHANGERS_PARAMETER,
@@ -465,7 +477,8 @@ public class CgmesImport implements Importer {
             STORE_CGMES_MODEL_AS_NETWORK_EXTENSION_PARAMETER,
             CREATE_ACTIVE_POWER_CONTROL_EXTENSION_PARAMETER,
             DECODE_ESCAPED_IDENTIFIERS_PARAMETER,
-            CREATE_FICTITIOUS_SWITCHES_FOR_DISCONNECTED_TERMINALS_MODE_PARAMETER);
+            CREATE_FICTITIOUS_SWITCHES_FOR_DISCONNECTED_TERMINALS_MODE_PARAMETER,
+            IMPORT_NODE_BREAKER_AS_BUS_BREAKER_PARAMETER);
 
     private final Parameter boundaryLocationParameter;
     private final Parameter preProcessorsParameter;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Context.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Context.java
@@ -46,7 +46,7 @@ public class Context {
         // create buses directly from topological nodes,
         // the configuration says if we are performing the conversion
         // based on existing node-breaker info
-        nodeBreaker = cgmes.isNodeBreaker() && config.useNodeBreaker();
+        nodeBreaker = cgmes.isNodeBreaker() && !config.importNodeBreakerAsBusBreaker();
 
         namingStrategy = config.getNamingStrategy();
         cgmesBoundary = new CgmesBoundary(cgmes);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -729,8 +729,13 @@ public class Conversion {
             return this;
         }
 
-        public boolean useNodeBreaker() {
-            return true;
+        public boolean importNodeBreakerAsBusBreaker() {
+            return importNodeBreakerAsBusBreaker;
+        }
+
+        public Config setImportNodeBreakerAsBusBreaker(boolean importNodeBreakerAsBusBreaker) {
+            this.importNodeBreakerAsBusBreaker = importNodeBreakerAsBusBreaker;
+            return this;
         }
 
         public double lowImpedanceLineR() {
@@ -925,6 +930,7 @@ public class Conversion {
 
         private boolean ensureIdAliasUnicity = false;
         private boolean importControlAreas = true;
+        private boolean importNodeBreakerAsBusBreaker = false;
 
         private NamingStrategy namingStrategy = new NamingStrategy.Identity();
 
@@ -936,7 +942,6 @@ public class Conversion {
         private Xfmr3RatioPhaseInterpretationAlternative xfmr3RatioPhase = Xfmr3RatioPhaseInterpretationAlternative.NETWORK_SIDE;
         private Xfmr3ShuntInterpretationAlternative xfmr3Shunt = Xfmr3ShuntInterpretationAlternative.NETWORK_SIDE;
         private Xfmr3StructuralRatioInterpretationAlternative xfmr3StructuralRatio = Xfmr3StructuralRatioInterpretationAlternative.STAR_BUS_SIDE;
-
     }
 
     private final CgmesModel cgmes;

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
@@ -14,8 +14,11 @@ import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conformity.CgmesConformity1NetworkCatalog;
 import com.powsybl.cgmes.conversion.CgmesExport;
 import com.powsybl.cgmes.conversion.CgmesImport;
+import com.powsybl.cgmes.conversion.CgmesModelExtension;
 import com.powsybl.cgmes.conversion.test.ConversionTester;
 import com.powsybl.cgmes.conversion.test.network.compare.ComparisonConfig;
+import com.powsybl.cgmes.model.CgmesModel;
+import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.ActivePowerControl;
 import com.powsybl.triplestore.api.TripleStoreFactory;
@@ -194,6 +197,38 @@ class CgmesConformity1ConversionTest {
         t.testConversion(null, CgmesConformity1Catalog.miniNodeBreaker());
         t.lastConvertedNetwork().getVoltageLevels()
             .forEach(vl -> assertEquals(TopologyKind.NODE_BREAKER, vl.getTopologyKind()));
+    }
+
+    @Test
+    void miniNodeBreakerAsBusBranchBusBalanceValidation() throws IOException {
+        // This test will check that IIDM buses,
+        // that will be created during conversion from CGMES TopologicalNodes,
+        // have proper balances from SV values
+        Properties params = new Properties();
+        params.put(CgmesImport.PROFILE_FOR_INITIAL_VALUES_SHUNT_SECTIONS_TAP_POSITIONS, "SV");
+        params.put(CgmesImport.IMPORT_NODE_BREAKER_AS_BUS_BREAKER, "true");
+        ConversionTester t = new ConversionTester(
+                params,
+                TripleStoreFactory.onlyDefaultImplementation(),
+                new ComparisonConfig());
+        t.setValidateBusBalances(true);
+        t.testConversion(null, CgmesConformity1Catalog.miniNodeBreaker());
+
+        Network network = t.lastConvertedNetwork();
+        CgmesModel cgmes = network.getExtension(CgmesModelExtension.class).getCgmesModel();
+
+        // All voltage levels must have bus/breaker topology kind
+        network.getVoltageLevels()
+                .forEach(vl -> assertEquals(TopologyKind.BUS_BREAKER, vl.getTopologyKind()));
+
+        // All bus identifiers in the bus/breaker view must correspond to Topological Nodes of CGMES model
+        List<String> iidmBusIds = network.getBusBreakerView().getBusStream().map(Identifiable::getId).sorted().toList();
+        List<String> cgmesTNIds = cgmes.topologicalNodes().pluckIdentifiers(CgmesNames.TOPOLOGICAL_NODE).stream().sorted().toList();
+        // Boundary nodes of CGMES model are not mapped to buses in IIDM
+        List<String> cgmesBoundaryTNIds = cgmes.boundaryNodes().pluckIdentifiers(CgmesNames.TOPOLOGICAL_NODE).stream().sorted().toList();
+        List<String> expectedBusIds = new ArrayList<>(cgmesTNIds);
+        expectedBusIds.removeAll(cgmesBoundaryTNIds);
+        assertEquals(expectedBusIds, iidmBusIds);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #2700 


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**
A new parameter has been introduced. Set `iidm.import.cgmes.import-node-breaker-as-bus-breaker = true` to force the model be imported as bus/breaker (TP instance file is required).


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
