### PR TITLE
Rename 'Network.create(Network...)' in 'Network.merge(Network...)'

### DIFF
--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity3ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity3ConversionTest.java
@@ -41,7 +41,7 @@ class CgmesConformity3ConversionTest {
         // Both networks have the same number of dangling lines
         assertEquals(nDlBE, nDlNL);
 
-        Network merge = Network.create(be, nl);
+        Network merge = Network.merge(be, nl);
         int nSub = merge.getSubstationCount();
         assertEquals(nSubBE + nSubNL, nSub);
         long nTl = merge.getTieLineCount();

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
@@ -308,7 +308,7 @@ class CgmesExportTest {
 
         Network network = DanglingLineNetworkFactory.create();
         DanglingLine expected = network.getDanglingLine("DL");
-        Network merged = Network.create(network, BatteryNetworkFactory.create()); // add battery
+        Network merged = Network.merge(network, BatteryNetworkFactory.create()); // add battery
         Battery battery = merged.getBattery("BAT");
 
         // Before exporting, we have to define to which point

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
@@ -507,8 +507,10 @@ public interface Network extends Container<Network> {
     }
 
     /**
-     * Create a network (using default implementation) as the result of the merge of the given networks. Each underlying
-     * network becomes a subnetwork.
+     * Create a network (using default implementation) as the result of the merge of the given networks. Each given
+     * network is represented as a subnetwork in the resulting network. As a result of that merge, the given networks
+     * are empty at the end of the call.
+     * Note that, as no id is given, the id of the network created is generated.
      *
      * @return the merged network with subnetworks inside.
      */
@@ -517,8 +519,9 @@ public interface Network extends Container<Network> {
     }
 
     /**
-     * Create a network (using default implementation) as the result of the merge of the given networks. Each underlying
-     * network becomes a subnetwork.
+     * Create a network (using default implementation) as the result of the merge of the given networks. Each given
+     * network is represented as a subnetwork in the resulting network. As a result of that merge, the given networks
+     * are empty at the end of the call.
      *
      * @param id id of the network to create
      * @return the merged network with subnetworks inside.

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
@@ -512,8 +512,8 @@ public interface Network extends Container<Network> {
      *
      * @return the merged network with subnetworks inside.
      */
-    static Network create(Network... networks) {
-        return NetworkFactory.findDefault().createNetwork(networks);
+    static Network merge(Network... networks) {
+        return NetworkFactory.findDefault().merge(networks);
     }
 
     /**
@@ -523,8 +523,8 @@ public interface Network extends Container<Network> {
      * @param id id of the network to create
      * @return the merged network with subnetworks inside.
      */
-    static Network create(String id, Network... networks) {
-        return NetworkFactory.findDefault().createNetwork(id, networks);
+    static Network merge(String id, Network... networks) {
+        return NetworkFactory.findDefault().merge(id, networks);
     }
 
     /**

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkFactory.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkFactory.java
@@ -31,7 +31,7 @@ public interface NetworkFactory {
      * @param networks the networks to merge
      * @return the merged network
      */
-    Network createNetwork(String id, Network... networks);
+    Network merge(String id, Network... networks);
 
     /**
      * Create a network as the result of the merge of the given networks.
@@ -39,7 +39,7 @@ public interface NetworkFactory {
      * @param networks the networks to merge
      * @return the merged network
      */
-    Network createNetwork(Network... networks);
+    Network merge(Network... networks);
 
     /**
      * Find a {@code NetworkFactory} instance base on its name.

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkFactory.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/NetworkFactory.java
@@ -25,7 +25,9 @@ public interface NetworkFactory {
     Network createNetwork(String id, String sourceFormat);
 
     /**
-     * Create a network as the result of the merge of the given networks.
+     * Create a network as the result of the merge of the given networks. Each given network is represented as a
+     * subnetwork in the resulting network. As a result of that merge, the given networks are empty at the end of the
+     * call.
      *
      * @param id id of the network
      * @param networks the networks to merge
@@ -34,7 +36,9 @@ public interface NetworkFactory {
     Network merge(String id, Network... networks);
 
     /**
-     * Create a network as the result of the merge of the given networks.
+     * Create a network as the result of the merge of the given networks. Each given network is represented as a
+     * subnetwork in the resulting network. As a result of that merge, the given networks are empty at the end of the
+     * call. Note that, as no id is given, the id of the network created is generated.
      *
      * @param networks the networks to merge
      * @return the merged network

--- a/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/NetworkFactoryMock.java
+++ b/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/NetworkFactoryMock.java
@@ -36,12 +36,12 @@ public class NetworkFactoryMock implements NetworkFactory {
     }
 
     @Override
-    public Network createNetwork(String id, Network... networks) {
+    public Network merge(String id, Network... networks) {
         throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override
-    public Network createNetwork(Network... networks) {
+    public Network merge(Network... networks) {
         throw new UnsupportedOperationException("Not yet implemented");
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkFactoryImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkFactoryImpl.java
@@ -24,15 +24,15 @@ public class NetworkFactoryImpl implements NetworkFactory {
     }
 
     @Override
-    public Network createNetwork(String id, Network... networks) {
-        return NetworkImpl.create(id, id, networks);
+    public Network merge(String id, Network... networks) {
+        return NetworkImpl.merge(id, id, networks);
     }
 
     @Override
-    public Network createNetwork(Network... networks) {
+    public Network merge(Network... networks) {
         String id = Arrays.stream(Objects.requireNonNull(networks))
                 .map(Network::getId)
                 .collect(Collectors.joining("+"));
-        return createNetwork(id, networks);
+        return merge(id, networks);
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -130,7 +130,7 @@ class NetworkImpl extends AbstractNetwork implements VariantManagerHolder, Multi
         index.checkAndAdd(this);
     }
 
-    static Network create(String id, String name, Network... networks) {
+    static Network merge(String id, String name, Network... networks) {
         if (networks == null || networks.length < 2) {
             throw new IllegalArgumentException("At least 2 networks are expected");
         }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MergeTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/MergeTest.java
@@ -31,7 +31,7 @@ class MergeTest {
         Network n2 = createNetworkWithDanglingLine("2");
 
         logVoltageLevel("Network 1 first voltage level", n1.getVoltageLevels().iterator().next());
-        Network merge = Network.create(n1, n2);
+        Network merge = Network.merge(n1, n2);
         // If we try to get connected components directly on the merged network,
         // A Null Pointer Exception happens in AbstractConnectable.notifyUpdate:
         // There is a CalculatedBus that has a terminal that refers to the removed DanglingLine
@@ -46,7 +46,7 @@ class MergeTest {
         Network n2 = createNetworkWithDanglingLine("2");
 
         // The test passes if we do not log voltage level (exportTopology)
-        Network merge = Network.create(n1, n2);
+        Network merge = Network.merge(n1, n2);
         checkConnectedComponents(merge);
     }
 
@@ -58,7 +58,7 @@ class MergeTest {
         logVoltageLevel("Network 1 first voltage level", n1.getVoltageLevels().iterator().next());
         // The test also passes if we "force" the connected component calculation before merge
         checkConnectedComponents(n1);
-        Network merge = Network.create(n1, n2);
+        Network merge = Network.merge(n1, n2);
         checkConnectedComponents(n1);
     }
 
@@ -110,7 +110,7 @@ class MergeTest {
         valMerge.addAll(val1);
         valMerge.addAll(val2);
 
-        Network merge = Network.create(network1, network2);
+        Network merge = Network.merge(network1, network2);
         assertTrue(voltageAngleLimitsAreEqual(valMerge, merge.getVoltageAngleLimitsStream().toList()));
 
         network1 = merge.getSubnetwork(network1.getId()).detach();
@@ -126,7 +126,7 @@ class MergeTest {
     void failMergeWithVoltageAngleLimits() {
         Network network1 = createNodeBreakerWithVoltageAngleLimit("1", "duplicate");
         Network network2 = createNodeBreakerWithVoltageAngleLimit("2", "duplicate");
-        PowsyblException e = assertThrows(PowsyblException.class, () -> Network.create(network1, network2));
+        PowsyblException e = assertThrows(PowsyblException.class, () -> Network.merge(network1, network2));
         assertEquals("The following voltage angle limit(s) exist(s) in both networks: [duplicate]", e.getMessage());
     }
 
@@ -134,7 +134,7 @@ class MergeTest {
     void failDetachWithVoltageAngleLimits() {
         Network network1 = createNodeBreakerWithVoltageAngleLimit("1");
         Network network2 = createNodeBreakerWithVoltageAngleLimit("2");
-        Network merge = Network.create(network1, network2);
+        Network merge = Network.merge(network1, network2);
         merge.newVoltageAngleLimit()
                 .setId("valMerge")
                 .from(merge.getLine(id("Line-2-2", "1")).getTerminal1())
@@ -164,7 +164,7 @@ class MergeTest {
                 .setHighLimit(0.25)
                 .add();
 
-        PowsyblException e = assertThrows(PowsyblException.class, () -> Network.create(network1, network2));
+        PowsyblException e = assertThrows(PowsyblException.class, () -> Network.merge(network1, network2));
         assertEquals("The following voltage angle limit(s) exist(s) in both networks: [LimitCollision]", e.getMessage());
     }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAliasesTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAliasesTest.java
@@ -164,7 +164,7 @@ public abstract class AbstractAliasesTest {
         Network network = EurostagTutorialExample1Factory.create();
         Network otherNetwork = FourSubstationsNodeBreakerFactory.create();
         otherNetwork.getGenerator("GH1").addAlias("NHV2_NLOAD");
-        assertThrows(PowsyblException.class, () -> Network.create(network, otherNetwork));
+        assertThrows(PowsyblException.class, () -> Network.merge(network, otherNetwork));
     }
 
     @Test
@@ -173,6 +173,6 @@ public abstract class AbstractAliasesTest {
         Network otherNetwork = FourSubstationsNodeBreakerFactory.create();
         network.getTwoWindingsTransformer("NHV2_NLOAD").addAlias("Alias");
         otherNetwork.getGenerator("GH1").addAlias("Alias");
-        assertThrows(PowsyblException.class, () -> Network.create(network, otherNetwork));
+        assertThrows(PowsyblException.class, () -> Network.merge(network, otherNetwork));
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractComponentCalculationBugWhenMergingTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractComponentCalculationBugWhenMergingTest.java
@@ -75,7 +75,7 @@ public abstract class AbstractComponentCalculationBugWhenMergingTest {
             b.getConnectedComponent();
         }
         assertEquals(0, n1.getTieLineCount());
-        Network merged = Network.create(n1, n2);
+        Network merged = Network.merge(n1, n2);
         for (Bus b : merged.getBusView().getBuses()) {
             assertDoesNotThrow(b::getConnectedComponent);
             assertEquals(0, b.getConnectedComponent().getNum());

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
@@ -44,7 +44,7 @@ public abstract class AbstractMergeNetworkTest {
     @Test
     public void failMergeIfMultiVariants() {
         n1.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, "Totest");
-        PowsyblException e = assertThrows(PowsyblException.class, () -> Network.create(n2, n1));
+        PowsyblException e = assertThrows(PowsyblException.class, () -> Network.merge(n2, n1));
         assertTrue(e.getMessage().contains("Merging of multi-variants network is not supported"));
     }
 
@@ -52,7 +52,7 @@ public abstract class AbstractMergeNetworkTest {
     public void failMergeWithSameObj() {
         addSubstation(n1, "P1");
         addSubstation(n2, "P1");
-        PowsyblException e = assertThrows(PowsyblException.class, () -> Network.create(n1, n2));
+        PowsyblException e = assertThrows(PowsyblException.class, () -> Network.merge(n1, n2));
         assertEquals("The following object(s) of type SubstationImpl exist(s) in both networks: [P1]", e.getMessage());
     }
 
@@ -62,7 +62,7 @@ public abstract class AbstractMergeNetworkTest {
         Network n0 = Network.create("n0", "rid");
         addSubstationAndVoltageLevel(n0, "s0", Country.FR, "vl0", "b0");
         addCommonDanglingLines("dl1", "code", "dl2", "code");
-        Network merge = Network.create(n0, n1, n2);
+        Network merge = Network.merge(n0, n1, n2);
         assertEquals(3, merge.getSubnetworks().size());
         assertEquals(1, merge.getSubnetwork(n0.getId()).getVoltageLevelCount());
         assertEquals(1, merge.getSubnetwork(N1).getVoltageLevelCount());
@@ -89,7 +89,7 @@ public abstract class AbstractMergeNetworkTest {
         addCommonSubstationsAndVoltageLevels();
         addCommonDanglingLines("dl1", "code", "dl2", "code");
         // merge(n1, n2)
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
         TieLine tieLine = merge.getTieLine("dl1 + dl2");
         assertNotNull(tieLine);
         assertEquals("dl1_name + dl2_name", tieLine.getOptionalName().orElse(null));
@@ -164,7 +164,7 @@ public abstract class AbstractMergeNetworkTest {
                 .withVariableReactivePower(30f)
                 .add();
 
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
         Network subnetwork1 = merge.getSubnetwork("sim1");
         checkExtensions(subnetwork1);
 
@@ -187,7 +187,7 @@ public abstract class AbstractMergeNetworkTest {
     @Test
     public void failDetachWithALineBetween2Subnetworks() {
         addCommonSubstationsAndVoltageLevels();
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
         merge.newLine()
                 .setId("line1")
                 .setVoltageLevel1("vl1")
@@ -210,7 +210,7 @@ public abstract class AbstractMergeNetworkTest {
     @Test
     public void failDetachIfMultiVariants() {
         addCommonSubstationsAndVoltageLevels();
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
         merge.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, "Totest");
 
         Network subnetwork1 = merge.getSubnetwork(N1);
@@ -229,7 +229,7 @@ public abstract class AbstractMergeNetworkTest {
         addDanglingLines(n3, "vl3", "dl4", "code2", "b3");
 
         //merge.merge(n1, n2, n3);
-        Network merge = Network.create(MERGE, n1, n2, n3);
+        Network merge = Network.merge(MERGE, n1, n2, n3);
         TieLine tieLine1 = merge.getTieLine("dl1 + dl2");
         assertNotNull(tieLine1);
         assertEquals("dl1_name + dl2_name", tieLine1.getOptionalName().orElse(null));
@@ -264,7 +264,7 @@ public abstract class AbstractMergeNetworkTest {
     public void failMergeDanglingLinesWithSameId() {
         addCommonSubstationsAndVoltageLevels();
         addCommonDanglingLines("dl", null, "dl", "code");
-        PowsyblException e = assertThrows(PowsyblException.class, () -> Network.create(n0, n1, n2));
+        PowsyblException e = assertThrows(PowsyblException.class, () -> Network.merge(n0, n1, n2));
         assertTrue(e.getMessage().contains("The following object(s) of type DanglingLineImpl exist(s) in both networks: [dl]"));
     }
 
@@ -285,7 +285,7 @@ public abstract class AbstractMergeNetworkTest {
                 .add();
 
         // merge(n1, n2)
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
 
         assertValidationLevels(merge, ValidationLevel.EQUIPMENT);
     }
@@ -307,7 +307,7 @@ public abstract class AbstractMergeNetworkTest {
                 .add();
 
         // merge(n1, n2)
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
 
         assertValidationLevels(merge, ValidationLevel.EQUIPMENT);
     }
@@ -329,7 +329,7 @@ public abstract class AbstractMergeNetworkTest {
                 .add();
 
         // merge(n1, n2)
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
 
         assertValidationLevels(merge, ValidationLevel.STEADY_STATE_HYPOTHESIS);
     }
@@ -343,48 +343,48 @@ public abstract class AbstractMergeNetworkTest {
 
     @Test
     void failMergeOnlyOneNetwork() {
-        Exception e = assertThrows(IllegalArgumentException.class, () -> Network.create(MERGE, n1));
+        Exception e = assertThrows(IllegalArgumentException.class, () -> Network.merge(MERGE, n1));
         assertTrue(e.getMessage().contains("At least 2 networks are expected"));
     }
 
     @Test
     void failMergeOnSubnetworks() {
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
         Network subnetwork1 = merge.getSubnetwork(N1);
         Network other1 = Network.create("other1", "format");
         Network other2 = Network.create("other2", "format");
 
-        Exception e = assertThrows(IllegalArgumentException.class, () -> Network.create(subnetwork1, other1));
+        Exception e = assertThrows(IllegalArgumentException.class, () -> Network.merge(subnetwork1, other1));
         assertEquals("The network n1 is already a subnetwork", e.getMessage());
 
-        e = assertThrows(IllegalArgumentException.class, () -> Network.create(subnetwork1, other1, other2));
+        e = assertThrows(IllegalArgumentException.class, () -> Network.merge(subnetwork1, other1, other2));
         assertEquals("The network n1 is already a subnetwork", e.getMessage());
     }
 
     @Test
     void failMergeSubnetworks() {
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
         Network subnetwork1 = merge.getSubnetwork(N1);
         Network other = Network.create("other", "format");
 
         Exception e = assertThrows(IllegalArgumentException.class,
-                () -> Network.create("test", other, subnetwork1));
+                () -> Network.merge("test", other, subnetwork1));
         assertTrue(e.getMessage().contains("is already a subnetwork"));
     }
 
     @Test
     void failMergeContainingSubnetworks() {
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
         Network other = Network.create("other", "format");
 
         Exception e = assertThrows(IllegalArgumentException.class,
-                () -> Network.create("test", other, merge));
+                () -> Network.merge("test", other, merge));
         assertTrue(e.getMessage().contains("already contains subnetworks"));
     }
 
     @Test
     void testNoEmptyAdditionalSubnetworkIsCreated() {
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
         assertEquals(2, merge.getSubnetworks().size());
         assertNull(merge.getSubnetwork(MERGE));
         assertNotNull(merge.getSubnetwork(N1));
@@ -406,7 +406,7 @@ public abstract class AbstractMergeNetworkTest {
         addSubstation(n1, "s1");
         assertTrue(listenerCalled.booleanValue());
 
-        Network merge = Network.create(MERGE, n1, n2);
+        Network merge = Network.merge(MERGE, n1, n2);
         Network subnetwork1 = merge.getSubnetwork(N1);
         Network subnetwork2 = merge.getSubnetwork(N2);
 
@@ -509,7 +509,7 @@ public abstract class AbstractMergeNetworkTest {
         addCommonSubstationsAndVoltageLevels();
         addLoad(n1, 1);
         addLoad(n2, 2);
-        Network merge = Network.create(MERGE, n0, n1, n2);
+        Network merge = Network.merge(MERGE, n0, n1, n2);
         assertEquals(MERGE, merge.getId());
         assertEquals("hybrid", merge.getSourceFormat());
         assertEquals(3, merge.getSubnetworks().size());
@@ -586,14 +586,14 @@ public abstract class AbstractMergeNetworkTest {
 
     @Test
     public void checkMergingSameFormat() {
-        Network merge = Network.create(MERGE, n0, n1);
+        Network merge = Network.merge(MERGE, n0, n1);
         assertEquals(MERGE, merge.getId());
         assertEquals("asdf", merge.getSourceFormat());
     }
 
     @Test
     public void checkMergingDifferentFormat() {
-        Network merge = Network.create(n1, n2);
+        Network merge = Network.merge(n1, n2);
         assertEquals(MERGE_DEFAULT_ID, merge.getId());
         assertEquals("hybrid", merge.getSourceFormat());
     }
@@ -609,7 +609,7 @@ public abstract class AbstractMergeNetworkTest {
                 .setP0(0.0)
                 .setQ0(0.0)
                 .add();
-        Network merge = Network.create(n1, n2);
+        Network merge = Network.merge(n1, n2);
         merge.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, "test");
         merge.getVariantManager().setWorkingVariant("test");
         ld2.setP0(10);
@@ -622,7 +622,7 @@ public abstract class AbstractMergeNetworkTest {
         addCommonSubstationsAndVoltageLevels();
         addCommonDanglingLines("dl1", "code", "dl2", "code");
         addDanglingLine(n2, "vl2", "dl3", "code", "b2", null);
-        Network merge = Network.create(n1, n2);
+        Network merge = Network.merge(n1, n2);
         assertNotNull(merge.getTieLine("dl1 + dl2"));
         assertEquals("dl1_name + dl2_name", merge.getTieLine("dl1 + dl2").getOptionalName().orElse(null));
         assertEquals("dl1_name + dl2_name", merge.getTieLine("dl1 + dl2").getNameOrId());
@@ -633,7 +633,7 @@ public abstract class AbstractMergeNetworkTest {
         addCommonSubstationsAndVoltageLevels();
         addCommonDanglingLines("dl1", "code", "dl2", "code");
         addDanglingLine(n1, "vl1", "dl3", "code", "b1", null);
-        Network merge = Network.create(n1, n2);
+        Network merge = Network.merge(n1, n2);
         assertNotNull(merge.getTieLine("dl1 + dl2"));
         assertEquals("dl1_name + dl2_name", merge.getTieLine("dl1 + dl2").getOptionalName().orElse(null));
         assertEquals("dl1_name + dl2_name", merge.getTieLine("dl1 + dl2").getNameOrId());

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNullPointerWhenRemovingMergedLineBugTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNullPointerWhenRemovingMergedLineBugTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractNullPointerWhenRemovingMergedLineBugTest {
         assertEquals(1, n1.getDanglingLineCount());
         assertEquals(0, n2.getLineCount());
         assertEquals(1, n2.getDanglingLineCount());
-        Network merged = Network.create(n1, n2);
+        Network merged = Network.merge(n1, n2);
         assertEquals(1, merged.getTieLineCount());
         assertEquals(2, merged.getDanglingLineCount());
         merged.getTieLine("dl1 + dl2").remove();

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksExplorationTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksExplorationTest.java
@@ -45,7 +45,7 @@ public abstract class AbstractSubnetworksExplorationTest {
         n1Identifiables = getIdentifiables(n1);
         n2Identifiables = getIdentifiables(n2);
 
-        merged = Network.create("merged", n1, n2);
+        merged = Network.merge("merged", n1, n2);
         subnetwork1 = merged.getSubnetwork(id("network", ID_1));
         subnetwork2 = merged.getSubnetwork(id("network", ID_2));
     }

--- a/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
+++ b/iidm/iidm-xml-converter/src/test/java/com/powsybl/iidm/xml/NetworkXmlTest.java
@@ -166,7 +166,7 @@ class NetworkXmlTest extends AbstractXmlConverterTest {
         n1.setCaseDate(DateTime.parse("2013-01-15T18:41:00+01:00"));
         n2.setCaseDate(DateTime.parse("2013-01-15T18:42:00+01:00"));
 
-        Network merged = Network.create("Merged", n1, n2);
+        Network merged = Network.merge("Merged", n1, n2);
         merged.setCaseDate(DateTime.parse("2013-01-15T18:40:00+01:00"));
         // add an extension at root network level
         NetworkSourceExtension source = new NetworkSourceExtensionImpl("Source_0");

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteExporterTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteExporterTest.java
@@ -71,7 +71,7 @@ class UcteExporterTest extends AbstractConverterTest {
         Network networkBE = loadNetworkFromResourceFile("/beTestGridForMerging.uct");
         testExporter(networkBE, "/beTestGridForMerging.uct");
 
-        Network merge = Network.create(networkBE, networkFR);
+        Network merge = Network.merge(networkBE, networkFR);
         testExporter(merge, "/uxTestGridForMerging.uct");
     }
 
@@ -83,7 +83,7 @@ class UcteExporterTest extends AbstractConverterTest {
         Network networkBE = loadNetworkFromResourceFile("/beForMergeProperties.uct");
         testExporter(networkBE, "/beForMergeProperties.uct");
 
-        Network mergedNetwork = Network.create(networkBE, networkFR);
+        Network mergedNetwork = Network.merge(networkBE, networkFR);
         testExporter(mergedNetwork, "/uxForMergeProperties.uct");
     }
 

--- a/ucte/ucte-util/src/test/java/com/powsybl/ucte/util/UcteAliasesCreationTest.java
+++ b/ucte/ucte-util/src/test/java/com/powsybl/ucte/util/UcteAliasesCreationTest.java
@@ -69,7 +69,7 @@ class UcteAliasesCreationTest {
         assertNotNull(networkBE.getIdentifiable("BBBBBB11 XXXXXX11 ABCDE"));
         assertNotNull(networkFR.getIdentifiable("FFFFFF11 XXXXXX11 ABCDE"));
 
-        Network merge = Network.create(networkBE, networkFR);
+        Network merge = Network.merge(networkBE, networkFR);
 
         // Aliases on element name have been kept after merge
         assertNotNull(merge.getIdentifiable("BBBBBB11 XXXXXX11 ABCDE"));
@@ -88,7 +88,7 @@ class UcteAliasesCreationTest {
     void checkAliasesCreationAfterIidmMerging() {
         Network networkFR = loadNetworkFromResourceFile("/frTestGridForMerging.uct");
         Network networkBE = loadNetworkFromResourceFile("/beTestGridForMerging.uct");
-        Network merge = Network.create(networkBE, networkFR);
+        Network merge = Network.merge(networkBE, networkFR);
 
         // No aliases on dangling lines element name
         assertNull(merge.getIdentifiable("BBBBBB11 XXXXXX11 ABCDE"));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Quality


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The method to merge several networks was `Network.create(Network...)`.


**What is the new behavior (if this is a feature change)?**
The method to merge several networks is now `Network.merge(Network...)`, which is clearer.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
