### PR TITLE
add minValue and maxValue to compound scalables

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/AbstractCompoundScalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/AbstractCompoundScalable.java
@@ -17,6 +17,8 @@ import java.util.Objects;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 abstract class AbstractCompoundScalable extends AbstractScalable {
+    protected double minValue = -Double.MAX_VALUE;
+    protected double maxValue = Double.MAX_VALUE;
 
     abstract Collection<Scalable> getScalables();
 
@@ -52,7 +54,7 @@ abstract class AbstractCompoundScalable extends AbstractScalable {
         for (Scalable scalable : getScalables()) {
             value += scalable.maximumValue(n, powerConvention);
         }
-        return value;
+        return (powerConvention == ScalingConvention.GENERATOR) ? Math.min(maxValue, value) : Math.min(-minValue, value);
     }
 
     @Override
@@ -68,7 +70,7 @@ abstract class AbstractCompoundScalable extends AbstractScalable {
         for (Scalable scalable : getScalables()) {
             value += scalable.minimumValue(n, powerConvention);
         }
-        return value;
+        return (powerConvention == ScalingConvention.GENERATOR) ? Math.max(minValue, value) : Math.max(-maxValue, value);
     }
 
     @Override
@@ -76,5 +78,11 @@ abstract class AbstractCompoundScalable extends AbstractScalable {
         for (Scalable scalable : getScalables()) {
             scalable.filterInjections(n, injections, notFoundInjections);
         }
+    }
+
+    protected double getBoundedVariation(double variationAsked, double currentGlobalPower, ScalingConvention scalingConvention) {
+        double minWithConvention = scalingConvention == ScalingConvention.GENERATOR ? minValue : -maxValue;
+        double maxWithConvention = scalingConvention == ScalingConvention.GENERATOR ? maxValue : -minValue;
+        return Math.min(maxWithConvention - currentGlobalPower, Math.max(minWithConvention - currentGlobalPower, variationAsked));
     }
 }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/Scalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/Scalable.java
@@ -194,8 +194,16 @@ public interface Scalable {
         return new ProportionalScalable(injections, distributionMode);
     }
 
+    static ProportionalScalable proportional(List<? extends Injection> injections, ProportionalScalable.DistributionMode distributionMode, double minValue, double maxValue) {
+        return new ProportionalScalable(injections, distributionMode, minValue, maxValue);
+    }
+
     static ProportionalScalable proportional(List<Double> percentages, List<Scalable> scalables) {
         return new ProportionalScalable(percentages, scalables);
+    }
+
+    static ProportionalScalable proportional(List<Double> percentages, List<Scalable> scalables, double minValue, double maxValue) {
+        return new ProportionalScalable(percentages, scalables, minValue, maxValue);
     }
 
     static ProportionalScalable proportional(double percentage, Scalable scalable) {
@@ -227,13 +235,27 @@ public interface Scalable {
         return new StackScalable(injectionScalables);
     }
 
+    static StackScalable stack(double minValue, double maxValue, Injection<?>... injections) {
+        List<Scalable> injectionScalables = Arrays.stream(injections).map(ScalableAdapter::new).collect(Collectors.toList());
+        return new StackScalable(injectionScalables, minValue, maxValue);
+    }
+
     static StackScalable stack(List<? extends Injection<?>> injections) {
         List<Scalable> injectionScalables = injections.stream().map(ScalableAdapter::new).collect(Collectors.toList());
         return new StackScalable(injectionScalables);
     }
 
+    static StackScalable stack(List<? extends Injection<?>> injections, double minValue, double maxValue) {
+        List<Scalable> injectionScalables = injections.stream().map(ScalableAdapter::new).collect(Collectors.toList());
+        return new StackScalable(injectionScalables, minValue, maxValue);
+    }
+
     static StackScalable stack(Scalable... scalables) {
         return new StackScalable(scalables);
+    }
+
+    static StackScalable stack(double minValue, double maxValue, Scalable... scalables) {
+        return new StackScalable(minValue, maxValue, scalables);
     }
 
     static StackScalable stack(String... ids) {
@@ -241,8 +263,17 @@ public interface Scalable {
         return new StackScalable(identifierScalables);
     }
 
+    static StackScalable stack(double minValue, double maxValue, String... ids) {
+        List<Scalable> identifierScalables = Arrays.stream(ids).map(ScalableAdapter::new).collect(Collectors.toList());
+        return new StackScalable(identifierScalables, minValue, maxValue);
+    }
+
     static UpDownScalable upDown(Scalable upScalable, Scalable downScalable) {
         return new UpDownScalable(upScalable, downScalable);
+    }
+
+    static UpDownScalable upDown(Scalable upScalable, Scalable downScalable, double minValue, double maxValue) {
+        return new UpDownScalable(upScalable, downScalable, minValue, maxValue);
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Compound scalables scaling is not bounded.


**What is the new behavior (if this is a feature change)?**
We can set a minValue and maxValue that will bound the possible scaling of compound scalables (the same already exists for "individual" scalables)


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
