### PR TITLE
[WIP] Find common denominator between 2 sides enum Branch.Side and 3 sides …

### DIFF
--- a/action/action-simulator/src/test/java/com/powsybl/action/simulator/tools/SecurityAnalysisResultBuilderTest.java
+++ b/action/action-simulator/src/test/java/com/powsybl/action/simulator/tools/SecurityAnalysisResultBuilderTest.java
@@ -31,11 +31,11 @@ class SecurityAnalysisResultBuilderTest {
     }
 
     private List<LimitViolation> createPreContingencyViolations() {
-        return Collections.singletonList(new LimitViolation("line1", LimitViolationType.CURRENT, "IST", Integer.MAX_VALUE, 0.0, 100f, 101, Branch.Side.ONE));
+        return Collections.singletonList(new LimitViolation("line1", LimitViolationType.CURRENT, "IST", Integer.MAX_VALUE, 0.0, 100f, 101, Branch.Side.ONE.name()));
     }
 
     private List<LimitViolation> createPostContingencyViolations() {
-        return Collections.singletonList(new LimitViolation("line2", LimitViolationType.CURRENT, "IST", Integer.MAX_VALUE, 0.0, 100f, 110, Branch.Side.ONE));
+        return Collections.singletonList(new LimitViolation("line2", LimitViolationType.CURRENT, "IST", Integer.MAX_VALUE, 0.0, 100f, 110, Branch.Side.ONE.name()));
     }
 
     private void testLimitViolation(LimitViolationsResult result, boolean convergent, List<String> equipmentsId, List<String> actionsId) {

--- a/commons/src/main/java/com/powsybl/commons/json/JsonUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/json/JsonUtil.java
@@ -162,15 +162,6 @@ public final class JsonUtil {
         }
     }
 
-    public static void writeOptionalEnumField(JsonGenerator jsonGenerator, String fieldName, Enum<?> value) throws IOException {
-        Objects.requireNonNull(jsonGenerator);
-        Objects.requireNonNull(fieldName);
-
-        if (value != null) {
-            jsonGenerator.writeStringField(fieldName, value.name());
-        }
-    }
-
     public static void writeOptionalBooleanField(JsonGenerator jsonGenerator, String fieldName, boolean value, boolean defaultValue) throws IOException {
         Objects.requireNonNull(jsonGenerator);
         Objects.requireNonNull(fieldName);

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolation.java
@@ -8,7 +8,6 @@
 package com.powsybl.security;
 
 import com.powsybl.commons.extensions.AbstractExtendable;
-import com.powsybl.iidm.network.*;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
@@ -37,7 +36,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
 
     private final double value;
 
-    private final Branch.Side side;
+    private final String side;
 
     /**
      * Create a new LimitViolation.
@@ -55,7 +54,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch equipments.
      */
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
-                          double limit, float limitReduction, double value, @Nullable Branch.Side side) {
+                          double limit, float limitReduction, double value, @Nullable String side) {
         this.subjectId = Objects.requireNonNull(subjectId);
         this.subjectName = subjectName;
         this.limitType = Objects.requireNonNull(limitType);
@@ -82,7 +81,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch equipments.
      */
     public LimitViolation(String subjectId, LimitViolationType limitType, String limitName, int acceptableDuration,
-                          double limit, float limitReduction, double value, Branch.Side side) {
+                          double limit, float limitReduction, double value, String side) {
         this(subjectId, null, limitType, limitName, acceptableDuration, limit, limitReduction, value, side);
     }
 
@@ -202,11 +201,11 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * other than branches.
      */
     @Nullable
-    public Branch.Side getSide() {
+    public String getSide() {
         return side;
     }
 
-    private static Branch.Side checkSide(LimitViolationType limitType, Branch.Side side) {
+    private static String checkSide(LimitViolationType limitType, String side) {
         if (limitType == LimitViolationType.ACTIVE_POWER
             || limitType == LimitViolationType.APPARENT_POWER
             || limitType == LimitViolationType.CURRENT) {

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationBuilder.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationBuilder.java
@@ -6,8 +6,6 @@
  */
 package com.powsybl.security;
 
-import com.powsybl.iidm.network.Branch;
-
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
@@ -27,7 +25,7 @@ public class LimitViolationBuilder {
     private Integer duration;
     private float reduction = 1.0f;
     private Double value;
-    private Branch.Side side;
+    private String side;
 
     public LimitViolationBuilder type(LimitViolationType type) {
         this.type = requireNonNull(type);
@@ -74,17 +72,17 @@ public class LimitViolationBuilder {
         return this;
     }
 
-    public LimitViolationBuilder side(Branch.Side side) {
+    public LimitViolationBuilder side(String side) {
         this.side = requireNonNull(side);
         return this;
     }
 
     public LimitViolationBuilder side1() {
-        return side(Branch.Side.ONE);
+        return side("ONE");
     }
 
     public LimitViolationBuilder side2() {
-        return side(Branch.Side.TWO);
+        return side("TWO");
     }
 
     public LimitViolationBuilder current() {

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationDetector.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationDetector.java
@@ -333,7 +333,7 @@ public interface LimitViolationDetector {
                     limit,
                     limitReduction,
                     value,
-                    side));
+                    side.name()));
         }
     }
 
@@ -351,7 +351,7 @@ public interface LimitViolationDetector {
                     overload.getPreviousLimit(),
                     limitReduction,
                     value,
-                    side));
+                    side.name()));
         }
     }
 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationHelper.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationHelper.java
@@ -34,7 +34,7 @@ public final class LimitViolationHelper {
             }
         }
         if (identifiable instanceof Branch<?> branch) {
-            return branch.getTerminal(limitViolation.getSide()).getVoltageLevel();
+            return branch.getTerminal(Branch.Side.valueOf(limitViolation.getSide())).getVoltageLevel();
         } else if (identifiable instanceof Injection<?> injection) {
             return injection.getTerminal().getVoltageLevel();
         } else if (identifiable instanceof VoltageLevel voltageLevel) {

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolations.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolations.java
@@ -6,8 +6,6 @@
  */
 package com.powsybl.security;
 
-import com.powsybl.iidm.network.Branch;
-
 import java.util.Comparator;
 
 /**
@@ -19,7 +17,7 @@ public final class LimitViolations {
 
     private static final Comparator<LimitViolation> COMPARATOR = Comparator.comparing(LimitViolation::getLimitType)
             .thenComparing(LimitViolation::getSubjectId)
-            .thenComparing(LimitViolation::getSide, Comparator.nullsFirst(Branch.Side::compareTo))
+            .thenComparing(LimitViolation::getSide, Comparator.nullsFirst(String::compareTo))
             .thenComparing(LimitViolation::getLimitName, Comparator.nullsFirst(String::compareTo))
             .thenComparing(LimitViolation::getAcceptableDuration)
             .thenComparing(LimitViolation::getLimit)

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/comparator/SecurityAnalysisResultComparisonWriter.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/comparator/SecurityAnalysisResultComparisonWriter.java
@@ -18,7 +18,6 @@ import com.powsybl.commons.io.table.Column;
 import com.powsybl.commons.io.table.CsvTableFormatterFactory;
 import com.powsybl.commons.io.table.TableFormatter;
 import com.powsybl.commons.io.table.TableFormatterConfig;
-import com.powsybl.iidm.network.Branch;
 import com.powsybl.security.LimitViolation;
 import com.powsybl.security.LimitViolationType;
 
@@ -95,7 +94,7 @@ public class SecurityAnalysisResultComparisonWriter implements AutoCloseable {
             formatter = contingency == null ? formatter.writeEmptyCell() : formatter.writeCell(contingency);
             formatter.writeEmptyCells(2);
             formatter.writeCell(getEquipment(violation1, violation2));
-            formatter = getEnd(violation1, violation2) == null ? formatter.writeEmptyCell() : formatter.writeCell(getEnd(violation1, violation2).name());
+            formatter = getEnd(violation1, violation2) == null ? formatter.writeEmptyCell() : formatter.writeCell(getEnd(violation1, violation2));
             formatter.writeCell(getViolationType(violation1, violation2).name());
             writeViolation(violation1);
             writeViolation(violation2);
@@ -111,7 +110,7 @@ public class SecurityAnalysisResultComparisonWriter implements AutoCloseable {
         return violation1 == null ? violation2.getSubjectId() : violation1.getSubjectId();
     }
 
-    private Branch.Side getEnd(LimitViolation violation1, LimitViolation violation2) {
+    private String getEnd(LimitViolation violation1, LimitViolation violation2) {
         return violation1 == null ? violation2.getSide() : violation1.getSide();
     }
 

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/interceptors/CurrentLimitViolationInterceptor.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/interceptors/CurrentLimitViolationInterceptor.java
@@ -25,7 +25,7 @@ public class CurrentLimitViolationInterceptor extends DefaultSecurityAnalysisInt
             if (limitViolation.getLimitType() == LimitViolationType.CURRENT) {
                 Branch branch = context.getNetwork().getBranch(limitViolation.getSubjectId());
 
-                double preContingencyValue = branch.getTerminal(limitViolation.getSide()).getP();
+                double preContingencyValue = branch.getTerminal(Branch.Side.valueOf(limitViolation.getSide())).getP();
                 limitViolation.addExtension(ActivePowerExtension.class, new ActivePowerExtension(preContingencyValue));
             }
         }
@@ -41,11 +41,11 @@ public class CurrentLimitViolationInterceptor extends DefaultSecurityAnalysisInt
                     Branch branch = context.getNetwork().getBranch(limitViolation.getSubjectId());
 
                     context.getNetwork().getVariantManager().setWorkingVariant(runningContext.getInitialStateId());
-                    limitViolation.addExtension(CurrentExtension.class, new CurrentExtension(branch.getTerminal(limitViolation.getSide()).getI()));
-                    double preContingencyValue = branch.getTerminal(limitViolation.getSide()).getP();
+                    limitViolation.addExtension(CurrentExtension.class, new CurrentExtension(branch.getTerminal(Branch.Side.valueOf(limitViolation.getSide())).getI()));
+                    double preContingencyValue = branch.getTerminal(Branch.Side.valueOf(limitViolation.getSide())).getP();
 
                     context.getNetwork().getVariantManager().setWorkingVariant(workingStateId);
-                    double postContingencyValue = branch.getTerminal(limitViolation.getSide()).getP();
+                    double postContingencyValue = branch.getTerminal(Branch.Side.valueOf(limitViolation.getSide())).getP();
 
                     limitViolation.addExtension(ActivePowerExtension.class, new ActivePowerExtension(preContingencyValue, postContingencyValue));
                 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/LimitViolationDeserializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/LimitViolationDeserializer.java
@@ -14,7 +14,6 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.powsybl.commons.extensions.*;
 import com.powsybl.commons.json.JsonUtil;
-import com.powsybl.iidm.network.Branch;
 import com.powsybl.security.LimitViolation;
 import com.powsybl.security.LimitViolationType;
 
@@ -44,7 +43,7 @@ public class LimitViolationDeserializer extends StdDeserializer<LimitViolation> 
         double limit = Double.NaN;
         float limitReduction = Float.NaN;
         double value = Double.NaN;
-        Branch.Side side = null;
+        String side = null;
 
         List<Extension<LimitViolation>> extensions = Collections.emptyList();
 
@@ -89,7 +88,7 @@ public class LimitViolationDeserializer extends StdDeserializer<LimitViolation> 
 
                 case "side":
                     parser.nextToken();
-                    side = JsonUtil.readValue(deserializationContext, parser, Branch.Side.class);
+                    side = JsonUtil.readValue(deserializationContext, parser, String.class);
                     break;
 
                 case "extensions":

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/LimitViolationSerializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/LimitViolationSerializer.java
@@ -37,7 +37,7 @@ public class LimitViolationSerializer extends StdSerializer<LimitViolation> {
         jsonGenerator.writeNumberField("limit", limitViolation.getLimit());
         jsonGenerator.writeNumberField("limitReduction", limitViolation.getLimitReduction());
         jsonGenerator.writeNumberField("value", limitViolation.getValue());
-        JsonUtil.writeOptionalEnumField(jsonGenerator, "side", limitViolation.getSide());
+        JsonUtil.writeOptionalStringField(jsonGenerator, "side", limitViolation.getSide());
 
         JsonUtil.writeExtensions(limitViolation, jsonGenerator, serializerProvider);
 

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationBuilderTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationBuilderTest.java
@@ -49,7 +49,7 @@ class LimitViolationBuilderTest {
         LimitViolation violation = builder.build();
         assertEquals("id", violation.getSubjectId());
         assertSame(LimitViolationType.CURRENT, violation.getLimitType());
-        assertEquals(Branch.Side.ONE, violation.getSide());
+        assertEquals(Branch.Side.ONE, Branch.Side.valueOf(violation.getSide()));
         assertNull(violation.getLimitName());
         assertEquals(1500, violation.getLimit(), 0);
         assertEquals(2000, violation.getValue(), 0);
@@ -63,7 +63,7 @@ class LimitViolationBuilderTest {
                 .side2()
                 .duration(60)
                 .build();
-        assertEquals(Branch.Side.TWO, violation2.getSide());
+        assertEquals(Branch.Side.TWO, Branch.Side.valueOf(violation2.getSide()));
         assertEquals("name", violation2.getSubjectName());
         assertEquals("limitName", violation2.getLimitName());
         assertEquals(0.9f, violation2.getLimitReduction(), 0);
@@ -176,12 +176,12 @@ class LimitViolationBuilderTest {
                                                        .limit(1500)
                                                        .value(2000)
                                                        .duration(20, TimeUnit.MINUTES)
-                                                       .side(Branch.Side.ONE);
+                                                       .side(Branch.Side.ONE.name());
 
         LimitViolation violation = builder.build();
         assertEquals("id", violation.getSubjectId());
         assertSame(LimitViolationType.ACTIVE_POWER, violation.getLimitType());
-        assertSame(Branch.Side.ONE, violation.getSide());
+        assertSame(Branch.Side.ONE, Branch.Side.valueOf(violation.getSide()));
         assertNull(violation.getLimitName());
         assertEquals(1500, violation.getLimit(), 0);
         assertEquals(2000, violation.getValue(), 0);
@@ -195,12 +195,12 @@ class LimitViolationBuilderTest {
                                                        .limit(1500)
                                                        .value(2000)
                                                        .duration(20, TimeUnit.MINUTES)
-                                                       .side(Branch.Side.TWO);
+                                                       .side(Branch.Side.TWO.name());
 
         LimitViolation violation = builder.build();
         assertEquals("id", violation.getSubjectId());
         assertSame(LimitViolationType.APPARENT_POWER, violation.getLimitType());
-        assertSame(Branch.Side.TWO, violation.getSide());
+        assertSame(Branch.Side.TWO, Branch.Side.valueOf(violation.getSide()));
         assertNull(violation.getLimitName());
         assertEquals(1500, violation.getLimit(), 0);
         assertEquals(2000, violation.getValue(), 0);

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationFilterTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationFilterTest.java
@@ -89,11 +89,11 @@ class LimitViolationFilterTest {
                 .to(network.getLine("LINE1").getTerminal2())
                 .add();
 
-        LimitViolation line1Violation = new LimitViolation("LINE1", LimitViolationType.CURRENT, "", Integer.MAX_VALUE, 1000.0, 1, 1100.0, Branch.Side.ONE);
-        LimitViolation line2Violation = new LimitViolation("LINE2", LimitViolationType.CURRENT, "", Integer.MAX_VALUE, 900.0, 1, 950.0, Branch.Side.TWO);
+        LimitViolation line1Violation = new LimitViolation("LINE1", LimitViolationType.CURRENT, "", Integer.MAX_VALUE, 1000.0, 1, 1100.0, Branch.Side.ONE.name());
+        LimitViolation line2Violation = new LimitViolation("LINE2", LimitViolationType.CURRENT, "", Integer.MAX_VALUE, 900.0, 1, 950.0, Branch.Side.TWO.name());
         LimitViolation vl1Violation = new LimitViolation("VL1", LimitViolationType.HIGH_VOLTAGE, 200.0, 1, 250.0);
-        LimitViolation line1ViolationAcP = new LimitViolation("VL1", LimitViolationType.ACTIVE_POWER, "", Integer.MAX_VALUE, 200.0, 1, 250.0, Branch.Side.ONE);
-        LimitViolation line1ViolationApP = new LimitViolation("VL1", LimitViolationType.APPARENT_POWER, "", Integer.MAX_VALUE, 200.0, 1, 250.0, Branch.Side.TWO);
+        LimitViolation line1ViolationAcP = new LimitViolation("VL1", LimitViolationType.ACTIVE_POWER, "", Integer.MAX_VALUE, 200.0, 1, 250.0, Branch.Side.ONE.name());
+        LimitViolation line1ViolationApP = new LimitViolation("VL1", LimitViolationType.APPARENT_POWER, "", Integer.MAX_VALUE, 200.0, 1, 250.0, Branch.Side.TWO.name());
         LimitViolation voltageAngleLimit = new LimitViolation("val", LimitViolationType.HIGH_VOLTAGE_ANGLE, "", Integer.MAX_VALUE, 0.25, 1, 0.26, null);
 
         LimitViolationFilter filter = new LimitViolationFilter();

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationTest.java
@@ -85,7 +85,7 @@ class LimitViolationTest {
         LimitViolation limitViolation1 = new LimitViolation("testId", null, LimitViolationType.HIGH_VOLTAGE, "high", Integer.MAX_VALUE,
                 420, 1, 500, null);
         LimitViolation limitViolation2 = new LimitViolation("testId", null, LimitViolationType.CURRENT, null, 6300,
-                1000, 1, 1100, Branch.Side.ONE);
+                1000, 1, 1100, Branch.Side.ONE.name());
         String expected1 = "Subject id: testId, Subject name: null, limitType: HIGH_VOLTAGE, limit: 420.0, limitName: high, acceptableDuration: 2147483647, limitReduction: 1.0, value: 500.0, side: null";
         String expected2 = "Subject id: testId, Subject name: null, limitType: CURRENT, limit: 1000.0, limitName: null, acceptableDuration: 6300, limitReduction: 1.0, value: 1100.0, side: ONE";
 

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisResultMergerTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisResultMergerTest.java
@@ -36,13 +36,13 @@ class SecurityAnalysisResultMergerTest {
     @BeforeEach
     void setup() {
         // create pre-contingency results, just one violation on line1
-        LimitViolation line1Violation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000f, 0.95f, 1100, Branch.Side.ONE);
+        LimitViolation line1Violation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000f, 0.95f, 1100, Branch.Side.ONE.name());
         preContingencyResult = new LimitViolationsResult(Collections.singletonList(line1Violation), Collections.singletonList("action1"));
 
         // create post-contingency results, still the line1 violation plus line2 violation
         Contingency contingency1 = Mockito.mock(Contingency.class);
         Mockito.when(contingency1.getId()).thenReturn("contingency1");
-        LimitViolation line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900f, 0.95f, 950, Branch.Side.ONE);
+        LimitViolation line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900f, 0.95f, 950, Branch.Side.ONE.name());
         postContingencyResult = new PostContingencyResult(contingency1, PostContingencyComputationStatus.CONVERGED, Arrays.asList(line1Violation, line2Violation), Collections.singletonList("action2"));
 
         Contingency contingency2 = Mockito.mock(Contingency.class);

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityTest.java
@@ -47,13 +47,13 @@ class SecurityTest {
         network = EurostagTutorialExample1Factory.createWithCurrentLimits();
 
         // create pre-contingency results, just one violation on line1
-        line1Violation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
+        line1Violation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
         LimitViolationsResult preContingencyResult = new LimitViolationsResult(Collections.singletonList(line1Violation), Collections.singletonList("action1"));
 
         // create post-contingency results, still the line1 violation plus line2 violation
         Contingency contingency1 = Mockito.mock(Contingency.class);
         Mockito.when(contingency1.getId()).thenReturn("contingency1");
-        line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, Branch.Side.ONE);
+        line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, Branch.Side.ONE.name());
         PostContingencyResult postContingencyResult = new PostContingencyResult(contingency1, PostContingencyComputationStatus.CONVERGED, Arrays.asList(line1Violation, line2Violation), Collections.singletonList("action2"));
 
         result = new SecurityAnalysisResult(preContingencyResult, LoadFlowResult.ComponentResult.Status.CONVERGED, Collections.singletonList(postContingencyResult));

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationComparatorTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationComparatorTest.java
@@ -26,13 +26,13 @@ class LimitViolationComparatorTest {
 
     @Test
     void compare() {
-        LimitViolation line1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
-        LimitViolation line1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO);
-        LimitViolation line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, Branch.Side.ONE);
+        LimitViolation line1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
+        LimitViolation line1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO.name());
+        LimitViolation line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, Branch.Side.ONE.name());
         LimitViolation vl1Violation1 = new LimitViolation("VL1", LimitViolationType.HIGH_VOLTAGE, 200.0, 1, 250.0);
         LimitViolation vl1Violation2 = new LimitViolation("VL1", LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT, 200.0, 1, 250.0);
-        LimitViolation line1AcPViolation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.ACTIVE_POWER, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
-        LimitViolation line2AppViolation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.APPARENT_POWER, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, Branch.Side.ONE);
+        LimitViolation line1AcPViolation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.ACTIVE_POWER, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
+        LimitViolation line2AppViolation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.APPARENT_POWER, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, Branch.Side.ONE.name());
 
         List<LimitViolation> violations = Arrays.asList(line1Violation2, vl1Violation1, line2Violation, line1Violation1, vl1Violation2, line1AcPViolation, line2AppViolation);
         Collections.sort(violations, new LimitViolationComparator());

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationEquivalenceTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationEquivalenceTest.java
@@ -25,30 +25,30 @@ class LimitViolationEquivalenceTest {
     void equivalent() {
         LimitViolationEquivalence violationEquivalence = new LimitViolationEquivalence(0.1);
 
-        LimitViolation violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
+        LimitViolation violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
 
-        LimitViolation violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
+        LimitViolation violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
         assertTrue(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.ONE);
+        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.ONE.name());
         assertTrue(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, Branch.Side.ONE);
+        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, Branch.Side.ONE.name());
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO);
+        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO.name());
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
+        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
+        violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.ACTIVE_POWER, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
+        violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.ACTIVE_POWER, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.APPARENT_POWER, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO);
+        violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.APPARENT_POWER, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO.name());
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
     }
 

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationsResultEquivalenceTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationsResultEquivalenceTest.java
@@ -30,15 +30,15 @@ class LimitViolationsResultEquivalenceTest {
     void equivalent() {
         LimitViolationsResultEquivalence resultEquivalence = new LimitViolationsResultEquivalence(0.1, NullWriter.NULL_WRITER);
 
-        LimitViolation line1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
-        LimitViolation sameLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
-        LimitViolation line1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO);
-        LimitViolation sameLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO);
-        LimitViolation similarLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.TWO);
-        LimitViolation differentLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, Branch.Side.TWO);
-        LimitViolation line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, Branch.Side.ONE);
-        LimitViolation sameLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, Branch.Side.ONE);
-        LimitViolation smallLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 1, 900.09, Branch.Side.TWO);
+        LimitViolation line1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
+        LimitViolation sameLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
+        LimitViolation line1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO.name());
+        LimitViolation sameLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO.name());
+        LimitViolation similarLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.TWO.name());
+        LimitViolation differentLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, Branch.Side.TWO.name());
+        LimitViolation line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, Branch.Side.ONE.name());
+        LimitViolation sameLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, Branch.Side.ONE.name());
+        LimitViolation smallLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 1, 900.09, Branch.Side.TWO.name());
         LimitViolation vl1Violation1 = new LimitViolation("VL1", LimitViolationType.HIGH_VOLTAGE, 200.0, 1, 250.0);
         LimitViolation sameVl1Violation1 = new LimitViolation("VL1", LimitViolationType.HIGH_VOLTAGE, 200.0, 1, 250.0);
         LimitViolation vl1Violation2 = new LimitViolation("VL1", LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT, 200.0, 1, 250.0);

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/SecurityAnalysisResultComparisonWriterTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/SecurityAnalysisResultComparisonWriterTest.java
@@ -41,8 +41,8 @@ class SecurityAnalysisResultComparisonWriterTest {
     @BeforeEach
     void setUp() {
         vlViolation = new LimitViolation("VL1", LimitViolationType.HIGH_VOLTAGE, 200.0, 1, 250.0);
-        lineViolation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, "PermanentLimit", Integer.MAX_VALUE, 1000.0, 1, 1100.0, Branch.Side.ONE);
-        similarLineViolation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, "PermanentLimit", Integer.MAX_VALUE, 1000.0, 1, 1100.09, Branch.Side.ONE);
+        lineViolation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, "PermanentLimit", Integer.MAX_VALUE, 1000.0, 1, 1100.0, Branch.Side.ONE.name());
+        similarLineViolation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, "PermanentLimit", Integer.MAX_VALUE, 1000.0, 1, 1100.09, Branch.Side.ONE.name());
         actions = Arrays.asList("action1", "action2");
         writer = new StringWriter();
         comparisonWriter = new SecurityAnalysisResultComparisonWriter(writer);

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/SecurityAnalysisResultEquivalenceTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/SecurityAnalysisResultEquivalenceTest.java
@@ -31,20 +31,20 @@ class SecurityAnalysisResultEquivalenceTest {
     void equivalent() {
         SecurityAnalysisResultEquivalence resultEquivalence = new SecurityAnalysisResultEquivalence(0.1, NullWriter.NULL_WRITER);
 
-        LimitViolation line1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
-        LimitViolation similarLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.ONE);
-        LimitViolation differentLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, Branch.Side.ONE);
-        LimitViolation smallLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 950.09, Branch.Side.ONE);
+        LimitViolation line1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
+        LimitViolation similarLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.ONE.name());
+        LimitViolation differentLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, Branch.Side.ONE.name());
+        LimitViolation smallLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 950.09, Branch.Side.ONE.name());
 
-        LimitViolation line1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO);
-        LimitViolation similarLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.TWO);
-        LimitViolation differentLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, Branch.Side.TWO);
+        LimitViolation line1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.TWO.name());
+        LimitViolation similarLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.TWO.name());
+        LimitViolation differentLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, Branch.Side.TWO.name());
 
-        LimitViolation line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
-        LimitViolation similarLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.ONE);
-        LimitViolation smallLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 950.09, Branch.Side.ONE);
-        LimitViolation line3Violation = new LimitViolation("NHV1_NHV2_3", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE);
-        LimitViolation similarLine3Violation = new LimitViolation("NHV1_NHV2_3", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.ONE);
+        LimitViolation line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
+        LimitViolation similarLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.ONE.name());
+        LimitViolation smallLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 950.09, Branch.Side.ONE.name());
+        LimitViolation line3Violation = new LimitViolation("NHV1_NHV2_3", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, Branch.Side.ONE.name());
+        LimitViolation similarLine3Violation = new LimitViolation("NHV1_NHV2_3", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, Branch.Side.ONE.name());
 
         Contingency contingency1 = Mockito.mock(Contingency.class);
         Mockito.when(contingency1.getId()).thenReturn("contingency1");

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
@@ -43,10 +43,10 @@ class ExporterTest extends AbstractConverterTest {
 
     private static SecurityAnalysisResult create() {
         // Create a LimitViolation(CURRENT) to ensure backward compatibility works
-        LimitViolation violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 100, 0.95f, 110.0, Branch.Side.ONE);
+        LimitViolation violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 100, 0.95f, 110.0, Branch.Side.ONE.name());
         violation1.addExtension(ActivePowerExtension.class, new ActivePowerExtension(220.0));
 
-        LimitViolation violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, "20'", 1200, 100, 1.0f, 110.0, Branch.Side.TWO);
+        LimitViolation violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, "20'", 1200, 100, 1.0f, 110.0, Branch.Side.TWO.name());
         violation2.addExtension(ActivePowerExtension.class, new ActivePowerExtension(220.0, 230.0));
         violation2.addExtension(CurrentExtension.class, new CurrentExtension(95.0));
 
@@ -54,8 +54,8 @@ class ExporterTest extends AbstractConverterTest {
         LimitViolation violation4 = new LimitViolation("GEN2", LimitViolationType.LOW_VOLTAGE, 100, 0.7f, 115);
         violation4.addExtension(VoltageExtension.class, new VoltageExtension(400.0));
 
-        LimitViolation violation5 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.ACTIVE_POWER, "20'", 1200, 100, 1.0f, 110.0, Branch.Side.ONE);
-        LimitViolation violation6 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.APPARENT_POWER, "20'", 1200, 100, 1.0f, 110.0, Branch.Side.TWO);
+        LimitViolation violation5 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.ACTIVE_POWER, "20'", 1200, 100, 1.0f, 110.0, Branch.Side.ONE.name());
+        LimitViolation violation6 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.APPARENT_POWER, "20'", 1200, 100, 1.0f, 110.0, Branch.Side.TWO.name());
 
         Contingency contingency = Contingency.builder("contingency")
                 .addBranch("NHV1_NHV2_2", "VLNHV1")
@@ -87,7 +87,7 @@ class ExporterTest extends AbstractConverterTest {
 
     @Test
     void testCompatibilityV1Deserialization() {
-        LimitViolation violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 100, 0.95f, 110.0, Branch.Side.ONE);
+        LimitViolation violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 100, 0.95f, 110.0, Branch.Side.ONE.name());
         violation1.addExtension(ActivePowerExtension.class, new ActivePowerExtension(220.0));
         SecurityAnalysisResult result = SecurityAnalysisResultDeserializer.read(getClass().getResourceAsStream("/SecurityAnalysisResultV1.json"));
         Assertions.assertThat(result.getPreContingencyLimitViolationsResult().getLimitViolations()).hasSize(1);

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/detectors/DefaultLimitViolationDetectorTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/detectors/DefaultLimitViolationDetectorTest.java
@@ -64,7 +64,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1100, l.getLimit(), 0d);
                     assertEquals(1101, l.getValue(), 0d);
-                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                     assertEquals(600, l.getAcceptableDuration());
                     assertEquals(PERMANENT_LIMIT_NAME, l.getLimitName());
                 });
@@ -107,7 +107,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1200, l.getLimit(), 0d);
                     assertEquals(1201, l.getValue(), 0d);
-                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                     assertEquals(60, l.getAcceptableDuration());
                 });
     }
@@ -121,7 +121,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1200, l.getLimit(), 0d);
                     assertEquals(1250, l.getValue(), 0d);
-                    assertSame(Branch.Side.ONE, l.getSide());
+                    assertSame(Branch.Side.ONE, Branch.Side.valueOf(l.getSide()));
                     assertEquals(60, l.getAcceptableDuration());
                 });
     }
@@ -136,7 +136,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1100, l.getLimit(), 0d);
                     assertEquals(1101, l.getValue(), 0d);
-                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                     assertEquals(600, l.getAcceptableDuration());
                     assertEquals(PERMANENT_LIMIT_NAME, l.getLimitName());
                 });
@@ -179,7 +179,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1200, l.getLimit(), 0d);
                     assertEquals(1201, l.getValue(), 0d);
-                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                     assertEquals(60, l.getAcceptableDuration());
                 });
     }
@@ -193,7 +193,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1200, l.getLimit(), 0d);
                     assertEquals(1250, l.getValue(), 0d);
-                    assertSame(Branch.Side.ONE, l.getSide());
+                    assertSame(Branch.Side.ONE, Branch.Side.valueOf(l.getSide()));
                     assertEquals(60, l.getAcceptableDuration());
                 });
     }
@@ -306,7 +306,7 @@ class DefaultLimitViolationDetectorTest {
                   .allSatisfy(l -> {
                       assertEquals(1100, l.getLimit(), 0d);
                       assertEquals(1101, l.getValue(), 0d);
-                      assertSame(Branch.Side.TWO, l.getSide());
+                      assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                       assertEquals(PERMANENT_LIMIT_NAME, l.getLimitName());
                   });
     }
@@ -321,7 +321,7 @@ class DefaultLimitViolationDetectorTest {
                   .allSatisfy(l -> {
                       assertEquals(1100, l.getLimit(), 0d);
                       assertEquals(1101, l.getValue(), 0d);
-                      assertSame(Branch.Side.TWO, l.getSide());
+                      assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                       assertEquals(PERMANENT_LIMIT_NAME, l.getLimitName());
                       assertEquals(1.0f, l.getLimitReduction());
                   });
@@ -337,7 +337,7 @@ class DefaultLimitViolationDetectorTest {
                   .allSatisfy(l -> {
                       assertEquals(1200, l.getLimit(), 0d);
                       assertEquals(1201, l.getValue(), 0d);
-                      assertSame(Branch.Side.TWO, l.getSide());
+                      assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                       assertNotEquals(PERMANENT_LIMIT_NAME, l.getLimitName());
                   });
     }
@@ -353,7 +353,7 @@ class DefaultLimitViolationDetectorTest {
                   .allSatisfy(l -> {
                       assertEquals(1200, l.getLimit(), 0d);
                       assertEquals(1201, l.getValue(), 0d);
-                      assertSame(Branch.Side.TWO, l.getSide());
+                      assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                       assertNotEquals(PERMANENT_LIMIT_NAME, l.getLimitName());
                   });
     }
@@ -370,7 +370,7 @@ class DefaultLimitViolationDetectorTest {
                   .allSatisfy(l -> {
                       assertEquals(1200, l.getLimit(), 0d);
                       assertEquals(1201, l.getValue(), 0d);
-                      assertSame(Branch.Side.TWO, l.getSide());
+                      assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                   });
     }
 
@@ -386,7 +386,7 @@ class DefaultLimitViolationDetectorTest {
                   .allSatisfy(l -> {
                       assertEquals(1200, l.getLimit(), 0d);
                       assertEquals(1201, l.getValue(), 0d);
-                      assertSame(Branch.Side.TWO, l.getSide());
+                      assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                   });
     }
 
@@ -411,7 +411,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1100, l.getLimit(), 0d);
                     assertEquals(1101, l.getValue(), 0d);
-                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                     assertEquals(PERMANENT_LIMIT_NAME, l.getLimitName());
                 });
     }
@@ -426,7 +426,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1100, l.getLimit(), 0d);
                     assertEquals(1101, l.getValue(), 0d);
-                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                     assertEquals(PERMANENT_LIMIT_NAME, l.getLimitName());
                     assertEquals(1.0f, l.getLimitReduction());
                 });
@@ -442,7 +442,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1200, l.getLimit(), 0d);
                     assertEquals(1201, l.getValue(), 0d);
-                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                     assertNotEquals(PERMANENT_LIMIT_NAME, l.getLimitName());
                 });
     }
@@ -458,7 +458,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1200, l.getLimit(), 0d);
                     assertEquals(1201, l.getValue(), 0d);
-                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                     assertNotEquals(PERMANENT_LIMIT_NAME, l.getLimitName());
                 });
     }
@@ -475,7 +475,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1200, l.getLimit(), 0d);
                     assertEquals(1201, l.getValue(), 0d);
-                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                 });
     }
 
@@ -491,7 +491,7 @@ class DefaultLimitViolationDetectorTest {
                 .allSatisfy(l -> {
                     assertEquals(1200, l.getLimit(), 0d);
                     assertEquals(1201, l.getValue(), 0d);
-                    assertSame(Branch.Side.TWO, l.getSide());
+                    assertSame(Branch.Side.TWO, Branch.Side.valueOf(l.getSide()));
                 });
     }
 

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/detectors/LimitViolationDetectorTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/detectors/LimitViolationDetectorTest.java
@@ -46,7 +46,7 @@ class LimitViolationDetectorTest {
         if (branch == line1) {
             consumer.accept(LimitViolations.current()
                     .subject(branch.getId())
-                    .side(side)
+                    .side(side.name())
                     .duration(1200)
                     .value(1500)
                     .limit(1200)
@@ -57,7 +57,7 @@ class LimitViolationDetectorTest {
             consumer.accept(LimitViolations.current()
                     .subject(branch.getId())
                     .duration(1200)
-                    .side(side)
+                    .side(side.name())
                     .value(1500)
                     .limit(1200)
                     .build());
@@ -68,7 +68,7 @@ class LimitViolationDetectorTest {
             consumer.accept(LimitViolations.current()
                     .subject(branch.getId())
                     .duration(1200)
-                    .side(side)
+                    .side(side.name())
                     .value(1500)
                     .limit(1200)
                     .build());
@@ -105,7 +105,7 @@ class LimitViolationDetectorTest {
         if (voltageAngleLimit == voltageAngleLimit0) {
             consumer.accept(LimitViolations.highVoltageAngle()
                 .subject(voltageAngleLimit.getTerminalFrom().getConnectable().getId())
-                .side(Branch.Side.ONE)
+                .side(Branch.Side.ONE.name())
                 .value(0.30)
                 .limit(0.25)
                 .build());
@@ -113,7 +113,7 @@ class LimitViolationDetectorTest {
         if (contingency == contingency1 && voltageAngleLimit == voltageAngleLimit1) {
             consumer.accept(LimitViolations.lowVoltageAngle()
                 .subject(voltageAngleLimit.getTerminalFrom().getConnectable().getId())
-                .side(Branch.Side.ONE)
+                .side(Branch.Side.ONE.name())
                 .value(-0.22)
                 .limit(0.20)
                 .build());


### PR DESCRIPTION
Find common denominator between 2 sides enum Branch.Side and 3 sides enum ThreeWindingsTransformer.Side as String (Enum.name())

With String, compareTo will give different results in case of non equality than the enum (lexicographic order) but json API will be unchanged NB. check for == vs equals

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
