### PR TITLE
CGMES phase tap changer xMin: optional and consistent with transformer x

### DIFF
--- a/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/Cgmes3ModifiedCatalog.java
+++ b/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/Cgmes3ModifiedCatalog.java
@@ -96,5 +96,24 @@ public final class Cgmes3ModifiedCatalog {
                 new ResourceSet(base, "20171002T0930Z_ENTSO-E_EQ_BD_2.xml"));
     }
 
+    public static GridModelReferenceResources microGridBaseCasePhaseTapChangerXMin() {
+        String base = CGMES_3_MODIFIED_TEST_MODELS
+                + "/MicroGrid/phaseTapChangerXMin/";
+        return new GridModelReferenceResources(
+                "MicroGrid-phaseTapChanger-xMin",
+                null,
+                new ResourceSet(base, "20210209T1930Z_1D_BE_EQ_9.xml"),
+                new ResourceSet(CGMES_3_MICRO_GRID_BASE,
+                        "20210209T1930Z_1D_ASSEMBLED_DL_9.xml",
+                        "20210209T1930Z_1D_ASSEMBLED_SV_9.xml",
+                        "20210209T1930Z_1D_BE_GL_9.xml",
+                        "20210209T1930Z_1D_BE_SSH_9.xml",
+                        "20210209T1930Z_1D_NL_EQ_9.xml",
+                        "20210209T1930Z_1D_NL_GL_9.xml",
+                        "20210209T1930Z_1D_NL_SSH_9.xml",
+                        "20210209T2323Z_1D_ASSEMBLED_TP_9.xml"),
+                new ResourceSet(CGMES_3_MICRO_GRID_BASE, "20171002T0930Z_ENTSO-E_EQ_BD_2.xml"));
+    }
+
     private static final String CGMES_3_MODIFIED_TEST_MODELS = "/cgmes3-test-models-modified";
 }

--- a/cgmes/cgmes-conformity/src/main/resources/cgmes3-test-models-modified/MicroGrid/phaseTapChangerXMin/20210209T1930Z_1D_BE_EQ_9.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/cgmes3-test-models-modified/MicroGrid/phaseTapChangerXMin/20210209T1930Z_1D_BE_EQ_9.xml
@@ -1,0 +1,2325 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/CIM100#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:eu="http://iec.ch/TC57/CIM100-European#">
+  <md:FullModel rdf:about="urn:uuid:9e7050a8-960b-4e1a-8e34-7f56bc2b2a7b">
+    <md:Model.created>2021-02-09T19:28:14Z</md:Model.created>
+    <md:Model.scenarioTime>2021-02-09T19:30:00Z</md:Model.scenarioTime>
+    <md:Model.description>CGMES Conformity Assessment Test Configuration. The Test Configuration is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CGMES</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0</md:Model.profile>
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/Operation-EU/3.0</md:Model.profile>
+    <md:Model.version>5</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:2399cbd0-9a39-11e0-aa80-0800200c9a66" />
+    <md:Model.profile>http://iec.ch/TC57/ns/CIM/ShortCircuit-EU/3.0</md:Model.profile>
+  </md:FullModel>
+  <cim:LoadArea rdf:ID="_6ab47762-da13-45de-885b-98e1e409972f">
+    <cim:IdentifiedObject.name>BE LoadArea</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>6ab47762-da13-45de-885b-98e1e409972f</cim:IdentifiedObject.mRID>
+  </cim:LoadArea>
+  <cim:SubLoadArea rdf:ID="_7521cc3f-7c69-493b-b72a-3f20d72d8a56">
+    <cim:IdentifiedObject.name>ELIA-Anvers SubLoadArea</cim:IdentifiedObject.name>
+    <cim:SubLoadArea.LoadArea rdf:resource="#_6ab47762-da13-45de-885b-98e1e409972f" />
+    <cim:IdentifiedObject.mRID>7521cc3f-7c69-493b-b72a-3f20d72d8a56</cim:IdentifiedObject.mRID>
+  </cim:SubLoadArea>
+  <cim:SubLoadArea rdf:ID="_8e1e7c28-cd22-40c6-b289-21b3bd365dc3">
+    <cim:IdentifiedObject.name>ELIA-Brussels SubLoadArea</cim:IdentifiedObject.name>
+    <cim:SubLoadArea.LoadArea rdf:resource="#_6ab47762-da13-45de-885b-98e1e409972f" />
+    <cim:IdentifiedObject.mRID>8e1e7c28-cd22-40c6-b289-21b3bd365dc3</cim:IdentifiedObject.mRID>
+  </cim:SubLoadArea>
+  <cim:GeographicalRegion rdf:ID="_7bf89875-1476-4d1a-a56d-a2965cce3575">
+    <cim:IdentifiedObject.name>BE</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.mRID>_7bf89875-1476-4d1a-a56d-a2965cce3575</cim:IdentifiedObject.mRID>
+  </cim:GeographicalRegion>
+  <cim:SubGeographicalRegion rdf:ID="_02047c0b-b5a4-4e0d-bae6-fc5437a55e74">
+    <cim:IdentifiedObject.name>ELIA-Anvers</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_7bf89875-1476-4d1a-a56d-a2965cce3575" />
+    <cim:IdentifiedObject.mRID>02047c0b-b5a4-4e0d-bae6-fc5437a55e74</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <cim:Substation rdf:ID="_87f7002b-056f-4a6a-a872-1744eea757e3">
+    <cim:IdentifiedObject.name>Anvers</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>Anvers</eu:IdentifiedObject.shortName>
+    <cim:Substation.Region rdf:resource="#_02047c0b-b5a4-4e0d-bae6-fc5437a55e74" />
+    <cim:IdentifiedObject.mRID>87f7002b-056f-4a6a-a872-1744eea757e3</cim:IdentifiedObject.mRID>
+  </cim:Substation>
+  <cim:SubGeographicalRegion rdf:ID="_61378219-a236-4070-bbec-4e30a6ac848d">
+    <cim:IdentifiedObject.name>ELIA-Brussels</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_7bf89875-1476-4d1a-a56d-a2965cce3575" />
+    <cim:IdentifiedObject.mRID>61378219-a236-4070-bbec-4e30a6ac848d</cim:IdentifiedObject.mRID>
+  </cim:SubGeographicalRegion>
+  <cim:Substation rdf:ID="_37e14a0f-5e34-4647-a062-8bfd9305fa9d">
+    <cim:IdentifiedObject.name>PP_Brussels</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>PP_Brussels</eu:IdentifiedObject.shortName>
+    <cim:Substation.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d" />
+    <cim:IdentifiedObject.mRID>37e14a0f-5e34-4647-a062-8bfd9305fa9d</cim:IdentifiedObject.mRID>
+  </cim:Substation>
+  <cim:VoltageLevel rdf:ID="_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0">
+    <cim:IdentifiedObject.name>110.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>121</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>99</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:IdentifiedObject.mRID>8bbd7e74-ae20-4dce-8780-c20f8e18c2e0</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_56ca173b-fd2d-4ef3-bc32-4ae86a318c39">
+    <cim:IdentifiedObject.name>BE_TR_BUS3</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:IdentifiedObject.mRID>56ca173b-fd2d-4ef3-bc32-4ae86a318c39</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:VoltageLevel rdf:ID="_469df5f7-058f-4451-a998-57a48e8a56fe">
+    <cim:IdentifiedObject.name>380.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>418</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>342</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:IdentifiedObject.mRID>469df5f7-058f-4451-a998-57a48e8a56fe</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_3a849ea6-8dd5-4406-ac11-c89db47ef753">
+    <cim:IdentifiedObject.name>N1230991739</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>3a849ea6-8dd5-4406-ac11-c89db47ef753</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:VoltageLevel rdf:ID="_69ef0dbd-da79-4eef-a02f-690cb8a28361">
+    <cim:IdentifiedObject.name>225.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>247.5</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>202.5</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_87f7002b-056f-4a6a-a872-1744eea757e3" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:IdentifiedObject.mRID>69ef0dbd-da79-4eef-a02f-690cb8a28361</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_36f63f4c-df3b-4507-baf5-bb4934c09183">
+    <cim:IdentifiedObject.name>N1230992414</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_3</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>36f63f4c-df3b-4507-baf5-bb4934c09183</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_d6986ea6-fadc-4113-806a-a8f95f62c216">
+    <cim:IdentifiedObject.name>N1230992414</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>d6986ea6-fadc-4113-806a-a8f95f62c216</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_ad794c0e-b9ec-420b-ada1-97680e3dde05">
+    <cim:IdentifiedObject.name>N1230992414_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d6986ea6-fadc-4113-806a-a8f95f62c216" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_36f63f4c-df3b-4507-baf5-bb4934c09183" />
+    <cim:IdentifiedObject.mRID>ad794c0e-b9ec-420b-ada1-97680e3dde05</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_bb6a1e59-1071-4985-b80f-d227cf133067">
+    <cim:IdentifiedObject.name>BE_BUSBAR_12</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>bb6a1e59-1071-4985-b80f-d227cf133067</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_d5b267d8-29d8-434b-b3aa-08f8f3435fc0">
+    <cim:IdentifiedObject.name>BE_TR_BUS1</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:IdentifiedObject.mRID>d5b267d8-29d8-434b-b3aa-08f8f3435fc0</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_4836f99b-c6e9-4ee8-a956-b1e3da882d46">
+    <cim:IdentifiedObject.name>BE-Busbar_1</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_1</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>4836f99b-c6e9-4ee8-a956-b1e3da882d46</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c">
+    <cim:IdentifiedObject.name>BE-Busbar_1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_fa9e0f4d-8a2f-45e1-9e36-3611600d1c94">
+    <cim:IdentifiedObject.name>BE-Busbar_1_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>fa9e0f4d-8a2f-45e1-9e36-3611600d1c94</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_929ba893-c9dc-44d7-b1fd-30834bd3ab85">
+    <cim:IdentifiedObject.name>21.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>23.1</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>18.9</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2" />
+    <cim:IdentifiedObject.mRID>929ba893-c9dc-44d7-b1fd-30834bd3ab85</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_84c93a56-e0ca-4deb-a2ce-5eeb10682cab">
+    <cim:IdentifiedObject.name>BE_BUSBAR_10</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85" />
+    <cim:IdentifiedObject.mRID>84c93a56-e0ca-4deb-a2ce-5eeb10682cab</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_ae99bd74-26b1-443a-b1a5-656320283a36">
+    <cim:IdentifiedObject.name>BE-Busbar_2</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_2</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>ae99bd74-26b1-443a-b1a5-656320283a36</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_ef45b632-3028-4afe-bc4c-a4fa323d83fe">
+    <cim:IdentifiedObject.name>BE-Busbar_2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>ef45b632-3028-4afe-bc4c-a4fa323d83fe</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_800ada75-8c8c-4568-aec5-20f799e45f3c">
+    <cim:IdentifiedObject.name>BE-Busbar_2_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ef45b632-3028-4afe-bc4c-a4fa323d83fe" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>800ada75-8c8c-4568-aec5-20f799e45f3c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_29a37807-af63-402d-ac87-2e248d844793">
+    <cim:IdentifiedObject.name>N1230991550</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>29a37807-af63-402d-ac87-2e248d844793</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33">
+    <cim:IdentifiedObject.name>BE-Busbar_5</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_5</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85" />
+    <cim:IdentifiedObject.mRID>f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_1695eb20-9044-4133-a3fd-2147f55f170d">
+    <cim:IdentifiedObject.name>BE-Busbar_6</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_6</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:IdentifiedObject.mRID>1695eb20-9044-4133-a3fd-2147f55f170d</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_364c9ca2-0d1d-4363-8f46-e586f8f66a8c">
+    <cim:IdentifiedObject.name>BE-Busbar_6</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:BusbarSection.ipMax>5000</cim:BusbarSection.ipMax>
+    <cim:IdentifiedObject.mRID>364c9ca2-0d1d-4363-8f46-e586f8f66a8c</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_a1b46f53-86f1-497e-bf57-c3b6268bcd6c">
+    <cim:IdentifiedObject.name>BE-Busbar_6_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_364c9ca2-0d1d-4363-8f46-e586f8f66a8c" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>a1b46f53-86f1-497e-bf57-c3b6268bcd6c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_3293fcc7-4962-47df-a7c1-ce150600c388">
+    <cim:IdentifiedObject.name>BE_TR_BUS5</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:IdentifiedObject.mRID>3293fcc7-4962-47df-a7c1-ce150600c388</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:VoltageLevel rdf:ID="_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c">
+    <cim:IdentifiedObject.name>225.0</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>247.5</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>202.5</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:IdentifiedObject.mRID>b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_a09067cc-e7b3-4743-8134-f5e42b32e88a">
+    <cim:IdentifiedObject.name>BE_TR_BUS4</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>a09067cc-e7b3-4743-8134-f5e42b32e88a</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_21032053-e646-46a7-9a09-6a9a96dbf108">
+    <cim:IdentifiedObject.name>N1230991529</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>21032053-e646-46a7-9a09-6a9a96dbf108</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_bf851342-832e-4ea2-b2ad-b09729b3af23">
+    <cim:IdentifiedObject.name>BE-Busbar_3</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_3</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>bf851342-832e-4ea2-b2ad-b09729b3af23</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_5caf27ed-d2f8-458a-834a-6b3193a982e6">
+    <cim:IdentifiedObject.name>BE-Busbar_3</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>5caf27ed-d2f8-458a-834a-6b3193a982e6</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492">
+    <cim:IdentifiedObject.name>BE-Busbar_3_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5caf27ed-d2f8-458a-834a-6b3193a982e6" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_f33cc626-2c46-46b6-8536-88f30ab532cb">
+    <cim:IdentifiedObject.name>N1230991724</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>f33cc626-2c46-46b6-8536-88f30ab532cb</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_2dde989e-28c3-45f0-aa21-8695843ce894">
+    <cim:IdentifiedObject.name>N1230992291</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_3</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>2dde989e-28c3-45f0-aa21-8695843ce894</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_c8ce5e08-5ee3-42d9-aa44-5792db252d9f">
+    <cim:IdentifiedObject.name>N1230992291</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>c8ce5e08-5ee3-42d9-aa44-5792db252d9f</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_302fe23a-f64d-41bd-8a81-78130433916d">
+    <cim:IdentifiedObject.name>N1230992291_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_c8ce5e08-5ee3-42d9-aa44-5792db252d9f" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_2dde989e-28c3-45f0-aa21-8695843ce894" />
+    <cim:IdentifiedObject.mRID>302fe23a-f64d-41bd-8a81-78130433916d</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_18dca121-6c3b-440f-8bf4-8e365b8af551">
+    <cim:IdentifiedObject.name>N1230992288</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_3</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>18dca121-6c3b-440f-8bf4-8e365b8af551</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_63f25be7-7592-4cf1-8401-5772046ef2ae">
+    <cim:IdentifiedObject.name>N1230992288</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:IdentifiedObject.mRID>63f25be7-7592-4cf1-8401-5772046ef2ae</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_8f1c492f-a7cc-4160-9a14-54f1743e4850">
+    <cim:IdentifiedObject.name>N1230992288_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_63f25be7-7592-4cf1-8401-5772046ef2ae" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_18dca121-6c3b-440f-8bf4-8e365b8af551" />
+    <cim:IdentifiedObject.mRID>8f1c492f-a7cc-4160-9a14-54f1743e4850</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:VoltageLevel rdf:ID="_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386">
+    <cim:IdentifiedObject.name>10.5</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.highVoltageLimit>11.55</cim:VoltageLevel.highVoltageLimit>
+    <cim:VoltageLevel.lowVoltageLimit>9.45</cim:VoltageLevel.lowVoltageLimit>
+    <cim:VoltageLevel.Substation rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_862a4658-6b03-4550-9de2-b5c413912b75" />
+    <cim:IdentifiedObject.mRID>4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386</cim:IdentifiedObject.mRID>
+  </cim:VoltageLevel>
+  <cim:ConnectivityNode rdf:ID="_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c">
+    <cim:IdentifiedObject.name>BE-Busbar_4</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_4</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386" />
+    <cim:IdentifiedObject.mRID>0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_fd649fe1-bdf5-4062-98ea-bbb66f50402d">
+    <cim:IdentifiedObject.name>BE-Busbar_4</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386" />
+    <cim:IdentifiedObject.mRID>fd649fe1-bdf5-4062-98ea-bbb66f50402d</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_65b8c937-9b25-4b9e-addf-602dbc1337f9">
+    <cim:IdentifiedObject.name>BE-Busbar_4_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fd649fe1-bdf5-4062-98ea-bbb66f50402d" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c" />
+    <cim:IdentifiedObject.mRID>65b8c937-9b25-4b9e-addf-602dbc1337f9</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:ConnectivityNode rdf:ID="_93cec50e-e92e-4773-b408-e2419dad090d">
+    <cim:IdentifiedObject.name>BE_TR_BUS2</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:IdentifiedObject.mRID>93cec50e-e92e-4773-b408-e2419dad090d</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_af14c8ab-eb51-42be-89cb-abbcf37e20a3">
+    <cim:IdentifiedObject.name>Series Compensator</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>af14c8ab-eb51-42be-89cb-abbcf37e20a3</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_d0aad282-7c05-4990-b0cf-d9168815048e">
+    <cim:IdentifiedObject.name>N1230992411</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>BE-B_3</eu:IdentifiedObject.shortName>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>d0aad282-7c05-4990-b0cf-d9168815048e</cim:IdentifiedObject.mRID>
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_8da0ff82-2f23-4231-ac9b-28b9c9141432">
+    <cim:IdentifiedObject.name>N1230992411</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:IdentifiedObject.mRID>8da0ff82-2f23-4231-ac9b-28b9c9141432</cim:IdentifiedObject.mRID>
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_3c6d83a3-b5f9-41a2-a3d9-cf15d903ed0a">
+    <cim:IdentifiedObject.name>N1230992411_Busbar_Section</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConductingEquipment rdf:resource="#_8da0ff82-2f23-4231-ac9b-28b9c9141432" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d0aad282-7c05-4990-b0cf-d9168815048e" />
+    <cim:IdentifiedObject.mRID>3c6d83a3-b5f9-41a2-a3d9-cf15d903ed0a</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_0a84038e-1952-4d9d-9909-3b49c364a1ac">
+    <cim:IdentifiedObject.name>CIRCB-1230992408</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>0a84038e-1952-4d9d-9909-3b49c364a1ac</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_6b564930-b5e2-49d3-9d06-e1de28d6fd65">
+    <cim:IdentifiedObject.name>BE_Breaker_2</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>6b564930-b5e2-49d3-9d06-e1de28d6fd65</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_484536e9-762a-49a3-9970-d60b9fae03fe">
+    <cim:IdentifiedObject.name>CIRCB-1230991544</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>484536e9-762a-49a3-9970-d60b9fae03fe</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_969470b9-e74c-40d2-b3f7-bcfd88400fd1">
+    <cim:IdentifiedObject.name>BE_Breaker_10</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>969470b9-e74c-40d2-b3f7-bcfd88400fd1</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_fd136c65-d001-41a1-adc7-c5430b5c5e72">
+    <cim:IdentifiedObject.name>CIRCB-1230992399</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>fd136c65-d001-41a1-adc7-c5430b5c5e72</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_2922c1dd-4113-466e-8cad-002572f3f557">
+    <cim:IdentifiedObject.name>BE_Breaker_3</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>2922c1dd-4113-466e-8cad-002572f3f557</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_0e8cd279-ad5d-485a-b3a9-093ae8714b72">
+    <cim:IdentifiedObject.name>CIRCB-1230991736</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>0e8cd279-ad5d-485a-b3a9-093ae8714b72</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_3b394dab-ab47-4022-98be-8123c6dfe7d4">
+    <cim:IdentifiedObject.name>CIRCB-1230992276</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>3b394dab-ab47-4022-98be-8123c6dfe7d4</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_96c2b5c8-8e28-4b08-96d2-ca9b09cdbd83">
+    <cim:IdentifiedObject.name>BE_Breaker_12</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>96c2b5c8-8e28-4b08-96d2-ca9b09cdbd83</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_ddc148fc-3abd-459d-aec1-396283e0def6">
+    <cim:IdentifiedObject.name>CIRCB-1230992285</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>ddc148fc-3abd-459d-aec1-396283e0def6</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_6e86cd52-4594-435e-92ce-6dc673288ab4">
+    <cim:IdentifiedObject.name>BE_Breaker_5</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>6e86cd52-4594-435e-92ce-6dc673288ab4</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_14d55344-c118-4f54-a430-72f16d12bf7b">
+    <cim:IdentifiedObject.name>CIRCB-1230991718</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>14d55344-c118-4f54-a430-72f16d12bf7b</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_38dfcc80-600f-44e2-8f71-fb595b4f00ac">
+    <cim:IdentifiedObject.name>BE_Breaker_1</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>38dfcc80-600f-44e2-8f71-fb595b4f00ac</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_a603d890-5d9d-42ef-98d0-acf47d121c0e">
+    <cim:IdentifiedObject.name>BE_Breaker_4</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>a603d890-5d9d-42ef-98d0-acf47d121c0e</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:Breaker rdf:ID="_925a3a38-cd26-4f89-8891-c5bc8494e1ae">
+    <cim:IdentifiedObject.name>CIRCB-1230991526</cim:IdentifiedObject.name>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+    <cim:IdentifiedObject.mRID>925a3a38-cd26-4f89-8891-c5bc8494e1ae</cim:IdentifiedObject.mRID>
+  </cim:Breaker>
+  <cim:EquivalentInjection rdf:ID="_87ea56f3-962a-427a-85d6-13b1f9295174">
+    <cim:IdentifiedObject.name>BE-Inj-XZE_ST23</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XZE_ST2</eu:IdentifiedObject.shortName>
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>87ea56f3-962a-427a-85d6-13b1f9295174</cim:IdentifiedObject.mRID>
+	<cim:Equipment.EquipmentContainer rdf:resource="#_2e08aa26-2719-4b3e-a0eb-a9bd0ddbcae1" />
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_f7f61a91-eca2-4492-8bd7-9ec2b28fc837">
+    <cim:IdentifiedObject.name>BE-Inj-XZE_ST24</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XZE_ST2</eu:IdentifiedObject.shortName>
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>f7f61a91-eca2-4492-8bd7-9ec2b28fc837</cim:IdentifiedObject.mRID>
+	<cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa3" />
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf">
+    <cim:IdentifiedObject.name>BE-Inj-XWI_GY11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XWI_GY1</eu:IdentifiedObject.shortName>
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf</cim:IdentifiedObject.mRID>
+	<cim:Equipment.EquipmentContainer rdf:resource="#_bd25e87a-c626-4dd7-a846-7fba517fbb8f" />
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_14b352cb-5574-40c5-bf83-0ed3574554a3">
+    <cim:IdentifiedObject.name>BE-Inj-XKA_MA11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XKA_MA1</eu:IdentifiedObject.shortName>
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>14b352cb-5574-40c5-bf83-0ed3574554a3</cim:IdentifiedObject.mRID>
+	<cim:Equipment.EquipmentContainer rdf:resource="#_54a2e470-ef70-443f-ae81-bcf2d117caa2" />
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:ID="_24413233-26c3-4f7e-9f72-4461796938be">
+    <cim:IdentifiedObject.name>BE-Inj-XCA_AL11</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-I-XCA_AL1</eu:IdentifiedObject.shortName>
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_597e44dc-2a6e-4c62-82f3-f82cc46e0e14" />
+    <cim:EquivalentInjection.r>0</cim:EquivalentInjection.r>
+    <cim:EquivalentInjection.r0>0</cim:EquivalentInjection.r0>
+    <cim:EquivalentInjection.r2>0</cim:EquivalentInjection.r2>
+    <cim:EquivalentInjection.regulationCapability>false</cim:EquivalentInjection.regulationCapability>
+    <cim:EquivalentInjection.x>0</cim:EquivalentInjection.x>
+    <cim:EquivalentInjection.x0>0</cim:EquivalentInjection.x0>
+    <cim:EquivalentInjection.x2>0</cim:EquivalentInjection.x2>
+    <cim:IdentifiedObject.mRID>24413233-26c3-4f7e-9f72-4461796938be</cim:IdentifiedObject.mRID>
+	<cim:Equipment.EquipmentContainer rdf:resource="#_eac31e3d-fdf5-4656-b10e-66481bfcfec5" />
+  </cim:EquivalentInjection>
+  <cim:ACLineSegment rdf:ID="_b18cd1aa-7808-49b9-a7cf-605eaf07b006">
+    <cim:IdentifiedObject.name>BE-Line_5</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00009W</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00009W</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_5</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_608059fa-f262-463d-a8a8-80844a2a7021" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:Conductor.length>35</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>3.40863E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>6.59734E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>4.2E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>4.2E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.42</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>1.26</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>6.3</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>18.9</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>b18cd1aa-7808-49b9-a7cf-605eaf07b006</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_b639998f-3a5c-496d-96fd-759131b6c307">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_5 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22" />
+    <cim:IdentifiedObject.mRID>b639998f-3a5c-496d-96fd-759131b6c307</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_6ee07f23-59d3-4de0-a730-47bcb6d7a0cc">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1876</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>6ee07f23-59d3-4de0-a730-47bcb6d7a0cc</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_bfac8992-f589-493e-a7e2-dfe6d5b91044">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b639998f-3a5c-496d-96fd-759131b6c307" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>bfac8992-f589-493e-a7e2-dfe6d5b91044</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_4af71c73-fd57-45d2-aa83-f1b52fcc3bee">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_5 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_051d49ba-4360-4372-86bf-50eb8cf29778" />
+    <cim:IdentifiedObject.mRID>4af71c73-fd57-45d2-aa83-f1b52fcc3bee</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_af73fcf1-d40c-4350-81b0-b25645a5170f">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1876</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>af73fcf1-d40c-4350-81b0-b25645a5170f</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_7ace5f66-ca42-415c-b15e-7c137c631b08">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_4af71c73-fd57-45d2-aa83-f1b52fcc3bee" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>7ace5f66-ca42-415c-b15e-7c137c631b08</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_78736387-5f60-4832-b3fe-d50daf81b0a6">
+    <cim:IdentifiedObject.name>BE-Line_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00008Y</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00008Y</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_185273ba-a4e8-4754-8038-3b33eb76132e" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:Conductor.length>30</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>2.92168E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>0.000149854</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>6E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>6E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>1.05</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>3.15</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>12</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>36</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>78736387-5f60-4832-b3fe-d50daf81b0a6</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_99941f7a-11bb-4a7b-928b-ef8145db7799">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_3 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_231a4cf8-5069-4d53-96e4-e839f073f1ea" />
+    <cim:IdentifiedObject.mRID>99941f7a-11bb-4a7b-928b-ef8145db7799</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_fe392eba-9ca0-47e1-8562-ceca886b81bf">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1233.9</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>fe392eba-9ca0-47e1-8562-ceca886b81bf</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_7879d0ee-6c40-4766-91d2-4ce527f097e2">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_99941f7a-11bb-4a7b-928b-ef8145db7799" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>7879d0ee-6c40-4766-91d2-4ce527f097e2</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_0acd95d7-aff7-41f6-aa8a-863c42f4bc36">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_3 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_f3b56334-4638-49d3-a6a0-3f417422b8f5" />
+    <cim:IdentifiedObject.mRID>0acd95d7-aff7-41f6-aa8a-863c42f4bc36</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_0ba70561-d603-4238-8d6c-f49a0751dddf">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1233.9</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>0ba70561-d603-4238-8d6c-f49a0751dddf</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_1aa9b61b-03ae-4dc3-b985-8a7840630eed">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0acd95d7-aff7-41f6-aa8a-863c42f4bc36" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>1aa9b61b-03ae-4dc3-b985-8a7840630eed</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_ed0c5d75-4a54-43c8-b782-b20d7431630b">
+    <cim:IdentifiedObject.name>BE-Line_4</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>to be connected to the boundary set</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_4</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_f04af3a9-24e3-46dd-91c0-97fea3ecc6a7" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:Conductor.length>40</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>6.28319E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.51956E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>4E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>4E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>0.24</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>0.72</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>2</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>6</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>ed0c5d75-4a54-43c8-b782-b20d7431630b</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_b93ba071-c1d4-4c7a-960d-48dcd5d7c389">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_4 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0" />
+    <cim:IdentifiedObject.mRID>b93ba071-c1d4-4c7a-960d-48dcd5d7c389</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_29258f79-f877-4bfe-a169-68db7176110b">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1226</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>29258f79-f877-4bfe-a169-68db7176110b</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_59e373f9-96fc-451a-85c9-b75f30ec8848">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b93ba071-c1d4-4c7a-960d-48dcd5d7c389" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>59e373f9-96fc-451a-85c9-b75f30ec8848</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_67fa7320-7477-47e9-89ff-e3a407644aef">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_4 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe" />
+    <cim:IdentifiedObject.mRID>67fa7320-7477-47e9-89ff-e3a407644aef</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_e8b7c916-6157-484d-8887-a2a79e9fc59f">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1226</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>e8b7c916-6157-484d-8887-a2a79e9fc59f</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_dc0e417c-cf34-4484-a909-ba9549621078">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_67fa7320-7477-47e9-89ff-e3a407644aef" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>dc0e417c-cf34-4484-a909-ba9549621078</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_17086487-56ba-4979-b8de-064025a6b4da">
+    <cim:IdentifiedObject.name>BE-Line_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-000061</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_2b659afe-2ac3-425c-9418-3383e09b4b39" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Conductor.length>22</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>2.62637E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>8.2938E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>3.08E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>3.08E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>2.2</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>6.6</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>68.2</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>204.6</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>17086487-56ba-4979-b8de-064025a6b4da</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_a5b37323-8f73-449a-8931-f73193d95587">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_70d962fb-a492-4c36-8cad-b5c584df53bd" />
+    <cim:IdentifiedObject.mRID>a5b37323-8f73-449a-8931-f73193d95587</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_d31e6626-f696-4d7e-bd75-07b09b992bae">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>d31e6626-f696-4d7e-bd75-07b09b992bae</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_f3cc39ae-99e2-4a19-b725-ebc88ba51d35">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a5b37323-8f73-449a-8931-f73193d95587" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>f3cc39ae-99e2-4a19-b725-ebc88ba51d35</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_aef3c15e-c567-476a-83ad-3fe46c817fb2">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_1ef0715a-d5a9-477b-b6e7-b635529ac140" />
+    <cim:IdentifiedObject.mRID>aef3c15e-c567-476a-83ad-3fe46c817fb2</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_28d3bee2-1634-4cd0-806c-0931cac4bd9c">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>28d3bee2-1634-4cd0-806c-0931cac4bd9c</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_ad16769b-4fad-4017-ab5f-a4eb96bdc5e7">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_aef3c15e-c567-476a-83ad-3fe46c817fb2" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>ad16769b-4fad-4017-ab5f-a4eb96bdc5e7</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ACLineSegment rdf:ID="_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4">
+    <cim:IdentifiedObject.name>BE-Line_7</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-000061</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-000061</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_7</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_a8aa134c-be99-4e28-8e51-2d01a3b3e078" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_a7f1d8de-d658-428a-821b-3a5ae5965fd1" />
+    <cim:Conductor.length>23</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>2.89027E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.1677E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>5.75E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>5.75E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>4.6</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>13.8</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>69</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>207</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_00672e1a-599a-44f3-aeaa-5a3c99c29ba1">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_7 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1" />
+    <cim:IdentifiedObject.mRID>00672e1a-599a-44f3-aeaa-5a3c99c29ba1</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_51e4c1ab-a505-43fb-9bdc-45c51d6b2581">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1062</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>51e4c1ab-a505-43fb-9bdc-45c51d6b2581</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_c339b64c-6834-4eb4-ab70-5990422b6337">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_00672e1a-599a-44f3-aeaa-5a3c99c29ba1" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>c339b64c-6834-4eb4-ab70-5990422b6337</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_56c9ef56-9268-47e6-bed2-044324c03830">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_7 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_57ae9251-c022-4c67-a8eb-611ad54c963c" />
+    <cim:IdentifiedObject.mRID>56c9ef56-9268-47e6-bed2-044324c03830</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_631a5891-a1f3-46b6-b5a5-a09db8b904d1">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1062</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>631a5891-a1f3-46b6-b5a5-a09db8b904d1</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_2b233cc2-30de-4a58-a7b4-c96f862c4eae">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_56c9ef56-9268-47e6-bed2-044324c03830" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2b233cc2-30de-4a58-a7b4-c96f862c4eae</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:Line rdf:ID="_cc4b99a5-e20d-407c-9d8e-a682b9723613">
+    <cim:IdentifiedObject.name>container of BE-Line_6</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d" />
+    <cim:IdentifiedObject.mRID>cc4b99a5-e20d-407c-9d8e-a682b9723613</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:ACLineSegment rdf:ID="_ffbabc27-1ccd-4fdc-b037-e341706c8d29">
+    <cim:IdentifiedObject.name>BE-Line_6</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>TYNDP project BE-4; map reference 567</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_6</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>true</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_cc4b99a5-e20d-407c-9d8e-a682b9723613" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:Conductor.length>100</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>0.0001476549</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>2.00119E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>0.00012</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>0.00012</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>5.203</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>15</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>71</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>213</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>ffbabc27-1ccd-4fdc-b037-e341706c8d29</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_6 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_05a17350-55f5-4a00-9a50-8c0048a25495" />
+    <cim:IdentifiedObject.mRID>cb5b5011-9f6c-4af2-93f9-26ae7e30c8db</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_2eb563f4-76d2-4aac-9d4d-215da4ea6586">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1312</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2eb563f4-76d2-4aac-9d4d-215da4ea6586</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_c733f2b6-b563-4c9e-af72-e42d52fd00d3">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_cb5b5011-9f6c-4af2-93f9-26ae7e30c8db" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>c733f2b6-b563-4c9e-af72-e42d52fd00d3</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_30cbcb48-f02e-4791-83ab-486d7688874c">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_6 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809" />
+    <cim:IdentifiedObject.mRID>30cbcb48-f02e-4791-83ab-486d7688874c</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_97bcf2de-9ce1-469b-b258-4ed51696328b">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1312</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>97bcf2de-9ce1-469b-b258-4ed51696328b</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_96b1e452-9a13-46bd-9b24-7f214423ba01">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_30cbcb48-f02e-4791-83ab-486d7688874c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>96b1e452-9a13-46bd-9b24-7f214423ba01</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:Line rdf:ID="_b5d6ed2b-c961-4521-8aef-b943d7dc6c15">
+    <cim:IdentifiedObject.name>container of BE-Line_2</cim:IdentifiedObject.name>
+    <cim:Line.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d" />
+    <cim:IdentifiedObject.mRID>b5d6ed2b-c961-4521-8aef-b943d7dc6c15</cim:IdentifiedObject.mRID>
+  </cim:Line>
+  <cim:ACLineSegment rdf:ID="_b58bf21a-096a-4dae-9a01-3f03b60c24c7">
+    <cim:IdentifiedObject.name>BE-Line_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>10T-AT-DE-00010A</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.energyIdentCodeEic>10T-AT-DE-00010A</eu:IdentifiedObject.energyIdentCodeEic>
+    <eu:IdentifiedObject.shortName>BE-L_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>true</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b5d6ed2b-c961-4521-8aef-b943d7dc6c15" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:Conductor.length>45</cim:Conductor.length>
+    <cim:ACLineSegment.b0ch>6.64447E-05</cim:ACLineSegment.b0ch>
+    <cim:ACLineSegment.bch>4.24115E-05</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.g0ch>6.75E-05</cim:ACLineSegment.g0ch>
+    <cim:ACLineSegment.gch>6.75E-05</cim:ACLineSegment.gch>
+    <cim:ACLineSegment.r>1.935</cim:ACLineSegment.r>
+    <cim:ACLineSegment.r0>3.195</cim:ACLineSegment.r0>
+    <cim:ACLineSegment.shortCircuitEndTemperature>160</cim:ACLineSegment.shortCircuitEndTemperature>
+    <cim:ACLineSegment.x>34.2</cim:ACLineSegment.x>
+    <cim:ACLineSegment.x0>102.6</cim:ACLineSegment.x0>
+    <cim:IdentifiedObject.mRID>b58bf21a-096a-4dae-9a01-3f03b60c24c7</cim:IdentifiedObject.mRID>
+  </cim:ACLineSegment>
+  <cim:OperationalLimitSet rdf:ID="_ecc2f619-5716-4af0-9d76-0631a3832e4f">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_2 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_699545b9-82b9-4331-bc80-538d73b4ba56" />
+    <cim:IdentifiedObject.mRID>ecc2f619-5716-4af0-9d76-0631a3832e4f</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_11aebb44-01eb-42d7-a2d6-91534c00141d">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1574</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>11aebb44-01eb-42d7-a2d6-91534c00141d</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_2b2f7220-3e87-41cd-a13e-23fb4ad797b5">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_ecc2f619-5716-4af0-9d76-0631a3832e4f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>2b2f7220-3e87-41cd-a13e-23fb4ad797b5</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_7168dee1-15a7-4444-839f-feef071e956d">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-Line_2 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_77f04391-aa23-49b6-b3e9-6089130bb5d5" />
+    <cim:IdentifiedObject.mRID>7168dee1-15a7-4444-839f-feef071e956d</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_9dd2280b-2c66-4425-8b7c-7f62a7faed1f">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1574</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>9dd2280b-2c66-4425-8b7c-7f62a7faed1f</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:CurrentLimit rdf:ID="_41f2dcaf-edb5-4a88-8c34-8ac421f06974">
+    <cim:IdentifiedObject.name>TATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_7168dee1-15a7-4444-839f-feef071e956d" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_6d00cfdb-d400-4acd-b32b-7a48617593e7" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>41f2dcaf-edb5-4a88-8c34-8ac421f06974</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:ConformLoad rdf:ID="_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8">
+    <cim:IdentifiedObject.name>BE-Load_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>EVN</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_b10b171b-3bc5-4849-bb1f-61ed9ea1ec7c" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_e20dfefd-63d6-4324-862d-15b74423d064" />
+    <cim:IdentifiedObject.mRID>1c6beed6-1acf-42e7-ba55-0cc9f04bddd8</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:ConformLoadGroup rdf:ID="_e20dfefd-63d6-4324-862d-15b74423d064">
+    <cim:IdentifiedObject.name>ELIA-BrusselsconfLoadGr</cim:IdentifiedObject.name>
+    <cim:LoadGroup.SubLoadArea rdf:resource="#_8e1e7c28-cd22-40c6-b289-21b3bd365dc3" />
+    <cim:IdentifiedObject.mRID>e20dfefd-63d6-4324-862d-15b74423d064</cim:IdentifiedObject.mRID>
+  </cim:ConformLoadGroup>
+  <cim:ConformLoad rdf:ID="_cb459405-cc14-4215-a45c-416789205904">
+    <cim:IdentifiedObject.name>BE-Load_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Electrabel</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-L_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_e20dfefd-63d6-4324-862d-15b74423d064" />
+    <cim:IdentifiedObject.mRID>cb459405-cc14-4215-a45c-416789205904</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:ConformLoad rdf:ID="_b1480a00-b427-4001-a26c-51954d2bb7e9">
+    <cim:IdentifiedObject.name>L-1230804819</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Eq_Injection</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>L-1230804819</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:EnergyConsumer.LoadResponse rdf:resource="#_8e3e7a69-a64a-43a8-906e-82cc63edfcd3" />
+    <cim:ConformLoad.LoadGroup rdf:resource="#_dd357cc1-c41e-455c-92cf-2a572191dc48" />
+    <cim:IdentifiedObject.mRID>b1480a00-b427-4001-a26c-51954d2bb7e9</cim:IdentifiedObject.mRID>
+  </cim:ConformLoad>
+  <cim:ConformLoadGroup rdf:ID="_dd357cc1-c41e-455c-92cf-2a572191dc48">
+    <cim:IdentifiedObject.name>ELIA-AnversconfLoadGr</cim:IdentifiedObject.name>
+    <cim:LoadGroup.SubLoadArea rdf:resource="#_7521cc3f-7c69-493b-b72a-3f20d72d8a56" />
+    <cim:IdentifiedObject.mRID>dd357cc1-c41e-455c-92cf-2a572191dc48</cim:IdentifiedObject.mRID>
+  </cim:ConformLoadGroup>
+  <cim:LoadResponseCharacteristic rdf:ID="_8e3e7a69-a64a-43a8-906e-82cc63edfcd3">
+    <cim:IdentifiedObject.name>L-1230804819</cim:IdentifiedObject.name>
+    <cim:LoadResponseCharacteristic.exponentModel>false</cim:LoadResponseCharacteristic.exponentModel>
+    <cim:LoadResponseCharacteristic.pConstantCurrent>0</cim:LoadResponseCharacteristic.pConstantCurrent>
+    <cim:LoadResponseCharacteristic.pConstantImpedance>0</cim:LoadResponseCharacteristic.pConstantImpedance>
+    <cim:LoadResponseCharacteristic.pConstantPower>1</cim:LoadResponseCharacteristic.pConstantPower>
+    <cim:LoadResponseCharacteristic.qConstantCurrent>0</cim:LoadResponseCharacteristic.qConstantCurrent>
+    <cim:LoadResponseCharacteristic.qConstantImpedance>0</cim:LoadResponseCharacteristic.qConstantImpedance>
+    <cim:LoadResponseCharacteristic.qConstantPower>1</cim:LoadResponseCharacteristic.qConstantPower>
+    <cim:IdentifiedObject.mRID>8e3e7a69-a64a-43a8-906e-82cc63edfcd3</cim:IdentifiedObject.mRID>
+  </cim:LoadResponseCharacteristic>
+  <cim:SeriesCompensator rdf:ID="_df16b3dd-c905-4a6f-84ee-f067be86f5da">
+    <cim:IdentifiedObject.name>SER-RLC-1230822986</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:SeriesCompensator.r>0</cim:SeriesCompensator.r>
+    <cim:SeriesCompensator.r0>0</cim:SeriesCompensator.r0>
+    <cim:SeriesCompensator.varistorPresent>true</cim:SeriesCompensator.varistorPresent>
+    <cim:SeriesCompensator.varistorRatedCurrent>500</cim:SeriesCompensator.varistorRatedCurrent>
+    <cim:SeriesCompensator.varistorVoltageThreshold>250</cim:SeriesCompensator.varistorVoltageThreshold>
+    <cim:SeriesCompensator.x>-31.83099</cim:SeriesCompensator.x>
+    <cim:SeriesCompensator.x0>-31.83099</cim:SeriesCompensator.x0>
+	<cim:ConductingEquipment.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:IdentifiedObject.mRID>df16b3dd-c905-4a6f-84ee-f067be86f5da</cim:IdentifiedObject.mRID>
+  </cim:SeriesCompensator>
+  <cim:OperationalLimitSet rdf:ID="_38c765fb-5707-404a-87f6-ace386edce11">
+    <cim:IdentifiedObject.name>SER-RLC-1230822986</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_8171fc34-6891-40e0-92d1-da9f4ba69e26" />
+    <cim:IdentifiedObject.mRID>38c765fb-5707-404a-87f6-ace386edce11</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_28338dd1-b451-49f5-9c06-40bda7b53a75">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_38c765fb-5707-404a-87f6-ace386edce11" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>28338dd1-b451-49f5-9c06-40bda7b53a75</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_653b4e65-a657-40fc-b987-c9e28104410f">
+    <cim:IdentifiedObject.name>SER-RLC-1230822986</cim:IdentifiedObject.name>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7" />
+    <cim:IdentifiedObject.mRID>653b4e65-a657-40fc-b987-c9e28104410f</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_dd1f9fb4-78f3-4ea9-b09f-755a94154385">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_653b4e65-a657-40fc-b987-c9e28104410f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>500</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>dd1f9fb4-78f3-4ea9-b09f-755a94154385</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:LinearShuntCompensator rdf:ID="_d771118f-36e9-4115-a128-cc3d9ce3e3da">
+    <cim:IdentifiedObject.name>BE_S1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>shunt with 4 sections</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE_S1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_8bbd7e74-ae20-4dce-8780-c20f8e18c2e0" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_4d50f86d-0d12-4ca3-9430-56bb05f9eee6" />
+    <cim:ShuntCompensator.grounded>true</cim:ShuntCompensator.grounded>
+    <cim:ShuntCompensator.maximumSections>1</cim:ShuntCompensator.maximumSections>
+    <cim:ShuntCompensator.nomU>110</cim:ShuntCompensator.nomU>
+    <cim:ShuntCompensator.normalSections>1</cim:ShuntCompensator.normalSections>
+    <cim:LinearShuntCompensator.b0PerSection>0</cim:LinearShuntCompensator.b0PerSection>
+    <cim:LinearShuntCompensator.bPerSection>0.02479339</cim:LinearShuntCompensator.bPerSection>
+    <cim:LinearShuntCompensator.g0PerSection>0</cim:LinearShuntCompensator.g0PerSection>
+    <cim:LinearShuntCompensator.gPerSection>0</cim:LinearShuntCompensator.gPerSection>
+    <cim:IdentifiedObject.mRID>d771118f-36e9-4115-a128-cc3d9ce3e3da</cim:IdentifiedObject.mRID>
+  </cim:LinearShuntCompensator>
+  <cim:RegulatingControl rdf:ID="_4d50f86d-0d12-4ca3-9430-56bb05f9eee6">
+    <cim:IdentifiedObject.name>BE_S1</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c" />
+    <cim:IdentifiedObject.mRID>4d50f86d-0d12-4ca3-9430-56bb05f9eee6</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:NonlinearShuntCompensator rdf:ID="_002b0a40-3957-46db-b84a-30420083558f">
+    <cim:IdentifiedObject.name>BE_S2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>another shunt</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE_S2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_469df5f7-058f-4451-a998-57a48e8a56fe" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_bee06911-8d5c-44c4-b2d2-5c22a461b5a0" />
+    <cim:ShuntCompensator.grounded>true</cim:ShuntCompensator.grounded>
+    <cim:ShuntCompensator.maximumSections>5</cim:ShuntCompensator.maximumSections>
+    <cim:ShuntCompensator.nomU>380</cim:ShuntCompensator.nomU>
+    <cim:ShuntCompensator.normalSections>1</cim:ShuntCompensator.normalSections>
+    <cim:IdentifiedObject.mRID>002b0a40-3957-46db-b84a-30420083558f</cim:IdentifiedObject.mRID>
+  </cim:NonlinearShuntCompensator>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_48c4da87-08f6-408e-96e6-68fb5fd77d53">
+    <cim:NonlinearShuntCompensatorPoint.b>0.0003459834</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>1</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_ffcbe3c9-5f5e-4de1-942c-c309e537b616">
+    <cim:NonlinearShuntCompensatorPoint.b>0.0001729917</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>2</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_8e4e1de4-71ba-4f36-9065-3d96c9702670">
+    <cim:NonlinearShuntCompensatorPoint.b>0.0001389889</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>3</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_a370cc7d-dad8-4b9e-8a36-0e202f6b028a">
+    <cim:NonlinearShuntCompensatorPoint.b>6.897507E-05</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>4</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:NonlinearShuntCompensatorPoint rdf:ID="_9347aeec-ab42-424e-a651-11ea7c3b6eb3">
+    <cim:NonlinearShuntCompensatorPoint.b>3.49723E-05</cim:NonlinearShuntCompensatorPoint.b>
+    <cim:NonlinearShuntCompensatorPoint.b0>0</cim:NonlinearShuntCompensatorPoint.b0>
+    <cim:NonlinearShuntCompensatorPoint.g>2.18E-06</cim:NonlinearShuntCompensatorPoint.g>
+    <cim:NonlinearShuntCompensatorPoint.g0>2.18E-06</cim:NonlinearShuntCompensatorPoint.g0>
+    <cim:NonlinearShuntCompensatorPoint.sectionNumber>5</cim:NonlinearShuntCompensatorPoint.sectionNumber>
+    <cim:NonlinearShuntCompensatorPoint.NonlinearShuntCompensator rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+  </cim:NonlinearShuntCompensatorPoint>
+  <cim:RegulatingControl rdf:ID="_bee06911-8d5c-44c4-b2d2-5c22a461b5a0">
+    <cim:IdentifiedObject.name>BE_S2</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe" />
+    <cim:IdentifiedObject.mRID>bee06911-8d5c-44c4-b2d2-5c22a461b5a0</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:StaticVarCompensator rdf:ID="_3c69652c-ff14-4550-9a87-b6fdaccbb5f4">
+    <cim:IdentifiedObject.name>SVC-1230797516</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_69ef0dbd-da79-4eef-a02f-690cb8a28361" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_caf65447-3cfb-48d7-aaaa-cd9af3d34261" />
+    <cim:StaticVarCompensator.capacitiveRating>5062.5</cim:StaticVarCompensator.capacitiveRating>
+    <cim:StaticVarCompensator.inductiveRating>-5062.5</cim:StaticVarCompensator.inductiveRating>
+    <cim:StaticVarCompensator.slope>0.102</cim:StaticVarCompensator.slope>
+    <cim:IdentifiedObject.mRID>3c69652c-ff14-4550-9a87-b6fdaccbb5f4</cim:IdentifiedObject.mRID>
+  </cim:StaticVarCompensator>
+  <cim:RegulatingControl rdf:ID="_caf65447-3cfb-48d7-aaaa-cd9af3d34261">
+    <cim:IdentifiedObject.name>SVC-1230797516</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_8171fc34-6891-40e0-92d1-da9f4ba69e26" />
+    <cim:IdentifiedObject.mRID>caf65447-3cfb-48d7-aaaa-cd9af3d34261</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:SynchronousMachine rdf:ID="_550ebe0d-f2b2-48c1-991f-cebea43a21aa">
+    <cim:IdentifiedObject.name>BE-G2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-G2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_929ba893-c9dc-44d7-b1fd-30834bd3ab85" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_84bf5be8-eb59-4555-b131-fce4d2d7775d" />
+    <cim:RotatingMachine.ratedPowerFactor>0.85</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>300</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>21</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_5b7a4d43-09ec-4033-882d-64a76d557631" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>200</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>-200</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>100</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.2</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>2</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries1" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generator" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.13</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.17</cim:SynchronousMachine.x2>
+    <cim:IdentifiedObject.mRID>550ebe0d-f2b2-48c1-991f-cebea43a21aa</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_5b7a4d43-09ec-4033-882d-64a76d557631">
+    <cim:IdentifiedObject.name>Gen-1229753024</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>200</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>50</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>255</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>5b7a4d43-09ec-4033-882d-64a76d557631</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:ID="_3a3b27be-b18b-4385-b557-6735d733baf0">
+    <cim:IdentifiedObject.name>BE-G1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-G1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_4ba71b59-ee2f-450b-9f7d-cc2f1cc5e386" />
+    <cim:RegulatingCondEq.RegulatingControl rdf:resource="#_6ba406ce-78cf-4485-9b01-a34e584f1a8d" />
+    <cim:RotatingMachine.ratedPowerFactor>0.85</cim:RotatingMachine.ratedPowerFactor>
+    <cim:RotatingMachine.ratedS>300</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.ratedU>10.5</cim:RotatingMachine.ratedU>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_18993b11-2966-4bce-bab9-d86103f83b53" />
+    <cim:SynchronousMachine.earthing>true</cim:SynchronousMachine.earthing>
+    <cim:SynchronousMachine.earthingStarPointR>0</cim:SynchronousMachine.earthingStarPointR>
+    <cim:SynchronousMachine.earthingStarPointX>0</cim:SynchronousMachine.earthingStarPointX>
+    <cim:SynchronousMachine.ikk>0</cim:SynchronousMachine.ikk>
+    <cim:SynchronousMachine.maxQ>300</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>-300</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.mu>0</cim:SynchronousMachine.mu>
+    <cim:SynchronousMachine.qPercent>50</cim:SynchronousMachine.qPercent>
+    <cim:SynchronousMachine.r>0</cim:SynchronousMachine.r>
+    <cim:SynchronousMachine.r0>0</cim:SynchronousMachine.r0>
+    <cim:SynchronousMachine.r2>0</cim:SynchronousMachine.r2>
+    <cim:SynchronousMachine.satDirectSubtransX>0.2</cim:SynchronousMachine.satDirectSubtransX>
+    <cim:SynchronousMachine.satDirectSyncX>2</cim:SynchronousMachine.satDirectSyncX>
+    <cim:SynchronousMachine.satDirectTransX>0</cim:SynchronousMachine.satDirectTransX>
+    <cim:SynchronousMachine.shortCircuitRotorType rdf:resource="http://iec.ch/TC57/CIM100#ShortCircuitRotorKind.turboSeries1" />
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/CIM100#SynchronousMachineKind.generatorOrMotor" />
+    <cim:SynchronousMachine.voltageRegulationRange>0</cim:SynchronousMachine.voltageRegulationRange>
+    <cim:SynchronousMachine.x0>0.13</cim:SynchronousMachine.x0>
+    <cim:SynchronousMachine.x2>0.171</cim:SynchronousMachine.x2>
+    <cim:SynchronousMachine.InitialReactiveCapabilityCurve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+    <cim:IdentifiedObject.mRID>3a3b27be-b18b-4385-b557-6735d733baf0</cim:IdentifiedObject.mRID>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:ID="_18993b11-2966-4bce-bab9-d86103f83b53">
+    <cim:IdentifiedObject.name>Gen-1229753060</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Machine</cim:IdentifiedObject.description>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:GeneratingUnit.genControlSource rdf:resource="http://iec.ch/TC57/CIM100#GeneratorControlSource.offAGC" />
+    <cim:GeneratingUnit.maxOperatingP>200</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>-100</cim:GeneratingUnit.minOperatingP>
+    <cim:GeneratingUnit.nominalP>255</cim:GeneratingUnit.nominalP>
+    <cim:IdentifiedObject.mRID>18993b11-2966-4bce-bab9-d86103f83b53</cim:IdentifiedObject.mRID>
+  </cim:GeneratingUnit>
+  <cim:ReactiveCapabilityCurve rdf:ID="_59ff1e53-0e1a-44c0-ada5-7a0b3a660170">
+    <cim:IdentifiedObject.name>BE-G1CapabilityCurve</cim:IdentifiedObject.name>
+    <cim:Curve.curveStyle rdf:resource="http://iec.ch/TC57/CIM100#CurveStyle.straightLineYValues" />
+    <cim:Curve.xUnit rdf:resource="http://iec.ch/TC57/CIM100#UnitSymbol.W" />
+    <cim:Curve.y1Unit rdf:resource="http://iec.ch/TC57/CIM100#UnitSymbol.VAr" />
+    <cim:Curve.y2Unit rdf:resource="http://iec.ch/TC57/CIM100#UnitSymbol.VAr" />
+    <cim:IdentifiedObject.mRID>59ff1e53-0e1a-44c0-ada5-7a0b3a660170</cim:IdentifiedObject.mRID>
+  </cim:ReactiveCapabilityCurve>
+  <cim:CurveData rdf:ID="_3a31cb5b-eac5-4717-acdb-48f357c6eefe">
+    <cim:CurveData.xvalue>-100</cim:CurveData.xvalue>
+    <cim:CurveData.y1value>-200</cim:CurveData.y1value>
+    <cim:CurveData.y2value>200</cim:CurveData.y2value>
+    <cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+  </cim:CurveData>
+  <cim:CurveData rdf:ID="_5cef00db-5dda-4458-bc68-cc59804b1187">
+    <cim:CurveData.xvalue>0</cim:CurveData.xvalue>
+    <cim:CurveData.y1value>-300</cim:CurveData.y1value>
+    <cim:CurveData.y2value>300</cim:CurveData.y2value>
+    <cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+  </cim:CurveData>
+  <cim:CurveData rdf:ID="_52da6f7d-e9b6-4293-b1a3-d87a5f453a1c">
+    <cim:CurveData.xvalue>200</cim:CurveData.xvalue>
+    <cim:CurveData.y1value>-200</cim:CurveData.y1value>
+    <cim:CurveData.y2value>200</cim:CurveData.y2value>
+    <cim:CurveData.Curve rdf:resource="#_59ff1e53-0e1a-44c0-ada5-7a0b3a660170" />
+  </cim:CurveData>
+  <cim:PowerTransformer rdf:ID="_b94318f6-6d24-4f56-96b9-df2531ad6543">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>This is T2 in the center</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_2</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>b94318f6-6d24-4f56-96b9-df2531ad6543</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_3c59d1b0-1ee9-4ca3-9086-4fe102b51b21">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_4c19ace6-c825-4c5b-87d9-031e6e6a3379" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.8228</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.8228</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>11.13888</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>11.13888</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:IdentifiedObject.mRID>3c59d1b0-1ee9-4ca3-9086-4fe102b51b21</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_ba56158e-0c51-448d-999b-44cb0b3cebf5">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_ab7ece75-d726-48c8-a924-b0a9325e6d51" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>110</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:IdentifiedObject.mRID>ba56158e-0c51-448d-999b-44cb0b3cebf5</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PhaseTapChangerAsymmetrical rdf:ID="_36b83adb-3d45-4693-8967-96627b5f9ec9">
+    <cim:IdentifiedObject.name>BE-TR2_2</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>25</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>13</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>220</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>10</cim:TapChanger.normalStep>
+    <cim:PhaseTapChanger.TransformerEnd rdf:resource="#_3c59d1b0-1ee9-4ca3-9086-4fe102b51b21" />
+    <cim:PhaseTapChangerNonLinear.voltageStepIncrement>1.25</cim:PhaseTapChangerNonLinear.voltageStepIncrement>
+    <cim:PhaseTapChangerNonLinear.xMax>11.88148</cim:PhaseTapChangerNonLinear.xMax>
+    <cim:PhaseTapChangerNonLinear.xMin>0.0</cim:PhaseTapChangerNonLinear.xMin>
+    <cim:PhaseTapChangerAsymmetrical.windingConnectionAngle>30</cim:PhaseTapChangerAsymmetrical.windingConnectionAngle>
+    <cim:IdentifiedObject.mRID>36b83adb-3d45-4693-8967-96627b5f9ec9</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerAsymmetrical>
+  <cim:OperationalLimitSet rdf:ID="_d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_2 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_ab7ece75-d726-48c8-a924-b0a9325e6d51" />
+    <cim:IdentifiedObject.mRID>d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_4f50fcc3-7a30-46e4-ba6a-314bb72e5181">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_d6f4f557-12b9-4b53-9e99-2d2ed8cd11dd" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>3411.617</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>4f50fcc3-7a30-46e4-ba6a-314bb72e5181</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_88aa13e4-d3fe-4c47-9e47-39f8bb805e73">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_2 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_4c19ace6-c825-4c5b-87d9-031e6e6a3379" />
+    <cim:IdentifiedObject.mRID>88aa13e4-d3fe-4c47-9e47-39f8bb805e73</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_b70180fc-cc97-41c5-aab6-e00a7b52fef4">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_88aa13e4-d3fe-4c47-9e47-39f8bb805e73" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1705.808</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>b70180fc-cc97-41c5-aab6-e00a7b52fef4</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>T1 that is after maintenance</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>a708c3bc-465d-4fe7-b6ef-6fa6408a62b0</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_bf76ac9d-0144-48f5-a24a-34ae15a455fb">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_c3774d3f-f48c-4954-a0cf-b4572eb714fd" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>2.707692</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>2.72</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>400</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>14.5189</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>14.5166</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:IdentifiedObject.mRID>bf76ac9d-0144-48f5-a24a-34ae15a455fb</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_e22f3c30-63f5-47bf-a8c4-fee2483d426c">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>110</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:IdentifiedObject.mRID>e22f3c30-63f5-47bf-a8c4-fee2483d426c</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:TapChangerControl rdf:ID="_f43499bf-6bf3-483d-ae2a-e46d696a66b2">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.activePower" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89" />
+    <cim:IdentifiedObject.mRID>f43499bf-6bf3-483d-ae2a-e46d696a66b2</cim:IdentifiedObject.mRID>
+  </cim:TapChangerControl>
+  <cim:PhaseTapChangerSymmetrical rdf:ID="_63454a73-f439-45bb-951a-e7b193986571">
+    <cim:IdentifiedObject.name>BE-TR2_1</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>25</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>13</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>400</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>10</cim:TapChanger.normalStep>
+    <cim:TapChanger.TapChangerControl rdf:resource="#_f43499bf-6bf3-483d-ae2a-e46d696a66b2" />
+    <cim:PhaseTapChanger.TransformerEnd rdf:resource="#_bf76ac9d-0144-48f5-a24a-34ae15a455fb" />
+    <cim:PhaseTapChangerNonLinear.voltageStepIncrement>1.25</cim:PhaseTapChangerNonLinear.voltageStepIncrement>
+    <cim:PhaseTapChangerNonLinear.xMax>16.93872</cim:PhaseTapChangerNonLinear.xMax>
+    <cim:IdentifiedObject.mRID>63454a73-f439-45bb-951a-e7b193986571</cim:IdentifiedObject.mRID>
+  </cim:PhaseTapChangerSymmetrical>
+  <cim:OperationalLimitSet rdf:ID="_3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89" />
+    <cim:IdentifiedObject.mRID>3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_a38be74a-351c-48fd-94d6-299258473614">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_3b5aa2ae-a3fb-4ea6-9941-f7ccd2c6d925" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>3411.617</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>a38be74a-351c-48fd-94d6-299258473614</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_0b7c4239-3c1b-438e-994d-f2a402ba743c">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_c3774d3f-f48c-4954-a0cf-b4572eb714fd" />
+    <cim:IdentifiedObject.mRID>0b7c4239-3c1b-438e-994d-f2a402ba743c</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_f4a1899a-5050-4d4b-8aa0-399344bd5c62">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_0b7c4239-3c1b-438e-994d-f2a402ba743c" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>938.1946</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>f4a1899a-5050-4d4b-8aa0-399344bd5c62</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_e482b89a-fa84-4ea9-8e70-a83d44790957">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>This is free description</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_3</eu:IdentifiedObject.shortName>
+    <cim:Equipment.aggregate>false</cim:Equipment.aggregate>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:PowerTransformer.operationalValuesConsidered>false</cim:PowerTransformer.operationalValuesConsidered>
+    <cim:IdentifiedObject.mRID>e482b89a-fa84-4ea9-8e70-a83d44790957</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_f58281c5-862a-465e-97ec-d809be6e24ab">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_ca7974cf-b25e-4898-9221-7154233e5eb2" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_00b17311-075f-48f6-a79b-597f42af4694" />
+    <cim:PowerTransformerEnd.b>-8.30339E-05</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>1.73295E-05</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.104711</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0.104711</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>250</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>110.3438</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>5.843419</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>5.843419</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:IdentifiedObject.mRID>f58281c5-862a-465e-97ec-d809be6e24ab</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_35651e25-a77a-46a1-92f4-443d6acce90e">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.rground>0</cim:TransformerEnd.rground>
+    <cim:TransformerEnd.xground>0</cim:TransformerEnd.xground>
+    <cim:TransformerEnd.Terminal rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_862a4658-6b03-4550-9de2-b5c413912b75" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>250</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>10.5</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:IdentifiedObject.mRID>35651e25-a77a-46a1-92f4-443d6acce90e</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:RatioTapChanger rdf:ID="_83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e">
+    <cim:IdentifiedObject.name>BE-TR2_3</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>10.5</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>14</cim:TapChanger.normalStep>
+    <cim:RatioTapChanger.stepVoltageIncrement>0.8</cim:RatioTapChanger.stepVoltageIncrement>
+    <cim:RatioTapChanger.TransformerEnd rdf:resource="#_35651e25-a77a-46a1-92f4-443d6acce90e" />
+    <cim:IdentifiedObject.mRID>83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e</cim:IdentifiedObject.mRID>
+  </cim:RatioTapChanger>
+  <cim:OperationalLimitSet rdf:ID="_e40d809b-2f3f-4866-817d-7acec0fde34f">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_3 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_ca7974cf-b25e-4898-9221-7154233e5eb2" />
+    <cim:IdentifiedObject.mRID>e40d809b-2f3f-4866-817d-7acec0fde34f</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_cad59010-1344-48b3-bc5d-6a11137f2715">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_e40d809b-2f3f-4866-817d-7acec0fde34f" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1308.073</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>cad59010-1344-48b3-bc5d-6a11137f2715</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_40b75fae-2597-40df-98d2-8a0d83c238fd">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR2_3 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a" />
+    <cim:IdentifiedObject.mRID>40b75fae-2597-40df-98d2-8a0d83c238fd</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_f48991a6-fe4f-417a-9362-4fc624bb2258">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_40b75fae-2597-40df-98d2-8a0d83c238fd" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>13746.44</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>f48991a6-fe4f-417a-9362-4fc624bb2258</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:PowerTransformer rdf:ID="_84ed55f4-61f5-4d9d-8755-bba7b877a246">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>new in 2015</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>BE-T_1</eu:IdentifiedObject.shortName>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_37e14a0f-5e34-4647-a062-8bfd9305fa9d" />
+    <cim:PowerTransformer.isPartOfGeneratorUnit>false</cim:PowerTransformer.isPartOfGeneratorUnit>
+    <cim:IdentifiedObject.mRID>84ed55f4-61f5-4d9d-8755-bba7b877a246</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformer>
+  <cim:PowerTransformerEnd rdf:ID="_5f68a129-d5d8-4b71-9743-9ca2572ba26b">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>1</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_76e9ca77-f805-40ea-8120-5a6d58416d34" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_35cf638d-9a9d-4ae5-ae90-2f01ef898cb6" />
+    <cim:PowerTransformerEnd.b>-2.4375E-06</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>-2.4375E-06</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.898462</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>400</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>17.20413</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>17.23077</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:IdentifiedObject.mRID>5f68a129-d5d8-4b71-9743-9ca2572ba26b</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_e1f661c0-971d-4ce5-ad39-0ec427f288ab">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>2</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_63893f24-5b4e-407c-9a1e-4ff71121f33c" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.323908</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>220</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>5.949086</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>5.956923</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:IdentifiedObject.mRID>e1f661c0-971d-4ce5-ad39-0ec427f288ab</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:PowerTransformerEnd rdf:ID="_2e21d1ef-2287-434c-a767-1ca807cf2478">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TransformerEnd.endNumber>3</cim:TransformerEnd.endNumber>
+    <cim:TransformerEnd.grounded>false</cim:TransformerEnd.grounded>
+    <cim:TransformerEnd.Terminal rdf:resource="#_ca0f7e2e-3442-4ada-a704-91f319c0ebe3" />
+    <cim:TransformerEnd.BaseVoltage rdf:resource="#_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2" />
+    <cim:PowerTransformerEnd.b>0</cim:PowerTransformerEnd.b>
+    <cim:PowerTransformerEnd.b0>0</cim:PowerTransformerEnd.b0>
+    <cim:PowerTransformerEnd.connectionKind rdf:resource="http://iec.ch/TC57/CIM100#WindingConnection.Y" />
+    <cim:PowerTransformerEnd.g>0</cim:PowerTransformerEnd.g>
+    <cim:PowerTransformerEnd.g0>0</cim:PowerTransformerEnd.g0>
+    <cim:PowerTransformerEnd.phaseAngleClock>0</cim:PowerTransformerEnd.phaseAngleClock>
+    <cim:PowerTransformerEnd.r>0.013332</cim:PowerTransformerEnd.r>
+    <cim:PowerTransformerEnd.r0>0</cim:PowerTransformerEnd.r0>
+    <cim:PowerTransformerEnd.ratedS>650</cim:PowerTransformerEnd.ratedS>
+    <cim:PowerTransformerEnd.ratedU>21</cim:PowerTransformerEnd.ratedU>
+    <cim:PowerTransformerEnd.x>0.059978</cim:PowerTransformerEnd.x>
+    <cim:PowerTransformerEnd.x0>0.061062</cim:PowerTransformerEnd.x0>
+    <cim:PowerTransformerEnd.PowerTransformer rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:IdentifiedObject.mRID>2e21d1ef-2287-434c-a767-1ca807cf2478</cim:IdentifiedObject.mRID>
+  </cim:PowerTransformerEnd>
+  <cim:RatioTapChanger rdf:ID="_fe25f43a-7341-446e-a71a-8ab7119ba806">
+    <cim:IdentifiedObject.name>BE-TR3_1</cim:IdentifiedObject.name>
+    <cim:TapChanger.highStep>33</cim:TapChanger.highStep>
+    <cim:TapChanger.lowStep>1</cim:TapChanger.lowStep>
+    <cim:TapChanger.ltcFlag>true</cim:TapChanger.ltcFlag>
+    <cim:TapChanger.neutralStep>17</cim:TapChanger.neutralStep>
+    <cim:TapChanger.neutralU>220</cim:TapChanger.neutralU>
+    <cim:TapChanger.normalStep>17</cim:TapChanger.normalStep>
+    <cim:RatioTapChanger.stepVoltageIncrement>0.625</cim:RatioTapChanger.stepVoltageIncrement>
+    <cim:RatioTapChanger.TransformerEnd rdf:resource="#_e1f661c0-971d-4ce5-ad39-0ec427f288ab" />
+    <cim:IdentifiedObject.mRID>fe25f43a-7341-446e-a71a-8ab7119ba806</cim:IdentifiedObject.mRID>
+  </cim:RatioTapChanger>
+  <cim:OperationalLimitSet rdf:ID="_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a">
+    <cim:IdentifiedObject.name>Limits at Port 1</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 1</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_76e9ca77-f805-40ea-8120-5a6d58416d34" />
+    <cim:IdentifiedObject.mRID>b655ab41-8bc0-4bd3-a28c-cf9048e32b4a</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_cef9755c-bfa7-47da-8d78-a383248bdd98">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_b655ab41-8bc0-4bd3-a28c-cf9048e32b4a" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>938.1946</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>cef9755c-bfa7-47da-8d78-a383248bdd98</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1">
+    <cim:IdentifiedObject.name>Limits at Port 3</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 3</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_ca0f7e2e-3442-4ada-a704-91f319c0ebe3" />
+    <cim:IdentifiedObject.mRID>f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_a0705e3f-b856-4816-9f12-be4c02d25cc6">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_f4fb6a66-b9f6-4c71-bdd2-7e97938d1fe1" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>17870.37</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>a0705e3f-b856-4816-9f12-be4c02d25cc6</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:OperationalLimitSet rdf:ID="_a2f11542-aeb8-4d7c-9594-25ac63e148bb">
+    <cim:IdentifiedObject.name>Limits at Port 2</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Limit-Ratings for branch BE-TR3_1 at Port 2</cim:IdentifiedObject.description>
+    <cim:OperationalLimitSet.Terminal rdf:resource="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0" />
+    <cim:IdentifiedObject.mRID>a2f11542-aeb8-4d7c-9594-25ac63e148bb</cim:IdentifiedObject.mRID>
+  </cim:OperationalLimitSet>
+  <cim:CurrentLimit rdf:ID="_0c31b120-e79a-4bde-9b40-b496de48a4f9">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <cim:OperationalLimit.OperationalLimitSet rdf:resource="#_a2f11542-aeb8-4d7c-9594-25ac63e148bb" />
+    <cim:OperationalLimit.OperationalLimitType rdf:resource="#_3e6aa424-8f24-49a5-bbe0-0868441e25ae" />
+    <cim:CurrentLimit.normalValue>1705.808</cim:CurrentLimit.normalValue>
+    <cim:IdentifiedObject.mRID>0c31b120-e79a-4bde-9b40-b496de48a4f9</cim:IdentifiedObject.mRID>
+  </cim:CurrentLimit>
+  <cim:BaseVoltage rdf:ID="_862a4658-6b03-4550-9de2-b5c413912b75">
+    <cim:IdentifiedObject.name>10.50 kV</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>10.50</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>10.5</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>862a4658-6b03-4550-9de2-b5c413912b75</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_00b17311-075f-48f6-a79b-597f42af4694">
+    <cim:IdentifiedObject.name>110.00 kV</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>110.00</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>110</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>00b17311-075f-48f6-a79b-597f42af4694</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:BaseVoltage rdf:ID="_1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2">
+    <cim:IdentifiedObject.name>21.00 kV</cim:IdentifiedObject.name>
+    <cim:IdentifiedObject.description>Base Voltage Level</cim:IdentifiedObject.description>
+    <eu:IdentifiedObject.shortName>21.00</eu:IdentifiedObject.shortName>
+    <cim:BaseVoltage.nominalVoltage>21</cim:BaseVoltage.nominalVoltage>
+    <cim:IdentifiedObject.mRID>1cefd53a-79bd-4ad4-aa9a-5a4ad0191ce2</cim:IdentifiedObject.mRID>
+  </cim:BaseVoltage>
+  <cim:Terminal rdf:ID="_02a244ca-8bcb-4e25-8613-e948b8ba1f22">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>02a244ca-8bcb-4e25-8613-e948b8ba1f22</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_051d49ba-4360-4372-86bf-50eb8cf29778">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b18cd1aa-7808-49b9-a7cf-605eaf07b006" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f33cc626-2c46-46b6-8536-88f30ab532cb" />
+    <cim:IdentifiedObject.mRID>051d49ba-4360-4372-86bf-50eb8cf29778</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_ab7ece75-d726-48c8-a924-b0a9325e6d51">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_56ca173b-fd2d-4ef3-bc32-4ae86a318c39" />
+    <cim:IdentifiedObject.mRID>ab7ece75-d726-48c8-a924-b0a9325e6d51</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_4c19ace6-c825-4c5b-87d9-031e6e6a3379">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b94318f6-6d24-4f56-96b9-df2531ad6543" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_a09067cc-e7b3-4743-8134-f5e42b32e88a" />
+    <cim:IdentifiedObject.mRID>4c19ace6-c825-4c5b-87d9-031e6e6a3379</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_231a4cf8-5069-4d53-96e4-e839f073f1ea">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_3a849ea6-8dd5-4406-ac11-c89db47ef753" />
+    <cim:IdentifiedObject.mRID>231a4cf8-5069-4d53-96e4-e839f073f1ea</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f3b56334-4638-49d3-a6a0-3f417422b8f5">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_78736387-5f60-4832-b3fe-d50daf81b0a6" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>f3b56334-4638-49d3-a6a0-3f417422b8f5</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_3fa4866b-1714-4be9-afab-3909ae092016">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_0a84038e-1952-4d9d-9909-3b49c364a1ac" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_36f63f4c-df3b-4507-baf5-bb4934c09183" />
+    <cim:IdentifiedObject.mRID>3fa4866b-1714-4be9-afab-3909ae092016</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b741ce25-3f99-4aa8-9b03-d9de0ba6e342">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_0a84038e-1952-4d9d-9909-3b49c364a1ac" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>b741ce25-3f99-4aa8-9b03-d9de0ba6e342</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_76e9ca77-f805-40ea-8120-5a6d58416d34">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bb6a1e59-1071-4985-b80f-d227cf133067" />
+    <cim:IdentifiedObject.mRID>76e9ca77-f805-40ea-8120-5a6d58416d34</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_ca0f7e2e-3442-4ada-a704-91f319c0ebe3">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>3</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_84c93a56-e0ca-4deb-a2ce-5eeb10682cab" />
+    <cim:IdentifiedObject.mRID>ca0f7e2e-3442-4ada-a704-91f319c0ebe3</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_53fd6693-57e6-482e-8fbe-dcf3531a7ce0">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_84ed55f4-61f5-4d9d-8755-bba7b877a246" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>53fd6693-57e6-482e-8fbe-dcf3531a7ce0</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_2cd21c77-b8b1-4896-95fb-240f45b9ac89">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d5b267d8-29d8-434b-b3aa-08f8f3435fc0" />
+    <cim:IdentifiedObject.mRID>2cd21c77-b8b1-4896-95fb-240f45b9ac89</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c3774d3f-f48c-4954-a0cf-b4572eb714fd">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a708c3bc-465d-4fe7-b6ef-6fa6408a62b0" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_93cec50e-e92e-4773-b408-e2419dad090d" />
+    <cim:IdentifiedObject.mRID>c3774d3f-f48c-4954-a0cf-b4572eb714fd</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f9f29835-8a31-4310-9780-b1ad26f3cbb0">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>f9f29835-8a31-4310-9780-b1ad26f3cbb0</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ed0c5d75-4a54-43c8-b782-b20d7431630b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>c14d2036-72ec-4df3-b1b7-75d8afd9a1fe</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_907dbcfe-2037-4f84-97f1-6e59f782168e">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6b564930-b5e2-49d3-9d06-e1de28d6fd65" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>907dbcfe-2037-4f84-97f1-6e59f782168e</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_345d8528-1a7e-4245-92d6-15db7a7e3c86">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6b564930-b5e2-49d3-9d06-e1de28d6fd65" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_93cec50e-e92e-4773-b408-e2419dad090d" />
+    <cim:IdentifiedObject.mRID>345d8528-1a7e-4245-92d6-15db7a7e3c86</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_8171fc34-6891-40e0-92d1-da9f4ba69e26">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>8171fc34-6891-40e0-92d1-da9f4ba69e26</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_df16b3dd-c905-4a6f-84ee-f067be86f5da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_af14c8ab-eb51-42be-89cb-abbcf37e20a3" />
+    <cim:IdentifiedObject.mRID>13dcec71-4b02-4c0c-93a7-8e16db4aa0b7</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_678a3049-afc0-432f-8f53-b30aa71907b2">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_484536e9-762a-49a3-9970-d60b9fae03fe" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_29a37807-af63-402d-ac87-2e248d844793" />
+    <cim:IdentifiedObject.mRID>678a3049-afc0-432f-8f53-b30aa71907b2</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_310c303a-b0ed-4e42-9854-628f34c53d2b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_484536e9-762a-49a3-9970-d60b9fae03fe" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>310c303a-b0ed-4e42-9854-628f34c53d2b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_f392d0d3-47cb-4ec1-925f-b3762d4a787c">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_969470b9-e74c-40d2-b3f7-bcfd88400fd1" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33" />
+    <cim:IdentifiedObject.mRID>f392d0d3-47cb-4ec1-925f-b3762d4a787c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b3bf6cbd-abe8-42b6-95f4-20682475b484">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_969470b9-e74c-40d2-b3f7-bcfd88400fd1" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_84c93a56-e0ca-4deb-a2ce-5eeb10682cab" />
+    <cim:IdentifiedObject.mRID>b3bf6cbd-abe8-42b6-95f4-20682475b484</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b6e23b90-9c48-4285-ac02-5b68d0c572a6">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fd136c65-d001-41a1-adc7-c5430b5c5e72" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>b6e23b90-9c48-4285-ac02-5b68d0c572a6</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_e57dd4ed-5ea0-4374-9b36-40a294a8e2be">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_fd136c65-d001-41a1-adc7-c5430b5c5e72" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d0aad282-7c05-4990-b0cf-d9168815048e" />
+    <cim:IdentifiedObject.mRID>e57dd4ed-5ea0-4374-9b36-40a294a8e2be</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_d771118f-36e9-4115-a128-cc3d9ce3e3da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_4bb5407b-b4a5-416c-80ad-1a778ada2b9b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f51dce2d-2dc6-4cfe-9486-f9d9a5b0fe33" />
+    <cim:IdentifiedObject.mRID>4bb5407b-b4a5-416c-80ad-1a778ada2b9b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_ca7974cf-b25e-4898-9221-7154233e5eb2">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_3293fcc7-4962-47df-a7c1-ce150600c388" />
+    <cim:IdentifiedObject.mRID>ca7974cf-b25e-4898-9221-7154233e5eb2</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_e482b89a-fa84-4ea9-8e70-a83d44790957" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c" />
+    <cim:IdentifiedObject.mRID>1182d878-2eaa-4eec-91be-ce7b2b1e7f9a</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_4bbaf84d-2437-44e1-a56c-e79723370e77">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2922c1dd-4113-466e-8cad-002572f3f557" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>4bbaf84d-2437-44e1-a56c-e79723370e77</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b8bca219-a924-434f-8163-50aae6d486a7">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_2922c1dd-4113-466e-8cad-002572f3f557" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_56ca173b-fd2d-4ef3-bc32-4ae86a318c39" />
+    <cim:IdentifiedObject.mRID>b8bca219-a924-434f-8163-50aae6d486a7</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_22af3121-1a66-4546-bd80-4371f417c644">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_002b0a40-3957-46db-b84a-30420083558f" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>22af3121-1a66-4546-bd80-4371f417c644</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_70d962fb-a492-4c36-8cad-b5c584df53bd">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_29a37807-af63-402d-ac87-2e248d844793" />
+    <cim:IdentifiedObject.mRID>70d962fb-a492-4c36-8cad-b5c584df53bd</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1ef0715a-d5a9-477b-b6e7-b635529ac140">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_17086487-56ba-4979-b8de-064025a6b4da" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>1ef0715a-d5a9-477b-b6e7-b635529ac140</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_36fedfd8-280b-4ee4-b58a-cd2063e5d706">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_0e8cd279-ad5d-485a-b3a9-093ae8714b72" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_3a849ea6-8dd5-4406-ac11-c89db47ef753" />
+    <cim:IdentifiedObject.mRID>36fedfd8-280b-4ee4-b58a-cd2063e5d706</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_0cca0f16-c476-4a99-b289-d660ff57b891">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_0e8cd279-ad5d-485a-b3a9-093ae8714b72" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>0cca0f16-c476-4a99-b289-d660ff57b891</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_5b2c65b0-68ce-4530-85b7-385346a3b5e1">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_21032053-e646-46a7-9a09-6a9a96dbf108" />
+    <cim:IdentifiedObject.mRID>5b2c65b0-68ce-4530-85b7-385346a3b5e1</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_57ae9251-c022-4c67-a8eb-611ad54c963c">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>57ae9251-c022-4c67-a8eb-611ad54c963c</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_756dff85-b2c8-4a06-9a4c-4dde854e668b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3b394dab-ab47-4022-98be-8123c6dfe7d4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>756dff85-b2c8-4a06-9a4c-4dde854e668b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_3f8b7c82-ca57-401a-9e2d-b719f8c83030">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3b394dab-ab47-4022-98be-8123c6dfe7d4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_18dca121-6c3b-440f-8bf4-8e365b8af551" />
+    <cim:IdentifiedObject.mRID>3f8b7c82-ca57-401a-9e2d-b719f8c83030</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_a45d705f-46f6-4bde-8790-11a762da8c01">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_96c2b5c8-8e28-4b08-96d2-ca9b09cdbd83" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>a45d705f-46f6-4bde-8790-11a762da8c01</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_5c206db8-ef8c-4e53-b2b9-38b52b194c5a">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_96c2b5c8-8e28-4b08-96d2-ca9b09cdbd83" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bb6a1e59-1071-4985-b80f-d227cf133067" />
+    <cim:IdentifiedObject.mRID>5c206db8-ef8c-4e53-b2b9-38b52b194c5a</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_a036b765-1669-4f64-acd3-1e8fbd513312">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>a036b765-1669-4f64-acd3-1e8fbd513312</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b501caa7-949f-49c6-b4d4-f50ef3625ede">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ddc148fc-3abd-459d-aec1-396283e0def6" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>b501caa7-949f-49c6-b4d4-f50ef3625ede</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_fd2867a9-0c57-4cf2-acfb-439c4039b06b">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ddc148fc-3abd-459d-aec1-396283e0def6" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_2dde989e-28c3-45f0-aa21-8695843ce894" />
+    <cim:IdentifiedObject.mRID>fd2867a9-0c57-4cf2-acfb-439c4039b06b</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_05a17350-55f5-4a00-9a50-8c0048a25495">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_2dde989e-28c3-45f0-aa21-8695843ce894" />
+    <cim:IdentifiedObject.mRID>05a17350-55f5-4a00-9a50-8c0048a25495</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_a4d42d33-ae54-4fe9-ad59-f30da0dfb809">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ffbabc27-1ccd-4fdc-b037-e341706c8d29" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_36f63f4c-df3b-4507-baf5-bb4934c09183" />
+    <cim:IdentifiedObject.mRID>a4d42d33-ae54-4fe9-ad59-f30da0dfb809</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_61562178-c201-43c7-b56d-a300ab07c723">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6e86cd52-4594-435e-92ce-6dc673288ab4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>61562178-c201-43c7-b56d-a300ab07c723</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_5245aa5c-9600-4632-95db-e981a19ed857">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6e86cd52-4594-435e-92ce-6dc673288ab4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_3293fcc7-4962-47df-a7c1-ce150600c388" />
+    <cim:IdentifiedObject.mRID>5245aa5c-9600-4632-95db-e981a19ed857</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_042688a6-140f-473c-98f9-94a3cfdc00d3">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_14d55344-c118-4f54-a430-72f16d12bf7b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_4836f99b-c6e9-4ee8-a956-b1e3da882d46" />
+    <cim:IdentifiedObject.mRID>042688a6-140f-473c-98f9-94a3cfdc00d3</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_6811721b-252c-45fd-8474-6db1e7d5739e">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_14d55344-c118-4f54-a430-72f16d12bf7b" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_f33cc626-2c46-46b6-8536-88f30ab532cb" />
+    <cim:IdentifiedObject.mRID>6811721b-252c-45fd-8474-6db1e7d5739e</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_d238885e-d9b6-4edc-8567-6a68c605ed67">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_87ea56f3-962a-427a-85d6-13b1f9295174" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b66f15c0-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>d238885e-d9b6-4edc-8567-6a68c605ed67</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_699545b9-82b9-4331-bc80-538d73b4ba56">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_18dca121-6c3b-440f-8bf4-8e365b8af551" />
+    <cim:IdentifiedObject.mRID>699545b9-82b9-4331-bc80-538d73b4ba56</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_77f04391-aa23-49b6-b3e9-6089130bb5d5">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b58bf21a-096a-4dae-9a01-3f03b60c24c7" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d0aad282-7c05-4990-b0cf-d9168815048e" />
+    <cim:IdentifiedObject.mRID>77f04391-aa23-49b6-b3e9-6089130bb5d5</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_beffa353-7d10-421d-9c08-036b744b1cee">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3a3b27be-b18b-4385-b557-6735d733baf0" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_0f074167-d8ad-40ed-b0fa-7dc7e9f5f77c" />
+    <cim:IdentifiedObject.mRID>beffa353-7d10-421d-9c08-036b744b1cee</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b6978550-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>4a7363a4-0b21-4f65-8bba-33e3a8f6bac3</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b9539c41-d114-4280-8a54-8ecec398091e">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67c8340-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>b9539c41-d114-4280-8a54-8ecec398091e</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_95f1d705-35fa-4102-ba5b-43dfe7a0e0cc">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_38dfcc80-600f-44e2-8f71-fb595b4f00ac" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_d5b267d8-29d8-434b-b3aa-08f8f3435fc0" />
+    <cim:IdentifiedObject.mRID>95f1d705-35fa-4102-ba5b-43dfe7a0e0cc</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_9f5dbaf3-e384-4e86-9d49-f43c30b4e354">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_38dfcc80-600f-44e2-8f71-fb595b4f00ac" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>9f5dbaf3-e384-4e86-9d49-f43c30b4e354</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_68d47f87-1a1f-4c63-80ca-d3becb4a47f9">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a603d890-5d9d-42ef-98d0-acf47d121c0e" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_bf851342-832e-4ea2-b2ad-b09729b3af23" />
+    <cim:IdentifiedObject.mRID>68d47f87-1a1f-4c63-80ca-d3becb4a47f9</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_529a048e-7681-4e59-aba1-f7474a562cba">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_a603d890-5d9d-42ef-98d0-acf47d121c0e" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_a09067cc-e7b3-4743-8134-f5e42b32e88a" />
+    <cim:IdentifiedObject.mRID>529a048e-7681-4e59-aba1-f7474a562cba</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_381fc1a6-63f7-4728-bb84-d4d7fe4f8794">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_925a3a38-cd26-4f89-8891-c5bc8494e1ae" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_af14c8ab-eb51-42be-89cb-abbcf37e20a3" />
+    <cim:IdentifiedObject.mRID>381fc1a6-63f7-4728-bb84-d4d7fe4f8794</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_e1e6f751-259f-4182-b4e1-12eba54a54ce">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_925a3a38-cd26-4f89-8891-c5bc8494e1ae" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_21032053-e646-46a7-9a09-6a9a96dbf108" />
+    <cim:IdentifiedObject.mRID>e1e6f751-259f-4182-b4e1-12eba54a54ce</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_cbdf1842-74ed-4fce-a5d4-0296c82cbc92">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_cb459405-cc14-4215-a45c-416789205904" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_1695eb20-9044-4133-a3fd-2147f55f170d" />
+    <cim:IdentifiedObject.mRID>cbdf1842-74ed-4fce-a5d4-0296c82cbc92</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_67bb74f1-8620-4a32-9d7d-a44092d11d22">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>67bb74f1-8620-4a32-9d7d-a44092d11d22</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_c41978db-794b-4bae-953e-60fc519e87dd">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_14b352cb-5574-40c5-bf83-0ed3574554a3" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b67cf870-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>c41978db-794b-4bae-953e-60fc519e87dd</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_53072f42-f77b-47e2-bd9a-e097c910b173">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_24413233-26c3-4f7e-9f72-4461796938be" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_b675a570-cb6e-11e1-bcee-406c8f32ef58" />
+    <cim:IdentifiedObject.mRID>53072f42-f77b-47e2-bd9a-e097c910b173</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_b9376bea-c75d-49f3-94ca-6a71fa0086a5">
+    <cim:IdentifiedObject.name>Terminal</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.phases rdf:resource="http://iec.ch/TC57/CIM100#PhaseCode.ABC" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_b1480a00-b427-4001-a26c-51954d2bb7e9" />
+    <cim:Terminal.ConnectivityNode rdf:resource="#_ae99bd74-26b1-443a-b1a5-656320283a36" />
+    <cim:IdentifiedObject.mRID>b9376bea-c75d-49f3-94ca-6a71fa0086a5</cim:IdentifiedObject.mRID>
+  </cim:Terminal>
+  <cim:OperationalLimitType rdf:ID="_3e6aa424-8f24-49a5-bbe0-0868441e25ae">
+    <cim:IdentifiedObject.name>PATL</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>PATL</eu:IdentifiedObject.shortName>
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind.absoluteValue" />
+    <eu:OperationalLimitType.kind rdf:resource="http://iec.ch/TC57/CIM100-European#LimitKind.patl" />
+    <cim:IdentifiedObject.mRID>3e6aa424-8f24-49a5-bbe0-0868441e25ae</cim:IdentifiedObject.mRID>
+    <cim:OperationalLimitType.isInfiniteDuration>true</cim:OperationalLimitType.isInfiniteDuration>
+  </cim:OperationalLimitType>
+  <cim:OperationalLimitType rdf:ID="_6d00cfdb-d400-4acd-b32b-7a48617593e7">
+    <cim:IdentifiedObject.name>TATL10</cim:IdentifiedObject.name>
+    <eu:IdentifiedObject.shortName>TATL</eu:IdentifiedObject.shortName>
+    <cim:OperationalLimitType.acceptableDuration>10</cim:OperationalLimitType.acceptableDuration>
+    <cim:OperationalLimitType.direction rdf:resource="http://iec.ch/TC57/CIM100#OperationalLimitDirectionKind.absoluteValue" />
+    <eu:OperationalLimitType.kind rdf:resource="http://iec.ch/TC57/CIM100-European#LimitKind.tatl" />
+    <cim:IdentifiedObject.mRID>6d00cfdb-d400-4acd-b32b-7a48617593e7</cim:IdentifiedObject.mRID>
+    <cim:OperationalLimitType.isInfiniteDuration>false</cim:OperationalLimitType.isInfiniteDuration>
+  </cim:OperationalLimitType>
+  <cim:ControlArea rdf:ID="_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7">
+    <cim:IdentifiedObject.name>BE</cim:IdentifiedObject.name>
+    <cim:ControlArea.type rdf:resource="http://iec.ch/TC57/CIM100#ControlAreaTypeKind.Interchange" />
+    <cim:ControlArea.EnergyArea rdf:resource="#_6ab47762-da13-45de-885b-98e1e409972f" />
+    <cim:IdentifiedObject.mRID>50487bb8-be6d-42a8-9358-cc0bbfe6cfa7</cim:IdentifiedObject.mRID>
+  </cim:ControlArea>
+  <cim:TieFlow rdf:ID="_a6c895fe-e902-431d-8b7a-c63ff6138225">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>a6c895fe-e902-431d-8b7a-c63ff6138225</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_29df7113-56b3-4617-a5a7-77a251947d8c">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_f3b56334-4638-49d3-a6a0-3f417422b8f5" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>29df7113-56b3-4617-a5a7-77a251947d8c</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_f13a43a5-fe0c-462a-a191-b47ca63142ba">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>f13a43a5-fe0c-462a-a191-b47ca63142ba</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_d1999e14-1783-4205-ae76-756ddedf828c">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_1ef0715a-d5a9-477b-b6e7-b635529ac140" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>d1999e14-1783-4205-ae76-756ddedf828c</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:TieFlow rdf:ID="_d94fe7e3-96a1-407d-b2d7-71f0a26443cd">
+    <cim:IdentifiedObject.name>TieFlow</cim:IdentifiedObject.name>
+    <cim:TieFlow.positiveFlowIn>true</cim:TieFlow.positiveFlowIn>
+    <cim:TieFlow.Terminal rdf:resource="#_57ae9251-c022-4c67-a8eb-611ad54c963c" />
+    <cim:TieFlow.ControlArea rdf:resource="#_50487bb8-be6d-42a8-9358-cc0bbfe6cfa7" />
+    <cim:IdentifiedObject.mRID>d94fe7e3-96a1-407d-b2d7-71f0a26443cd</cim:IdentifiedObject.mRID>
+  </cim:TieFlow>
+  <cim:RegulatingControl rdf:ID="_84bf5be8-eb59-4555-b131-fce4d2d7775d">
+    <cim:IdentifiedObject.name>BE-G2</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b" />
+    <cim:IdentifiedObject.mRID>84bf5be8-eb59-4555-b131-fce4d2d7775d</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:ID="_6ba406ce-78cf-4485-9b01-a34e584f1a8d">
+    <cim:IdentifiedObject.name>BE-G1</cim:IdentifiedObject.name>
+    <cim:RegulatingControl.mode rdf:resource="http://iec.ch/TC57/CIM100#RegulatingControlModeKind.voltage" />
+    <cim:RegulatingControl.Terminal rdf:resource="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c" />
+    <cim:IdentifiedObject.mRID>6ba406ce-78cf-4485-9b01-a34e584f1a8d</cim:IdentifiedObject.mRID>
+  </cim:RegulatingControl>
+	<cim:Line rdf:ID="_2b659afe-2ac3-425c-9418-3383e09b4b39">
+		<cim:IdentifiedObject.name>container of BE-Line_1</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_02047c0b-b5a4-4e0d-bae6-fc5437a55e74"/>
+		<cim:IdentifiedObject.mRID>2b659afe-2ac3-425c-9418-3383e09b4b39</cim:IdentifiedObject.mRID>
+	</cim:Line>
+	<cim:Line rdf:ID="_185273ba-a4e8-4754-8038-3b33eb76132e">
+		<cim:IdentifiedObject.name>container of BE-Line_3</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d"/>
+		<cim:IdentifiedObject.mRID>185273ba-a4e8-4754-8038-3b33eb76132e</cim:IdentifiedObject.mRID>
+	</cim:Line>
+	<cim:Line rdf:ID="_f04af3a9-24e3-46dd-91c0-97fea3ecc6a7">
+		<cim:IdentifiedObject.name>container of BE-Line_4</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d"/>
+		<cim:IdentifiedObject.mRID>f04af3a9-24e3-46dd-91c0-97fea3ecc6a7</cim:IdentifiedObject.mRID>
+	</cim:Line>
+	<cim:Line rdf:ID="_608059fa-f262-463d-a8a8-80844a2a7021">
+		<cim:IdentifiedObject.name>container of BE-Line_5</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_61378219-a236-4070-bbec-4e30a6ac848d"/>
+		<cim:IdentifiedObject.mRID>608059fa-f262-463d-a8a8-80844a2a7021</cim:IdentifiedObject.mRID>
+	</cim:Line>
+	<cim:Line rdf:ID="_a8aa134c-be99-4e28-8e51-2d01a3b3e078">
+		<cim:IdentifiedObject.name>container of BE-Line_7</cim:IdentifiedObject.name>
+		<cim:Line.Region rdf:resource="#_02047c0b-b5a4-4e0d-bae6-fc5437a55e74"/>
+		<cim:IdentifiedObject.mRID>a8aa134c-be99-4e28-8e51-2d01a3b3e078</cim:IdentifiedObject.mRID>
+	</cim:Line>
+</rdf:RDF>

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
@@ -144,8 +144,8 @@ public class CgmesPhaseTapChangerBuilder extends AbstractCgmesTapChangerBuilder 
                     .setRatio(ratio)
                     .endStep();
         }
-        double xMin = p.asDouble(CgmesNames.X_STEP_MIN, p.asDouble(CgmesNames.X_MIN));
-        double xMax = p.asDouble(CgmesNames.X_STEP_MAX, p.asDouble(CgmesNames.X_MAX));
+        double xMin = getXMin();
+        double xMax = getXMax();
         if (Double.isNaN(xMin) || Double.isNaN(xMax) || xMin < 0 || xMax <= 0 || xMin > xMax) {
             return;
         }
@@ -194,8 +194,8 @@ public class CgmesPhaseTapChangerBuilder extends AbstractCgmesTapChangerBuilder 
     }
 
     private void stepXforLinearAndSymmetrical() {
-        double xMin = p.asDouble(CgmesNames.X_STEP_MIN, p.asDouble(CgmesNames.X_MIN));
-        double xMax = p.asDouble(CgmesNames.X_STEP_MAX, p.asDouble(CgmesNames.X_MAX));
+        double xMin = getXMin();
+        double xMax = getXMax();
         if (Double.isNaN(xMin) || Double.isNaN(xMax) || xMin < 0 || xMax <= 0 || xMin > xMax) {
             return;
         }
@@ -234,6 +234,24 @@ public class CgmesPhaseTapChangerBuilder extends AbstractCgmesTapChangerBuilder 
 
     private boolean isAsymmetrical() {
         return typeLowerCase != null && typeLowerCase.endsWith(CgmesNames.ASYMMETRICAL);
+    }
+
+    private double getXMin() {
+        // xMin has been deprecated in CGMES 3, and is optional
+        // Also, if the value read is inconsistent, x of the transformer must be used.
+        // Quoting the definition from CGMES 3:
+        // "PowerTransformerEnd.x shall be consistent with PhaseTapChangerLinear.xMin
+        // and PhaseTapChangerNonLinear.xMin.
+        // In case of inconsistency, PowerTransformerEnd.x shall be used."
+        double xMin = p.asDouble(CgmesNames.X_STEP_MIN, p.asDouble(CgmesNames.X_MIN, 0));
+        if (xMin <= 0) {
+            return xtx;
+        }
+        return xtx;
+    }
+
+    private double getXMax() {
+        return p.asDouble(CgmesNames.X_STEP_MAX, p.asDouble(CgmesNames.X_MAX));
     }
 
     private static String toClassTypeFromClassOrKind(String type) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
@@ -247,7 +247,7 @@ public class CgmesPhaseTapChangerBuilder extends AbstractCgmesTapChangerBuilder 
         if (xMin <= 0) {
             return xtx;
         }
-        return xtx;
+        return xMin;
     }
 
     private double getXMax() {

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TransformerConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TransformerConversionTest.java
@@ -7,6 +7,7 @@
 
 package com.powsybl.cgmes.conversion.test;
 
+import com.powsybl.cgmes.conformity.Cgmes3ModifiedCatalog;
 import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conformity.CgmesConformity1ModifiedCatalog;
 import com.powsybl.cgmes.conversion.CgmesImportPostProcessor;
@@ -28,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -389,6 +391,23 @@ class TransformerConversionTest {
 
         boolean ok = t3xCompareFlow(n, "_5d38b7ed-73fd-405a-9cdb-78425e003773", -1494.636083, 1530.638656, 981.686099, 1826.870720, 562.199867, 309.289551);
         assertTrue(ok);
+    }
+
+    @Test
+    void microGridBaseCaseBEPhaseTapChangerXMin() throws IOException {
+        Network n = networkModel(Cgmes3ModifiedCatalog.microGridBaseCasePhaseTapChangerXMin(), new Conversion.Config());
+
+        TwoWindingsTransformer twt1 = n.getTwoWindingsTransformer("a708c3bc-465d-4fe7-b6ef-6fa6408a62b0");
+        TwoWindingsTransformer twt2 = n.getTwoWindingsTransformer("b94318f6-6d24-4f56-96b9-df2531ad6543");
+
+        assertEquals(1.109429, obtainXcurrentStep(twt1), 0.00001);
+        assertEquals(2.796323, obtainXcurrentStep(twt2), 0.00001);
+    }
+
+    private static double obtainXcurrentStep(TwoWindingsTransformer twt) {
+        double xtx = twt.getX();
+        double ptcStepX = twt.getOptionalPhaseTapChanger().map(ptc -> ptc.getCurrentStep().getX()).orElse(0d);
+        return xtx * (1 + ptcStepX / 100);
     }
 
     private boolean t2xCompareFlow(Network n, String id, double p1, double q1, double p2, double q2) {

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -630,8 +630,8 @@ WHERE {
     OPTIONAL {
         ?PhaseTapChanger
             cim:PhaseTapChangerLinear.xMax ?xMax ;
-            cim:PhaseTapChangerLinear.xMin ?xMin ;
-            cim:PhaseTapChangerLinear.stepPhaseShiftIncrement ?stepPhaseShiftIncrement
+            cim:PhaseTapChangerLinear.stepPhaseShiftIncrement ?stepPhaseShiftIncrement .
+        OPTIONAL { ?PhaseTapChanger cim:PhaseTapChangerLinear.xMin ?xMin ; }
     }
     OPTIONAL {
         ?PhaseTapChanger cim:PhaseTapChangerAsymmetrical.windingConnectionAngle ?windingConnectionAngle
@@ -639,8 +639,8 @@ WHERE {
     OPTIONAL {
         ?PhaseTapChanger
             cim:PhaseTapChangerNonLinear.xMax ?xMax ;
-            cim:PhaseTapChangerNonLinear.xMin ?xMin ;
-            cim:PhaseTapChangerNonLinear.voltageStepIncrement ?voltageStepIncrement
+            cim:PhaseTapChangerNonLinear.voltageStepIncrement ?voltageStepIncrement .
+        OPTIONAL { ?PhaseTapChanger cim:PhaseTapChangerNonLinear.xMin ?xMin ; }
     }
     OPTIONAL {
         ?PhaseTapChanger cim:PhaseTapChangerTabular.PhaseTapChangerTable ?PhaseTapChangerTable


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Error observed when `xMin = 0` for a symmetrical phase tap changer. This resulted in an actual `x = 0` for the neutral tap position, when it should be equal to `transformerEnd.x`. 


**What is the new behavior (if this is a feature change)?**
According to the standard, `xMin` must be consistent with `transformerEnd.x`. So, if `xMin <= 0` is found in the input, its value will be ignored, and we will be consider `xMin = transformerEnd.x`.
In addition, `xMin` has been deprecated in CGMES 3. This means that one can specify only `xMax` (and phase shift increment / voltage step increment) when defining a linear / non-linear phase tap changer.



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
