### PR TITLE
CGMES: improve log message for merged containers (substations and voltage levels)

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/SubstationIdMapping.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/SubstationIdMapping.java
@@ -101,7 +101,7 @@ public class SubstationIdMapping {
     // All the keys for a given value, all the merged substations that have cgmesIdentifier as representative
     public Set<String> mergedSubstations(String cgmesIdentifier) {
         String sid = context.namingStrategy().getIidmId(CgmesNames.SUBSTATION, cgmesIdentifier);
-        return substationMapping.entrySet().stream().filter(record -> record.getValue().equals(sid))
+        return substationMapping.entrySet().stream().filter(r -> r.getValue().equals(sid))
             .map(Map.Entry::getKey).collect(Collectors.toSet());
     }
 
@@ -121,7 +121,7 @@ public class SubstationIdMapping {
     // All the keys for a given value, all the merged voltageLevels that have cgmesIdentifier as representative
     public Set<String> mergedVoltageLevels(String cgmesIdentifier) {
         String vlid = context.namingStrategy().getIidmId(CgmesNames.VOLTAGE_LEVEL, cgmesIdentifier);
-        return voltageLevelMapping.entrySet().stream().filter(record -> record.getValue().equals(vlid))
+        return voltageLevelMapping.entrySet().stream().filter(r -> r.getValue().equals(vlid))
             .map(Map.Entry::getKey).collect(Collectors.toSet());
     }
 
@@ -224,7 +224,7 @@ public class SubstationIdMapping {
             }
         }
         if (!voltageLevelMapping.isEmpty()) {
-            LOG.warn("VoltageLevel id mapping needed for {} voltageLevels: {}",
+            LOG.warn("Original {} VoltageLevel container(s) connected by switches have been merged in IIDM. Map of original VoltageLevel to IIDM: {}",
                 voltageLevelMapping.size(), voltageLevelMapping);
         }
     }
@@ -239,7 +239,7 @@ public class SubstationIdMapping {
             }
         }
         if (!substationMapping.isEmpty()) {
-            LOG.warn("Substation id mapping needed for {} substations: {}",
+            LOG.warn("Original {} Substation container(s) connected by transformers have been merged in IIDM. Map of original Substation to IIDM: {}",
                 substationMapping.size(), substationMapping);
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Log message improvement.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
CGMES substations connected by transformers are mapped to a single IIDM substation. The log message that prints which substations have been merged has been improved.
CGMES voltage levels connected by switches are mapped to a single IIDM voltage level. The log message that prints which voltage levels have been merged has been improved.

Changed the name of a variable (`record`) that is considered a restricted identifier.
