### PR TITLE
Fix merging networks with a tie line and a dangling line of same pairing key

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
@@ -172,6 +172,9 @@ public final class TieLineUtil {
      * @return The list of the dangling lines which are candidate to become tie lines (one or zero by pairing key)
      */
     public static List<DanglingLine> findCandidateDanglingLines(Network network, Predicate<String> logPairingKey) {
+        Objects.requireNonNull(network);
+        Objects.requireNonNull(logPairingKey);
+
         List<DanglingLine> candidates = new ArrayList<>();
         Set<String> pairingKeys = new HashSet<>();
         Map<String, List<DanglingLine>> connectedByPairingKey = new HashMap<>();
@@ -226,6 +229,8 @@ public final class TieLineUtil {
      */
     public static void findAndAssociateDanglingLines(DanglingLine candidateDanglingLine, Function<String, List<DanglingLine>> getDanglingLinesByPairingKey,
                                                      BiConsumer<DanglingLine, DanglingLine> associateDanglingLines) {
+        //TODO This method is quite complicated. It would be better to call `findCandidateDanglingLines` on both networks to merge
+        // and to only process the retrieved candidate lists together.
         Objects.requireNonNull(candidateDanglingLine);
         Objects.requireNonNull(getDanglingLinesByPairingKey);
         Objects.requireNonNull(associateDanglingLines);

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
@@ -201,7 +201,7 @@ public final class TieLineUtil {
                 candidates.add(dl);
                 if (!disconnected.isEmpty() && doLog) {
                     LOGGER.warn("Several dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " +
-                                    "Only {} is considered (the only connected one)",
+                                    "Only '{}' is considered (the only connected one)",
                             Stream.concat(Stream.of(dl.getId()), disconnected.stream().map(DanglingLine::getId)).collect(Collectors.toList()),
                             pairingKey, dl.getId());
                 }
@@ -247,7 +247,7 @@ public final class TieLineUtil {
                     List<DanglingLine> connectedDls = dls.stream().filter(dl -> dl.getTerminal().isConnected()).collect(Collectors.toList());
                     if (connectedDls.size() == 1) { // if there is exactly one connected dangling line in the merging network, merge it. Otherwise, do nothing
                         LOGGER.warn("Several dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " +
-                                        "Tie line was automatically created using the only one which is connected: {}",
+                                        "Tie line automatically created using the only connected one '{}'.",
                                 dls.stream().map(DanglingLine::getId).collect(Collectors.toList()), connectedDls.get(0).getPairingKey(),
                                 connectedDls.get(0).getId());
                         associateDanglingLines.accept(connectedDls.get(0), candidateDanglingLine);

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
@@ -36,6 +36,8 @@ public final class TieLineUtil {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TieLineUtil.class);
 
+    public static final String NO_TIE_LINE_MESSAGE = "No tie line automatically created, tie lines must be created by hand.";
+
     private TieLineUtil() {
     }
 
@@ -159,14 +161,15 @@ public final class TieLineUtil {
     }
 
     /**
-     * <b>Analyze a network and return its dangling lines which are candidate to a tie line creation when merging the network with another.</b>
-     * <b>Are candidates for a pairing key 'k':
-     * <li>the only connected dangling line of pairing key 'k', whether disconnected dangling lines of pairing key 'k' exist;</li>
-     * <li>the only disconnected dangling line of pairing key 'k', if no connected dangling lines of pairing key 'k' exist.</li>
+     * <b>Analyze a network and return its dangling lines which are candidate to become tie lines when merging the network with another.</b>
+     * <b>Is candidate for a pairing key 'k':
+     * <li>the only connected dangling line of pairing key 'k', if disconnected dangling lines of pairing key 'k' exist;</li>
+     * <li>the only disconnected dangling line of pairing key 'k', if no connected dangling line of pairing key 'k' exists.</li>
+     * <li>no dangling line at all</li>
      * </b>
      * @param network a network
      * @param logPairingKey a Predicate indicating if we want to log a warning when several dangling lines are found for the same pairing key.
-     * @return The list of the dangling lines which are candidate to a tie line creation
+     * @return The list of the dangling lines which are candidate to become tie lines (one or zero by pairing key)
      */
     public static List<DanglingLine> findCandidateDanglingLines(Network network, Predicate<String> logPairingKey) {
         List<DanglingLine> candidates = new ArrayList<>();
@@ -190,8 +193,7 @@ public final class TieLineUtil {
                 if (disconnected.size() == 1) {
                     candidates.add(dl);
                 } else if (doLog) {
-                    LOGGER.warn("Several disconnected dangling lines {} (and no connected ones) of the same subnetwork are candidate for merging for pairing key '{}'. " +
-                                    "No tie line will be automatically created for this pairing key, tie lines must be created by hand.",
+                    LOGGER.warn("Several disconnected dangling lines {} (and no connected one) of the same subnetwork are candidate for merging for pairing key '{}'. " + NO_TIE_LINE_MESSAGE,
                             disconnected.stream().map(DanglingLine::getId).toList(), pairingKey);
                 }
             } else if (connected.size() == 1) {
@@ -204,8 +206,7 @@ public final class TieLineUtil {
                             pairingKey, dl.getId());
                 }
             } else if (doLog) {
-                LOGGER.warn("Several connected dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " +
-                                "No tie line automatically created, tie lines must be created by hand.",
+                LOGGER.warn("Several connected dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " + NO_TIE_LINE_MESSAGE,
                         connected.stream().map(DanglingLine::getId).toList(), pairingKey);
             }
         }
@@ -252,8 +253,7 @@ public final class TieLineUtil {
                         associateDanglingLines.accept(connectedDls.get(0), candidateDanglingLine);
                     } else {
                         String status = connectedDls.size() > 1 ? "connected" : "disconnected";
-                        LOGGER.warn("Several {} dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " +
-                                "No tie line automatically created, tie lines must be created by hand.",
+                        LOGGER.warn("Several {} dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " + NO_TIE_LINE_MESSAGE,
                                 status, connectedDls.stream().map(DanglingLine::getId).collect(Collectors.toList()),
                                 connectedDls.get(0).getPairingKey());
                     }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Sets;
 import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.iidm.network.DanglingLine;
 import com.powsybl.iidm.network.DanglingLineFilter;
+import com.powsybl.iidm.network.Network;
 import org.apache.commons.math3.complex.Complex;
 
 import com.powsybl.iidm.network.Branch;
@@ -20,7 +21,9 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.powsybl.iidm.network.util.TieLineReports.*;
 
@@ -156,6 +159,60 @@ public final class TieLineUtil {
     }
 
     /**
+     * <b>Analyze a network and return its dangling lines which are candidate to a tie line creation when merging the network with another.</b>
+     * <b>Are candidates for a pairing key 'k':
+     * <li>the only connected dangling line of pairing key 'k', whether disconnected dangling lines of pairing key 'k' exist;</li>
+     * <li>the only disconnected dangling line of pairing key 'k', if no connected dangling lines of pairing key 'k' exist.</li>
+     * </b>
+     * @param network a network
+     * @param logPairingKey a Predicate indicating if we want to log a warning when several dangling lines are found for the same pairing key.
+     * @return The list of the dangling lines which are candidate to a tie line creation
+     */
+    public static List<DanglingLine> findCandidateDanglingLines(Network network, Predicate<String> logPairingKey) {
+        List<DanglingLine> candidates = new ArrayList<>();
+        Set<String> pairingKeys = new HashSet<>();
+        Map<String, List<DanglingLine>> connectedByPairingKey = new HashMap<>();
+        Map<String, List<DanglingLine>> disconnectedByPairingKey = new HashMap<>();
+
+        network.getDanglingLines(DanglingLineFilter.UNPAIRED).forEach(dl -> {
+            String pairingKey = dl.getPairingKey();
+            Map<String, List<DanglingLine>> mapToUpdate = dl.getTerminal().isConnected() ? connectedByPairingKey : disconnectedByPairingKey;
+            mapToUpdate.computeIfAbsent(pairingKey, k -> new ArrayList<>()).add(dl);
+            pairingKeys.add(pairingKey);
+        });
+
+        for (String pairingKey : pairingKeys) {
+            boolean doLog = logPairingKey.test(pairingKey);
+            List<DanglingLine> connected = Optional.ofNullable(connectedByPairingKey.get(pairingKey)).orElse(Collections.emptyList());
+            List<DanglingLine> disconnected = Optional.ofNullable(disconnectedByPairingKey.get(pairingKey)).orElse(Collections.emptyList());
+            if (connected.isEmpty()) {
+                DanglingLine dl = disconnected.get(0); // Cannot be empty here: we always have at least 1 connected or disconnected dangling line
+                if (disconnected.size() == 1) {
+                    candidates.add(dl);
+                } else if (doLog) {
+                    LOGGER.warn("Several disconnected dangling lines {} (and no connected ones) of the same subnetwork are candidate for merging for pairing key '{}'. " +
+                                    "No tie line will be automatically created for this pairing key, tie lines must be created by hand.",
+                            disconnected.stream().map(DanglingLine::getId).toList(), pairingKey);
+                }
+            } else if (connected.size() == 1) {
+                DanglingLine dl = connected.get(0);
+                candidates.add(dl);
+                if (!disconnected.isEmpty() && doLog) {
+                    LOGGER.warn("Several dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " +
+                                    "Only {} is considered (the only connected one)",
+                            Stream.concat(Stream.of(dl.getId()), disconnected.stream().map(DanglingLine::getId)).collect(Collectors.toList()),
+                            pairingKey, dl.getId());
+                }
+            } else if (doLog) {
+                LOGGER.warn("Several connected dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " +
+                                "No tie line automatically created, tie lines must be created by hand.",
+                        connected.stream().map(DanglingLine::getId).toList(), pairingKey);
+            }
+        }
+        return candidates;
+    }
+
+    /**
      * If it exists, find the dangling line in the merging network that should be associated to a candidate dangling line in the network to be merged.
      * Two dangling lines in different IGM should be associated if:
      * - they have the same non-null pairing key and are the only dangling lines to have this pairing key in their respective networks
@@ -173,6 +230,7 @@ public final class TieLineUtil {
         Objects.requireNonNull(associateDanglingLines);
         // mapping by pairing key
         if (candidateDanglingLine.getPairingKey() != null) { // if pairing key null: no associated dangling line
+            // If we call this method on the results of "findCandidateDanglingLines", the following test is useless
             if (candidateDanglingLine.getNetwork().getDanglingLineStream(DanglingLineFilter.UNPAIRED)
                     .filter(d -> d != candidateDanglingLine)
                     .filter(d -> candidateDanglingLine.getPairingKey().equals(d.getPairingKey()))
@@ -187,11 +245,17 @@ public final class TieLineUtil {
                 if (dls.size() > 1) { // if more than one dangling line in the merging network, check how many are connected
                     List<DanglingLine> connectedDls = dls.stream().filter(dl -> dl.getTerminal().isConnected()).collect(Collectors.toList());
                     if (connectedDls.size() == 1) { // if there is exactly one connected dangling line in the merging network, merge it. Otherwise, do nothing
+                        LOGGER.warn("Several dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " +
+                                        "Tie line was automatically created using the only one which is connected: {}",
+                                dls.stream().map(DanglingLine::getId).collect(Collectors.toList()), connectedDls.get(0).getPairingKey(),
+                                connectedDls.get(0).getId());
                         associateDanglingLines.accept(connectedDls.get(0), candidateDanglingLine);
                     } else {
-                        LOGGER.warn("Several connected dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " +
+                        String status = connectedDls.size() > 1 ? "connected" : "disconnected";
+                        LOGGER.warn("Several {} dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " +
                                 "No tie line automatically created, tie lines must be created by hand.",
-                                connectedDls.stream().map(DanglingLine::getId).collect(Collectors.toList()), connectedDls.get(0).getPairingKey());
+                                status, connectedDls.stream().map(DanglingLine::getId).collect(Collectors.toList()),
+                                connectedDls.get(0).getPairingKey());
                     }
                 }
             }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
@@ -188,6 +188,10 @@ public final class TieLineUtil {
                     List<DanglingLine> connectedDls = dls.stream().filter(dl -> dl.getTerminal().isConnected()).collect(Collectors.toList());
                     if (connectedDls.size() == 1) { // if there is exactly one connected dangling line in the merging network, merge it. Otherwise, do nothing
                         associateDanglingLines.accept(connectedDls.get(0), candidateDanglingLine);
+                    } else {
+                        LOGGER.warn("Several connected dangling lines {} of the same subnetwork are candidate for merging for pairing key '{}'. " +
+                                "No tie line automatically created, tie lines must be created by hand.",
+                                connectedDls.stream().map(DanglingLine::getId).collect(Collectors.toList()), connectedDls.get(0).getPairingKey());
                     }
                 }
             }

--- a/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/TieLineUtilTest.java
+++ b/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/TieLineUtilTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network;
+
+import com.powsybl.iidm.network.util.TieLineUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Olivier Perrin <olivier.perrin at rte-france.com>
+ */
+public class TieLineUtilTest {
+
+    public static final String PAIRING_KEY = "key";
+    private static Network network;
+    private static DanglingLine dlConnected1;
+    private static DanglingLine dlConnected2;
+    private static DanglingLine dlDisconnected1;
+    private static DanglingLine dlDisconnected2;
+
+    @BeforeAll
+    public static void setup() {
+        network = mock(Network.class);
+        dlConnected1 = createDanglingLine("connected1", true);
+        dlConnected2 = createDanglingLine("connected2", true);
+        dlDisconnected1 = createDanglingLine("disconnected1", false);
+        dlDisconnected2 = createDanglingLine("disconnected2", false);
+    }
+
+    @Test
+    void testFindCandidateDanglingLinesWithNoConnected() {
+        // 0 connected, 0 disconnected
+        configureDanglingLines();
+        Assertions.assertTrue(getCandidate().isEmpty());
+
+        // 0 connected, 1 disconnected
+        configureDanglingLines(dlDisconnected1);
+        Assertions.assertEquals(dlDisconnected1, getCandidate().orElse(null));
+
+        // 0 connected, several disconnected
+        configureDanglingLines(dlDisconnected1, dlDisconnected2);
+        Assertions.assertTrue(getCandidate().isEmpty());
+    }
+
+    @Test
+    void testFindCandidateDanglingLinesWithOneConnected() {
+        // 1 connected, 0 disconnected
+        configureDanglingLines(dlConnected1);
+        Assertions.assertEquals(dlConnected1, getCandidate().orElse(null));
+
+        // 1 connected, 1 disconnected
+        configureDanglingLines(dlConnected1, dlDisconnected1);
+        Assertions.assertEquals(dlConnected1, getCandidate().orElse(null));
+
+        // 1 connected, several disconnected
+        configureDanglingLines(dlConnected1, dlDisconnected1, dlDisconnected2);
+        Assertions.assertEquals(dlConnected1, getCandidate().orElse(null));
+    }
+
+    @Test
+    void testFindCandidateDanglingLinesWithSeveralConnected() {
+        // several connected, 0 disconnected
+        configureDanglingLines(dlConnected1, dlConnected2);
+        Assertions.assertTrue(getCandidate().isEmpty());
+
+        // several connected, 1 disconnected
+        configureDanglingLines(dlConnected1, dlConnected2, dlDisconnected1);
+        Assertions.assertTrue(getCandidate().isEmpty());
+
+        // several connected, several disconnected
+        configureDanglingLines(dlConnected1, dlConnected2, dlDisconnected1, dlDisconnected2);
+        Assertions.assertTrue(getCandidate().isEmpty());
+    }
+
+    private static void configureDanglingLines(DanglingLine... danglingLines) {
+        when(network.getDanglingLines(DanglingLineFilter.UNPAIRED)).thenReturn(Arrays.asList(danglingLines));
+    }
+
+    private static Optional<DanglingLine> getCandidate() {
+        return TieLineUtil.findCandidateDanglingLines(network, k -> false).stream().findFirst();
+    }
+
+    private static DanglingLine createDanglingLine(String id, boolean connected) {
+        DanglingLine dl = mock(DanglingLine.class);
+        when(dl.getId()).thenReturn(id);
+        when(dl.getPairingKey()).thenReturn(PAIRING_KEY);
+        Terminal terminal = mock(Terminal.class);
+        when(terminal.isConnected()).thenReturn(connected);
+        when(dl.getTerminal()).thenReturn(terminal);
+        return dl;
+    }
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -9,7 +9,6 @@ package com.powsybl.iidm.network.impl;
 import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.primitives.Ints;
 import com.powsybl.commons.PowsyblException;
@@ -916,7 +915,7 @@ class NetworkImpl extends AbstractNetwork implements VariantManagerHolder, Multi
                 dl1byPairingKey.computeIfAbsent(dl1.getPairingKey(), k -> new ArrayList<>()).add(dl1);
             }
         }
-        for (DanglingLine dl2 : Lists.newArrayList(other.getDanglingLines(DanglingLineFilter.ALL))) {
+        for (DanglingLine dl2 : findCandidateDanglingLines(other, dl1byPairingKey::containsKey)) {
             findAndAssociateDanglingLines(dl2, dl1byPairingKey::get, (dll1, dll2) -> pairDanglingLines(lines, dll1, dll2, dl1byPairingKey));
         }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
@@ -619,23 +619,61 @@ public abstract class AbstractMergeNetworkTest {
 
     @Test
     public void multipleDanglingLinesInMergedNetwork() {
+        // The code is not the same if the dangling line with the duplicate pairing key is in the current network
+        // or in the network we are adding when we try to associate dangling lines.
+        //
+        // This test covers the case where the duplicate pairing key is in the CURRENT network.
         addCommonSubstationsAndVoltageLevels();
         addCommonDanglingLines("dl1", "code", "dl2", "code");
         addDanglingLine(n2, "vl2", "dl3", "code", "b2", null);
         Network merge = Network.merge(n1, n2);
+        // Since n2 has ONLY ONE connected dangling line with the pairing key, the tie line is created
         assertNotNull(merge.getTieLine("dl1 + dl2"));
         assertEquals("dl1_name + dl2_name", merge.getTieLine("dl1 + dl2").getOptionalName().orElse(null));
         assertEquals("dl1_name + dl2_name", merge.getTieLine("dl1 + dl2").getNameOrId());
     }
 
     @Test
+    public void multipleConnectedDanglingLinesInMergedNetwork() {
+        // The code is not the same if the dangling line with the duplicate pairing key is in the current network
+        // or in the network we are adding when we try to associate dangling lines.
+        //
+        // This test covers the case where the duplicate pairing key is in the CURRENT network.
+        addCommonSubstationsAndVoltageLevels();
+        addCommonDanglingLines("dl1", "code", "dl2", "code");
+        addDanglingLine(n2, "vl2", "dl3", "code", "b2", "b2");
+        Network merge = Network.merge(n1, n2);
+        // Since n2 has SEVERAL connected dangling lines with the pairing key, we don't create the tie line
+        assertEquals(0, merge.getTieLineCount());
+    }
+
+    @Test
     public void multipleDanglingLinesInMergingNetwork() {
+        // The code is not the same if the dangling line with the duplicate pairing key is in the current network
+        // or in the network we are adding when we try to associate dangling lines.
+        //
+        // This test covers the case where the duplicate pairing key is in the ADDED network.
         addCommonSubstationsAndVoltageLevels();
         addCommonDanglingLines("dl1", "code", "dl2", "code");
         addDanglingLine(n1, "vl1", "dl3", "code", "b1", null);
         Network merge = Network.merge(n1, n2);
+        // Since n1 has ONLY ONE connected dangling line with the pairing key, the tie line is created
         assertNotNull(merge.getTieLine("dl1 + dl2"));
         assertEquals("dl1_name + dl2_name", merge.getTieLine("dl1 + dl2").getOptionalName().orElse(null));
         assertEquals("dl1_name + dl2_name", merge.getTieLine("dl1 + dl2").getNameOrId());
+    }
+
+    @Test
+    public void multipleConnectedDanglingLinesWithSamePairingKey() {
+        // The code is not the same if the dangling line with the duplicate pairing key is in the current network
+        // or in the network we are adding when we try to associate dangling lines.
+        //
+        // This test covers the case where the duplicate pairing key is in the ADDED network.
+        addCommonSubstationsAndVoltageLevels();
+        addCommonDanglingLines("dl1", "code", "dl2", "code");
+        addDanglingLine(n1, "vl1", "dl3", "code", "b1", "b1");
+        Network merge = Network.merge(n1, n2);
+        // Since n1 has SEVERAL connected dangling lines with the pairing key, we don't create the tie line
+        assertEquals(0, merge.getTieLineCount());
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
@@ -618,6 +618,48 @@ public abstract class AbstractMergeNetworkTest {
     }
 
     @Test
+    public void dontCreateATieLineWithAlreadyMergedDanglingLinesInMergedNetwork() {
+        // The code is not the same if the dangling line with the duplicate pairing key is in the current network
+        // or in the network we are adding when we try to associate dangling lines.
+        //
+        // This test covers the case where the duplicate pairing key is in the CURRENT network.
+        addCommonSubstationsAndVoltageLevels();
+        addCommonDanglingLines("dl1", "code", "dl2", "code");
+        addDanglingLine(n1, "vl1", "dl3", "code", "b1", "b1");
+        n1.newTieLine()
+                .setId("dl1 + dl3")
+                .setDanglingLine1("dl1")
+                .setDanglingLine2("dl3")
+                .add();
+        Network merge = Network.merge(n1, n2);
+        assertNotNull(merge.getTieLine("dl1 + dl3"));
+        assertNull(merge.getTieLine("dl1 + dl2"));
+        assertNull(merge.getTieLine("dl2 + dl3"));
+        assertEquals(1, merge.getTieLineCount());
+    }
+
+    @Test
+    public void dontCreateATieLineWithAlreadyMergedDanglingLinesInMergingNetwork() {
+        // The code is not the same if the dangling line with the duplicate pairing key is in the current network
+        // or in the network we are adding when we try to associate dangling lines.
+        //
+        // This test covers the case where the duplicate pairing key is in the ADDED network.
+        addCommonSubstationsAndVoltageLevels();
+        addCommonDanglingLines("dl1", "code", "dl2", "code");
+        addDanglingLine(n2, "vl2", "dl3", "code", "b2", "b2");
+        n2.newTieLine()
+                .setId("dl2 + dl3")
+                .setDanglingLine1("dl2")
+                .setDanglingLine2("dl3")
+                .add();
+        Network merge = Network.merge(n1, n2);
+        assertNotNull(merge.getTieLine("dl2 + dl3"));
+        assertNull(merge.getTieLine("dl1 + dl2"));
+        assertNull(merge.getTieLine("dl1 + dl3"));
+        assertEquals(1, merge.getTieLineCount());
+    }
+
+    @Test
     public void multipleDanglingLinesInMergedNetwork() {
         // The code is not the same if the dangling line with the duplicate pairing key is in the current network
         // or in the network we are adding when we try to associate dangling lines.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix (+ logs)


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When merging a network having a tie line between 2 dangling lines of pairing key `k` with another network having a sole dangling line of pairing key `k`, we try to create a tie line between the 2 networks, which prevents the merging (an Exception is thrown).

\+ Nothing indicates when dangling lines cannot be merged.


**What is the new behavior (if this is a feature change)?**
When merging a network having a tie line between 2 dangling lines of pairing key `k` with another network having a sole dangling line of pairing key `k`, we don't try to create a tie line between the 2 networks and the merge succeeds.

\+ Logs are added when dangling lines cannot be merged.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
This PR introduces a new method (`TieLineUtil.findCandidateDanglingLines`) to identify the dangling lines which are candidate to become tie lines when merging the network with another.

To limit the impact of this PR (to avoid breaking changes), which will be introduced in a bug fix release, we didn't refactor the whole dangling lines matching. This will be the object of another PR (see #2741).
