### PR TITLE
Implement VoltageAngleLimit removal

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -723,7 +723,11 @@ class NetworkImpl extends AbstractNetwork implements VariantManagerHolder, Multi
 
     @Override
     public VoltageAngleLimitAdder newVoltageAngleLimit() {
-        return new VoltageAngleLimitAdderImpl(ref);
+        return newVoltageAngleLimit(null);
+    }
+
+    VoltageAngleLimitAdder newVoltageAngleLimit(String subnetwork) {
+        return new VoltageAngleLimitAdderImpl(this, subnetwork);
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubnetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubnetworkImpl.java
@@ -218,7 +218,7 @@ public class SubnetworkImpl extends AbstractNetwork {
 
     @Override
     public VoltageAngleLimitAdder newVoltageAngleLimit() {
-        return new VoltageAngleLimitAdderImpl(rootNetworkRef, id);
+        return getNetwork().newVoltageAngleLimit(id);
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageAngleLimitImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageAngleLimitImpl.java
@@ -10,6 +10,7 @@ package com.powsybl.iidm.network.impl;
 import java.util.OptionalDouble;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.impl.util.Ref;
 
 /**
  *
@@ -19,18 +20,22 @@ import com.powsybl.iidm.network.*;
  */
 class VoltageAngleLimitImpl implements VoltageAngleLimit {
 
+    private final Ref<NetworkImpl> networkRef;
+
     private final String id;
     private final Terminal fromTerminal;
     private final Terminal toTerminal;
     private final double lowLimit;
     private final double highLimit;
 
-    VoltageAngleLimitImpl(String id, Terminal fromTerminal, Terminal toTerminal, double lowLimit, double highLimit) {
+    VoltageAngleLimitImpl(String id, Terminal fromTerminal, Terminal toTerminal,
+                          double lowLimit, double highLimit, Ref<NetworkImpl> networkRef) {
         this.id = id;
         this.fromTerminal = fromTerminal;
         this.toTerminal = toTerminal;
         this.lowLimit = lowLimit;
         this.highLimit = highLimit;
+        this.networkRef = networkRef;
     }
 
     @Override
@@ -56,5 +61,10 @@ class VoltageAngleLimitImpl implements VoltageAngleLimit {
     @Override
     public OptionalDouble getHighLimit() {
         return Double.isNaN(highLimit) ? OptionalDouble.empty() : OptionalDouble.of(highLimit);
+    }
+
+    @Override
+    public void remove() {
+        this.networkRef.get().getVoltageAngleLimitsIndex().remove(id);
     }
 }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VoltageAngleLimitTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VoltageAngleLimitTest.java
@@ -9,7 +9,6 @@ package com.powsybl.iidm.network.impl;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
-import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 
 import org.junit.jupiter.api.Test;
@@ -112,12 +111,19 @@ class VoltageAngleLimitTest {
 
     @Test
     void removeTest() {
-        Network network = EurostagTutorialExample1Factory.create();
-        Line line = network.getLine("NHV1_NHV2_1");
-        network.newVoltageAngleLimit().setId("val").from(line.getTerminal1()).to(line.getTerminal2()).setHighLimit(7.0).setLowLimit(-7.0).add();
-        assertNotNull(network.getVoltageAngleLimit("val"));
-        network.getVoltageAngleLimit("val").remove();
-        assertNull(network.getVoltageAngleLimit("val"));
+        String id = "VOLTAGE_ANGLE_LIMIT_LINE_S2S3";
+
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        Line lineS2S3 = network.getLine("LINE_S2S3");
+        network.newVoltageAngleLimit().setId(id)
+                .from(lineS2S3.getTerminal1())
+                .to(lineS2S3.getTerminal2())
+                .setHighLimit(10.0)
+                .add();
+
+        assertNotNull(network.getVoltageAngleLimit(id));
+        network.getVoltageAngleLimit(id).remove();
+        assertNull(network.getVoltageAngleLimit(id));
     }
 
 }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VoltageAngleLimitTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/VoltageAngleLimitTest.java
@@ -9,13 +9,12 @@ package com.powsybl.iidm.network.impl;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
 *
@@ -110,4 +109,15 @@ class VoltageAngleLimitTest {
         assertEquals("The network " + network.getId()
                 + " already contains a voltage angle limit with the id 'Limit'", e.getMessage());
     }
+
+    @Test
+    void removeTest() {
+        Network network = EurostagTutorialExample1Factory.create();
+        Line line = network.getLine("NHV1_NHV2_1");
+        network.newVoltageAngleLimit().setId("val").from(line.getTerminal1()).to(line.getTerminal2()).setHighLimit(7.0).setLowLimit(-7.0).add();
+        assertNotNull(network.getVoltageAngleLimit("val"));
+        network.getVoltageAngleLimit("val").remove();
+        assertNull(network.getVoltageAngleLimit("val"));
+    }
+
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksCreationTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksCreationTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -324,6 +325,90 @@ public abstract class AbstractSubnetworksCreationTest {
         assertFalse(listenerCalled.booleanValue());
     }
 
+    @Test
+    public void testAngleVoltageLimitCreation() {
+        addSubstation(network, "s0");
+        addSubstation(subnetwork1, "s1");
+        addSubstation(subnetwork2, "s2");
+
+        addVoltageLevel(network.getSubstation("s0").newVoltageLevel(), "vl0_0");
+        addVoltageLevel(network.getSubstation("s0").newVoltageLevel(), "vl0_1");
+        addVoltageLevel(network.getSubstation("s1").newVoltageLevel(), "vl1_0");
+        addVoltageLevel(network.getSubstation("s1").newVoltageLevel(), "vl1_1");
+        addVoltageLevel(network.getSubstation("s2").newVoltageLevel(), "vl2_0");
+        addVoltageLevel(network.getSubstation("s2").newVoltageLevel(), "vl2_1");
+
+        Line l0 = addLine(network, "l0", "vl0_0", "vl0_1");
+        Line l1 = addLine(network, "l1", "vl1_0", "vl1_1");
+        Line l2 = addLine(network, "l2", "vl2_0", "vl2_1");
+
+        // On root network, terminals both in root network
+        VoltageAngleLimit vla0 = addVoltageAngleLimit(network, "vla0", l0.getTerminal1(), l0.getTerminal2());
+
+        // On root network, terminals both in subnetwork1
+        VoltageAngleLimit vla1 = addVoltageAngleLimit(network, "vla1", l1.getTerminal1(), l1.getTerminal2());
+
+        // On subnetwork2, terminals both in subnetwork2
+        VoltageAngleLimit vla2 = addVoltageAngleLimit(subnetwork2, "vla2", l2.getTerminal1(), l2.getTerminal2());
+
+        // On root network, terminals in different subnetworks
+        VoltageAngleLimit vla3 = addVoltageAngleLimit(network, "vla3", l1.getTerminal1(), l2.getTerminal1());
+
+        // On root network, terminals in root network and subnetwork2
+        VoltageAngleLimit vla4 = addVoltageAngleLimit(network, "vla4", l0.getTerminal1(), l2.getTerminal1());
+
+        // Try to detach all. Some elements prevent it.
+        assertFalse(subnetwork1.isDetachable());
+        assertFalse(subnetwork2.isDetachable());
+        // Remove problematic elements
+        vla3.remove();
+        vla4.remove();
+
+        // Detach all
+        assertTrue(subnetwork1.isDetachable());
+        assertTrue(subnetwork2.isDetachable());
+        Network n1 = subnetwork1.detach();
+        Network n2 = subnetwork2.detach();
+        // - Check VoltageAngleLimits
+        assertEquals(1, List.of(network.getVoltageAngleLimits()).size());
+        assertEquals(1, List.of(n1.getVoltageAngleLimits()).size());
+        assertEquals(1, List.of(n2.getVoltageAngleLimits()).size());
+        assertEquals(vla0, network.getVoltageAngleLimit("vla0"));
+        assertNull(network.getVoltageAngleLimit("vla1"));
+        assertNull(network.getVoltageAngleLimit("vla2"));
+        assertEquals(vla1, n1.getVoltageAngleLimit("vla1"));
+        assertEquals(vla2, n2.getVoltageAngleLimit("vla2"));
+    }
+
+    @Test
+    public void failCreateVoltageAngleLimitFromSubnetworkBetweenRootAndSubnetwork() {
+        addSubstation(network, "s0");
+        addSubstation(subnetwork1, "s1");
+        addVoltageLevel(network.getSubstation("s0").newVoltageLevel(), "vl0_0");
+        addVoltageLevel(network.getSubstation("s0").newVoltageLevel(), "vl0_1");
+        addVoltageLevel(network.getSubstation("s1").newVoltageLevel(), "vl1_0");
+        addVoltageLevel(network.getSubstation("s1").newVoltageLevel(), "vl1_1");
+        Line l0 = addLine(network, "l0", "vl0_0", "vl0_1");
+        Line l1 = addLine(network, "l1", "vl1_0", "vl1_1");
+
+        // On subnetwork1, voltage levels in root network and subnetwork2 => should fail
+        Exception e = assertThrows(ValidationException.class, () -> addVoltageAngleLimit(subnetwork1, "vla", l0.getTerminal1(), l1.getTerminal1()));
+        assertTrue(e.getMessage().contains("Create this VoltageAngleLimit from the parent network"));
+    }
+
+    @Test
+    public void failCreateVoltageAngleLimitFromASubnetworkInAnother() {
+        addSubstation(subnetwork1, "s2");
+
+        addVoltageLevel(network.getSubstation("s2").newVoltageLevel(), "vl2_0");
+        addVoltageLevel(subnetwork2.newVoltageLevel(), "vl2_1");
+        Line l2 = addLine(network, "l2", "vl2_0", "vl2_1");
+
+        // On subnetwork1, voltage levels both in subnetwork2 => should fail
+        PowsyblException e = assertThrows(ValidationException.class, () -> addVoltageAngleLimit(subnetwork1, "vla", l2.getTerminal1(), l2.getTerminal2()));
+        assertTrue(e.getMessage().contains("Create this VoltageAngleLimit from the parent network"));
+    }
+
     void assertValidationLevels(ValidationLevel expected) {
         // The validation level must be the same between the root network and its subnetworks
         assertEquals(expected, network.getValidationLevel());
@@ -415,6 +500,12 @@ public abstract class AbstractSubnetworksCreationTest {
                 .setBus(getBusId(vlId3))
                 .setVoltageLevel(vlId3)
                 .add()
+                .add();
+    }
+
+    private VoltageAngleLimit addVoltageAngleLimit(Network network, String id, Terminal from, Terminal to) {
+        return network.newVoltageAngleLimit()
+                .setId(id).from(from).to(to)
                 .add();
     }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksCreationTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksCreationTest.java
@@ -392,7 +392,9 @@ public abstract class AbstractSubnetworksCreationTest {
         Line l1 = addLine(network, "l1", "vl1_0", "vl1_1");
 
         // On subnetwork1, voltage levels in root network and subnetwork2 => should fail
-        Exception e = assertThrows(ValidationException.class, () -> addVoltageAngleLimit(subnetwork1, "vla", l0.getTerminal1(), l1.getTerminal1()));
+        Terminal from = l0.getTerminal1();
+        Terminal to = l1.getTerminal1();
+        Exception e = assertThrows(ValidationException.class, () -> addVoltageAngleLimit(subnetwork1, "vla", from, to));
         assertTrue(e.getMessage().contains("Create this VoltageAngleLimit from the parent network"));
     }
 
@@ -405,7 +407,9 @@ public abstract class AbstractSubnetworksCreationTest {
         Line l2 = addLine(network, "l2", "vl2_0", "vl2_1");
 
         // On subnetwork1, voltage levels both in subnetwork2 => should fail
-        PowsyblException e = assertThrows(ValidationException.class, () -> addVoltageAngleLimit(subnetwork1, "vla", l2.getTerminal1(), l2.getTerminal2()));
+        Terminal from = l2.getTerminal1();
+        Terminal to = l2.getTerminal2();
+        PowsyblException e = assertThrows(ValidationException.class, () -> addVoltageAngleLimit(subnetwork1, "vla", from, to));
         assertTrue(e.getMessage().contains("Create this VoltageAngleLimit from the parent network"));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Calling `remove()` on a `VoltageAngleLimit` does nothing.


**What is the new behavior (if this is a feature change)?**
Calling `remove()` on a `VoltageAngleLimit` removes it from its network.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
