### PR TITLE
Fix VoltageAngleLimit retrieval by id from a subnetwork

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubnetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubnetworkImpl.java
@@ -236,8 +236,8 @@ public class SubnetworkImpl extends AbstractNetwork {
     public VoltageAngleLimit getVoltageAngleLimit(String id) {
         VoltageAngleLimitImpl val = (VoltageAngleLimitImpl) getNetwork().getVoltageAngleLimit(id);
         boolean valInSubnetwork = val != null
-                && id.equals(val.getTerminalFrom().getVoltageLevel().getParentNetwork().getId())
-                && id.equals(val.getTerminalTo().getVoltageLevel().getParentNetwork().getId());
+                && contains(val.getTerminalFrom().getVoltageLevel())
+                && contains(val.getTerminalTo().getVoltageLevel());
         return valInSubnetwork ? val : null;
     }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksCreationTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksCreationTest.java
@@ -364,6 +364,17 @@ public abstract class AbstractSubnetworksCreationTest {
         vla3.remove();
         vla4.remove();
 
+        // Test VoltageAngleLimit retrieval
+        assertEquals(vla0, network.getVoltageAngleLimit("vla0"));
+        assertEquals(vla1, network.getVoltageAngleLimit("vla1"));
+        assertEquals(vla2, network.getVoltageAngleLimit("vla2"));
+        assertNull(subnetwork1.getVoltageAngleLimit("vla0"));
+        assertEquals(vla1, subnetwork1.getVoltageAngleLimit("vla1"));
+        assertNull(subnetwork1.getVoltageAngleLimit("vla2"));
+        assertNull(subnetwork2.getVoltageAngleLimit("vla0"));
+        assertNull(subnetwork2.getVoltageAngleLimit("vla1"));
+        assertEquals(vla2, subnetwork2.getVoltageAngleLimit("vla2"));
+
         // Detach all
         assertTrue(subnetwork1.isDetachable());
         assertTrue(subnetwork2.isDetachable());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
On a subnetwork `n` containing a `VoltageAngleLimit` which identifier is "id", `n.getVoltageAngleLimit("id")` returns `null`.



**What is the new behavior (if this is a feature change)?**
On a subnetwork `n` containing a `VoltageAngleLimit` which identifier is "id", `n.getVoltageAngleLimit("id")` returns the said `VoltageAngleLimit`.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
