### PR TITLE
Cgmes Import: HVDC fix lost configurations

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/CgmesDcConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/CgmesDcConversion.java
@@ -8,6 +8,7 @@
 package com.powsybl.cgmes.conversion.elements.hvdc;
 
 import com.powsybl.cgmes.conversion.Context;
+import com.powsybl.cgmes.conversion.Conversion;
 import com.powsybl.cgmes.conversion.elements.hvdc.DcLineSegmentConversion.DcLineSegmentConverter;
 import com.powsybl.cgmes.conversion.elements.hvdc.Hvdc.HvdcConverter;
 import com.powsybl.cgmes.model.CgmesDcTerminal;
@@ -181,6 +182,11 @@ public class CgmesDcConversion {
 
         if (createHvdc()) {
             setCommonDataUsed();
+            // Add the second line segment identifier as an alias of the line created
+            HvdcLine line = context.network().getHvdcLine(dcLineSegmentId1);
+            if (line != null) {
+                line.addAlias(dcLineSegmentId2, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "DCLineSegment2");
+            }
             context.dc().setCgmesDcLineSegmentUsed(dcLineSegmentId2);
         }
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/NodeEquipment.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/NodeEquipment.java
@@ -7,10 +7,7 @@
 
 package com.powsybl.cgmes.conversion.elements.hvdc;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.powsybl.cgmes.model.CgmesDcTerminal;
@@ -143,6 +140,15 @@ class NodeEquipment {
         }
         return listEquipment.stream()
             .anyMatch(eq -> eq.type == EquipmentType.AC_DC_CONVERTER);
+    }
+
+    boolean containsAnyNotUsedAcDcConverter(String node, Set<String> usedAcDcConverters) {
+        List<EquipmentReference> listEquipment = nodeEquipment.get(node);
+        if (listEquipment == null) {
+            return false;
+        }
+        return listEquipment.stream()
+                .anyMatch(eq -> eq.type == EquipmentType.AC_DC_CONVERTER && !usedAcDcConverters.contains(eq.equipmentId));
     }
 
     boolean multiAcDcConverter(String node) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->

Some dc configurations are not imported.

The issue happens when multiple dc links lie on the same ac bus and the converters on the other dc ends have different ways of connecting to the ac network. All other ends are expected to be connected in the same way: either through transformers or directly to terminal buses, but a mix is not considered.

The following image shows the kind of connection that is not supported:
![hvdc-missing-one-end-with-tx-the-other-not 2](https://github.com/powsybl/powsybl-core/assets/3374819/ba5df95a-b9c2-46be-b775-c9117d9e25a6)

Because dc links share a common ac bus (the ac bus for converters R1 and R2) the configuration is explored as a group, during conversion. Converters L1 and L2 have different ways of connecting to the ac network: L2 has transformers, and L1 not. When configuration groups are explored, the same kind of connections are (wrongly) expected at L1 and L2. Because of this incorrect assumption, a proper matching between converters can not be completed and the whole configuration is discarded.


**What is the new behavior (if this is a feature change)?**
The wrong assumption has been removed from the CGMES importer that analyzes the dc configurations.
In addition, when two CGMES dc line segments are merged together in a single IIDM hvdc line, the identifier of the second dc line segment has been added as an alias in the created hvdc line.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
It has been verified that all real-world configurations that were detected and converted to IIDM have been preserved, in addition to the new configurations now supported.
