### PR TITLE
Cgmes import: fix atan in symmetrical phase shifters

### DIFF
--- a/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/CgmesConformity1NetworkCatalog.java
+++ b/cgmes/cgmes-conformity/src/main/java/com/powsybl/cgmes/conformity/CgmesConformity1NetworkCatalog.java
@@ -1179,7 +1179,7 @@ public final class CgmesConformity1NetworkCatalog {
                 LOG.debug("EXPECTED    n,dx,dy,angle,ratio  {} {} {} {} {}", n, dx, dy, angle, ratio);
             } else if (type == PhaseTapChangerType.SYMMETRICAL) {
                 double dy = (n * du / 2 - du0) * Math.sin(theta);
-                angle = 2 * Math.asin(dy);
+                angle = 2 * Math.atan(dy);
                 ratio = 1.0;
                 LOG.debug("EXPECTED    n,dy,angle,ratio  {} {} {} {}", n, dy, angle, ratio);
             } else {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/CgmesPhaseTapChangerBuilder.java
@@ -183,7 +183,7 @@ public class CgmesPhaseTapChangerBuilder extends AbstractCgmesTapChangerBuilder 
                 angle = (step - neutralStep) * stepPhaseShiftIncrement;
             } else {
                 double dy = (step - neutralStep) * (stepVoltageIncrement / 100.0);
-                angle = Math.toDegrees(2 * Math.asin(dy / 2));
+                angle = Math.toDegrees(2 * Math.atan(dy / 2));
             }
             tapChanger.beginStep()
                 .setRatio(1.0)

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TransformerConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TransformerConversionTest.java
@@ -400,7 +400,7 @@ class TransformerConversionTest {
         TwoWindingsTransformer twt1 = n.getTwoWindingsTransformer("a708c3bc-465d-4fe7-b6ef-6fa6408a62b0");
         TwoWindingsTransformer twt2 = n.getTwoWindingsTransformer("b94318f6-6d24-4f56-96b9-df2531ad6543");
 
-        assertEquals(1.109429, obtainXcurrentStep(twt1), 0.00001);
+        assertEquals(1.10949, obtainXcurrentStep(twt1), 0.00001);
         assertEquals(2.796323, obtainXcurrentStep(twt2), 0.00001);
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->
`asin` is used to calculate `alfa` in symmetrical phase shifters


**What is the new behavior (if this is a feature change)?**

Following CGMES documentation, `atan` is used in the formulas to calculate `alfa`.

**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
