### PR TITLE
Correct getCountryCount in SubnetworkImpl

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubnetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubnetworkImpl.java
@@ -93,7 +93,7 @@ public class SubnetworkImpl extends AbstractNetwork {
 
     @Override
     public int getCountryCount() {
-        return (int) getCountryStream().count();
+        return getCountries().size();
     }
 
     private Stream<Country> getCountryStream() {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubnetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubnetworkImpl.java
@@ -93,14 +93,15 @@ public class SubnetworkImpl extends AbstractNetwork {
 
     @Override
     public int getCountryCount() {
-        return getCountries().size();
+        return (int) getCountryStream().count();
     }
 
     private Stream<Country> getCountryStream() {
         return getNetwork().getSubstationStream()
                 .filter(this::contains)
                 .map(s -> s.getCountry().orElse(null))
-                .filter(Objects::nonNull);
+                .filter(Objects::nonNull)
+                .distinct();
     }
 
     @Override

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksCreationTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksCreationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -422,6 +423,19 @@ public abstract class AbstractSubnetworksCreationTest {
         Terminal to = l2.getTerminal2();
         PowsyblException e = assertThrows(ValidationException.class, () -> addVoltageAngleLimit(subnetwork1, "vla", from, to));
         assertTrue(e.getMessage().contains("Create this VoltageAngleLimit from the parent network"));
+    }
+
+    @Test
+    public void subnetworksWithSubstationFromSameCountry() {
+        addSubstation(subnetwork1, "substation1");
+        addSubstation(subnetwork1, "substation2");
+        assertEquals(1, subnetwork1.getCountryCount());
+
+        subnetwork1.newSubstation()
+                .setId("substation3")
+                .setCountry(Country.AD)
+                .add();
+        assertEquals(2, subnetwork1.getCountryCount());
     }
 
     void assertValidationLevels(ValidationLevel expected) {

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksCreationTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksCreationTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
If two subnetworks have the same country, then this country is counted twice.


**What is the new behavior (if this is a feature change)?**
The method should return the exact amount of countries.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
