### PR TITLE
Update CI actions due to node.js v12 deprecation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
 
       - name: Build with Maven (Ubuntu)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,9 +21,10 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 17
+          distribution: 'zulu'
+          java-version: '17'
 
       - name: Build with Maven (Ubuntu)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Build with Maven (Ubuntu)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: 'maven'
 
       - name: Build with Maven (Ubuntu)
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
[Official GitHub blog article](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
CI was using [setup-java](https://github.com/actions/setup-java/) v1 and [checkout](https://github.com/actions/checkout/) v1


**What is the new behavior (if this is a feature change)?**
CI is now using setup-java v3 and checkout v4


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
