### PR TITLE
CGMES export: add EquipmentContainer when exporting EnergySource

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -285,7 +285,7 @@ public final class EquipmentExport {
                     // As negative loads are not allowed, they are modeled as energy source.
                     // Note that negative loads can be the result of network reduction and could be modeled
                     // as equivalent injections.
-                    writeEnergySource(loadId, load.getNameOrId(), cimNamespace, writer, context);
+                    writeEnergySource(loadId, load.getNameOrId(), context.getNamingStrategy().getCgmesId(load.getTerminal().getVoltageLevel()), cimNamespace, writer, context);
                 } else {
                     String loadGroup = loadGroups.groupFor(className);
                     EnergyConsumerEq.write(className, loadId, load.getNameOrId(), loadGroup, context.getNamingStrategy().getCgmesId(load.getTerminal().getVoltageLevel()), cimNamespace, writer, context);
@@ -294,8 +294,9 @@ public final class EquipmentExport {
         }
     }
 
-    public static void writeEnergySource(String id, String name, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
+    public static void writeEnergySource(String id, String name, String equipmentContainer, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
         CgmesExportUtil.writeStartIdName("EnergySource", id, name, cimNamespace, writer, context);
+        CgmesExportUtil.writeReference("Equipment.EquipmentContainer", equipmentContainer, cimNamespace, writer, context);
         writer.writeEndElement();
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When exporting an EnergySource, only the name and ID are written.


**What is the new behavior (if this is a feature change)?**
According to QoCDC 3.3.1, every EnergySource must have an EquipmentContainer referred to, which is the Voltage Level. This information is added to the export.
