### PR TITLE
Update pom.xml to use project.groupId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -503,17 +503,17 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.powsybl</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>powsybl-powerfactory-model</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.powsybl</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>powsybl-powerfactory-dgs</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.powsybl</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>powsybl-powerfactory-converter</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -670,7 +670,7 @@
                 <version>${jimfs.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.powsybl</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>powsybl-math-native</artifactId>
                 <version>${powsyblmathnative.version}</version>
             </dependency>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
docs update



**What is the current behavior?**
In several cases of the project pom.xml, the parent Group ID is hardcoded, and should be referenced this way instead



**What is the new behavior (if this is a feature change)?**
Internal dependencies using `<groupId>com.powsybl</groupId>` now use `<groupId>${project.groupId}</groupId>`


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
