### PR TITLE
Remove arrayFieldName parameter from TreeDataWriter::startNodes

### DIFF
--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/BaseVoltageMappingSerDe.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/BaseVoltageMappingSerDe.java
@@ -44,7 +44,7 @@ public class BaseVoltageMappingSerDe extends AbstractExtensionSerDe<Network, Bas
         Map<Double, BaseVoltageMapping.BaseVoltageSource> sortedBaseVoltages = extension.getBaseVoltages().entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> oldValue, LinkedHashMap::new));
-        writer.writeStartNodes(BASE_VOLTAGE_ARRAY_ELEMENT);
+        writer.writeStartNodes();
         sortedBaseVoltages.forEach((nominalV, baseVoltageSource) -> {
             writer.writeStartNode(getNamespaceUri(), BASE_VOLTAGE_ROOT_ELEMENT);
             writer.writeDoubleAttribute("nominalVoltage", nominalV);

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesControlAreasSerDe.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesControlAreasSerDe.java
@@ -55,7 +55,7 @@ public class CgmesControlAreasSerDe extends AbstractExtensionSerDe<Network, Cgme
     public void write(CgmesControlAreas extension, SerializerContext context) {
         NetworkSerializerContext networkContext = (NetworkSerializerContext) context;
         TreeDataWriter writer = networkContext.getWriter();
-        writer.writeStartNodes(CONTROL_AREA_ARRAY_ELEMENT);
+        writer.writeStartNodes();
         for (CgmesControlArea controlArea : extension.getCgmesControlAreas()) {
             writer.writeStartNode(getNamespaceUri(), CONTROL_AREA_ROOT_ELEMENT);
             writer.writeStringAttribute("id", controlArea.getId());
@@ -64,13 +64,13 @@ public class CgmesControlAreasSerDe extends AbstractExtensionSerDe<Network, Cgme
             writer.writeDoubleAttribute("netInterchange", controlArea.getNetInterchange());
             writer.writeDoubleAttribute("pTolerance", controlArea.getPTolerance());
 
-            writer.writeStartNodes(TERMINAL_ARRAY_ELEMENT);
+            writer.writeStartNodes();
             for (Terminal terminal : controlArea.getTerminals()) {
                 TerminalRefSerDe.writeTerminalRef(terminal, networkContext, getNamespaceUri(), TERMINAL_ROOT_ELEMENT);
             }
             writer.writeEndNodes();
 
-            writer.writeStartNodes(BOUNDARY_ARRAY_ELEMENT);
+            writer.writeStartNodes();
             for (Boundary boundary : controlArea.getBoundaries()) {
                 if (boundary.getDanglingLine() != null) { // TODO: delete this later, only for compatibility
                     writer.writeStartNode(getNamespaceUri(), BOUNDARY_ROOT_ELEMENT);

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesSshMetadataSerDe.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesSshMetadataSerDe.java
@@ -48,7 +48,7 @@ public class CgmesSshMetadataSerDe extends AbstractExtensionSerDe<Network, Cgmes
         writer.writeStringAttribute("description", extension.getDescription());
         writer.writeIntAttribute("sshVersion", extension.getSshVersion());
         writer.writeStringAttribute("modelingAuthoritySet", extension.getModelingAuthoritySet());
-        writer.writeStartNodes(DEPENDENCY_ARRAY_ELEMENT);
+        writer.writeStartNodes();
         for (String dep : extension.getDependencies()) {
             writer.writeStartNode(getNamespaceUri(), DEPENDENCY_ROOT_ELEMENT);
             writer.writeNodeContent(dep);

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesSvMetadataSerDe.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesSvMetadataSerDe.java
@@ -46,7 +46,7 @@ public class CgmesSvMetadataSerDe extends AbstractExtensionSerDe<Network, CgmesS
         writer.writeStringAttribute("description", extension.getDescription());
         writer.writeIntAttribute("svVersion", extension.getSvVersion());
         writer.writeStringAttribute("modelingAuthoritySet", extension.getModelingAuthoritySet());
-        writer.writeStartNodes(DEPENDENCY_ARRAY_ELEMENT);
+        writer.writeStartNodes();
         for (String dep : extension.getDependencies()) {
             writer.writeStartNode(getNamespaceUri(), DEPENDENCY_ROOT_ELEMENT);
             writer.writeNodeContent(dep);

--- a/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersSerDe.java
+++ b/cgmes/cgmes-extensions/src/main/java/com/powsybl/cgmes/extensions/CgmesTapChangersSerDe.java
@@ -44,7 +44,7 @@ public class CgmesTapChangersSerDe<C extends Connectable<C>> extends AbstractExt
     public void write(CgmesTapChangers<C> extension, SerializerContext context) {
         NetworkSerializerContext networkContext = (NetworkSerializerContext) context;
         TreeDataWriter writer = networkContext.getWriter();
-        writer.writeStartNodes(TAP_CHANGER_ARRAY_ELEMENT);
+        writer.writeStartNodes();
         for (CgmesTapChanger tapChanger : extension.getTapChangers()) {
             writer.writeStartNode(getNamespaceUri(), TAP_CHANGER_ROOT_ELEMENT);
             writer.writeStringAttribute("id", tapChanger.getId());

--- a/commons/src/main/java/com/powsybl/commons/io/TreeDataWriter.java
+++ b/commons/src/main/java/com/powsybl/commons/io/TreeDataWriter.java
@@ -14,7 +14,7 @@ import java.util.Map;
  */
 public interface TreeDataWriter extends AutoCloseable {
 
-    void writeStartNodes(String name);
+    void writeStartNodes();
 
     void writeEndNodes();
 

--- a/commons/src/main/java/com/powsybl/commons/json/JsonReader.java
+++ b/commons/src/main/java/com/powsybl/commons/json/JsonReader.java
@@ -216,7 +216,6 @@ public class JsonReader extends AbstractTreeDataReader {
                     }
                     case START_OBJECT -> {
                         Context arrayContext = checkNodeChain(ContextType.ARRAY);
-                        arrayContext.incrementObjectCount();
                         contextQueue.add(new Context(ContextType.OBJECT, arrayContext.getFieldName()));
                         childNodeReader.onStartNode(arrayElementNameToSingleElementName.get(arrayContext.getFieldName()));
                     }

--- a/commons/src/main/java/com/powsybl/commons/json/JsonUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/json/JsonUtil.java
@@ -40,8 +40,7 @@ public final class JsonUtil {
 
     static final class Context {
         private final ContextType type;
-        private final String fieldName;
-        private int objectCount = 0;
+        private String fieldName;
 
         Context(ContextType type, String fieldName) {
             this.type = Objects.requireNonNull(type);
@@ -56,12 +55,8 @@ public final class JsonUtil {
             return fieldName;
         }
 
-        int getObjectCount() {
-            return objectCount;
-        }
-
-        void incrementObjectCount() {
-            objectCount++;
+        public void setFieldName(String fieldName) {
+            this.fieldName = fieldName;
         }
     }
 

--- a/commons/src/main/java/com/powsybl/commons/xml/XmlWriter.java
+++ b/commons/src/main/java/com/powsybl/commons/xml/XmlWriter.java
@@ -41,7 +41,7 @@ public class XmlWriter implements TreeDataWriter {
     }
 
     @Override
-    public void writeStartNodes(String name) {
+    public void writeStartNodes() {
         // nothing to do
     }
 

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTransformerSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTransformerSerDe.java
@@ -84,7 +84,7 @@ abstract class AbstractTransformerSerDe<T extends Connectable<T>, A extends Iden
             TerminalRefSerDe.writeTerminalRef(rtc.getRegulationTerminal(), context, ELEM_TERMINAL_REF);
         }
 
-        context.getWriter().writeStartNodes(STEP_ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (int p = rtc.getLowTapPosition(); p <= rtc.getHighTapPosition(); p++) {
             RatioTapChangerStep rtcs = rtc.getStep(p);
             context.getWriter().writeStartNode(context.getVersion().getNamespaceURI(context.isValid()), STEP_ROOT_ELEMENT_NAME);
@@ -165,7 +165,7 @@ abstract class AbstractTransformerSerDe<T extends Connectable<T>, A extends Iden
             TerminalRefSerDe.writeTerminalRef(ptc.getRegulationTerminal(), context, ELEM_TERMINAL_REF);
         }
 
-        context.getWriter().writeStartNodes(STEP_ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (int p = ptc.getLowTapPosition(); p <= ptc.getHighTapPosition(); p++) {
             PhaseTapChangerStep ptcs = ptc.getStep(p);
             context.getWriter().writeStartNode(context.getVersion().getNamespaceURI(context.isValid()), STEP_ROOT_ELEMENT_NAME);

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AliasesSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AliasesSerDe.java
@@ -22,7 +22,7 @@ public final class AliasesSerDe {
 
     public static void write(Identifiable<?> identifiable, String rootElementName, NetworkSerializerContext context) {
         IidmSerDeUtil.assertMinimumVersionIfNotDefault(!identifiable.getAliases().isEmpty(), rootElementName, ROOT_ELEMENT_NAME, IidmSerDeUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmVersion.V_1_3, context);
-        context.getWriter().writeStartNodes(ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (String alias : identifiable.getAliases()) {
             context.getWriter().writeStartNode(context.getVersion().getNamespaceURI(context.isValid()), ROOT_ELEMENT_NAME);
             IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_4, context,

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ConnectableSerDeUtil.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ConnectableSerDeUtil.java
@@ -240,7 +240,7 @@ public final class ConnectableSerDeUtil {
                 || !limits.getTemporaryLimits().isEmpty()) {
             writer.writeStartNode(nsUri, type + indexToString(index));
             writer.writeDoubleAttribute("permanentLimit", limits.getPermanentLimit());
-            writer.writeStartNodes(TEMPORARY_LIMITS_ARRAY_ELEMENT_NAME);
+            writer.writeStartNodes();
             for (LoadingLimits.TemporaryLimit tl : IidmSerDeUtil.sortedTemporaryLimits(limits.getTemporaryLimits(), exportOptions)) {
                 writer.writeStartNode(version.getNamespaceURI(valid), TEMPORARY_LIMITS_ROOT_ELEMENT_NAME);
                 writer.writeStringAttribute("name", tl.getName());

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/PropertiesSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/PropertiesSerDe.java
@@ -27,7 +27,7 @@ public final class PropertiesSerDe {
 
     public static void write(Identifiable<?> identifiable, NetworkSerializerContext context) {
         if (identifiable.hasProperty()) {
-            context.getWriter().writeStartNodes(ARRAY_ELEMENT_NAME);
+            context.getWriter().writeStartNodes();
             for (String name : IidmSerDeUtil.sortedNames(identifiable.getPropertyNames(), context.getOptions())) {
                 String value = identifiable.getProperty(name);
                 context.getWriter().writeStartNode(context.getVersion().getNamespaceURI(identifiable.getNetwork().getValidationLevel() == ValidationLevel.STEADY_STATE_HYPOTHESIS), ROOT_ELEMENT_NAME);

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ReactiveLimitsSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ReactiveLimitsSerDe.java
@@ -31,7 +31,7 @@ public class ReactiveLimitsSerDe {
             case CURVE:
                 ReactiveCapabilityCurve curve = holder.getReactiveLimits(ReactiveCapabilityCurve.class);
                 context.getWriter().writeStartNode(context.getVersion().getNamespaceURI(context.isValid()), ELEM_REACTIVE_CAPABILITY_CURVE);
-                context.getWriter().writeStartNodes(POINT_ARRAY_ELEMENT_NAME);
+                context.getWriter().writeStartNodes();
                 for (ReactiveCapabilityCurve.Point point : curve.getPoints()) {
                     context.getWriter().writeStartNode(context.getVersion().getNamespaceURI(context.isValid()), POINT_ROOT_ELEMENT_NAME);
                     context.getWriter().writeDoubleAttribute("p", point.getP());

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ShuntSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ShuntSerDe.java
@@ -114,7 +114,7 @@ class ShuntSerDe extends AbstractComplexIdentifiableSerDe<ShuntCompensator, Shun
         } else if (sc.getModelType() == ShuntCompensatorModelType.NON_LINEAR) {
             IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_3, context, () -> {
                 context.getWriter().writeStartNode(context.getVersion().getNamespaceURI(context.isValid()), SHUNT_NON_LINEAR_MODEL);
-                context.getWriter().writeStartNodes(SECTION_ARRAY_ELEMENT_NAME);
+                context.getWriter().writeStartNodes();
                 for (ShuntCompensatorNonLinearModel.Section s : sc.getModel(ShuntCompensatorNonLinearModel.class).getAllSections()) {
                     context.getWriter().writeStartNode(context.getVersion().getNamespaceURI(context.isValid()), SECTION_ROOT_ELEMENT_NAME);
                     context.getWriter().writeDoubleAttribute("b", s.getB());

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/SubstationSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/SubstationSerDe.java
@@ -47,13 +47,13 @@ class SubstationSerDe extends AbstractSimpleIdentifiableSerDe<Substation, Substa
 
     @Override
     protected void writeSubElements(Substation s, Network n, NetworkSerializerContext context) {
-        context.getWriter().writeStartNodes(VoltageLevelSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (VoltageLevel vl : IidmSerDeUtil.sorted(s.getVoltageLevels(), context.getOptions())) {
             VoltageLevelSerDe.INSTANCE.write(vl, null, context);
         }
         context.getWriter().writeEndNodes();
 
-        context.getWriter().writeStartNodes(TwoWindingsTransformerSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         Iterable<TwoWindingsTransformer> twts = IidmSerDeUtil.sorted(s.getTwoWindingsTransformers(), context.getOptions());
         for (TwoWindingsTransformer twt : twts) {
             if (!context.getFilter().test(twt)) {
@@ -63,7 +63,7 @@ class SubstationSerDe extends AbstractSimpleIdentifiableSerDe<Substation, Substa
         }
         context.getWriter().writeEndNodes();
 
-        context.getWriter().writeStartNodes(ThreeWindingsTransformerSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         Iterable<ThreeWindingsTransformer> twts2 = IidmSerDeUtil.sorted(s.getThreeWindingsTransformers(), context.getOptions());
         for (ThreeWindingsTransformer twt : twts2) {
             if (!context.getFilter().test(twt)) {

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/VoltageLevelSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/VoltageLevelSerDe.java
@@ -88,13 +88,13 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
         context.getWriter().writeStartNode(context.getVersion().getNamespaceURI(context.isValid()), NODE_BREAKER_TOPOLOGY_ELEMENT_NAME);
         IidmSerDeUtil.writeIntAttributeUntilMaximumVersion(NODE_COUNT, vl.getNodeBreakerView().getMaximumNodeIndex() + 1, IidmVersion.V_1_1, context);
 
-        context.getWriter().writeStartNodes(BusbarSectionSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (BusbarSection bs : IidmSerDeUtil.sorted(vl.getNodeBreakerView().getBusbarSections(), context.getOptions())) {
             BusbarSectionSerDe.INSTANCE.write(bs, null, context);
         }
         context.getWriter().writeEndNodes();
 
-        context.getWriter().writeStartNodes(AbstractSwitchSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (Switch sw : IidmSerDeUtil.sorted(vl.getNodeBreakerView().getSwitches(), context.getOptions())) {
             NodeBreakerViewSwitchSerDe.INSTANCE.write(sw, vl, context);
         }
@@ -104,7 +104,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
 
         IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_1, context, () -> {
             Map<String, Set<Integer>> nodesByBus = Networks.getNodesByBus(vl);
-            context.getWriter().writeStartNodes(BusSerDe.ARRAY_ELEMENT_NAME);
+            context.getWriter().writeStartNodes();
             IidmSerDeUtil.sorted(vl.getBusView().getBusStream(), context.getOptions())
                     .filter(bus -> !Double.isNaN(bus.getV()) || !Double.isNaN(bus.getAngle()))
                     .forEach(bus -> {
@@ -114,7 +114,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
             context.getWriter().writeEndNodes();
         });
         IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_8, context, () -> {
-            context.getWriter().writeStartNodes(INJ_ARRAY_ELEMENT_NAME);
+            context.getWriter().writeStartNodes();
             for (int node : vl.getNodeBreakerView().getNodes()) {
                 double fictP0 = vl.getNodeBreakerView().getFictitiousP0(node);
                 double fictQ0 = vl.getNodeBreakerView().getFictitiousQ0(node);
@@ -143,7 +143,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
     }
 
     private void writeNodeBreakerTopologyInternalConnections(VoltageLevel vl, NetworkSerializerContext context) {
-        context.getWriter().writeStartNodes(NodeBreakerViewInternalConnectionSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (VoltageLevel.NodeBreakerView.InternalConnection ic : IidmSerDeUtil.sortedInternalConnections(vl.getNodeBreakerView().getInternalConnections(), context.getOptions())) {
             NodeBreakerViewInternalConnectionSerDe.INSTANCE.write(ic.getNode1(), ic.getNode2(), context);
         }
@@ -153,7 +153,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
     private void writeBusBreakerTopology(VoltageLevel vl, NetworkSerializerContext context) {
         context.getWriter().writeStartNode(context.getVersion().getNamespaceURI(context.isValid()), BUS_BREAKER_TOPOLOGY_ELEMENT_NAME);
 
-        context.getWriter().writeStartNodes(BusSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (Bus b : IidmSerDeUtil.sorted(vl.getBusBreakerView().getBuses(), context.getOptions())) {
             if (!context.getFilter().test(b)) {
                 continue;
@@ -162,7 +162,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
         }
         context.getWriter().writeEndNodes();
 
-        context.getWriter().writeStartNodes(AbstractSwitchSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (Switch sw : IidmSerDeUtil.sorted(vl.getBusBreakerView().getSwitches(), context.getOptions())) {
             Bus b1 = vl.getBusBreakerView().getBus1(sw.getId());
             Bus b2 = vl.getBusBreakerView().getBus2(sw.getId());
@@ -179,7 +179,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
     private void writeBusBranchTopology(VoltageLevel vl, NetworkSerializerContext context) {
         context.getWriter().writeStartNode(context.getVersion().getNamespaceURI(context.isValid()), BUS_BREAKER_TOPOLOGY_ELEMENT_NAME);
 
-        context.getWriter().writeStartNodes(BusSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (Bus b : IidmSerDeUtil.sorted(vl.getBusView().getBuses(), context.getOptions())) {
             if (!context.getFilter().test(b)) {
                 continue;
@@ -192,7 +192,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
     }
 
     private void writeGenerators(VoltageLevel vl, NetworkSerializerContext context) {
-        context.getWriter().writeStartNodes(GeneratorSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (Generator g : IidmSerDeUtil.sorted(vl.getGenerators(), context.getOptions())) {
             if (!context.getFilter().test(g)) {
                 continue;
@@ -203,7 +203,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
     }
 
     private void writeBatteries(VoltageLevel vl, NetworkSerializerContext context) {
-        context.getWriter().writeStartNodes(BatterySerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (Battery b : IidmSerDeUtil.sorted(vl.getBatteries(), context.getOptions())) {
             if (!context.getFilter().test(b)) {
                 continue;
@@ -214,7 +214,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
     }
 
     private void writeLoads(VoltageLevel vl, NetworkSerializerContext context) {
-        context.getWriter().writeStartNodes(LoadSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (Load l : IidmSerDeUtil.sorted(vl.getLoads(), context.getOptions())) {
             if (!context.getFilter().test(l)) {
                 continue;
@@ -225,7 +225,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
     }
 
     private void writeShuntCompensators(VoltageLevel vl, NetworkSerializerContext context) {
-        context.getWriter().writeStartNodes(ShuntSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (ShuntCompensator sc : IidmSerDeUtil.sorted(vl.getShuntCompensators(), context.getOptions())) {
             if (!context.getFilter().test(sc)) {
                 continue;
@@ -236,7 +236,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
     }
 
     private void writeDanglingLines(VoltageLevel vl, NetworkSerializerContext context) {
-        context.getWriter().writeStartNodes(DanglingLineSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (DanglingLine dl : IidmSerDeUtil.sorted(vl.getDanglingLines(DanglingLineFilter.ALL), context.getOptions())) {
             if (!context.getFilter().test(dl) || context.getVersion().compareTo(IidmVersion.V_1_10) < 0 && dl.isPaired()) {
                 continue;
@@ -247,7 +247,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
     }
 
     private void writeStaticVarCompensators(VoltageLevel vl, NetworkSerializerContext context) {
-        context.getWriter().writeStartNodes(StaticVarCompensatorSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (StaticVarCompensator svc : IidmSerDeUtil.sorted(vl.getStaticVarCompensators(), context.getOptions())) {
             if (!context.getFilter().test(svc)) {
                 continue;
@@ -258,7 +258,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
     }
 
     private void writeVscConverterStations(VoltageLevel vl, NetworkSerializerContext context) {
-        context.getWriter().writeStartNodes(VscConverterStationSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (VscConverterStation cs : IidmSerDeUtil.sorted(vl.getVscConverterStations(), context.getOptions())) {
             if (!context.getFilter().test(cs)) {
                 continue;
@@ -269,7 +269,7 @@ class VoltageLevelSerDe extends AbstractSimpleIdentifiableSerDe<VoltageLevel, Vo
     }
 
     private void writeLccConverterStations(VoltageLevel vl, NetworkSerializerContext context) {
-        context.getWriter().writeStartNodes(LccConverterStationSerDe.ARRAY_ELEMENT_NAME);
+        context.getWriter().writeStartNodes();
         for (LccConverterStation cs : IidmSerDeUtil.sorted(vl.getLccConverterStations(), context.getOptions())) {
             if (!context.getFilter().test(cs)) {
                 continue;

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/DiscreteMeasurementsSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/DiscreteMeasurementsSerDe.java
@@ -49,7 +49,7 @@ public class DiscreteMeasurementsSerDe<I extends Identifiable<I>> extends Abstra
     @Override
     public void write(DiscreteMeasurements<I> extension, SerializerContext context) {
         TreeDataWriter writer = context.getWriter();
-        writer.writeStartNodes(DISCRETE_MEASUREMENT_ARRAY);
+        writer.writeStartNodes();
         for (DiscreteMeasurement discreteMeasurement : extension.getDiscreteMeasurements()) {
             writer.writeStartNode(getNamespaceUri(), DISCRETE_MEASUREMENT_ROOT);
             writer.writeStringAttribute("id", discreteMeasurement.getId());
@@ -71,7 +71,7 @@ public class DiscreteMeasurementsSerDe<I extends Identifiable<I>> extends Abstra
             }
             writer.writeBooleanAttribute("valid", discreteMeasurement.isValid());
 
-            writer.writeStartNodes(PROPERTY_ARRAY);
+            writer.writeStartNodes();
             for (String name : discreteMeasurement.getPropertyNames()) {
                 writer.writeStartNode(getNamespaceUri(), PROPERTY_ROOT);
                 writer.writeStringAttribute("name", name);

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/LinePositionSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/LinePositionSerDe.java
@@ -42,7 +42,7 @@ public class LinePositionSerDe<T extends Identifiable<T>> extends AbstractExtens
 
     @Override
     public void write(LinePosition<T> linePosition, SerializerContext context) {
-        context.getWriter().writeStartNodes(COORDINATE_ARRAY_NODE);
+        context.getWriter().writeStartNodes();
         for (Coordinate point : linePosition.getCoordinates()) {
             context.getWriter().writeStartNode(getNamespaceUri(), COORDINATE_ROOT_NODE);
             context.getWriter().writeDoubleAttribute("longitude", point.getLongitude());

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/MeasurementsSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/MeasurementsSerDe.java
@@ -45,7 +45,7 @@ public class MeasurementsSerDe<C extends Connectable<C>> extends AbstractExtensi
     @Override
     public void write(Measurements<C> extension, SerializerContext context) {
         TreeDataWriter writer = context.getWriter();
-        writer.writeStartNodes(MEASUREMENT_ARRAY_ELEMENT);
+        writer.writeStartNodes();
         for (Measurement measurement : extension.getMeasurements()) {
             writer.writeStartNode(getNamespaceUri(), MEASUREMENT_ROOT_ELEMENT);
             if (measurement.getId() != null) {
@@ -63,7 +63,7 @@ public class MeasurementsSerDe<C extends Connectable<C>> extends AbstractExtensi
     }
 
     private void writeProperties(Measurement measurement, TreeDataWriter writer) {
-        writer.writeStartNodes(PROPERTY_ARRAY_ELEMENT);
+        writer.writeStartNodes();
         for (String name : measurement.getPropertyNames()) {
             writer.writeStartNode(getNamespaceUri(), PROPERTY_ROOT_ELEMENT);
             writer.writeStringAttribute("name", name);

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/SecondaryVoltageControlSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/SecondaryVoltageControlSerDe.java
@@ -55,7 +55,7 @@ public class SecondaryVoltageControlSerDe extends AbstractExtensionSerDe<Network
     @Override
     public void write(SecondaryVoltageControl control, SerializerContext context) {
         TreeDataWriter writer = context.getWriter();
-        writer.writeStartNodes(CONTROL_ZONE_ARRAY_ELEMENT);
+        writer.writeStartNodes();
         for (SecondaryVoltageControl.ControlZone controlZone : control.getControlZones()) {
             writer.writeStartNode(getNamespaceUri(), CONTROL_ZONE_ROOT_ELEMENT);
             writer.writeStringAttribute("name", controlZone.getName());
@@ -69,7 +69,7 @@ public class SecondaryVoltageControlSerDe extends AbstractExtensionSerDe<Network
     private void writePilotPoint(ControlZone controlZone, TreeDataWriter writer) {
         writer.writeStartNode(getNamespaceUri(), PILOT_POINT_ELEMENT);
         writer.writeDoubleAttribute("targetV", controlZone.getPilotPoint().getTargetV());
-        writer.writeStartNodes(BUSBAR_SECTION_OR_BUS_ID_ARRAY_ELEMENT);
+        writer.writeStartNodes();
         for (String busbarSectionOrBusId : controlZone.getPilotPoint().getBusbarSectionsOrBusesIds()) {
             writer.writeStartNode(getNamespaceUri(), BUSBAR_SECTION_OR_BUS_ID_ROOT_ELEMENT);
             writer.writeNodeContent(busbarSectionOrBusId);
@@ -80,7 +80,7 @@ public class SecondaryVoltageControlSerDe extends AbstractExtensionSerDe<Network
     }
 
     private void writeControlUnits(List<ControlUnit> controlUnits, TreeDataWriter writer) {
-        writer.writeStartNodes(CONTROL_UNIT_ARRAY_ELEMENT);
+        writer.writeStartNodes();
         for (ControlUnit controlUnit : controlUnits) {
             writer.writeStartNode(getNamespaceUri(), CONTROL_UNIT_ROOT_ELEMENT);
             writer.writeBooleanAttribute("participate", controlUnit.isParticipate());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Feature



**What is the current behavior?**
`TreeDataWriter::startNodes` expects the arrayFieldName which has to be consistent with the corresponding element name



**What is the new behavior (if this is a feature change)?**
`TreeDataWriter::startNodes` does not take any argument and gets the array field name from a arrayFieldName/elementFieldName map when writing the first element by a call to `TreeDataWriter::startNodes`


**Does this PR introduce a breaking change or deprecate an API?**
No, this API is not yet released