### PR TITLE
Move criterion package and criterion serializer/deserializer

### DIFF
--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/AbstractEquipmentCriterionContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/AbstractEquipmentCriterionContingencyList.java
@@ -9,9 +9,9 @@ package com.powsybl.contingency.contingency.list;
 import com.google.common.collect.ImmutableList;
 import com.powsybl.contingency.Contingency;
 import com.powsybl.contingency.ContingencyElement;
-import com.powsybl.contingency.contingency.list.criterion.Criterion;
-import com.powsybl.contingency.contingency.list.criterion.PropertyCriterion;
-import com.powsybl.contingency.contingency.list.criterion.RegexCriterion;
+import com.powsybl.iidm.network.util.criterion.Criterion;
+import com.powsybl.iidm.network.util.criterion.PropertyCriterion;
+import com.powsybl.iidm.network.util.criterion.RegexCriterion;
 import com.powsybl.iidm.network.IdentifiableType;
 import com.powsybl.iidm.network.Network;
 

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/AbstractLineCriterionContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/AbstractLineCriterionContingencyList.java
@@ -7,10 +7,10 @@
  */
 package com.powsybl.contingency.contingency.list;
 
-import com.powsybl.contingency.contingency.list.criterion.PropertyCriterion;
-import com.powsybl.contingency.contingency.list.criterion.RegexCriterion;
-import com.powsybl.contingency.contingency.list.criterion.TwoCountriesCriterion;
-import com.powsybl.contingency.contingency.list.criterion.TwoNominalVoltageCriterion;
+import com.powsybl.iidm.network.util.criterion.PropertyCriterion;
+import com.powsybl.iidm.network.util.criterion.RegexCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoCountriesCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoNominalVoltageCriterion;
 import com.powsybl.iidm.network.IdentifiableType;
 
 import java.util.List;

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/HvdcLineCriterionContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/HvdcLineCriterionContingencyList.java
@@ -6,10 +6,10 @@
  */
 package com.powsybl.contingency.contingency.list;
 
-import com.powsybl.contingency.contingency.list.criterion.PropertyCriterion;
-import com.powsybl.contingency.contingency.list.criterion.RegexCriterion;
-import com.powsybl.contingency.contingency.list.criterion.TwoCountriesCriterion;
-import com.powsybl.contingency.contingency.list.criterion.TwoNominalVoltageCriterion;
+import com.powsybl.iidm.network.util.criterion.PropertyCriterion;
+import com.powsybl.iidm.network.util.criterion.RegexCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoCountriesCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoNominalVoltageCriterion;
 import com.powsybl.iidm.network.IdentifiableType;
 
 import java.util.List;

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/InjectionCriterionContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/InjectionCriterionContingencyList.java
@@ -6,10 +6,10 @@
  */
 package com.powsybl.contingency.contingency.list;
 
-import com.powsybl.contingency.contingency.list.criterion.PropertyCriterion;
-import com.powsybl.contingency.contingency.list.criterion.RegexCriterion;
-import com.powsybl.contingency.contingency.list.criterion.SingleCountryCriterion;
-import com.powsybl.contingency.contingency.list.criterion.SingleNominalVoltageCriterion;
+import com.powsybl.iidm.network.util.criterion.PropertyCriterion;
+import com.powsybl.iidm.network.util.criterion.RegexCriterion;
+import com.powsybl.iidm.network.util.criterion.SingleCountryCriterion;
+import com.powsybl.iidm.network.util.criterion.SingleNominalVoltageCriterion;
 import com.powsybl.iidm.network.IdentifiableType;
 
 import java.util.List;

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/LineCriterionContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/LineCriterionContingencyList.java
@@ -8,6 +8,10 @@ package com.powsybl.contingency.contingency.list;
 
 import com.powsybl.contingency.contingency.list.criterion.*;
 import com.powsybl.iidm.network.IdentifiableType;
+import com.powsybl.iidm.network.util.criterion.PropertyCriterion;
+import com.powsybl.iidm.network.util.criterion.RegexCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoCountriesCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoNominalVoltageCriterion;
 
 import java.util.List;
 

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/ThreeWindingsTransformerCriterionContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/ThreeWindingsTransformerCriterionContingencyList.java
@@ -6,10 +6,10 @@
  */
 package com.powsybl.contingency.contingency.list;
 
-import com.powsybl.contingency.contingency.list.criterion.PropertyCriterion;
-import com.powsybl.contingency.contingency.list.criterion.RegexCriterion;
-import com.powsybl.contingency.contingency.list.criterion.SingleCountryCriterion;
-import com.powsybl.contingency.contingency.list.criterion.ThreeNominalVoltageCriterion;
+import com.powsybl.iidm.network.util.criterion.PropertyCriterion;
+import com.powsybl.iidm.network.util.criterion.RegexCriterion;
+import com.powsybl.iidm.network.util.criterion.SingleCountryCriterion;
+import com.powsybl.iidm.network.util.criterion.ThreeNominalVoltageCriterion;
 import com.powsybl.iidm.network.IdentifiableType;
 
 import java.util.List;

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/TieLineCriterionContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/TieLineCriterionContingencyList.java
@@ -7,10 +7,10 @@
  */
 package com.powsybl.contingency.contingency.list;
 
-import com.powsybl.contingency.contingency.list.criterion.PropertyCriterion;
-import com.powsybl.contingency.contingency.list.criterion.RegexCriterion;
-import com.powsybl.contingency.contingency.list.criterion.SingleNominalVoltageCriterion;
-import com.powsybl.contingency.contingency.list.criterion.TwoCountriesCriterion;
+import com.powsybl.iidm.network.util.criterion.PropertyCriterion;
+import com.powsybl.iidm.network.util.criterion.RegexCriterion;
+import com.powsybl.iidm.network.util.criterion.SingleNominalVoltageCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoCountriesCriterion;
 import com.powsybl.iidm.network.IdentifiableType;
 
 import java.util.List;

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/TwoWindingsTransformerCriterionContingencyList.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/contingency/list/TwoWindingsTransformerCriterionContingencyList.java
@@ -6,10 +6,10 @@
  */
 package com.powsybl.contingency.contingency.list;
 
-import com.powsybl.contingency.contingency.list.criterion.PropertyCriterion;
-import com.powsybl.contingency.contingency.list.criterion.RegexCriterion;
-import com.powsybl.contingency.contingency.list.criterion.SingleCountryCriterion;
-import com.powsybl.contingency.contingency.list.criterion.TwoNominalVoltageCriterion;
+import com.powsybl.iidm.network.util.criterion.PropertyCriterion;
+import com.powsybl.iidm.network.util.criterion.RegexCriterion;
+import com.powsybl.iidm.network.util.criterion.SingleCountryCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoNominalVoltageCriterion;
 import com.powsybl.iidm.network.IdentifiableType;
 
 import java.util.List;

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/AbstractEquipmentCriterionContingencyListDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/AbstractEquipmentCriterionContingencyListDeserializer.java
@@ -12,9 +12,9 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.contingency.contingency.list.AbstractEquipmentCriterionContingencyList;
-import com.powsybl.contingency.contingency.list.criterion.Criterion;
-import com.powsybl.contingency.contingency.list.criterion.PropertyCriterion;
-import com.powsybl.contingency.contingency.list.criterion.RegexCriterion;
+import com.powsybl.iidm.network.util.criterion.Criterion;
+import com.powsybl.iidm.network.util.criterion.PropertyCriterion;
+import com.powsybl.iidm.network.util.criterion.RegexCriterion;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ContingencyJsonModule.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ContingencyJsonModule.java
@@ -9,8 +9,10 @@ package com.powsybl.contingency.json;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.powsybl.contingency.*;
 import com.powsybl.contingency.contingency.list.*;
-import com.powsybl.contingency.contingency.list.criterion.Criterion;
+import com.powsybl.iidm.network.util.criterion.Criterion;
 import com.powsybl.contingency.contingency.list.identifier.NetworkElementIdentifier;
+import com.powsybl.iidm.network.util.criterion.json.CriterionDeserializer;
+import com.powsybl.iidm.network.util.criterion.json.CriterionSerializer;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/HvdcLineCriterionContingencyListDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/HvdcLineCriterionContingencyListDeserializer.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.contingency.contingency.list.HvdcLineCriterionContingencyList;
 import com.powsybl.contingency.contingency.list.criterion.*;
+import com.powsybl.iidm.network.util.criterion.TwoCountriesCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoNominalVoltageCriterion;
 
 import java.io.IOException;
 

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/InjectionCriterionContingencyListDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/InjectionCriterionContingencyListDeserializer.java
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.contingency.contingency.list.InjectionCriterionContingencyList;
-import com.powsybl.contingency.contingency.list.criterion.SingleCountryCriterion;
-import com.powsybl.contingency.contingency.list.criterion.SingleNominalVoltageCriterion;
+import com.powsybl.iidm.network.util.criterion.SingleCountryCriterion;
+import com.powsybl.iidm.network.util.criterion.SingleNominalVoltageCriterion;
 
 import java.io.IOException;
 

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/LineCriterionContingencyListDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/LineCriterionContingencyListDeserializer.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.contingency.contingency.list.LineCriterionContingencyList;
 import com.powsybl.contingency.contingency.list.criterion.*;
+import com.powsybl.iidm.network.util.criterion.TwoCountriesCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoNominalVoltageCriterion;
 
 import java.io.IOException;
 

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ThreeWindingsTransformerCriterionContingencyListDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ThreeWindingsTransformerCriterionContingencyListDeserializer.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.contingency.contingency.list.ThreeWindingsTransformerCriterionContingencyList;
 import com.powsybl.contingency.contingency.list.criterion.*;
+import com.powsybl.iidm.network.util.criterion.SingleCountryCriterion;
+import com.powsybl.iidm.network.util.criterion.ThreeNominalVoltageCriterion;
 
 import java.io.IOException;
 

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/TieLineCriterionContingencyListDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/TieLineCriterionContingencyListDeserializer.java
@@ -11,8 +11,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.contingency.contingency.list.TieLineCriterionContingencyList;
-import com.powsybl.contingency.contingency.list.criterion.SingleNominalVoltageCriterion;
-import com.powsybl.contingency.contingency.list.criterion.TwoCountriesCriterion;
+import com.powsybl.iidm.network.util.criterion.SingleNominalVoltageCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoCountriesCriterion;
 
 import java.io.IOException;
 

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/TwoWindingsTransformerCriterionContingencyListDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/TwoWindingsTransformerCriterionContingencyListDeserializer.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.contingency.contingency.list.TwoWindingsTransformerCriterionContingencyList;
 import com.powsybl.contingency.contingency.list.criterion.*;
+import com.powsybl.iidm.network.util.criterion.SingleCountryCriterion;
+import com.powsybl.iidm.network.util.criterion.TwoNominalVoltageCriterion;
 
 import java.io.IOException;
 

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/CriterionContingencyListTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/CriterionContingencyListTest.java
@@ -14,6 +14,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.DanglingLineNetworkFactory;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
+import com.powsybl.iidm.network.util.criterion.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/CriterionContingencyListJsonTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/CriterionContingencyListJsonTest.java
@@ -14,6 +14,7 @@ import com.powsybl.contingency.contingency.list.*;
 import com.powsybl.contingency.contingency.list.criterion.*;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.IdentifiableType;
+import com.powsybl.iidm.network.util.criterion.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/ListOfContingencyListsJsonTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/ListOfContingencyListsJsonTest.java
@@ -15,6 +15,7 @@ import com.powsybl.contingency.contingency.list.*;
 import com.powsybl.contingency.contingency.list.criterion.*;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.IdentifiableType;
+import com.powsybl.iidm.network.util.criterion.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/Criterion.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/Criterion.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.contingency.contingency.list.criterion;
+package com.powsybl.iidm.network.util.criterion;
 
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.IdentifiableType;

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/PropertyCriterion.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/PropertyCriterion.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.contingency.contingency.list.criterion;
+package com.powsybl.iidm.network.util.criterion;
 
 import com.google.common.collect.ImmutableList;
 import com.powsybl.commons.PowsyblException;

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/RegexCriterion.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/RegexCriterion.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.contingency.contingency.list.criterion;
+package com.powsybl.iidm.network.util.criterion;
 
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.IdentifiableType;

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/SingleCountryCriterion.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/SingleCountryCriterion.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.contingency.contingency.list.criterion;
+package com.powsybl.iidm.network.util.criterion;
 
 import com.google.common.collect.ImmutableList;
 import com.powsybl.iidm.network.*;

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/SingleNominalVoltageCriterion.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/SingleNominalVoltageCriterion.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.contingency.contingency.list.criterion;
+package com.powsybl.iidm.network.util.criterion;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.powsybl.iidm.network.*;

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/ThreeNominalVoltageCriterion.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/ThreeNominalVoltageCriterion.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.contingency.contingency.list.criterion;
+package com.powsybl.iidm.network.util.criterion;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.powsybl.iidm.network.*;

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/TwoCountriesCriterion.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/TwoCountriesCriterion.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.contingency.contingency.list.criterion;
+package com.powsybl.iidm.network.util.criterion;
 
 import com.google.common.collect.ImmutableList;
 import com.powsybl.iidm.network.*;

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/TwoNominalVoltageCriterion.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/TwoNominalVoltageCriterion.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.contingency.contingency.list.criterion;
+package com.powsybl.iidm.network.util.criterion;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.powsybl.iidm.network.*;

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/json/CriterionDeserializer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/json/CriterionDeserializer.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.contingency.json;
+package com.powsybl.iidm.network.util.criterion.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.contingency.contingency.list.criterion.*;
 import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.util.criterion.*;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/json/CriterionSerializer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/criterion/json/CriterionSerializer.java
@@ -4,13 +4,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.contingency.json;
+package com.powsybl.iidm.network.util.criterion.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.powsybl.contingency.contingency.list.criterion.*;
 import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.util.criterion.*;
 
 import java.io.IOException;
 import java.util.stream.Collectors;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
No.


**What kind of change does this PR introduce?**
It moves classes from one module to another.


**What is the current behavior?**
The criterion package and CriterionSerializer / CriterionDeserializer classes are located in the contingency-api module.


**What is the new behavior (if this is a feature change)?**
the criterion package and CriterionSerializer / CriterionDeserializer classes are located in the iidm-api module, thus making them more accessible, since the iidm-api module is more generally used than the contingency-api module.


**Does this PR introduce a breaking change or deprecate an API?**
Is this a breaking change since the contingency-api pom contains an iidm-api dependency?
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*