### PR TITLE
Fix CGMES date parsing

### DIFF
--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/DateParsingTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/DateParsingTest.java
@@ -26,14 +26,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class DateParsingTest {
 
     @Test
-
     void test() {
         Conversion.Config config = new Conversion.Config();
         GridModelReferenceResources gridModel = new GridModelReferenceResources(
-                "dateParsing", null, new ResourceSet("/", "timeParsing.xml"));
+                "dateParsing", null, new ResourceSet("/", "dateParsing.xml"));
         Network n = networkModel(gridModel, config);
 
-        ZonedDateTime caseDateExpected = ZonedDateTime.of(2030, 1, 2, 9, 0, 0, 321, ZoneOffset.UTC);
+        ZonedDateTime caseDateExpected = ZonedDateTime.of(2030, 1, 2, 9, 0, 0, 987654321, ZoneOffset.UTC);
         ZonedDateTime createdDateExpected = ZonedDateTime.of(2021, 5, 18, 7, 43, 27, 0, ZoneOffset.of("+01"));
         long forecastMinutes = Duration.between(createdDateExpected, caseDateExpected).toMinutes();
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/DateParsingTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/DateParsingTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.test;
+
+import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.cgmes.model.GridModelReferenceResources;
+import com.powsybl.commons.datasource.ResourceSet;
+import com.powsybl.iidm.network.Network;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static com.powsybl.cgmes.conversion.test.ConversionUtil.networkModel;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ */
+class DateParsingTest {
+
+    @Test
+
+    void test() {
+        Conversion.Config config = new Conversion.Config();
+        GridModelReferenceResources gridModel = new GridModelReferenceResources(
+                "dateParsing", null, new ResourceSet("/", "timeParsing.xml"));
+        Network n = networkModel(gridModel, config);
+
+        ZonedDateTime caseDateExpected = ZonedDateTime.of(2030, 1, 2, 9, 0, 0, 321, ZoneOffset.UTC);
+        ZonedDateTime createdDateExpected = ZonedDateTime.of(2021, 5, 18, 7, 43, 27, 0, ZoneOffset.of("+01"));
+        long forecastMinutes = Duration.between(createdDateExpected, caseDateExpected).toMinutes();
+
+        assertEquals(caseDateExpected, n.getCaseDate());
+        assertEquals(forecastMinutes, n.getForecastDistance());
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/resources/dateParsing.xml
+++ b/cgmes/cgmes-conversion/src/test/resources/dateParsing.xml
@@ -2,7 +2,7 @@
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#"
          xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#">
     <md:FullModel rdf:about="urn:uuid:7bf718c6-2a99-450b-ba9b-2c334e133248">
-        <md:Model.scenarioTime>2030-01-02T09:00:00.000000321Z</md:Model.scenarioTime>
+        <md:Model.scenarioTime>2030-01-02T09:00:00.987654321Z</md:Model.scenarioTime>
         <md:Model.created>2021-05-18T07:43:27+01</md:Model.created>
         <md:Model.description>EQ Model</md:Model.description>
         <md:Model.version>1</md:Model.version>

--- a/cgmes/cgmes-conversion/src/test/resources/timeParsing.xml
+++ b/cgmes/cgmes-conversion/src/test/resources/timeParsing.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#"
+         xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#">
+    <md:FullModel rdf:about="urn:uuid:7bf718c6-2a99-450b-ba9b-2c334e133248">
+        <md:Model.scenarioTime>2030-01-02T09:00:00.000000321Z</md:Model.scenarioTime>
+        <md:Model.created>2021-05-18T07:43:27+01</md:Model.created>
+        <md:Model.description>EQ Model</md:Model.description>
+        <md:Model.version>1</md:Model.version>
+        <md:Model.profile>http://entsoe.eu/CIM/EquipmentCore/3/1</md:Model.profile>
+        <md:Model.profile>http://entsoe.eu/CIM/EquipmentOperation/3/1</md:Model.profile>
+        <md:Model.modelingAuthoritySet>powsybl.org</md:Model.modelingAuthoritySet>
+    </md:FullModel>
+</rdf:RDF>

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -322,7 +322,7 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
             // Fixed mandatory pattern
             .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
             // Between 0 and 6 decimals
-            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 7, true)
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 9, true)
             // Potentially a suffix for localisation (for example "Z", "+01:00", "+3", etc.)
             .appendPattern("[VV][x][xx][xxx]")
             .toFormatter();

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -321,9 +321,9 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
         DateTimeFormatter dateTimeFormatterLocalised = new DateTimeFormatterBuilder()
             // Fixed mandatory pattern
             .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
-            // Between 0 and 6 decimals
+            // Between 0 and 9 decimals (9 is the maximum)
             .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 9, true)
-            // Potentially a suffix for localisation (for example "Z", "+01:00", "+3", etc.)
+            // Potentially a suffix for localisation (VV: zoneId, x: +HHmm, xx: +HHMM, xxx: +HH:MM)
             .appendPattern("[VV][x][xx][xxx]")
             .toFormatter();
 

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -322,7 +322,7 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
             // Fixed mandatory pattern
             .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
             // Between 0 and 6 decimals
-            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 7, true)
             // Potentially a suffix for localisation (for example "Z", "+01:00", "+3", etc.)
             .appendPattern("[VV][x][xx][xxx]")
             .toFormatter();

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -322,7 +322,7 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
             // Fixed mandatory pattern
             .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
             // Between 0 and 9 decimals (9 is the maximum)
-            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 9, true)
+            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
             // Potentially a suffix for localisation (VV: zoneId, x: +HHmm, xx: +HHMM, xxx: +HH:MM)
             .appendPattern("[VV][x][xx][xxx]")
             .toFormatter();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
In some CGMES files, the fractions of second may be written with more than 6 digits, for instance:
`2023-07-31T00:30:00.0000000Z`
Such a date leads to a DateTimeParseException, and then the caseDate is overwritten with ZonedDateTime.now()



**What is the new behavior (if this is a feature change)?**
Increasing to maximum the max width (9).


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
