### PR TITLE
fix: ensure correct initialization of contingencyIndex when loaded fr…

### DIFF
--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityValue.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityValue.java
@@ -79,7 +79,7 @@ public class SensitivityValue {
 
     static final class ParsingContext {
         private int factorIndex;
-        private int contingencyIndex;
+        private int contingencyIndex = -1;
         private double value;
         private double functionReference;
     }

--- a/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityValueTest.java
+++ b/sensitivity-analysis-api/src/test/java/com/powsybl/sensitivity/SensitivityValueTest.java
@@ -6,15 +6,18 @@
  */
 package com.powsybl.sensitivity;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.sensitivity.json.JsonSensitivityAnalysisParameters;
+import com.powsybl.sensitivity.json.SensitivityJsonModule;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -37,5 +40,20 @@ class SensitivityValueTest extends AbstractSerDeTest {
         ObjectMapper objectMapper = JsonSensitivityAnalysisParameters.createObjectMapper();
         roundTripTest(value, (value2, jsonFile) -> JsonUtil.writeJson(jsonFile, value, objectMapper),
             jsonFile -> JsonUtil.readJson(jsonFile, SensitivityValue.class, objectMapper), "/valueRef.json");
+    }
+
+    @Test
+    void testJsonWhenContingencyIndexIsMinus1() throws JsonProcessingException {
+        SensitivityValue value = new SensitivityValue(0, -1, 1d, 2d);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new SensitivityJsonModule());
+        String sensitivityValueString = objectMapper.writeValueAsString(value);
+
+        // When the contingency index is -1 it should not be present in the json
+        assertFalse(sensitivityValueString.contains("contingencyIndex"));
+
+        SensitivityValue value2 = objectMapper.readValue(sensitivityValueString, SensitivityValue.class);
+        assertEquals(value.getContingencyIndex(), value2.getContingencyIndex());
+
     }
 }


### PR DESCRIPTION
…om JSON in case it does not exist in the generated JSON

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
When the `contingencyIndex` is -1 it is not part of the generated JSON represention. But the default value when reading is 0. Therefore, to/from JSON roundtrip does not work when `contingencyIndex` is -1



**What is the new behavior (if this is a feature change)?**
The default value of `contingencyIndex` is now -1. Thus, when it is not present in the JSON representation it will be set to `-1`


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
