### PR TITLE
Fix random ordering in index identifables and in extendable extensions

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/extensions/AbstractExtendable.java
+++ b/commons/src/main/java/com/powsybl/commons/extensions/AbstractExtendable.java
@@ -6,10 +6,7 @@
  */
 package com.powsybl.commons.extensions;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
@@ -18,7 +15,7 @@ public abstract class AbstractExtendable<T> implements Extendable<T> {
 
     private final Map<Class<?>, Extension<T>> extensions = new HashMap<>();
 
-    private final Map<String, Extension<T>> extensionsByName = new HashMap<>();
+    private final Map<String, Extension<T>> extensionsByName = new LinkedHashMap<>();
 
     @Override
     public <E extends Extension<T>> void addExtension(Class<? super E> type, E extension) {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkIndex.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkIndex.java
@@ -20,7 +20,7 @@ import java.util.*;
  */
 class NetworkIndex {
 
-    private final Map<String, Identifiable<?>> objectsById = new HashMap<>();
+    private final Map<String, Identifiable<?>> objectsById = new LinkedHashMap<>();
     private final Map<String, String> idByAlias = new HashMap<>();
 
     private final Map<Class<? extends Identifiable>, Set<Identifiable<?>>> objectsByClass = new HashMap<>();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
Two collections returned are in random order:
- `NetworkIndex::getIdentifiables` are values of a `HashMap`
- `AbstractExtendable::getExtensions` are values of a `HashMap`

Leading to unwanted behaviour:
- Random order when writing extensions
- Random order of all equipments when merging two networks
- Random order when validating equipments (thrown exception might vary from one run to the other)


**What is the new behavior (if this is a feature change)?**
The corresponding `HashMap`s are replaced by `LinkedHashMap`s


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No