### PR TITLE
Add new type of NodeCalc to compute Min/Max between timeseries

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/json/JsonUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/json/JsonUtil.java
@@ -6,11 +6,11 @@
  */
 package com.powsybl.commons.json;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -32,6 +32,8 @@ import java.util.function.Function;
  * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
  */
 public final class JsonUtil {
+
+    private final static String UNEXPECTED_TOKEN = "Unexpected token ";
 
     enum ContextType {
         OBJECT,
@@ -67,10 +69,11 @@ public final class JsonUtil {
     }
 
     public static ObjectMapper createObjectMapper() {
-        return new ObjectMapper()
+        return JsonMapper.builder()
                 .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
-                .disable(JsonGenerator.Feature.QUOTE_NON_NUMERIC_NUMBERS)
-                .enable(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS);
+                .disable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
+                .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
+            .build();
     }
 
     public static void writeJson(Path jsonFile, Object object, ObjectMapper objectMapper) {
@@ -117,9 +120,10 @@ public final class JsonUtil {
     }
 
     public static JsonFactory createJsonFactory() {
-        return new JsonFactory()
-                .disable(JsonGenerator.Feature.QUOTE_NON_NUMERIC_NUMBERS)
-                .enable(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS);
+        return new JsonFactoryBuilder()
+            .disable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
+            .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
+            .build();
     }
 
     public static void writeJson(Writer writer, Consumer<JsonGenerator> consumer) {
@@ -512,7 +516,7 @@ public final class JsonUtil {
                 } else if (token == JsonToken.END_OBJECT) {
                     break;
                 } else {
-                    throw new PowsyblException("Unexpected token " + token);
+                    throw new PowsyblException(UNEXPECTED_TOKEN + token);
                 }
                 token = parser.nextToken();
             }
@@ -530,13 +534,12 @@ public final class JsonUtil {
             if (token != JsonToken.START_ARRAY) {
                 throw new PowsyblException("Start array token was expected");
             }
-            while ((token = parser.nextToken()) != null) {
-                if (token == JsonToken.START_OBJECT) {
-                    objectAdder.accept(objectParser.apply(parser));
-                } else if (token == JsonToken.END_ARRAY) {
-                    break;
-                } else {
-                    throw new PowsyblException("Unexpected token " + token);
+            boolean continueLoop = true;
+            while (continueLoop && (token = parser.nextToken()) != null) {
+                switch (token) {
+                    case START_OBJECT -> objectAdder.accept(objectParser.apply(parser));
+                    case END_ARRAY -> continueLoop = false;
+                    default -> throw new PowsyblException(UNEXPECTED_TOKEN + token);
                 }
             }
         } catch (IOException e) {
@@ -564,7 +567,7 @@ public final class JsonUtil {
                 } else if (token == JsonToken.END_ARRAY) {
                     break;
                 } else {
-                    throw new PowsyblException("Unexpected token " + token);
+                    throw new PowsyblException(UNEXPECTED_TOKEN + token);
                 }
             }
         } catch (IOException e) {

--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityVariableSet.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityVariableSet.java
@@ -96,14 +96,9 @@ public class SensitivityVariableSet {
                 if (token == JsonToken.FIELD_NAME) {
                     String fieldName = parser.getCurrentName();
                     switch (fieldName) {
-                        case "id":
-                            id = parser.nextTextValue();
-                            break;
-                        case "variables":
-                            variables = WeightedSensitivityVariable.parseJson(parser);
-                            break;
-                        default:
-                            throw new PowsyblException("Unexpected field: " + fieldName);
+                        case "id" -> id = parser.nextTextValue();
+                        case "variables" -> variables = WeightedSensitivityVariable.parseJson(parser);
+                        default -> throw new PowsyblException("Unexpected field: " + fieldName);
                     }
                 } else if (token == JsonToken.END_OBJECT) {
                     return new SensitivityVariableSet(id, variables);

--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/WeightedSensitivityVariable.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/WeightedSensitivityVariable.java
@@ -81,15 +81,14 @@ public class WeightedSensitivityVariable {
                 if (token == JsonToken.FIELD_NAME) {
                     String fieldName = parser.getCurrentName();
                     switch (fieldName) {
-                        case "id":
-                            context.id = parser.nextTextValue();
-                            break;
-                        case "weight":
+                        case "id" -> context.id = parser.nextTextValue();
+                        case "weight" -> {
                             parser.nextToken();
                             context.weight = parser.getDoubleValue();
-                            break;
-                        default:
-                            break;
+                        }
+                        default -> {
+                            // Do nothing
+                        }
                     }
                 } else if (token == JsonToken.END_ARRAY) {
                     break;

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/DataChunk.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/DataChunk.java
@@ -204,24 +204,24 @@ public interface DataChunk<P extends AbstractPoint, A extends DataChunk<P, A>> {
     static void parseFieldName(JsonParser parser, JsonParsingContext context) throws IOException {
         String fieldName = parser.getCurrentName();
         switch (fieldName) {
-            case "offset":
+            case "offset" -> {
                 context.offset = parser.nextIntValue(-1);
                 context.doubleValues = null;
                 context.stringValues = null;
-                break;
-            case "uncompressedLength":
+            }
+            case "uncompressedLength" -> {
                 context.uncompressedLength = parser.nextIntValue(-1);
-                break;
-            case "stepLengths":
+            }
+            case "stepLengths" -> {
                 context.stepLengths = new TIntArrayList();
                 context.valuesOrLengthArray = true;
-                break;
-            case "values":
-            case "stepValues":
+            }
+            case "values", "stepValues" -> {
                 context.valuesOrLengthArray = true;
-                break;
-            default:
-                break;
+            }
+            default -> {
+                // Do nothing
+            }
         }
     }
 
@@ -288,38 +288,27 @@ public interface DataChunk<P extends AbstractPoint, A extends DataChunk<P, A>> {
             JsonToken token;
             while ((token = parser.nextToken()) != null) {
                 switch (token) {
-                    case FIELD_NAME:
-                        parseFieldName(parser, context);
-                        break;
-                    case END_OBJECT:
+                    case FIELD_NAME -> parseFieldName(parser, context);
+                    case END_OBJECT -> {
                         parseEndObject(context);
                         if (single) {
                             return;
-                        } else {
-                            break;
                         }
-                    case END_ARRAY:
+                    }
+                    case END_ARRAY -> {
                         if (context.valuesOrLengthArray) {
                             context.valuesOrLengthArray = false;
                         } else {
                             return; // end of chunk parsing
                         }
-                        break;
-                    case VALUE_NUMBER_FLOAT:
-                        context.addDoubleValue(parser.getDoubleValue());
-                        break;
-                    case VALUE_NUMBER_INT:
-                        parseValueNumberInt(parser, context);
-                        break;
-                    case VALUE_STRING:
-                        context.addStringValue(parser.getValueAsString());
-                        break;
-                    case VALUE_NULL:
-                        context.addStringValue(null);
-                        break;
-
-                    default:
-                        break;
+                    }
+                    case VALUE_NUMBER_FLOAT -> context.addDoubleValue(parser.getDoubleValue());
+                    case VALUE_NUMBER_INT -> parseValueNumberInt(parser, context);
+                    case VALUE_STRING -> context.addStringValue(parser.getValueAsString());
+                    case VALUE_NULL -> context.addStringValue(null);
+                    default -> {
+                        // Do nothing
+                    }
                 }
             }
         } catch (IOException e) {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
@@ -86,17 +86,10 @@ public class RegularTimeSeriesIndex extends AbstractTimeSeriesIndex {
                 if (token == JsonToken.FIELD_NAME) {
                     String fieldName = parser.getCurrentName();
                     switch (fieldName) {
-                        case "startTime":
-                            startTime = parser.nextLongValue(-1);
-                            break;
-                        case "endTime":
-                            endTime = parser.nextLongValue(-1);
-                            break;
-                        case "spacing":
-                            spacing = parser.nextLongValue(-1);
-                            break;
-                        default:
-                            throw new IllegalStateException("Unexpected field " + fieldName);
+                        case "startTime" -> startTime = parser.nextLongValue(-1);
+                        case "endTime" -> endTime = parser.nextLongValue(-1);
+                        case "spacing" -> spacing = parser.nextLongValue(-1);
+                        default -> throw new IllegalStateException("Unexpected field " + fieldName);
                     }
                 } else if (token == JsonToken.END_OBJECT) {
                     if (startTime == -1 || endTime == -1 || spacing == -1) {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/RegularTimeSeriesIndex.java
@@ -83,19 +83,25 @@ public class RegularTimeSeriesIndex extends AbstractTimeSeriesIndex {
             long endTime = -1;
             long spacing = -1;
             while ((token = parser.nextToken()) != null) {
-                if (token == JsonToken.FIELD_NAME) {
-                    String fieldName = parser.getCurrentName();
-                    switch (fieldName) {
-                        case "startTime" -> startTime = parser.nextLongValue(-1);
-                        case "endTime" -> endTime = parser.nextLongValue(-1);
-                        case "spacing" -> spacing = parser.nextLongValue(-1);
-                        default -> throw new IllegalStateException("Unexpected field " + fieldName);
+                switch (token) {
+                    case FIELD_NAME -> {
+                        String fieldName = parser.getCurrentName();
+                        switch (fieldName) {
+                            case "startTime" -> startTime = parser.nextLongValue(-1);
+                            case "endTime" -> endTime = parser.nextLongValue(-1);
+                            case "spacing" -> spacing = parser.nextLongValue(-1);
+                            default -> throw new IllegalStateException("Unexpected field " + fieldName);
+                        }
                     }
-                } else if (token == JsonToken.END_OBJECT) {
-                    if (startTime == -1 || endTime == -1 || spacing == -1) {
-                        throw new IllegalStateException("Incomplete regular time series index json");
+                    case END_OBJECT -> {
+                        if (startTime == -1 || endTime == -1 || spacing == -1) {
+                            throw new IllegalStateException("Incomplete regular time series index json");
+                        }
+                        return new RegularTimeSeriesIndex(startTime, endTime, spacing);
                     }
-                    return new RegularTimeSeriesIndex(startTime, endTime, spacing);
+                    default -> {
+                        // Do nothing
+                    }
                 }
             }
             throw new IllegalStateException("Should not happen");

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/TimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/TimeSeries.java
@@ -261,19 +261,16 @@ public interface TimeSeries<P extends AbstractPoint, T extends TimeSeries<P, T>>
 
         void parseTokenTime(String[] tokens) {
             switch (timeSeriesCsvConfig.timeFormat()) {
-                case DATE_TIME:
-                    times.add(ZonedDateTime.parse(tokens[0]).toInstant().toEpochMilli());
-                    break;
-                case FRACTIONS_OF_SECOND:
+                case DATE_TIME -> times.add(ZonedDateTime.parse(tokens[0]).toInstant().toEpochMilli());
+                case FRACTIONS_OF_SECOND -> {
                     Double time = Double.parseDouble(tokens[0]) * 1000;
                     times.add(time.longValue());
-                    break;
-                case MILLIS:
+                }
+                case MILLIS -> {
                     Double millis = Double.parseDouble(tokens[0]);
                     times.add(millis.longValue());
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown time format " + timeSeriesCsvConfig.timeFormat());
+                }
+                default -> throw new IllegalStateException("Unknown time format " + timeSeriesCsvConfig.timeFormat());
             }
         }
 
@@ -498,26 +495,23 @@ public interface TimeSeries<P extends AbstractPoint, T extends TimeSeries<P, T>>
                 if (token == JsonToken.FIELD_NAME) {
                     String fieldName = parser.getCurrentName();
                     switch (fieldName) {
-                        case "metadata":
-                            metadata = TimeSeriesMetadata.parseJson(parser);
-                            break;
-                        case "chunks":
+                        case "metadata" -> metadata = TimeSeriesMetadata.parseJson(parser);
+                        case "chunks" -> {
                             if (metadata == null) {
                                 throw new TimeSeriesException("metadata is null");
                             }
                             parseChunks(parser, metadata, timeSeriesList);
                             metadata = null;
-                            break;
-                        case "name":
-                            name = parser.nextTextValue();
-                            break;
-                        case "expr":
+                        }
+                        case "name" -> name = parser.nextTextValue();
+                        case "expr" -> {
                             Objects.requireNonNull(name);
                             NodeCalc nodeCalc = NodeCalc.parseJson(parser);
                             timeSeriesList.add(new CalculatedTimeSeries(name, nodeCalc));
-                            break;
-                        default:
-                            break;
+                        }
+                        default -> {
+                            // Do nothing
+                        }
                     }
                 } else if (token == JsonToken.END_OBJECT && single) {
                     break;

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/TimeSeriesMetadata.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/TimeSeriesMetadata.java
@@ -101,28 +101,16 @@ public class TimeSeriesMetadata {
             context.tags.put(fieldName, parser.nextTextValue());
         } else {
             switch (fieldName) {
-                case "metadata":
-                    break;
-                case "name":
-                    context.name = parser.nextTextValue();
-                    break;
-                case "dataType":
-                    context.dataType = TimeSeriesDataType.valueOf(parser.nextTextValue());
-                    break;
-                case "tags":
-                    context.insideTags = true;
-                    break;
-                case RegularTimeSeriesIndex.TYPE:
-                    context.index = RegularTimeSeriesIndex.parseJson(parser);
-                    break;
-                case IrregularTimeSeriesIndex.TYPE:
-                    context.index = IrregularTimeSeriesIndex.parseJson(parser);
-                    break;
-                case InfiniteTimeSeriesIndex.TYPE:
-                    context.index = InfiniteTimeSeriesIndex.parseJson(parser);
-                    break;
-                default:
-                    throw new IllegalStateException("Unexpected field name " + fieldName);
+                case "metadata" -> {
+                    // Do nothing
+                }
+                case "name" -> context.name = parser.nextTextValue();
+                case "dataType" -> context.dataType = TimeSeriesDataType.valueOf(parser.nextTextValue());
+                case "tags" -> context.insideTags = true;
+                case RegularTimeSeriesIndex.TYPE -> context.index = RegularTimeSeriesIndex.parseJson(parser);
+                case IrregularTimeSeriesIndex.TYPE -> context.index = IrregularTimeSeriesIndex.parseJson(parser);
+                case InfiniteTimeSeriesIndex.TYPE -> context.index = InfiniteTimeSeriesIndex.parseJson(parser);
+                default -> throw new IllegalStateException("Unexpected field name " + fieldName);
             }
         }
     }
@@ -133,15 +121,13 @@ public class TimeSeriesMetadata {
             JsonParsingContext context = new JsonParsingContext();
             while ((token = parser.nextToken()) != null) {
                 switch (token) {
-                    case FIELD_NAME:
-                        parseFieldName(parser, context);
-                        break;
-                    case END_ARRAY:
+                    case FIELD_NAME -> parseFieldName(parser, context);
+                    case END_ARRAY -> {
                         if (context.insideTags) {
                             context.insideTags = false;
                         }
-                        break;
-                    case END_OBJECT:
+                    }
+                    case END_OBJECT -> {
                         if (!context.insideTags) {
                             if (context.isComplete()) {
                                 return new TimeSeriesMetadata(context.name, context.dataType, context.tags, context.index);
@@ -149,9 +135,10 @@ public class TimeSeriesMetadata {
                                 throw new IllegalStateException("Incomplete time series metadata json");
                             }
                         }
-                        break;
-                    default:
-                        break;
+                    }
+                    default -> {
+                        // Do nothing
+                    }
                 }
             }
             throw new IllegalStateException("should not happen");

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/TimeSeriesTable.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/TimeSeriesTable.java
@@ -650,18 +650,13 @@ public class TimeSeriesTable {
     private void writeTime(Writer writer, TimeSeriesCsvConfig timeSeriesCsvConfig, int point, int cachedPoint) throws IOException {
         long time = tableIndex.getTimeAt(point + cachedPoint);
         switch (timeSeriesCsvConfig.timeFormat()) {
-            case DATE_TIME:
+            case DATE_TIME -> {
                 ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(time), ZoneId.systemDefault());
                 writer.write(zonedDateTime.format(timeSeriesCsvConfig.dateTimeFormatter()));
-                break;
-            case FRACTIONS_OF_SECOND:
-                writer.write(Double.toString(time / 1000.0));
-                break;
-            case MILLIS:
-                writer.write(Long.toString(time));
-                break;
-            default:
-                throw new IllegalStateException("Unknown time format " + timeSeriesCsvConfig.timeFormat());
+            }
+            case FRACTIONS_OF_SECOND -> writer.write(Double.toString(time / 1000.0));
+            case MILLIS -> writer.write(Long.toString(time));
+            default -> throw new IllegalStateException("Unknown time format " + timeSeriesCsvConfig.timeFormat());
         }
     }
 

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/AbstractBinaryMinMax.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/AbstractBinaryMinMax.java
@@ -64,17 +64,18 @@ public abstract class AbstractBinaryMinMax implements NodeCalc {
         ParsingContext context = new ParsingContext();
         JsonToken token;
         while ((token = parser.nextToken()) != null) {
-            if (token == JsonToken.START_OBJECT) {
-                // skip
-            } else if (token == JsonToken.END_OBJECT) {
-                if (context.left == null || context.right == null) {
-                    throw new TimeSeriesException("Invalid binary operation node calc JSON");
+            switch (token) {
+                case START_OBJECT -> {
+                    // Do nothing
                 }
-                return context;
-            } else if (token == JsonToken.FIELD_NAME) {
-                parseFieldName(parser, token, context);
-            } else {
-                throw NodeCalc.createUnexpectedToken(token);
+                case END_OBJECT -> {
+                    if (context.left == null || context.right == null) {
+                        throw new TimeSeriesException("Invalid binary operation node calc JSON");
+                    }
+                    return context;
+                }
+                case FIELD_NAME -> parseFieldName(parser, token, context);
+                default -> throw NodeCalc.createUnexpectedToken(token);
             }
         }
         throw NodeCalc.createUnexpectedToken(token);

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/AbstractBinaryMinMax.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/AbstractBinaryMinMax.java
@@ -1,0 +1,82 @@
+package com.powsybl.timeseries.ast;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.powsybl.timeseries.TimeSeriesException;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public abstract class AbstractBinaryMinMax implements NodeCalc {
+
+    protected NodeCalc left;
+    protected NodeCalc right;
+
+    protected AbstractBinaryMinMax(NodeCalc left, NodeCalc right) {
+        this.left = Objects.requireNonNull(left);
+        this.right = Objects.requireNonNull(right);
+    }
+
+    public NodeCalc getLeft() {
+        return left;
+    }
+
+    public void setLeft(NodeCalc left) {
+        this.left = Objects.requireNonNull(left);
+    }
+
+    public NodeCalc getRight() {
+        return right;
+    }
+
+    public void setRight(NodeCalc right) {
+        this.right = Objects.requireNonNull(right);
+    }
+
+    protected abstract String getJsonName();
+
+    @Override
+    public void writeJson(JsonGenerator generator) throws IOException {
+        generator.writeFieldName(getJsonName());
+        generator.writeStartObject();
+        left.writeJson(generator);
+        right.writeJson(generator);
+        generator.writeEndObject();
+    }
+
+    protected static class ParsingContext {
+        NodeCalc left = null;
+        NodeCalc right = null;
+    }
+
+    static void parseFieldName(JsonParser parser, JsonToken token, ParsingContext context) throws IOException {
+        if (context.left == null) {
+            context.left = NodeCalc.parseJson(parser, token);
+        } else if (context.right == null) {
+            context.right = NodeCalc.parseJson(parser, token);
+        } else {
+            throw new TimeSeriesException("2 operands expected for a binary min/max comparison");
+        }
+    }
+
+    protected static ParsingContext parseJson2(JsonParser parser) throws IOException {
+        ParsingContext context = new ParsingContext();
+        JsonToken token;
+        while ((token = parser.nextToken()) != null) {
+            if (token == JsonToken.START_OBJECT) {
+                // skip
+            } else if (token == JsonToken.END_OBJECT) {
+                if (context.left == null || context.right == null) {
+                    throw new TimeSeriesException("Invalid binary operation node calc JSON");
+                }
+                return context;
+            } else if (token == JsonToken.FIELD_NAME) {
+                parseFieldName(parser, token, context);
+            } else {
+                throw NodeCalc.createUnexpectedToken(token);
+            }
+        }
+        throw NodeCalc.createUnexpectedToken(token);
+    }
+}

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/AbstractMinMaxNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/AbstractMinMaxNodeCalc.java
@@ -70,17 +70,18 @@ public abstract class AbstractMinMaxNodeCalc implements NodeCalc {
         ParsingContext context = new ParsingContext();
         JsonToken token;
         while ((token = parser.nextToken()) != null) {
-            if (token == JsonToken.START_OBJECT) {
-                // skip
-            } else if (token == JsonToken.END_OBJECT) {
-                if (context.child == null || Double.isNaN(context.value)) {
-                    throw new TimeSeriesException("Invalid min/max node calc JSON");
+            switch (token) {
+                case START_OBJECT -> {
+                    // Do nothing
                 }
-                return context;
-            } else if (token == JsonToken.FIELD_NAME) {
-                parseFieldName(parser, token, context);
-            } else {
-                throw NodeCalc.createUnexpectedToken(token);
+                case END_OBJECT -> {
+                    if (context.child == null || Double.isNaN(context.value)) {
+                        throw new TimeSeriesException("Invalid min/max node calc JSON");
+                    }
+                    return context;
+                }
+                case FIELD_NAME -> parseFieldName(parser, token, context);
+                default -> throw NodeCalc.createUnexpectedToken(token);
             }
         }
         throw NodeCalc.createUnexpectedToken(token);

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BigDecimalNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BigDecimalNodeCalc.java
@@ -59,8 +59,8 @@ public class BigDecimalNodeCalc implements LiteralNodeCalc {
     }
 
     static NodeCalc parseJson(JsonParser parser) throws IOException {
-        JsonToken token;
-        while ((token = parser.nextToken()) != null) {
+        JsonToken token = parser.nextToken();
+        if (token != null) {
             if (token == JsonToken.VALUE_NUMBER_INT) {
                 return new BigDecimalNodeCalc(BigDecimal.valueOf(parser.getLongValue()));
             } else if (token == JsonToken.VALUE_NUMBER_FLOAT) {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BinaryMaxCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BinaryMaxCalc.java
@@ -1,0 +1,79 @@
+package com.powsybl.timeseries.ast;
+
+import com.fasterxml.jackson.core.JsonParser;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.io.IOException;
+import java.util.Deque;
+
+public class BinaryMaxCalc extends AbstractBinaryMinMax {
+
+    static final String NAME = "binaryMax";
+
+    public BinaryMaxCalc(NodeCalc left, NodeCalc right) {
+        super(left, right);
+    }
+
+    @Override
+    protected String getJsonName() {
+        return NAME;
+    }
+
+    static NodeCalc parseJson(JsonParser parser) throws IOException {
+        ParsingContext context = parseJson2(parser);
+        return new BinaryMaxCalc(context.left, context.right);
+    }
+
+    @Override
+    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg, int depth) {
+        if (depth < NodeCalcVisitors.RECURSION_THRESHOLD) {
+            Pair<NodeCalc, NodeCalc> p = visitor.iterate(this, arg);
+            R leftValue = null;
+            NodeCalc leftNode = p.getLeft();
+            if (leftNode != null) {
+                leftValue = leftNode.accept(visitor, arg, depth + 1);
+            }
+            R rightValue = null;
+            NodeCalc rightNode = p.getRight();
+            if (rightNode != null) {
+                rightValue = rightNode.accept(visitor, arg, depth + 1);
+            }
+            return visitor.visit(this, arg, leftValue, rightValue);
+        } else {
+            return NodeCalcVisitors.visit(this, arg, visitor);
+        }
+    }
+
+    @Override
+    public <R, A> void acceptIterate(NodeCalcVisitor<R, A> visitor, A arg, Deque<Object> nodesStack) {
+        Pair<NodeCalc, NodeCalc> p = visitor.iterate(this, arg);
+        Object leftNode = p.getLeft();
+        leftNode = leftNode == null ? NodeCalcVisitors.NULL : leftNode;
+        Object rightNode = p.getRight();
+        rightNode = rightNode == null ? NodeCalcVisitors.NULL : rightNode;
+        nodesStack.push(leftNode);
+        nodesStack.push(rightNode);
+    }
+
+    @Override
+    public <R, A> R acceptHandle(NodeCalcVisitor<R, A> visitor, A arg, Deque<Object> resultsStack) {
+        Object rightResult = resultsStack.pop();
+        rightResult = rightResult == NodeCalcVisitors.NULL ? null : rightResult;
+        Object leftResult = resultsStack.pop();
+        leftResult = leftResult == NodeCalcVisitors.NULL ? null : leftResult;
+        return visitor.visit(this, arg, (R) leftResult, (R) rightResult);
+    }
+
+    @Override
+    public int hashCode() {
+        return left.hashCode() + right.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BinaryMaxCalc binaryMaxCalc) {
+            return binaryMaxCalc.left.equals(left) && binaryMaxCalc.right == right;
+        }
+        return false;
+    }
+}

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BinaryMinCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BinaryMinCalc.java
@@ -1,0 +1,79 @@
+package com.powsybl.timeseries.ast;
+
+import com.fasterxml.jackson.core.JsonParser;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.io.IOException;
+import java.util.Deque;
+
+public class BinaryMinCalc extends AbstractBinaryMinMax {
+
+    static final String NAME = "binaryMin";
+
+    public BinaryMinCalc(NodeCalc left, NodeCalc right) {
+        super(left, right);
+    }
+
+    @Override
+    protected String getJsonName() {
+        return NAME;
+    }
+
+    static NodeCalc parseJson(JsonParser parser) throws IOException {
+        ParsingContext context = parseJson2(parser);
+        return new BinaryMinCalc(context.left, context.right);
+    }
+
+    @Override
+    public <R, A> R accept(NodeCalcVisitor<R, A> visitor, A arg, int depth) {
+        if (depth < NodeCalcVisitors.RECURSION_THRESHOLD) {
+            Pair<NodeCalc, NodeCalc> p = visitor.iterate(this, arg);
+            R leftValue = null;
+            NodeCalc leftNode = p.getLeft();
+            if (leftNode != null) {
+                leftValue = leftNode.accept(visitor, arg, depth + 1);
+            }
+            R rightValue = null;
+            NodeCalc rightNode = p.getRight();
+            if (rightNode != null) {
+                rightValue = rightNode.accept(visitor, arg, depth + 1);
+            }
+            return visitor.visit(this, arg, leftValue, rightValue);
+        } else {
+            return NodeCalcVisitors.visit(this, arg, visitor);
+        }
+    }
+
+    @Override
+    public <R, A> void acceptIterate(NodeCalcVisitor<R, A> visitor, A arg, Deque<Object> nodesStack) {
+        Pair<NodeCalc, NodeCalc> p = visitor.iterate(this, arg);
+        Object leftNode = p.getLeft();
+        leftNode = leftNode == null ? NodeCalcVisitors.NULL : leftNode;
+        Object rightNode = p.getRight();
+        rightNode = rightNode == null ? NodeCalcVisitors.NULL : rightNode;
+        nodesStack.push(leftNode);
+        nodesStack.push(rightNode);
+    }
+
+    @Override
+    public <R, A> R acceptHandle(NodeCalcVisitor<R, A> visitor, A arg, Deque<Object> resultsStack) {
+        Object rightResult = resultsStack.pop();
+        rightResult = rightResult == NodeCalcVisitors.NULL ? null : rightResult;
+        Object leftResult = resultsStack.pop();
+        leftResult = leftResult == NodeCalcVisitors.NULL ? null : leftResult;
+        return visitor.visit(this, arg, (R) leftResult, (R) rightResult);
+    }
+
+    @Override
+    public int hashCode() {
+        return left.hashCode() + right.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BinaryMinCalc binaryMinCalc) {
+            return binaryMinCalc.left.equals(left) && binaryMinCalc.right == right;
+        }
+        return false;
+    }
+}

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BinaryOperation.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/BinaryOperation.java
@@ -196,17 +196,18 @@ public class BinaryOperation implements NodeCalc {
         ParsingContext context = new ParsingContext();
         JsonToken token;
         while ((token = parser.nextToken()) != null) {
-            if (token == JsonToken.START_OBJECT) {
-                // skip
-            } else if (token == JsonToken.END_OBJECT) {
-                if (context.left == null || context.right == null || context.operator == null) {
-                    throw new TimeSeriesException("Invalid binary operation node calc JSON");
+            switch (token) {
+                case START_OBJECT -> {
+                    // Do nothing
                 }
-                return new BinaryOperation(context.left, context.right, context.operator);
-            } else if (token == JsonToken.FIELD_NAME) {
-                parseFieldName(parser, token, context);
-            } else {
-                throw NodeCalc.createUnexpectedToken(token);
+                case END_OBJECT -> {
+                    if (context.left == null || context.right == null || context.operator == null) {
+                        throw new TimeSeriesException("Invalid binary operation node calc JSON");
+                    }
+                    return new BinaryOperation(context.left, context.right, context.operator);
+                }
+                case FIELD_NAME -> parseFieldName(parser, token, context);
+                default -> throw NodeCalc.createUnexpectedToken(token);
             }
         }
         throw NodeCalc.createUnexpectedToken(token);

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/DefaultNodeCalcVisitor.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/DefaultNodeCalcVisitor.java
@@ -91,4 +91,14 @@ public class DefaultNodeCalcVisitor<R, A> implements NodeCalcVisitor<R, A> {
     public R visit(TimeSeriesNumNodeCalc nodeCalc, A arg) {
         return null;
     }
+
+    @Override
+    public R visit(BinaryMinCalc nodeCalc, A arg, R left, R right) {
+        return null;
+    }
+
+    @Override
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, A arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/DefaultNodeCalcVisitor.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/DefaultNodeCalcVisitor.java
@@ -101,4 +101,14 @@ public class DefaultNodeCalcVisitor<R, A> implements NodeCalcVisitor<R, A> {
     public Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, A arg) {
         return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
     }
+
+    @Override
+    public R visit(BinaryMaxCalc nodeCalc, A arg, R left, R right) {
+        return null;
+    }
+
+    @Override
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryMaxCalc nodeCalc, A arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/DoubleNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/DoubleNodeCalc.java
@@ -60,8 +60,8 @@ public class DoubleNodeCalc implements LiteralNodeCalc {
     }
 
     static NodeCalc parseJson(JsonParser parser) throws IOException {
-        JsonToken token;
-        while ((token = parser.nextToken()) != null) {
+        JsonToken token = parser.nextToken();
+        if (token != null) {
             if (token == JsonToken.VALUE_NUMBER_FLOAT) {
                 return new DoubleNodeCalc(parser.getDoubleValue());
             } else if (token == JsonToken.VALUE_NUMBER_INT) {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/FloatNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/FloatNodeCalc.java
@@ -58,8 +58,8 @@ public class FloatNodeCalc implements LiteralNodeCalc {
     }
 
     static NodeCalc parseJson(JsonParser parser) throws IOException {
-        JsonToken token;
-        while ((token = parser.nextToken()) != null) {
+        JsonToken token = parser.nextToken();
+        if (token != null) {
             if (token == JsonToken.VALUE_NUMBER_FLOAT) {
                 return new FloatNodeCalc(parser.getFloatValue());
             } else if (token == JsonToken.VALUE_NUMBER_INT) {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/IntegerNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/IntegerNodeCalc.java
@@ -58,8 +58,8 @@ public class IntegerNodeCalc implements LiteralNodeCalc {
     }
 
     static NodeCalc parseJson(JsonParser parser) throws IOException {
-        JsonToken token;
-        while ((token = parser.nextToken()) != null) {
+        JsonToken token = parser.nextToken();
+        if (token != null) {
             if (token == JsonToken.VALUE_NUMBER_INT) {
                 return new IntegerNodeCalc(parser.getIntValue());
             } else {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalc.java
@@ -140,6 +140,9 @@ public interface NodeCalc {
                 case BinaryMinCalc.NAME -> {
                     return BinaryMinCalc.parseJson(parser);
                 }
+                case BinaryMaxCalc.NAME -> {
+                    return BinaryMaxCalc.parseJson(parser);
+                }
                 default -> {
                     // Do nothing
                 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalc.java
@@ -137,6 +137,9 @@ public interface NodeCalc {
                 case TimeNodeCalc.NAME -> {
                     return TimeNodeCalc.parseJson(parser);
                 }
+                case BinaryMinCalc.NAME -> {
+                    return BinaryMinCalc.parseJson(parser);
+                }
                 default -> {
                     // Do nothing
                 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalc.java
@@ -107,38 +107,39 @@ public interface NodeCalc {
         if (token == JsonToken.FIELD_NAME) {
             String fieldName = parser.getCurrentName();
             switch (fieldName) {
-                case IntegerNodeCalc.NAME:
+                case IntegerNodeCalc.NAME -> {
                     return IntegerNodeCalc.parseJson(parser);
-
-                case FloatNodeCalc.NAME:
+                }
+                case FloatNodeCalc.NAME -> {
                     return FloatNodeCalc.parseJson(parser);
-
-                case DoubleNodeCalc.NAME:
+                }
+                case DoubleNodeCalc.NAME -> {
                     return DoubleNodeCalc.parseJson(parser);
-
-                case BigDecimalNodeCalc.NAME:
+                }
+                case BigDecimalNodeCalc.NAME -> {
                     return BigDecimalNodeCalc.parseJson(parser);
-
-                case BinaryOperation.NAME:
+                }
+                case BinaryOperation.NAME -> {
                     return BinaryOperation.parseJson(parser);
-
-                case UnaryOperation.NAME:
+                }
+                case UnaryOperation.NAME -> {
                     return UnaryOperation.parseJson(parser);
-
-                case MinNodeCalc.NAME:
+                }
+                case MinNodeCalc.NAME -> {
                     return MinNodeCalc.parseJson(parser);
-
-                case MaxNodeCalc.NAME:
+                }
+                case MaxNodeCalc.NAME -> {
                     return MaxNodeCalc.parseJson(parser);
-
-                case TimeSeriesNameNodeCalc.NAME:
+                }
+                case TimeSeriesNameNodeCalc.NAME -> {
                     return TimeSeriesNameNodeCalc.parseJson(parser);
-
-                case TimeNodeCalc.NAME:
+                }
+                case TimeNodeCalc.NAME -> {
                     return TimeNodeCalc.parseJson(parser);
-
-                default:
-                    break;
+                }
+                default -> {
+                    // Do nothing
+                }
             }
         }
         throw createUnexpectedToken(token);

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalc.java
@@ -82,13 +82,14 @@ public interface NodeCalc {
         try {
             NodeCalc nodeCalc = null;
             JsonToken token;
-            while ((token = parser.nextToken()) != null) {
-                if (token == JsonToken.START_OBJECT) {
-                    // skip
-                } else if (token == JsonToken.END_OBJECT) {
-                    break;
-                } else {
-                    nodeCalc = parseJson(parser, token);
+            boolean continueLoop = true;
+            while (continueLoop && (token = parser.nextToken()) != null) {
+                switch (token) {
+                    case START_OBJECT -> {
+                        // Do nothing
+                    }
+                    case END_OBJECT -> continueLoop = false;
+                    default -> nodeCalc = parseJson(parser, token);
                 }
             }
             return nodeCalc;

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcCloner.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcCloner.java
@@ -101,4 +101,14 @@ public class NodeCalcCloner<A> implements NodeCalcVisitor<NodeCalc, A> {
     public Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, A arg) {
         return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
     }
+
+    @Override
+    public NodeCalc visit(BinaryMaxCalc nodeCalc, A arg, NodeCalc left, NodeCalc right) {
+        return new BinaryMaxCalc(left, right);
+    }
+
+    @Override
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryMaxCalc nodeCalc, A arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcCloner.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcCloner.java
@@ -91,4 +91,14 @@ public class NodeCalcCloner<A> implements NodeCalcVisitor<NodeCalc, A> {
     public NodeCalc visit(TimeSeriesNumNodeCalc nodeCalc, A arg) {
         return new TimeSeriesNumNodeCalc(nodeCalc.getTimeSeriesNum());
     }
+
+    @Override
+    public NodeCalc visit(BinaryMinCalc nodeCalc, A arg, NodeCalc left, NodeCalc right) {
+        return new BinaryMinCalc(left, right);
+    }
+
+    @Override
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, A arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcEvaluator.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcEvaluator.java
@@ -43,19 +43,18 @@ public class NodeCalcEvaluator implements NodeCalcVisitor<Double, DoubleMultiPoi
     public Double visit(BinaryOperation nodeCalc, DoubleMultiPoint multiPoint, Double left, Double right) {
         double leftValue = left;
         double rightValue = right;
-        switch (nodeCalc.getOperator()) {
-            case PLUS: return leftValue + rightValue;
-            case MINUS: return leftValue - rightValue;
-            case MULTIPLY: return leftValue * rightValue;
-            case DIVIDE: return leftValue / rightValue;
-            case LESS_THAN: return leftValue < rightValue ? 1d : 0d;
-            case LESS_THAN_OR_EQUALS_TO: return leftValue <= rightValue ? 1d : 0d;
-            case GREATER_THAN: return leftValue > rightValue ? 1d : 0d;
-            case GREATER_THAN_OR_EQUALS_TO: return leftValue >= rightValue ? 1d : 0d;
-            case EQUALS: return leftValue == rightValue ? 1d : 0d;
-            case NOT_EQUALS: return leftValue != rightValue ? 1d : 0d;
-            default: throw new IllegalStateException("Unexpected operator value: " + nodeCalc.getOperator());
-        }
+        return switch (nodeCalc.getOperator()) {
+            case PLUS -> leftValue + rightValue;
+            case MINUS -> leftValue - rightValue;
+            case MULTIPLY -> leftValue * rightValue;
+            case DIVIDE -> leftValue / rightValue;
+            case LESS_THAN -> leftValue < rightValue ? 1d : 0d;
+            case LESS_THAN_OR_EQUALS_TO -> leftValue <= rightValue ? 1d : 0d;
+            case GREATER_THAN -> leftValue > rightValue ? 1d : 0d;
+            case GREATER_THAN_OR_EQUALS_TO -> leftValue >= rightValue ? 1d : 0d;
+            case EQUALS -> leftValue == rightValue ? 1d : 0d;
+            case NOT_EQUALS -> leftValue != rightValue ? 1d : 0d;
+        };
     }
 
     @Override
@@ -66,12 +65,11 @@ public class NodeCalcEvaluator implements NodeCalcVisitor<Double, DoubleMultiPoi
     @Override
     public Double visit(UnaryOperation nodeCalc, DoubleMultiPoint multiPoint, Double child) {
         double childValue = child;
-        switch (nodeCalc.getOperator()) {
-            case ABS: return Math.abs(childValue);
-            case NEGATIVE: return -childValue;
-            case POSITIVE: return childValue;
-            default: throw new IllegalStateException("Unexpected operator value: " + nodeCalc.getOperator());
-        }
+        return switch (nodeCalc.getOperator()) {
+            case ABS -> Math.abs(childValue);
+            case NEGATIVE -> -childValue;
+            case POSITIVE -> childValue;
+        };
     }
 
     @Override

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcEvaluator.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcEvaluator.java
@@ -121,4 +121,16 @@ public class NodeCalcEvaluator implements NodeCalcVisitor<Double, DoubleMultiPoi
     public Double visit(TimeSeriesNameNodeCalc nodeCalc, DoubleMultiPoint multiPoint) {
         throw new IllegalStateException("NodeCalc should have been resolved before");
     }
+
+    @Override
+    public Double visit(BinaryMinCalc nodeCalc, DoubleMultiPoint multiPoint, Double left, Double right) {
+        double leftValue = left;
+        double rightValue = right;
+        return Math.min(leftValue, rightValue);
+    }
+
+    @Override
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, DoubleMultiPoint multiPoint) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcEvaluator.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcEvaluator.java
@@ -133,4 +133,16 @@ public class NodeCalcEvaluator implements NodeCalcVisitor<Double, DoubleMultiPoi
     public Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, DoubleMultiPoint multiPoint) {
         return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
     }
+
+    @Override
+    public Double visit(BinaryMaxCalc nodeCalc, DoubleMultiPoint multiPoint, Double left, Double right) {
+        double leftValue = left;
+        double rightValue = right;
+        return Math.max(leftValue, rightValue);
+    }
+
+    @Override
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryMaxCalc nodeCalc, DoubleMultiPoint multiPoint) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcModifier.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcModifier.java
@@ -133,4 +133,22 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
     public Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, A arg) {
         return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
     }
+
+    @Override
+    public NodeCalc visit(BinaryMaxCalc nodeCalc, A arg, NodeCalc left, NodeCalc right) {
+        NodeCalc newLeft = left;
+        if (newLeft != null) {
+            nodeCalc.setLeft(newLeft);
+        }
+        NodeCalc newRight = right;
+        if (newRight != null) {
+            nodeCalc.setRight(newRight);
+        }
+        return null;
+    }
+
+    @Override
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryMaxCalc nodeCalc, A arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcModifier.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcModifier.java
@@ -115,4 +115,22 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
     public NodeCalc visit(TimeSeriesNumNodeCalc nodeCalc, A arg) {
         return null;
     }
+
+    @Override
+    public NodeCalc visit(BinaryMinCalc nodeCalc, A arg, NodeCalc left, NodeCalc right) {
+        NodeCalc newLeft = left;
+        if (newLeft != null) {
+            nodeCalc.setLeft(newLeft);
+        }
+        NodeCalc newRight = right;
+        if (newRight != null) {
+            nodeCalc.setRight(newRight);
+        }
+        return null;
+    }
+
+    @Override
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, A arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcModifier.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcModifier.java
@@ -34,13 +34,11 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
 
     @Override
     public NodeCalc visit(BinaryOperation nodeCalc, A arg, NodeCalc left, NodeCalc right) {
-        NodeCalc newLeft = left;
-        if (newLeft != null) {
-            nodeCalc.setLeft(newLeft);
+        if (left != null) {
+            nodeCalc.setLeft(left);
         }
-        NodeCalc newRight = right;
-        if (newRight != null) {
-            nodeCalc.setRight(newRight);
+        if (right != null) {
+            nodeCalc.setRight(right);
         }
         return null;
     }
@@ -52,9 +50,8 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
 
     @Override
     public NodeCalc visit(UnaryOperation nodeCalc, A arg, NodeCalc child) {
-        NodeCalc newChild = child;
-        if (newChild != null) {
-            nodeCalc.setChild(newChild);
+        if (child != null) {
+            nodeCalc.setChild(child);
         }
         return null;
     }
@@ -66,9 +63,8 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
 
     @Override
     public NodeCalc visit(MinNodeCalc nodeCalc, A arg, NodeCalc child) {
-        NodeCalc newChild = child;
-        if (newChild != null) {
-            nodeCalc.setChild(newChild);
+        if (child != null) {
+            nodeCalc.setChild(child);
         }
         return null;
     }
@@ -80,9 +76,8 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
 
     @Override
     public NodeCalc visit(MaxNodeCalc nodeCalc, A arg, NodeCalc child) {
-        NodeCalc newChild = child;
-        if (newChild != null) {
-            nodeCalc.setChild(newChild);
+        if (child != null) {
+            nodeCalc.setChild(child);
         }
         return null;
     }
@@ -94,9 +89,8 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
 
     @Override
     public NodeCalc visit(TimeNodeCalc nodeCalc, A arg, NodeCalc child) {
-        NodeCalc newChild = child;
-        if (newChild != null) {
-            nodeCalc.setChild(newChild);
+        if (child != null) {
+            nodeCalc.setChild(child);
         }
         return null;
     }
@@ -118,13 +112,11 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
 
     @Override
     public NodeCalc visit(BinaryMinCalc nodeCalc, A arg, NodeCalc left, NodeCalc right) {
-        NodeCalc newLeft = left;
-        if (newLeft != null) {
-            nodeCalc.setLeft(newLeft);
+        if (left != null) {
+            nodeCalc.setLeft(left);
         }
-        NodeCalc newRight = right;
-        if (newRight != null) {
-            nodeCalc.setRight(newRight);
+        if (right != null) {
+            nodeCalc.setRight(right);
         }
         return null;
     }
@@ -136,13 +128,11 @@ public class NodeCalcModifier<A> implements NodeCalcVisitor<NodeCalc, A> {
 
     @Override
     public NodeCalc visit(BinaryMaxCalc nodeCalc, A arg, NodeCalc left, NodeCalc right) {
-        NodeCalc newLeft = left;
-        if (newLeft != null) {
-            nodeCalc.setLeft(newLeft);
+        if (left != null) {
+            nodeCalc.setLeft(left);
         }
-        NodeCalc newRight = right;
-        if (newRight != null) {
-            nodeCalc.setRight(newRight);
+        if (right != null) {
+            nodeCalc.setRight(right);
         }
         return null;
     }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcPrinter.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcPrinter.java
@@ -73,6 +73,11 @@ public class NodeCalcPrinter implements NodeCalcVisitor<String, Void> {
     }
 
     @Override
+    public String visit(BinaryMinCalc nodeCalc, Void arg, String left, String right) {
+        return left + ".min(" + right + ")";
+    }
+
+    @Override
     public NodeCalc iterate(TimeNodeCalc nodeCalc, Void arg) {
         return nodeCalc.getChild();
     }
@@ -96,5 +101,11 @@ public class NodeCalcPrinter implements NodeCalcVisitor<String, Void> {
     public NodeCalc iterate(MaxNodeCalc nodeCalc, Void arg) {
         return nodeCalc.getChild();
     }
+
+    @Override
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, Void arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
+
 
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcPrinter.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcPrinter.java
@@ -74,7 +74,12 @@ public class NodeCalcPrinter implements NodeCalcVisitor<String, Void> {
 
     @Override
     public String visit(BinaryMinCalc nodeCalc, Void arg, String left, String right) {
-        return left + ".min(" + right + ")";
+        return "min(" + left + ", " + right + ")";
+    }
+
+    @Override
+    public String visit(BinaryMaxCalc nodeCalc, Void arg, String left, String right) {
+        return "max(" + left + ", " + right + ")";
     }
 
     @Override
@@ -104,6 +109,11 @@ public class NodeCalcPrinter implements NodeCalcVisitor<String, Void> {
 
     @Override
     public Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, Void arg) {
+        return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
+    }
+
+    @Override
+    public Pair<NodeCalc, NodeCalc> iterate(BinaryMaxCalc nodeCalc, Void arg) {
         return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
     }
 

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcPrinter.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcPrinter.java
@@ -116,6 +116,4 @@ public class NodeCalcPrinter implements NodeCalcVisitor<String, Void> {
     public Pair<NodeCalc, NodeCalc> iterate(BinaryMaxCalc nodeCalc, Void arg) {
         return Pair.of(nodeCalc.getLeft(), nodeCalc.getRight());
     }
-
-
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcVisitor.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcVisitor.java
@@ -56,4 +56,8 @@ public interface NodeCalcVisitor<R, A> {
     R visit(BinaryMinCalc nodeCalc, A arg, R left, R right);
 
     Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, A arg);
+
+    R visit(BinaryMaxCalc nodeCalc, A arg, R left, R right);
+
+    Pair<NodeCalc, NodeCalc> iterate(BinaryMaxCalc nodeCalc, A arg);
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcVisitor.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/NodeCalcVisitor.java
@@ -52,4 +52,8 @@ public interface NodeCalcVisitor<R, A> {
     R visit(TimeSeriesNameNodeCalc nodeCalc, A arg);
 
     R visit(TimeSeriesNumNodeCalc nodeCalc, A arg);
+
+    R visit(BinaryMinCalc nodeCalc, A arg, R left, R right);
+
+    Pair<NodeCalc, NodeCalc> iterate(BinaryMinCalc nodeCalc, A arg);
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeNodeCalc.java
@@ -65,17 +65,18 @@ public class TimeNodeCalc extends AbstractSingleChildNodeCalc {
         NodeCalc child = null;
         JsonToken token;
         while ((token = parser.nextToken()) != null) {
-            if (token == JsonToken.START_OBJECT) {
-                // skip
-            } else if (token == JsonToken.END_OBJECT) {
-                if (child == null) {
-                    throw new TimeSeriesException("Invalid time node calc JSON");
+            switch (token) {
+                case START_OBJECT -> {
+                    // Do nothing
                 }
-                return new TimeNodeCalc(child);
-            } else if (token == JsonToken.FIELD_NAME) {
-                child = NodeCalc.parseJson(parser, token);
-            } else {
-                throw NodeCalc.createUnexpectedToken(token);
+                case END_OBJECT -> {
+                    if (child == null) {
+                        throw new TimeSeriesException("Invalid time node calc JSON");
+                    }
+                    return new TimeNodeCalc(child);
+                }
+                case FIELD_NAME -> child = NodeCalc.parseJson(parser, token);
+                default -> throw NodeCalc.createUnexpectedToken(token);
             }
         }
         throw NodeCalc.createUnexpectedToken(token);

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeSeriesNameNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/TimeSeriesNameNodeCalc.java
@@ -53,8 +53,8 @@ public class TimeSeriesNameNodeCalc implements NodeCalc {
     }
 
     static NodeCalc parseJson(JsonParser parser) throws IOException {
-        JsonToken token;
-        while ((token = parser.nextToken()) != null) {
+        JsonToken token = parser.nextToken();
+        if (token != null) {
             if (token == JsonToken.VALUE_STRING) {
                 return new TimeSeriesNameNodeCalc(parser.getValueAsString());
             } else {

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/UnaryOperation.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/UnaryOperation.java
@@ -120,17 +120,18 @@ public class UnaryOperation extends AbstractSingleChildNodeCalc {
         ParsingContext context = new ParsingContext();
         JsonToken token;
         while ((token = parser.nextToken()) != null) {
-            if (token == JsonToken.START_OBJECT) {
-                // skip
-            } else if (token == JsonToken.END_OBJECT) {
-                if (context.child == null || context.operator == null) {
-                    throw new TimeSeriesException("Invalid unary operation node calc JSON");
+            switch (token) {
+                case START_OBJECT -> {
+                    // Do nothing
                 }
-                return new UnaryOperation(context.child, context.operator);
-            } else if (token == JsonToken.FIELD_NAME) {
-                parseFieldName(parser, token, context);
-            } else {
-                throw NodeCalc.createUnexpectedToken(token);
+                case END_OBJECT -> {
+                    if (context.child == null || context.operator == null) {
+                        throw new TimeSeriesException("Invalid unary operation node calc JSON");
+                    }
+                    return new UnaryOperation(context.child, context.operator);
+                }
+                case FIELD_NAME -> parseFieldName(parser, token, context);
+                default -> throw NodeCalc.createUnexpectedToken(token);
             }
         }
         throw NodeCalc.createUnexpectedToken(token);

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/NodeCalcEvaluatorAndPrintTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/NodeCalcEvaluatorAndPrintTest.java
@@ -126,4 +126,14 @@ class NodeCalcEvaluatorAndPrintTest {
         NodeCalc node = new MaxNodeCalc(new TimeSeriesNameNodeCalc("foo"), 2);
         assertEquals("timeSeries['foo'].max(2.0)", NodeCalcPrinter.print(node));
     }
+
+    @Test
+    void testBinaryMin() {
+        NodeCalc node = new BinaryMinCalc(new FloatNodeCalc(1f), new FloatNodeCalc(2f));
+        assertEquals(1f, NodeCalcEvaluator.eval(node, null), 0f);
+        assertEquals("1.0.min(2.0)", NodeCalcPrinter.print(node));
+
+        node = new BinaryMinCalc(new TimeSeriesNameNodeCalc("foo"), new FloatNodeCalc(2f));
+        assertEquals("timeSeries['foo'].min(2.0)", NodeCalcPrinter.print(node));
+    }
 }

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/NodeCalcEvaluatorAndPrintTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/NodeCalcEvaluatorAndPrintTest.java
@@ -131,9 +131,25 @@ class NodeCalcEvaluatorAndPrintTest {
     void testBinaryMin() {
         NodeCalc node = new BinaryMinCalc(new FloatNodeCalc(1f), new FloatNodeCalc(2f));
         assertEquals(1f, NodeCalcEvaluator.eval(node, null), 0f);
-        assertEquals("1.0.min(2.0)", NodeCalcPrinter.print(node));
+        assertEquals("min(1.0, 2.0)", NodeCalcPrinter.print(node));
 
         node = new BinaryMinCalc(new TimeSeriesNameNodeCalc("foo"), new FloatNodeCalc(2f));
-        assertEquals("timeSeries['foo'].min(2.0)", NodeCalcPrinter.print(node));
+        assertEquals("min(timeSeries['foo'], 2.0)", NodeCalcPrinter.print(node));
+
+        node = new BinaryMinCalc(new TimeSeriesNameNodeCalc("foo"), new TimeSeriesNameNodeCalc("bar"));
+        assertEquals("min(timeSeries['foo'], timeSeries['bar'])", NodeCalcPrinter.print(node));
+    }
+
+    @Test
+    void testBinaryMax() {
+        NodeCalc node = new BinaryMaxCalc(new FloatNodeCalc(1f), new FloatNodeCalc(2f));
+        assertEquals(2f, NodeCalcEvaluator.eval(node, null), 0f);
+        assertEquals("max(1.0, 2.0)", NodeCalcPrinter.print(node));
+
+        node = new BinaryMaxCalc(new TimeSeriesNameNodeCalc("foo"), new FloatNodeCalc(2f));
+        assertEquals("max(timeSeries['foo'], 2.0)", NodeCalcPrinter.print(node));
+
+        node = new BinaryMaxCalc(new TimeSeriesNameNodeCalc("foo"), new TimeSeriesNameNodeCalc("bar"));
+        assertEquals("max(timeSeries['foo'], timeSeries['bar'])", NodeCalcPrinter.print(node));
     }
 }

--- a/time-series/time-series-dsl/src/main/groovy/com/powsybl/timeseries/dsl/CalculatedTimeSeriesGroovyDslLoader.groovy
+++ b/time-series/time-series-dsl/src/main/groovy/com/powsybl/timeseries/dsl/CalculatedTimeSeriesGroovyDslLoader.groovy
@@ -107,6 +107,9 @@ class CalculatedTimeSeriesGroovyDslLoader implements CalculatedTimeSeriesDslLoad
         binding.time = { String str ->
             ZonedDateTime.parse(str).toInstant().toEpochMilli().toDouble()
         }
+        binding.min = { NodeCalc leftNode, NodeCalc rightNode ->
+            new BinaryMinCalc(leftNode, rightNode)
+        }
     }
 
     static CompilerConfiguration createCompilerConfig() {

--- a/time-series/time-series-dsl/src/main/groovy/com/powsybl/timeseries/dsl/CalculatedTimeSeriesGroovyDslLoader.groovy
+++ b/time-series/time-series-dsl/src/main/groovy/com/powsybl/timeseries/dsl/CalculatedTimeSeriesGroovyDslLoader.groovy
@@ -110,6 +110,9 @@ class CalculatedTimeSeriesGroovyDslLoader implements CalculatedTimeSeriesDslLoad
         binding.min = { NodeCalc leftNode, NodeCalc rightNode ->
             new BinaryMinCalc(leftNode, rightNode)
         }
+        binding.max = { NodeCalc leftNode, NodeCalc rightNode ->
+            new BinaryMaxCalc(leftNode, rightNode)
+        }
     }
 
     static CompilerConfiguration createCompilerConfig() {

--- a/time-series/time-series-dsl/src/main/groovy/com/powsybl/timeseries/dsl/NodeCalcGroovyExtensionModule.groovy
+++ b/time-series/time-series-dsl/src/main/groovy/com/powsybl/timeseries/dsl/NodeCalcGroovyExtensionModule.groovy
@@ -297,9 +297,4 @@ class NodeCalcGroovyExtensionModule {
     static NodeCalc max(NodeCalc self, BigDecimal value) {
         new MaxNodeCalc(self, value.doubleValue())
     }
-
-    // Binary min
-    static NodeCalc min(NodeCalc self, NodeCalc value) {
-        new BinaryMinCalc(self, value)
-    }
 }

--- a/time-series/time-series-dsl/src/main/groovy/com/powsybl/timeseries/dsl/NodeCalcGroovyExtensionModule.groovy
+++ b/time-series/time-series-dsl/src/main/groovy/com/powsybl/timeseries/dsl/NodeCalcGroovyExtensionModule.groovy
@@ -8,6 +8,7 @@ package com.powsybl.timeseries.dsl
 
 import com.powsybl.commons.PowsyblException
 import com.powsybl.timeseries.ast.BigDecimalNodeCalc
+import com.powsybl.timeseries.ast.BinaryMinCalc
 import com.powsybl.timeseries.ast.BinaryOperation
 import com.powsybl.timeseries.ast.DoubleNodeCalc
 import com.powsybl.timeseries.ast.FloatNodeCalc
@@ -295,5 +296,10 @@ class NodeCalcGroovyExtensionModule {
 
     static NodeCalc max(NodeCalc self, BigDecimal value) {
         new MaxNodeCalc(self, value.doubleValue())
+    }
+
+    // Binary min
+    static NodeCalc min(NodeCalc self, NodeCalc value) {
+        new BinaryMinCalc(self, value)
     }
 }

--- a/time-series/time-series-dsl/src/main/java/com/powsybl/timeseries/dsl/CalculatedTimeSeriesGroovyDslAstTransformation.java
+++ b/time-series/time-series-dsl/src/main/java/com/powsybl/timeseries/dsl/CalculatedTimeSeriesGroovyDslAstTransformation.java
@@ -37,20 +37,14 @@ public class CalculatedTimeSeriesGroovyDslAstTransformation extends AbstractPows
 
         private Expression transform(BinaryExpression binExpr) {
             String op = binExpr.getOperation().getText();
-            switch (op) {
-                case ">":
-                case ">=":
-                case "<":
-                case "<=":
-                case "==":
-                case "!=":
-                    return new MethodCallExpression(transform(binExpr.getLeftExpression()),
-                            "compareToNodeCalc",
-                            new ArgumentListExpression(transform(binExpr.getRightExpression()), new ConstantExpression(op)));
-                default:
-                    break;
-            }
-            return null;
+            return switch (op) {
+                case ">", ">=", "<", "<=", "==", "!=" ->
+                    new MethodCallExpression(transform(binExpr.getLeftExpression()),
+                        "compareToNodeCalc",
+                        new ArgumentListExpression(transform(binExpr.getRightExpression()), new ConstantExpression(op)));
+                default -> null;
+            };
+
         }
 
         @Override

--- a/time-series/time-series-dsl/src/test/java/com/powsybl/timeseries/dsl/CalculatedTimeSeriesGroovyDslTest.java
+++ b/time-series/time-series-dsl/src/test/java/com/powsybl/timeseries/dsl/CalculatedTimeSeriesGroovyDslTest.java
@@ -222,6 +222,8 @@ class CalculatedTimeSeriesGroovyDslTest {
         evaluate("timeSeries['foo'].max(5)", 5);
         evaluate("min(timeSeries['foo'], timeSeries['bar'])", 2f);
         evaluate("min(timeSeries['foo'], timeSeries['baz'])", new double[]{-1f, 3f});
+        evaluate("max(timeSeries['foo'], timeSeries['bar'])", 3f);
+        evaluate("max(timeSeries['foo'], timeSeries['baz'])", new double[]{3f, 4f});
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Using NodeCalc, it is only possible to get `timeseries["foo"].min(comparedValue)` the minimum between `comparedValue` and the values of the timeseries.

**What is the new behavior (if this is a feature change)?**
It is now possible to get the minimal value(s) between two timeseries using `min(timeseries["foo"], timeseries["bar"])` in a groovy script


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
