### PR TITLE
Network modification connect and disconnect

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Connectable.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Connectable.java
@@ -7,6 +7,7 @@
 package com.powsybl.iidm.network;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * An equipment that is part of a substation topology.
@@ -21,4 +22,8 @@ public interface Connectable<I extends Connectable<I>> extends Identifiable<I> {
      * Remove the connectable from the voltage level (dangling switches are kept).
      */
     void remove();
+
+    boolean connect(Predicate<Switch> isTypeSwitchToOperate);
+
+    boolean disconnect(Predicate<Switch> isSwitchOpenable);
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Connectable.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Connectable.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.iidm.network;
 
+import com.powsybl.commons.reporter.Reporter;
+
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -23,7 +25,19 @@ public interface Connectable<I extends Connectable<I>> extends Identifiable<I> {
      */
     void remove();
 
+    boolean connect();
+
     boolean connect(Predicate<Switch> isTypeSwitchToOperate);
 
+    boolean connect(Reporter reporter);
+
+    boolean connect(Predicate<Switch> isTypeSwitchToOperate, Reporter reporter);
+
+    boolean disconnect();
+
     boolean disconnect(Predicate<Switch> isSwitchOpenable);
+
+    boolean disconnect(Reporter reporter);
+
+    boolean disconnect(Predicate<Switch> isSwitchOpenable, Reporter reporter);
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -1197,12 +1197,27 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
      */
     @Override
     public boolean connect(TerminalExt terminal, Predicate<? super SwitchImpl> isSwitchOperable) {
-        if (!(terminal instanceof NodeTerminal)) {
-            throw new IllegalStateException(WRONG_TERMINAL_TYPE_EXCEPTION_MESSAGE + terminal.getClass().getName());
-        }
         // already connected?
         if (terminal.isConnected()) {
             return false;
+        }
+
+        // Initialisation of a list to open in case some terminals are in node-breaker view
+        Set<SwitchImpl> switchForDisconnection = new HashSet<>();
+
+        // Get the list of switches to close
+        if (getConnectingSwitches(terminal, isSwitchOperable, switchForDisconnection)) {
+            // Close the switches
+            switchForDisconnection.forEach(sw -> sw.setOpen(false));
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    boolean getConnectingSwitches(TerminalExt terminal, Predicate<? super SwitchImpl> isSwitchOperable, Set<SwitchImpl> switchForConnection) {
+        if (!(terminal instanceof NodeTerminal)) {
+            throw new IllegalStateException(WRONG_TERMINAL_TYPE_EXCEPTION_MESSAGE + terminal.getClass().getName());
         }
 
         int node = ((NodeTerminal) terminal).getNode();
@@ -1212,7 +1227,6 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         List<TIntArrayList> paths = graph.findAllPaths(node, NodeBreakerVoltageLevel::isBusbarSection, sw -> checkNonClosableSwitch(sw, isSwitchOperable),
             Comparator.comparing((TIntArrayList o) -> o.grep(idx -> SwitchPredicates.IS_OPEN.test(graph.getEdgeObject(idx))).size())
                 .thenComparing(TIntArrayList::size));
-        boolean connected = false;
         if (!paths.isEmpty()) {
             // the shortest path is the best
             TIntArrayList shortestPath = paths.get(0);
@@ -1223,13 +1237,12 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                 SwitchImpl sw = graph.getEdgeObject(e);
                 if (SwitchPredicates.IS_OPEN.test(sw)) {
                     // Since the paths were constructed using the method checkNonClosableSwitches, only operable switches can be open
-                    sw.setOpen(false);
+                    switchForConnection.add(sw);
                 }
             }
-            // Check that the terminal is connected (it should always be true, given how the paths are found)
-            connected = terminal.isConnected();
+            return true;
         }
-        return connected;
+        return false;
     }
 
     @Override
@@ -1248,6 +1261,28 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             return false;
         }
 
+        // Set of switches that are to be opened
+        Set<SwitchImpl> switchesToOpen = new HashSet<>();
+
+        // Get the list of switches to open
+        if (getDisconnectingSwitches(terminal, isSwitchOpenable, switchesToOpen)) {
+            // Open the switches
+            switchesToOpen.forEach(sw -> sw.setOpen(true));
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    boolean getDisconnectingSwitches(TerminalExt terminal, Predicate<? super SwitchImpl> isSwitchOpenable, Set<SwitchImpl> switchForDisconnection) {
+        if (!(terminal instanceof NodeTerminal)) {
+            throw new IllegalStateException(WRONG_TERMINAL_TYPE_EXCEPTION_MESSAGE + terminal.getClass().getName());
+        }
+        // already disconnected?
+        if (!terminal.isConnected()) {
+            return false;
+        }
+
         int node = ((NodeTerminal) terminal).getNode();
         // find all paths starting from the current terminal to a busbar section that does not contain an open switch
         List<TIntArrayList> paths = graph.findAllPaths(node, NodeBreakerVoltageLevel::isBusbarSection, SwitchPredicates.IS_OPEN);
@@ -1255,20 +1290,14 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             return false;
         }
 
-        // Set of switches that are to be opened
-        Set<SwitchImpl> switchesToOpen = new HashSet<>(paths.size());
-
         // Each path is visited and for each, the first openable switch found is added in the set of switches to open
         for (TIntArrayList path : paths) {
             // Identify the first openable switch on the path
-            if (!identifySwitchToOpenPath(path, isSwitchOpenable, switchesToOpen)) {
+            if (!identifySwitchToOpenPath(path, isSwitchOpenable, switchForDisconnection)) {
                 // If no such switch was found, return false immediately
                 return false;
             }
         }
-
-        // The switches are now opened
-        switchesToOpen.forEach(sw -> sw.setOpen(true));
         return true;
     }
 
@@ -1277,7 +1306,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
      * @param path the path to open
      * @param isSwitchOpenable predicate used to know if a switch can be opened
      * @param switchesToOpen set of switches to be opened
-     * @return true if the path has been opened, else false
+     * @return true if the path can be opened, else false
      */
     boolean identifySwitchToOpenPath(TIntArrayList path, Predicate<? super SwitchImpl> isSwitchOpenable, Set<SwitchImpl> switchesToOpen) {
         for (int i = 0; i < path.size(); i++) {

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/ConnectableTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/ConnectableTest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.powsybl.iidm.network.impl.tck;
+
+import com.powsybl.iidm.network.tck.AbstractConnectableTest;
+
+/**
+ * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
+ */
+class ConnectableTest extends AbstractConnectableTest {
+
+
+}

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/ConnectableTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/ConnectableTest.java
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 package com.powsybl.iidm.network.impl.tck;
 
 import com.powsybl.iidm.network.tck.AbstractConnectableTest;

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/ConnectableTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/ConnectableTest.java
@@ -13,6 +13,4 @@ import com.powsybl.iidm.network.tck.AbstractConnectableTest;
  * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
  */
 class ConnectableTest extends AbstractConnectableTest {
-
-
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractConnectableTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractConnectableTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.powsybl.iidm.network.tck;
+
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.extensions.BusbarSectionPositionAdder;
+
+/**
+ * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
+ */
+public class AbstractConnectableTest {
+
+    private Network createNetwork() {
+        Network network = Network.create("test", "test");
+        // Substations
+        Substation s1 = network.newSubstation()
+            .setId("S1")
+            .setCountry(Country.FR)
+            .add();
+        VoltageLevel vl = s1.newVoltageLevel()
+            .setId("VL1")
+            .setNominalV(1.0)
+            .setTopologyKind(TopologyKind.NODE_BREAKER)
+            .add();
+        VoltageLevel vl2 = s1.newVoltageLevel()
+            .setId("VL2")
+            .setNominalV(1.0)
+            .setTopologyKind(TopologyKind.BUS_BREAKER)
+            .add();
+
+        // Busbar sections
+        BusbarSection bbs11 = vl.getNodeBreakerView()
+            .newBusbarSection()
+            .setId("BBS11")
+            .setNode(0)
+            .add();
+        bbs11.newExtension(BusbarSectionPositionAdder.class)
+            .withBusbarIndex(1)
+            .withSectionIndex(1)
+            .add();
+        BusbarSection bbs21 = vl.getNodeBreakerView()
+            .newBusbarSection()
+            .setId("BBS21")
+            .setNode(1)
+            .add();
+        bbs21.newExtension(BusbarSectionPositionAdder.class)
+            .withBusbarIndex(2)
+            .withSectionIndex(1)
+            .add();
+        BusbarSection bbs12 = vl.getNodeBreakerView()
+            .newBusbarSection()
+            .setId("BBS12")
+            .setNode(2)
+            .add();
+        bbs12.newExtension(BusbarSectionPositionAdder.class)
+            .withBusbarIndex(1)
+            .withSectionIndex(2)
+            .add();
+        BusbarSection bbs22 = vl.getNodeBreakerView()
+            .newBusbarSection()
+            .setId("BBS22")
+            .setNode(3)
+            .add();
+        bbs22.newExtension(BusbarSectionPositionAdder.class)
+            .withBusbarIndex(2)
+            .withSectionIndex(2)
+            .add();
+        vl2.getBusBreakerView()
+            .newBus()
+            .setId("busB")
+            .add();
+
+        // Disconnectors for coupling
+        vl.getNodeBreakerView().newDisconnector()
+            .setId("D_BBS11_BBS12")
+            .setNode1(0)
+            .setNode2(2)
+            .setOpen(true)
+            .add();
+        vl.getNodeBreakerView().newDisconnector()
+            .setId("D_BBS21_BBS22")
+            .setNode1(1)
+            .setNode2(3)
+            .setOpen(false)
+            .add();
+
+        // Generators and loads
+        vl.newGenerator()
+            .setId("G1")
+            .setNode(5)
+            .setMaxP(100)
+            .setMinP(50)
+            .setTargetP(100)
+            .setTargetV(400)
+            .setVoltageRegulatorOn(true)
+            .add();
+        vl.newGenerator()
+            .setId("G2")
+            .setNode(6)
+            .setMaxP(100)
+            .setMinP(50)
+            .setTargetP(100)
+            .setTargetV(400)
+            .setVoltageRegulatorOn(true)
+            .add();
+        network.newLine()
+            .setId("L1")
+            .setName("LINE")
+            .setR(1.0)
+            .setX(2.0)
+            .setG1(3.0)
+            .setG2(3.5)
+            .setB1(4.0)
+            .setB2(4.5)
+            .setVoltageLevel1("vl")
+            .setVoltageLevel2("vl2")
+            .setNode1(4)
+            .setBus2("busB")
+            .setConnectableBus2("busB")
+            .add();
+
+        // Breakers
+        vl.getNodeBreakerView().newBreaker()
+            .setId("B_L1_1")
+            .setNode1(4)
+            .setNode2(7)
+            .setOpen(false)
+            .setFictitious(true)
+            .add();
+        vl.getNodeBreakerView().newBreaker()
+            .setId("B_L1_2")
+            .setNode1(4)
+            .setNode2(7)
+            .setOpen(false)
+            .add();
+        vl.getNodeBreakerView().newBreaker()
+            .setId("B_G1")
+            .setNode1(5)
+            .setNode2(8)
+            .setOpen(true)
+            .add();
+        vl.getNodeBreakerView().newBreaker()
+            .setId("B_G2")
+            .setNode1(6)
+            .setNode2(9)
+            .setOpen(false)
+            .setFictitious(true)
+            .add();
+        vl.getNodeBreakerView().newBreaker()
+            .setId("B0")
+            .setNode1(7)
+            .setNode2(17)
+            .setOpen(false)
+            .add();
+        vl.getNodeBreakerView().newBreaker()
+            .setId("B1")
+            .setNode1(8)
+            .setNode2(11)
+            .setOpen(true)
+            .add();
+        vl.getNodeBreakerView().newBreaker()
+            .setId("B2")
+            .setNode1(9)
+            .setNode2(12)
+            .setOpen(false)
+            .setFictitious(true)
+            .add();
+        vl.getNodeBreakerView().newBreaker()
+            .setId("B3")
+            .setNode1(7)
+            .setNode2(8)
+            .setOpen(false)
+            .add();
+        vl.getNodeBreakerView().newBreaker()
+            .setId("B4")
+            .setNode1(8)
+            .setNode2(9)
+            .setOpen(false)
+            .add();
+        vl.getNodeBreakerView().newBreaker()
+            .setId("B5")
+            .setNode1(17)
+            .setNode2(10)
+            .setOpen(false)
+            .add();
+
+        // Disconnectors
+        vl.getNodeBreakerView().newDisconnector()
+            .setId("D0")
+            .setNode1(0)
+            .setNode2(10)
+            .setOpen(true)
+            .add();
+        vl.getNodeBreakerView().newDisconnector()
+            .setId("D1")
+            .setNode1(1)
+            .setNode2(10)
+            .setOpen(false)
+            .add();
+        vl.getNodeBreakerView().newDisconnector()
+            .setId("D2")
+            .setNode1(0)
+            .setNode2(11)
+            .setOpen(false)
+            .add();
+        vl.getNodeBreakerView().newDisconnector()
+            .setId("D3")
+            .setNode1(1)
+            .setNode2(11)
+            .setOpen(true)
+            .add();
+        vl.getNodeBreakerView().newDisconnector()
+            .setId("D4")
+            .setNode1(2)
+            .setNode2(12)
+            .setOpen(false)
+            .add();
+        vl.getNodeBreakerView().newDisconnector()
+            .setId("D5")
+            .setNode1(3)
+            .setNode2(12)
+            .setOpen(true)
+            .add();
+        return network;
+    }
+}

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractConnectableTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractConnectableTest.java
@@ -8,22 +8,27 @@
 
 package com.powsybl.iidm.network.tck;
 
+import com.powsybl.commons.reporter.ReporterModel;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.BusbarSectionPositionAdder;
+import com.powsybl.iidm.network.util.SwitchPredicates;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
  */
-public class AbstractConnectableTest {
+public abstract class AbstractConnectableTest {
 
-    private Network createNetwork() {
+    public Network createNetwork() {
         Network network = Network.create("test", "test");
         // Substations
         Substation s1 = network.newSubstation()
             .setId("S1")
             .setCountry(Country.FR)
             .add();
-        VoltageLevel vl = s1.newVoltageLevel()
+        VoltageLevel vl1 = s1.newVoltageLevel()
             .setId("VL1")
             .setNominalV(1.0)
             .setTopologyKind(TopologyKind.NODE_BREAKER)
@@ -33,9 +38,14 @@ public class AbstractConnectableTest {
             .setNominalV(1.0)
             .setTopologyKind(TopologyKind.BUS_BREAKER)
             .add();
+        VoltageLevel vl3 = s1.newVoltageLevel()
+            .setId("VL3")
+            .setNominalV(1.0)
+            .setTopologyKind(TopologyKind.BUS_BREAKER)
+            .add();
 
         // Busbar sections
-        BusbarSection bbs11 = vl.getNodeBreakerView()
+        BusbarSection bbs11 = vl1.getNodeBreakerView()
             .newBusbarSection()
             .setId("BBS11")
             .setNode(0)
@@ -44,7 +54,7 @@ public class AbstractConnectableTest {
             .withBusbarIndex(1)
             .withSectionIndex(1)
             .add();
-        BusbarSection bbs21 = vl.getNodeBreakerView()
+        BusbarSection bbs21 = vl1.getNodeBreakerView()
             .newBusbarSection()
             .setId("BBS21")
             .setNode(1)
@@ -53,7 +63,7 @@ public class AbstractConnectableTest {
             .withBusbarIndex(2)
             .withSectionIndex(1)
             .add();
-        BusbarSection bbs12 = vl.getNodeBreakerView()
+        BusbarSection bbs12 = vl1.getNodeBreakerView()
             .newBusbarSection()
             .setId("BBS12")
             .setNode(2)
@@ -62,7 +72,7 @@ public class AbstractConnectableTest {
             .withBusbarIndex(1)
             .withSectionIndex(2)
             .add();
-        BusbarSection bbs22 = vl.getNodeBreakerView()
+        BusbarSection bbs22 = vl1.getNodeBreakerView()
             .newBusbarSection()
             .setId("BBS22")
             .setNode(3)
@@ -73,160 +83,295 @@ public class AbstractConnectableTest {
             .add();
         vl2.getBusBreakerView()
             .newBus()
-            .setId("busB")
+            .setId("bus2A")
+            .add();
+        vl2.getBusBreakerView()
+            .newBus()
+            .setId("bus2B")
+            .add();
+        vl3.getBusBreakerView()
+            .newBus()
+            .setId("bus3A")
+            .add();
+        vl3.getBusBreakerView()
+            .newBus()
+            .setId("bus3B")
             .add();
 
         // Disconnectors for coupling
-        vl.getNodeBreakerView().newDisconnector()
+        vl1.getNodeBreakerView().newDisconnector()
             .setId("D_BBS11_BBS12")
             .setNode1(0)
             .setNode2(2)
             .setOpen(true)
             .add();
-        vl.getNodeBreakerView().newDisconnector()
+        vl1.getNodeBreakerView().newDisconnector()
             .setId("D_BBS21_BBS22")
             .setNode1(1)
             .setNode2(3)
             .setOpen(false)
             .add();
 
-        // Generators and loads
-        vl.newGenerator()
-            .setId("G1")
-            .setNode(5)
-            .setMaxP(100)
-            .setMinP(50)
-            .setTargetP(100)
-            .setTargetV(400)
-            .setVoltageRegulatorOn(true)
-            .add();
-        vl.newGenerator()
-            .setId("G2")
-            .setNode(6)
-            .setMaxP(100)
-            .setMinP(50)
-            .setTargetP(100)
-            .setTargetV(400)
-            .setVoltageRegulatorOn(true)
-            .add();
+        // Line and transformer
         network.newLine()
             .setId("L1")
-            .setName("LINE")
+            .setName("LINE1")
             .setR(1.0)
             .setX(2.0)
             .setG1(3.0)
             .setG2(3.5)
             .setB1(4.0)
             .setB2(4.5)
-            .setVoltageLevel1("vl")
-            .setVoltageLevel2("vl2")
+            .setVoltageLevel1("VL1")
+            .setVoltageLevel2("VL2")
             .setNode1(4)
-            .setBus2("busB")
-            .setConnectableBus2("busB")
+            .setBus2("bus2A")
+            .setConnectableBus2("bus2A")
+            .add();
+        network.newLine()
+            .setId("L2")
+            .setName("LINE2")
+            .setR(1.0)
+            .setX(2.0)
+            .setG1(3.0)
+            .setG2(3.5)
+            .setB1(4.0)
+            .setB2(4.5)
+            .setVoltageLevel1("VL1")
+            .setVoltageLevel2("VL3")
+            .setNode1(5)
+            .setBus2("bus3A")
+            .setConnectableBus2("bus3A")
+            .add();
+        s1.newThreeWindingsTransformer()
+            .setId("twt")
+            .setName("TWT_NAME")
+            .newLeg1()
+            .setR(1.3)
+            .setX(1.4)
+            .setG(1.6)
+            .setB(1.7)
+            .setRatedU(1.1)
+            .setRatedS(1.2)
+            .setVoltageLevel("VL1")
+            .setNode(6)
+            .add()
+            .newLeg2()
+            .setR(2.03)
+            .setX(2.04)
+            .setG(0.0)
+            .setB(0.0)
+            .setRatedU(2.05)
+            .setRatedS(2.06)
+            .setVoltageLevel("VL2")
+            .setBus("bus2B")
+            .setConnectableBus("bus2B")
+            .add()
+            .newLeg3()
+            .setR(3.3)
+            .setX(3.4)
+            .setG(0.0)
+            .setB(0.0)
+            .setRatedU(3.5)
+            .setRatedS(3.6)
+            .setVoltageLevel("VL3")
+            .setBus("bus3B")
+            .setConnectableBus("bus3B")
+            .add()
             .add();
 
         // Breakers
-        vl.getNodeBreakerView().newBreaker()
+        vl1.getNodeBreakerView().newBreaker()
             .setId("B_L1_1")
             .setNode1(4)
             .setNode2(7)
             .setOpen(false)
             .setFictitious(true)
             .add();
-        vl.getNodeBreakerView().newBreaker()
+        vl1.getNodeBreakerView().newBreaker()
             .setId("B_L1_2")
             .setNode1(4)
             .setNode2(7)
             .setOpen(false)
             .add();
-        vl.getNodeBreakerView().newBreaker()
-            .setId("B_G1")
+        vl1.getNodeBreakerView().newBreaker()
+            .setId("B_L2")
             .setNode1(5)
             .setNode2(8)
             .setOpen(true)
-            .add();
-        vl.getNodeBreakerView().newBreaker()
-            .setId("B_G2")
-            .setNode1(6)
-            .setNode2(9)
-            .setOpen(false)
             .setFictitious(true)
             .add();
-        vl.getNodeBreakerView().newBreaker()
+        vl1.getNodeBreakerView().newBreaker()
+            .setId("B_TWT")
+            .setNode1(6)
+            .setNode2(9)
+            .setOpen(true)
+            .setFictitious(true)
+            .add();
+        vl1.getNodeBreakerView().newBreaker()
             .setId("B0")
             .setNode1(7)
             .setNode2(17)
             .setOpen(false)
+            .setFictitious(true)
             .add();
-        vl.getNodeBreakerView().newBreaker()
+        vl1.getNodeBreakerView().newBreaker()
             .setId("B1")
             .setNode1(8)
             .setNode2(11)
             .setOpen(true)
             .add();
-        vl.getNodeBreakerView().newBreaker()
+        vl1.getNodeBreakerView().newBreaker()
             .setId("B2")
             .setNode1(9)
             .setNode2(12)
             .setOpen(false)
             .setFictitious(true)
             .add();
-        vl.getNodeBreakerView().newBreaker()
+        vl1.getNodeBreakerView().newBreaker()
             .setId("B3")
             .setNode1(7)
             .setNode2(8)
             .setOpen(false)
             .add();
-        vl.getNodeBreakerView().newBreaker()
+        vl1.getNodeBreakerView().newBreaker()
             .setId("B4")
             .setNode1(8)
             .setNode2(9)
             .setOpen(false)
             .add();
-        vl.getNodeBreakerView().newBreaker()
+        vl1.getNodeBreakerView().newBreaker()
             .setId("B5")
             .setNode1(17)
             .setNode2(10)
             .setOpen(false)
+            .setFictitious(true)
             .add();
 
         // Disconnectors
-        vl.getNodeBreakerView().newDisconnector()
+        vl1.getNodeBreakerView().newDisconnector()
             .setId("D0")
             .setNode1(0)
             .setNode2(10)
             .setOpen(true)
             .add();
-        vl.getNodeBreakerView().newDisconnector()
+        vl1.getNodeBreakerView().newDisconnector()
             .setId("D1")
             .setNode1(1)
             .setNode2(10)
             .setOpen(false)
             .add();
-        vl.getNodeBreakerView().newDisconnector()
+        vl1.getNodeBreakerView().newDisconnector()
             .setId("D2")
             .setNode1(0)
             .setNode2(11)
             .setOpen(false)
             .add();
-        vl.getNodeBreakerView().newDisconnector()
+        vl1.getNodeBreakerView().newDisconnector()
             .setId("D3")
             .setNode1(1)
             .setNode2(11)
             .setOpen(true)
             .add();
-        vl.getNodeBreakerView().newDisconnector()
+        vl1.getNodeBreakerView().newDisconnector()
             .setId("D4")
             .setNode1(2)
             .setNode2(12)
             .setOpen(false)
             .add();
-        vl.getNodeBreakerView().newDisconnector()
+        vl1.getNodeBreakerView().newDisconnector()
             .setId("D5")
             .setNode1(3)
             .setNode2(12)
             .setOpen(true)
             .add();
         return network;
+    }
+
+    @Test
+    public void nominallyConnectedTest() {
+        // Network creation
+        Network network = createNetwork();
+
+        // Useful elements
+        VoltageLevel.NodeBreakerView topo = network.getVoltageLevel("VL1").getNodeBreakerView();
+        Line line1 = network.getLine("L1");
+
+        // Line1 is fully connected
+        assertTrue(topo.getOptionalTerminal(4).isPresent());
+        line1.getTerminals().forEach(terminal -> assertNotNull(terminal.getBusView().getBus()));
+        line1.getTerminals().forEach(terminal -> assertTrue(terminal.isConnected()));
+
+        // Failing disconnection
+        assertFalse(line1.disconnect(SwitchPredicates.IS_NONFICTIONAL_CLOSED_BREAKER));
+
+        // disconnect the line 1
+        assertTrue(line1.disconnect());
+
+        // check line 1 is disconnected
+        assertTrue(topo.getOptionalTerminal(4).isPresent());
+        line1.getTerminals().forEach(terminal -> assertNull(terminal.getBusView().getBus()));
+        line1.getTerminals().forEach(terminal -> assertFalse(terminal.isConnected()));
+
+        // disconnect the already fully disconnected line 1
+        ReporterModel reporter = new ReporterModel("reportTest", "Testing reporter");
+        assertFalse(line1.disconnect(reporter));
+        assertEquals("alreadyDisconnectedTerminal", reporter.getReports().iterator().next().getReportKey());
+
+        // Reconnect the line 1
+        assertTrue(line1.connect());
+
+        // check line 1 is connected
+        assertTrue(topo.getOptionalTerminal(5).isPresent());
+        line1.getTerminals().forEach(terminal -> assertNotNull(terminal.getBusView().getBus()));
+        line1.getTerminals().forEach(terminal -> assertTrue(terminal.isConnected()));
+    }
+
+    @Test
+    public void partiallyConnectedTest() {
+        // Network creation
+        Network network = createNetwork();
+
+        // Useful elements
+        VoltageLevel.NodeBreakerView topo = network.getVoltageLevel("VL1").getNodeBreakerView();
+        Line line2 = network.getLine("L2");
+        ThreeWindingsTransformer twt = network.getThreeWindingsTransformer("twt");
+
+        // Line1 and twt are fully connected
+        assertTrue(topo.getOptionalTerminal(5).isPresent());
+        assertTrue(topo.getOptionalTerminal(6).isPresent());
+        assertNotNull(line2.getTerminals().get(1).getBusView().getBus());
+        assertNull(twt.getTerminals().get(0).getBusView().getBus());
+        assertNotNull(twt.getTerminals().get(1).getBusView().getBus());
+        assertNotNull(twt.getTerminals().get(2).getBusView().getBus());
+        assertFalse(line2.getTerminals().get(0).isConnected());
+        assertTrue(line2.getTerminals().get(1).isConnected());
+        assertFalse(twt.getTerminals().get(0).isConnected());
+        assertTrue(twt.getTerminals().get(1).isConnected());
+        assertTrue(twt.getTerminals().get(2).isConnected());
+
+        // Failing connection
+        assertFalse(line2.connect(SwitchPredicates.IS_NONFICTIONAL_BREAKER));
+
+        // connect the line 2
+        assertTrue(line2.connect(SwitchPredicates.IS_BREAKER_OR_DISCONNECTOR));
+
+        // check line 2 is connected
+        assertTrue(topo.getOptionalTerminal(5).isPresent());
+        line2.getTerminals().forEach(terminal -> assertNotNull(terminal.getBusView().getBus()));
+        line2.getTerminals().forEach(terminal -> assertTrue(terminal.isConnected()));
+
+        // connect the already fully connected line 2
+        ReporterModel reporter = new ReporterModel("reportTest", "Testing reporter");
+        assertFalse(line2.connect(reporter));
+        assertEquals("alreadyConnectedTerminal", reporter.getReports().iterator().next().getReportKey());
+
+        // Disconnect the twt
+        assertTrue(twt.disconnect(SwitchPredicates.IS_CLOSED_BREAKER));
+
+        // check twt is disconnected
+        assertTrue(topo.getOptionalTerminal(6).isPresent());
+        twt.getTerminals().forEach(terminal -> assertNull(terminal.getBusView().getBus()));
+        twt.getTerminals().forEach(terminal -> assertFalse(terminal.isConnected()));
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractConnectableTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractConnectableTest.java
@@ -5,7 +5,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * SPDX-License-Identifier: MPL-2.0
  */
-
 package com.powsybl.iidm.network.tck;
 
 import com.powsybl.commons.reporter.ReporterModel;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When connecting/disconnecting a terminal, you get a confirmation boolean after the modification is done, which means that if you try to disconnect a connectable with 2 terminals, you will disconnect the first then the second. The problem is that if the 2nd disconnection fails, the first is still done so you have a connectable half-way disconnected

**What is the new behavior (if this is a feature change)?**
By using the connect/disconnect methods from the connectable class, you will connect/disconnect the different terminals if and only if all the terminals can be connected/disconnected.
If some terminals were already connected/disconnected, it will still work and the other terminals will be connected/disconnected.
If all the terminals were already connected/disconnected, it will fail and return false

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
