### PR TITLE
Fix sparse matrix construction from CSC arrays

### DIFF
--- a/math/src/main/java/com/powsybl/math/matrix/SparseMatrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/SparseMatrix.java
@@ -96,14 +96,22 @@ public class SparseMatrix extends AbstractMatrix {
      * @param rowIndices row indices vector
      * @param values value vector
      */
-    SparseMatrix(int rowCount, int columnCount, int[] columnStart, int[] rowIndices, double[] values) {
+    public SparseMatrix(int rowCount, int columnCount, int[] columnStart, int[] rowIndices, double[] values) {
+        checkSize(rowCount, columnCount);
         this.rowCount = rowCount;
         this.columnCount = columnCount;
         this.columnStart = Objects.requireNonNull(columnStart);
+        if (columnStart.length != columnCount + 1) {
+            throw new IllegalArgumentException("columnStart array length has to be columnCount + 1");
+        }
         columnValueCount = new int[columnCount];
         this.rowIndices = new TIntArrayListHack(Objects.requireNonNull(rowIndices));
         this.values = new TDoubleArrayListHack(Objects.requireNonNull(values));
+        if (rowIndices.length != values.length) {
+            throw new IllegalArgumentException("rowIndices and values arrays must have the same length");
+        }
         fillColumnValueCount(this.columnCount, this.columnStart, columnValueCount, this.values);
+        currentColumn = columnCount - 1;
     }
 
     private static void fillColumnValueCount(int columnCount, int[] columnStart, int[] columnValueCount, TDoubleArrayListHack values) {
@@ -129,12 +137,7 @@ public class SparseMatrix extends AbstractMatrix {
      * @param estimatedValueCount estimated number of values (used for internal pre-allocation)
      */
     SparseMatrix(int rowCount, int columnCount, int estimatedValueCount) {
-        if (rowCount < 0) {
-            throw new MatrixException("row count has to be positive");
-        }
-        if (columnCount < 0) {
-            throw new MatrixException("column count has to be positive");
-        }
+        checkSize(rowCount, columnCount);
         this.rowCount = rowCount;
         this.columnCount = columnCount;
         columnStart = new int[columnCount + 1];
@@ -143,6 +146,15 @@ public class SparseMatrix extends AbstractMatrix {
         this.columnStart[columnCount] = 0;
         rowIndices = new TIntArrayListHack(estimatedValueCount);
         values = new TDoubleArrayListHack(estimatedValueCount);
+    }
+
+    private static void checkSize(int rowCount, int columnCount) {
+        if (rowCount < 1) {
+            throw new MatrixException("row count has to be strictly positive");
+        }
+        if (columnCount < 1) {
+            throw new MatrixException("column count has to be strictly positive");
+        }
     }
 
     public double getRgrowthThreshold() {

--- a/math/src/main/java/com/powsybl/math/matrix/SparseMatrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/SparseMatrix.java
@@ -102,13 +102,13 @@ public class SparseMatrix extends AbstractMatrix {
         this.columnCount = columnCount;
         this.columnStart = Objects.requireNonNull(columnStart);
         if (columnStart.length != columnCount + 1) {
-            throw new IllegalArgumentException("columnStart array length has to be columnCount + 1");
+            throw new MatrixException("columnStart array length has to be columnCount + 1");
         }
         columnValueCount = new int[columnCount];
         this.rowIndices = new TIntArrayListHack(Objects.requireNonNull(rowIndices));
         this.values = new TDoubleArrayListHack(Objects.requireNonNull(values));
         if (rowIndices.length != values.length) {
-            throw new IllegalArgumentException("rowIndices and values arrays must have the same length");
+            throw new MatrixException("rowIndices and values arrays must have the same length");
         }
         fillColumnValueCount(this.columnCount, this.columnStart, columnValueCount, this.values);
         currentColumn = columnCount - 1;

--- a/math/src/test/java/com/powsybl/math/matrix/SparseMatrixTest.java
+++ b/math/src/test/java/com/powsybl/math/matrix/SparseMatrixTest.java
@@ -105,4 +105,12 @@ class SparseMatrixTest extends AbstractMatrixTest {
             assertArrayEquals(new double[] {0, 1}, x);
         }
     }
+
+    @Test
+    void testFromArrayConstructorErrors() {
+        MatrixException e = assertThrows(MatrixException.class, () -> new SparseMatrix(2, 2, new int[]{0, 1}, new int[]{0, 1}, new double[]{0.5, 0.3}));
+        assertEquals("columnStart array length has to be columnCount + 1", e.getMessage());
+        e = assertThrows(MatrixException.class, () -> new SparseMatrix(2, 2, new int[]{0, 1, 1}, new int[]{0, 1, 1}, new double[]{0.5, 0.3}));
+        assertEquals("rowIndices and values arrays must have the same length", e.getMessage());
+    }
 }

--- a/math/src/test/java/com/powsybl/math/matrix/SparseMatrixTest.java
+++ b/math/src/test/java/com/powsybl/math/matrix/SparseMatrixTest.java
@@ -86,4 +86,23 @@ class SparseMatrixTest extends AbstractMatrixTest {
             assertThrows(MatrixException.class, decomposition::update);
         }
     }
+
+    @Test
+    void initFromArrayIssue() {
+        SparseMatrix a = new SparseMatrix(2, 2, 2);
+        a.add(0, 0, 1d);
+        a.add(1, 0, 1d);
+        a.add(0, 1, 1d);
+        try (LUDecomposition decomposition = a.decomposeLU()) {
+            double[] x = new double[] {1, 0};
+            decomposition.solve(x);
+            assertArrayEquals(new double[] {0, 1}, x);
+        }
+        SparseMatrix m = new SparseMatrix(a.getRowCount(), a.getColumnCount(), a.getColumnStart(), a.getRowIndices(), a.getValues());
+        try (LUDecomposition decomposition = m.decomposeLU()) {
+            double[] x = new double[] {1, 0};
+            decomposition.solve(x);
+            assertArrayEquals(new double[] {0, 1}, x);
+        }
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
https://github.com/powsybl/powsybl-math-native/issues/37


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Once `SparseMatrix` has been contructed from array, we cannot anymore add new values or run a decomposition. 


**What is the new behavior (if this is a feature change)?**
Once `SparseMatrix` has been contructed from array, it is now possible to add new values or run a decomposition. 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
