### PR TITLE
Add CGMES model ID to reporter

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -116,6 +116,7 @@ public final class CgmesExportUtil {
         modelDescription.setIds(modelId);
         context.updateDependencies();
         writer.writeAttribute(RDF_NAMESPACE, CgmesNames.ABOUT, modelId);
+        context.getReporter().report("CgmesId", modelId);
         writer.writeStartElement(MD_NAMESPACE, CgmesNames.SCENARIO_TIME);
         writer.writeCharacters(DATE_TIME_FORMATTER.format(context.getScenarioTime()));
         writer.writeEndElement();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
This PR adds the CGMES file ID to the reporter, enabling their retrieval at a later time.


**What is the current behavior?**
Currently, there is no straightforward method to retrieve CGMES file IDs after their generation.



**What is the new behavior (if this is a feature change)?**
The reporter now stores the IDs of the SSH and TP files. These IDs can be accessed post file generation.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

