### PR TITLE
Fix secondary voltage control notifications

### DIFF
--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ControlUnit.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ControlUnit.java
@@ -12,6 +12,9 @@ package com.powsybl.iidm.network.extensions;
  */
 public interface ControlUnit {
 
+    record ParticipateEvent(String controlZoneName, String controlUnitId, boolean value) {
+    }
+
     String getId();
 
     boolean isParticipate();

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/PilotPoint.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/PilotPoint.java
@@ -14,6 +14,9 @@ import java.util.List;
  */
 public interface PilotPoint {
 
+    record TargetVoltageEvent(String controlZoneName, double value) {
+    }
+
     /**
      * Get pilot point busbar section ID or bus ID of the bus/breaker view.
      */

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/SecondaryVoltageControl.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/SecondaryVoltageControl.java
@@ -11,6 +11,7 @@ import com.powsybl.commons.extensions.Extension;
 import com.powsybl.iidm.network.Network;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -20,6 +21,8 @@ public interface SecondaryVoltageControl extends Extension<Network> {
     String NAME = "secondaryVoltageControl";
 
     List<ControlZone> getControlZones();
+
+    Optional<ControlZone> getControlZone(String name);
 
     @Override
     default String getName() {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ControlUnitImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ControlUnitImpl.java
@@ -48,7 +48,8 @@ class ControlUnitImpl implements ControlUnit {
             this.participate = participate;
             SecondaryVoltageControlImpl secondaryVoltageControl = controlZone.getSecondaryVoltageControl();
             NetworkImpl network = (NetworkImpl) secondaryVoltageControl.getExtendable();
-            network.getListeners().notifyExtensionUpdate(secondaryVoltageControl, "controlUnitParticipate", !this.participate, this.participate);
+            network.getListeners().notifyExtensionUpdate(secondaryVoltageControl, "controlUnitParticipate",
+                    new ParticipateEvent(controlZone.getName(), id, !this.participate), new ParticipateEvent(controlZone.getName(), id, this.participate));
         }
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/PilotPointImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/PilotPointImpl.java
@@ -58,7 +58,8 @@ class PilotPointImpl implements PilotPoint {
             this.targetV = targetV;
             SecondaryVoltageControlImpl secondaryVoltageControl = controlZone.getSecondaryVoltageControl();
             NetworkImpl network = (NetworkImpl) secondaryVoltageControl.getExtendable();
-            network.getListeners().notifyExtensionUpdate(secondaryVoltageControl, "pilotPointTargetV", oldTargetV, targetV);
+            network.getListeners().notifyExtensionUpdate(secondaryVoltageControl, "pilotPointTargetV",
+                    new TargetVoltageEvent(controlZone.getName(), oldTargetV), new TargetVoltageEvent(controlZone.getName(), targetV));
         }
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/SecondaryVoltageControlImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/SecondaryVoltageControlImpl.java
@@ -15,6 +15,7 @@ import com.powsybl.iidm.network.extensions.SecondaryVoltageControl;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -31,5 +32,11 @@ public class SecondaryVoltageControlImpl extends AbstractExtension<Network> impl
     @Override
     public List<ControlZone> getControlZones() {
         return Collections.unmodifiableList(controlZones);
+    }
+
+    @Override
+    public Optional<ControlZone> getControlZone(String name) {
+        Objects.requireNonNull(name);
+        return controlZones.stream().filter(z -> z.getName().equals(name)).findFirst();
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractSecondaryVoltageControlTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractSecondaryVoltageControlTest.java
@@ -11,10 +11,7 @@ import com.powsybl.commons.extensions.Extension;
 import com.powsybl.iidm.network.DefaultNetworkListener;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.extensions.ControlUnit;
-import com.powsybl.iidm.network.extensions.ControlZone;
-import com.powsybl.iidm.network.extensions.SecondaryVoltageControl;
-import com.powsybl.iidm.network.extensions.SecondaryVoltageControlAdder;
+import com.powsybl.iidm.network.extensions.*;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,6 +54,7 @@ public abstract class AbstractSecondaryVoltageControlTest {
     @Test
     void test() throws IOException {
         assertEquals(1, control.getControlZones().size());
+        assertTrue(control.getControlZone("z1").isPresent());
         ControlZone z1 = control.getControlZones().get(0);
         assertEquals("z1", z1.getName());
         assertNotNull(z1.getPilotPoint());
@@ -79,8 +77,8 @@ public abstract class AbstractSecondaryVoltageControlTest {
             public void onExtensionUpdate(Extension<?> extendable, String attribute, Object oldValue, Object newValue) {
                 assertInstanceOf(SecondaryVoltageControl.class, extendable);
                 assertEquals("pilotPointTargetV", attribute);
-                assertEquals(15d, (double) oldValue, 0d);
-                assertEquals(16d, (double) newValue, 0d);
+                assertEquals(new PilotPoint.TargetVoltageEvent("z1", 15d), oldValue);
+                assertEquals(new PilotPoint.TargetVoltageEvent("z1", 16d), newValue);
                 updated[0] = true;
             }
         });
@@ -98,8 +96,8 @@ public abstract class AbstractSecondaryVoltageControlTest {
             public void onExtensionUpdate(Extension<?> extendable, String attribute, Object oldValue, Object newValue) {
                 assertInstanceOf(SecondaryVoltageControl.class, extendable);
                 assertEquals("controlUnitParticipate", attribute);
-                assertFalse((boolean) oldValue);
-                assertTrue((boolean) newValue);
+                assertEquals(new ControlUnit.ParticipateEvent("z1", "GEN", false), oldValue);
+                assertEquals(new ControlUnit.ParticipateEvent("z1", "GEN", true), newValue);
                 updated[0] = true;
             }
         });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
We do not have enough information in secondary voltage notifications.


**What is the new behavior (if this is a feature change)?**
We can now known what is the control zone name and control unit emitting the notification 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
