### PR TITLE
Secondary voltage control: add convenient method

### DIFF
--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ControlZone.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ControlZone.java
@@ -8,6 +8,7 @@
 package com.powsybl.iidm.network.extensions;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -19,4 +20,6 @@ public interface ControlZone {
     PilotPoint getPilotPoint();
 
     List<ControlUnit> getControlUnits();
+
+    Optional<ControlUnit> getControlUnit(String id);
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ControlZoneImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ControlZoneImpl.java
@@ -14,6 +14,7 @@ import com.powsybl.iidm.network.extensions.PilotPoint;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -55,5 +56,11 @@ class ControlZoneImpl implements ControlZone {
     @Override
     public List<ControlUnit> getControlUnits() {
         return Collections.unmodifiableList(controlUnits);
+    }
+
+    @Override
+    public Optional<ControlUnit> getControlUnit(String id) {
+        Objects.requireNonNull(id);
+        return controlUnits.stream().filter(u -> u.getId().equals(id)).findFirst();
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractSecondaryVoltageControlTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractSecondaryVoltageControlTest.java
@@ -67,6 +67,7 @@ public abstract class AbstractSecondaryVoltageControlTest {
         assertTrue(z1.getControlUnits().get(1).isParticipate());
         z1.getPilotPoint().setTargetV(16);
         assertEquals(16d, z1.getPilotPoint().getTargetV(), 0d);
+        assertTrue(z1.getControlUnit("GEN").isPresent());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
To access to a `ControlUnit` of a `ControlZone` from its id, you need to loop on every `ControlUnit` of the result of `ControlZone.getControlUnits()`.


**What is the new behavior (if this is a feature change)?**
A convenient method `ControlZone.getControlUnit(String id)` allows a direct access.


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes, but the `ControlZone` class is not yet released (see #2852)
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

No need for the breaking change label since the modified class is not yet released.

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
