### PR TITLE
Fix deserialization bug in skipped extensions

### DIFF
--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
@@ -784,17 +784,17 @@ public final class NetworkSerDe {
             // extensions root elements are nested directly in 'extension' element, so there is no need
             // to check for an extension to exist if depth is greater than zero. Furthermore in case of
             // missing extension serializer, we must not check for an extension in sub elements.
-            if (!context.getOptions().withExtension(extensionName)) {
-                context.getReader().skipChildNodes();
-            }
-
-            ExtensionSerDe extensionXmlSerializer = EXTENSIONS_SUPPLIER.get().findProvider(extensionName);
-            if (extensionXmlSerializer != null) {
-                Extension<? extends Identifiable<?>> extension = extensionXmlSerializer.read(identifiable, context);
-                identifiable.addExtension(extensionXmlSerializer.getExtensionClass(), extension);
-                extensionNamesImported.add(extensionName);
+            if (context.getOptions().withExtension(extensionName)) {
+                ExtensionSerDe extensionXmlSerializer = EXTENSIONS_SUPPLIER.get().findProvider(extensionName);
+                if (extensionXmlSerializer != null) {
+                    Extension<? extends Identifiable<?>> extension = extensionXmlSerializer.read(identifiable, context);
+                    identifiable.addExtension(extensionXmlSerializer.getExtensionClass(), extension);
+                    extensionNamesImported.add(extensionName);
+                } else {
+                    extensionNamesNotFound.add(extensionName);
+                    context.getReader().skipChildNodes();
+                }
             } else {
-                extensionNamesNotFound.add(extensionName);
                 context.getReader().skipChildNodes();
             }
         });

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
@@ -13,6 +13,7 @@ import com.powsybl.commons.extensions.ExtensionSerDe;
 import com.powsybl.commons.io.DeserializerContext;
 import com.powsybl.commons.io.SerializerContext;
 import com.powsybl.commons.reporter.ReporterModel;
+import com.powsybl.commons.test.TestUtil;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.*;
 import com.powsybl.iidm.serde.extensions.util.NetworkSourceExtension;
@@ -66,7 +67,7 @@ class NetworkSerDeTest extends AbstractIidmSerDeTest {
                      Extension terminalMock imported.
                   + Not found extensions
                      Extension terminalMockNoSerDe not found.
-                """, sw1.toString());
+                """, TestUtil.normalizeLineSeparator(sw1.toString()));
 
         // Read file with only terminalMockNoSerDe extension included
         ReporterModel reporter2 = new ReporterModel("root", "Root reporter");
@@ -83,7 +84,7 @@ class NetworkSerDeTest extends AbstractIidmSerDeTest {
                   + Validation warnings
                   + Not found extensions
                      Extension terminalMockNoSerDe not found.
-                """, sw2.toString());
+                """, TestUtil.normalizeLineSeparator(sw2.toString()));
     }
 
     @Test

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
@@ -12,16 +12,14 @@ import com.powsybl.commons.extensions.AbstractExtensionSerDe;
 import com.powsybl.commons.extensions.ExtensionSerDe;
 import com.powsybl.commons.io.DeserializerContext;
 import com.powsybl.commons.io.SerializerContext;
+import com.powsybl.commons.reporter.ReporterModel;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.*;
 import com.powsybl.iidm.serde.extensions.util.NetworkSourceExtension;
 import com.powsybl.iidm.serde.extensions.util.NetworkSourceExtensionImpl;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -48,6 +46,44 @@ class NetworkSerDeTest extends AbstractIidmSerDeTest {
 
         // backward compatibility
         allFormatsRoundTripAllPreviousVersionedXmlTest("eurostag-tutorial-example1.xml");
+    }
+
+    @Test
+    void testSkippedExtension() throws IOException {
+        // Read file with all extensions included (default ImportOptions)
+        ReporterModel reporter1 = new ReporterModel("root", "Root reporter");
+        Network networkReadExtensions = NetworkSerDe.read(getNetworkAsStream("/skippedExtensions.xml"),
+                new ImportOptions(), null, NetworkFactory.findDefault(), reporter1);
+        Load load1 = networkReadExtensions.getLoad("LOAD");
+        assertNotNull(load1.getExtension(TerminalMockExt.class));
+
+        StringWriter sw1 = new StringWriter();
+        reporter1.export(sw1);
+        assertEquals("""
+                + Root reporter
+                  + Validation warnings
+                  + Imported extensions
+                     Extension terminalMock imported.
+                  + Not found extensions
+                     Extension terminalMockNoSerDe not found.
+                """, sw1.toString());
+
+        // Read file with only terminalMockNoSerDe extension included
+        ReporterModel reporter2 = new ReporterModel("root", "Root reporter");
+        ImportOptions noExtensions = new ImportOptions().addExtension("terminalMockNoSerDe");
+        Network networkSkippedExtensions = NetworkSerDe.read(getNetworkAsStream("/skippedExtensions.xml"),
+                noExtensions, null, NetworkFactory.findDefault(), reporter2);
+        Load load2 = networkSkippedExtensions.getLoad("LOAD");
+        assertNull(load2.getExtension(TerminalMockExt.class));
+
+        StringWriter sw2 = new StringWriter();
+        reporter2.export(sw2);
+        assertEquals("""
+                + Root reporter
+                  + Validation warnings
+                  + Not found extensions
+                     Extension terminalMockNoSerDe not found.
+                """, sw2.toString());
     }
 
     @Test

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
@@ -50,13 +50,14 @@ class NetworkSerDeTest extends AbstractIidmSerDeTest {
     }
 
     @Test
-    void testSkippedExtension() throws IOException {
+    void testSkippedExtension() {
         // Read file with all extensions included (default ImportOptions)
         ReporterModel reporter1 = new ReporterModel("root", "Root reporter");
         Network networkReadExtensions = NetworkSerDe.read(getNetworkAsStream("/skippedExtensions.xml"),
                 new ImportOptions(), null, NetworkFactory.findDefault(), reporter1);
         Load load1 = networkReadExtensions.getLoad("LOAD");
-        assertNotNull(load1.getExtension(TerminalMockExt.class));
+        assertNotNull(load1.getExtension(LoadBarExt.class));
+        assertNotNull(load1.getExtension(LoadZipModel.class));
 
         StringWriter sw1 = new StringWriter();
         reporter1.export(sw1);
@@ -64,24 +65,30 @@ class NetworkSerDeTest extends AbstractIidmSerDeTest {
                 + Root reporter
                   + Validation warnings
                   + Imported extensions
-                     Extension terminalMock imported.
+                     Extension loadBar imported.
+                     Extension loadZipModel imported.
                   + Not found extensions
                      Extension terminalMockNoSerDe not found.
                 """, TestUtil.normalizeLineSeparator(sw1.toString()));
 
-        // Read file with only terminalMockNoSerDe extension included
+        // Read file with only terminalMockNoSerDe and loadZipModel extensions included
         ReporterModel reporter2 = new ReporterModel("root", "Root reporter");
-        ImportOptions noExtensions = new ImportOptions().addExtension("terminalMockNoSerDe");
+        ImportOptions notAllExtensions = new ImportOptions().addExtension("terminalMockNoSerDe").addExtension("loadZipModel");
         Network networkSkippedExtensions = NetworkSerDe.read(getNetworkAsStream("/skippedExtensions.xml"),
-                noExtensions, null, NetworkFactory.findDefault(), reporter2);
+                notAllExtensions, null, NetworkFactory.findDefault(), reporter2);
         Load load2 = networkSkippedExtensions.getLoad("LOAD");
-        assertNull(load2.getExtension(TerminalMockExt.class));
+        assertNull(load2.getExtension(LoadBarExt.class));
+        LoadZipModel loadZipModelExt = load2.getExtension(LoadZipModel.class);
+        assertNotNull(loadZipModelExt);
+        assertEquals(3.0, loadZipModelExt.getA3(), 0.001);
 
         StringWriter sw2 = new StringWriter();
         reporter2.export(sw2);
         assertEquals("""
                 + Root reporter
                   + Validation warnings
+                  + Imported extensions
+                     Extension loadZipModel imported.
                   + Not found extensions
                      Extension terminalMockNoSerDe not found.
                 """, TestUtil.normalizeLineSeparator(sw2.toString()));

--- a/iidm/iidm-serde/src/test/resources/skippedExtensions.xml
+++ b/iidm/iidm-serde/src/test/resources/skippedExtensions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_12" xmlns:mock="http://www.powsybl.org/schema/iidm/ext/terminal_mock/1_12" xmlns:mockns="http://www.powsybl.org/schema/iidm/ext/terminal_mock_no_serde/1_12" id="test" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="substation" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BLOAD"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="BLOAD" connectableBus="BLOAD"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:extension id="LOAD">
+        <mock:terminalMock>
+            <mock:terminal id="LOAD"/>
+        </mock:terminalMock>
+        <mockns:terminalMockNoSerDe>
+            <mockns:terminal id="LOAD"/>
+        </mockns:terminalMockNoSerDe>
+    </iidm:extension>
+</iidm:network>

--- a/iidm/iidm-serde/src/test/resources/skippedExtensions.xml
+++ b/iidm/iidm-serde/src/test/resources/skippedExtensions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_12" xmlns:mock="http://www.powsybl.org/schema/iidm/ext/terminal_mock/1_12" xmlns:mockns="http://www.powsybl.org/schema/iidm/ext/terminal_mock_no_serde/1_12" id="test" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_12" xmlns:bar="http://www.itesla_project.eu/schema/iidm/ext/loadbar/1_0" xmlns:mockns="http://www.powsybl.org/schema/iidm/ext/terminal_mock_no_serde/1_12" xmlns:extZip="http://www.itesla_project.eu/schema/iidm/ext/loadzipmodel/1_0" id="test" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="substation" country="FR" tso="RTE" geographicalTags="B">
         <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -9,11 +9,10 @@
         </iidm:voltageLevel>
     </iidm:substation>
     <iidm:extension id="LOAD">
-        <mock:terminalMock>
-            <mock:terminal id="LOAD"/>
-        </mock:terminalMock>
+        <bar:loadBar/>
         <mockns:terminalMockNoSerDe>
             <mockns:terminal id="LOAD"/>
         </mockns:terminalMockNoSerDe>
+        <extZip:loadZipModel a1="1.0" a2="2.0" a3="3.0" a4="4.0" a5="5.0" a6="6.0" v0="0.0"/>
     </iidm:extension>
 </iidm:network>

--- a/iidm/iidm-serde/src/test/resources/xsd/terminalMockNoSerDe.xsd
+++ b/iidm/iidm-serde/src/test/resources/xsd/terminalMockNoSerDe.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema version="1.6"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_12"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/terminal_mock_no_serde/1_12"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_12" schemaLocation="iidm_V1_12.xsd"/>
+    <xs:element name="terminalMockNoSerDe">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminal" type="iidm:TerminalRef"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
Extensions not included in ImportOptions are skipped when deserializing, but then we try to read it anyway, leading to an exception.



**What is the new behavior (if this is a feature change)?**
Extensions skipped with ImportOptions are skipped


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

