### PR TITLE
Fix equipment_V1_12.xsd

### DIFF
--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_12.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_12.xsd
@@ -346,17 +346,13 @@
         </xs:sequence>
         <xs:attribute name="permanentLimit" use="optional" type="xs:double"/>
     </xs:complexType>
-    <xs:complexType name="LoadingLimitGroup">
+    <xs:complexType name="OperationalLimitsGroup">
         <xs:sequence>
-            <xs:element name="operationalLimitsGroups" type="iidm:LoadingLimitGroups" minOccurs="0"/>
+            <xs:element name="activePowerLimits" type="iidm:LoadingLimit" minOccurs="0"/>
+            <xs:element name="apparentPowerLimits" type="iidm:LoadingLimit" minOccurs="0"/>
+            <xs:element name="currentLimits" type="iidm:LoadingLimit" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="id" use="required" type="xs:string"/>
-    </xs:complexType>
-    <xs:complexType name="LoadingLimitGroups">
-        <xs:sequence>
-            <xs:element name="operationalLimitsGroup" type="iidm:LoadingLimitGroup" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-        <xs:attribute name="defaultOperationalLimitsGroupId" use="optional" type="xs:string"/>
     </xs:complexType>
     <xs:complexType name="DanglingLine">
         <xs:complexContent>
@@ -366,8 +362,9 @@
                         <xs:element name="reactiveCapabilityCurve" type="iidm:ReactiveCapabilityCurve"/>
                         <xs:element name="minMaxReactiveLimits" type="iidm:MinMaxReactiveLimits"/>
                     </xs:choice>
-                    <xs:element name="operationalLimitsGroups" type="iidm:LoadingLimitGroups" minOccurs="0"/>
+                    <xs:element name="operationalLimitsGroup" type="iidm:OperationalLimitsGroup" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
+                <xs:attribute name="selectedOperationalLimitsGroupId" use="optional" type="xs:string"/>
                 <xs:attribute name="p0" use="optional" type="xs:double"/>
                 <xs:attribute name="q0" use="optional" type="xs:double"/>
                 <xs:attribute name="r" use="required" type="xs:double"/>
@@ -429,9 +426,11 @@
                 <xs:sequence>
                     <xs:element name="ratioTapChanger" type="iidm:RatioTapChanger" minOccurs="0"/>
                     <xs:element name="phaseTapChanger" type="iidm:PhaseTapChanger" minOccurs="0"/>
-                    <xs:element name="operationalLimitsGroups1" type="iidm:LoadingLimitGroups" minOccurs="0"/>
-                    <xs:element name="operationalLimitsGroups2" type="iidm:LoadingLimitGroups" minOccurs="0"/>
+                    <xs:element name="operationalLimitsGroup1" type="iidm:OperationalLimitsGroup" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="operationalLimitsGroup2" type="iidm:OperationalLimitsGroup" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
+                <xs:attribute name="selectedOperationalLimitsGroupId1" use="optional" type="xs:string"/>
+                <xs:attribute name="selectedOperationalLimitsGroupId2" use="optional" type="xs:string"/>
                 <xs:attribute name="r" use="required" type="xs:double"/>
                 <xs:attribute name="x" use="required" type="xs:double"/>
                 <xs:attribute name="g" use="required" type="xs:double"/>
@@ -452,10 +451,13 @@
                     <xs:element name="phaseTapChanger2" type="iidm:PhaseTapChanger" minOccurs="0"/>
                     <xs:element name="ratioTapChanger3" type="iidm:RatioTapChanger" minOccurs="0"/>
                     <xs:element name="phaseTapChanger3" type="iidm:PhaseTapChanger" minOccurs="0"/>
-                    <xs:element name="operationalLimitsGroups1" type="iidm:LoadingLimitGroups" minOccurs="0"/>
-                    <xs:element name="operationalLimitsGroups2" type="iidm:LoadingLimitGroups" minOccurs="0"/>
-                    <xs:element name="operationalLimitsGroups3" type="iidm:LoadingLimitGroups" minOccurs="0"/>
+                    <xs:element name="operationalLimitsGroup1" type="iidm:OperationalLimitsGroup" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="operationalLimitsGroup2" type="iidm:OperationalLimitsGroup" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="operationalLimitsGroup3" type="iidm:OperationalLimitsGroup" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
+                <xs:attribute name="selectedOperationalLimitsGroupId1" use="optional" type="xs:string"/>
+                <xs:attribute name="selectedOperationalLimitsGroupId2" use="optional" type="xs:string"/>
+                <xs:attribute name="selectedOperationalLimitsGroupId3" use="optional" type="xs:string"/>
                 <xs:attribute name="ratedU0" use="required" type="xs:double"/>
                 <xs:attribute name="ratedU1" use="required" type="xs:double"/>
                 <xs:attribute name="ratedU2" use="required" type="xs:double"/>
@@ -607,9 +609,11 @@
         <xs:complexContent>
             <xs:extension base="iidm:Branch">
                 <xs:sequence>
-                    <xs:element name="operationalLimitsGroups1" type="iidm:LoadingLimitGroups" minOccurs="0"/>
-                    <xs:element name="operationalLimitsGroups2" type="iidm:LoadingLimitGroups" minOccurs="0"/>
+                    <xs:element name="operationalLimitsGroup1" type="iidm:OperationalLimitsGroup" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="operationalLimitsGroup2" type="iidm:OperationalLimitsGroup" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
+                <xs:attribute name="selectedOperationalLimitsGroupId1" use="optional" type="xs:string"/>
+                <xs:attribute name="selectedOperationalLimitsGroupId2" use="optional" type="xs:string"/>
                 <xs:attribute name="r" use="required" type="xs:double"/>
                 <xs:attribute name="x" use="required" type="xs:double"/>
                 <xs:attribute name="g1" use="required" type="xs:double"/>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_12.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_12.xsd
@@ -34,6 +34,7 @@
                 <xs:element name="tieLine" type="iidm:TieLine"/>
                 <xs:element name="hvdcLine" type="iidm:HvdcLine"/>
             </xs:choice>
+            <xs:element name="voltageAngleLimit" minOccurs="0" maxOccurs="unbounded" type="iidm:VoltageAngleLimit"/>
             <xs:element name="extension" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                     <xs:sequence>
@@ -109,6 +110,7 @@
                         <xs:element name="staticVarCompensator" type="iidm:StaticVarCompensator"/>
                         <xs:element name="vscConverterStation" type="iidm:VscConverterStation"/>
                         <xs:element name="lccConverterStation" type="iidm:LccConverterStation"/>
+                        <xs:element name="ground" type="iidm:Ground"/>
                     </xs:choice>
                 </xs:sequence>
                 <xs:attribute name="nominalV" use="required" type="xs:double"/>
@@ -151,6 +153,9 @@
         </xs:complexContent>
     </xs:complexType>
     <xs:complexType name="CalculatedBus">
+        <xs:sequence>
+            <xs:element name="property" type="iidm:Property" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
         <xs:attribute name="nodes" use="required" type="xs:string"/>
         <xs:attribute name="v" use="optional" type="xs:double"/>
         <xs:attribute name="angle" use="optional" type="xs:double"/>
@@ -644,13 +649,17 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
+
     <xs:complexType name="VscConverterStation">
         <xs:complexContent>
             <xs:extension base="iidm:HvdcConverterStation">
-                <xs:choice>
-                    <xs:element name="reactiveCapabilityCurve" type="iidm:ReactiveCapabilityCurve"/>
-                    <xs:element name="minMaxReactiveLimits" type="iidm:MinMaxReactiveLimits"/>
-                </xs:choice>
+                <xs:sequence>
+                    <xs:choice>
+                        <xs:element name="reactiveCapabilityCurve" type="iidm:ReactiveCapabilityCurve"/>
+                        <xs:element name="minMaxReactiveLimits" type="iidm:MinMaxReactiveLimits"/>
+                    </xs:choice>
+                    <xs:element name="regulatingTerminal" minOccurs="0" type="iidm:TerminalRef"/>
+                </xs:sequence>
                 <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
                 <xs:attribute name="voltageSetpoint" use="optional" type="xs:double"/>
                 <xs:attribute name="reactivePowerSetpoint" use="optional" type="xs:double"/>
@@ -674,6 +683,21 @@
                 <xs:attribute name="convertersMode" use="required" type="iidm:ConvertersMode"/>
                 <xs:attribute name="converterStation1" use="required" type="iidm:nonEmptyString"/>
                 <xs:attribute name="converterStation2" use="required" type="iidm:nonEmptyString"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="VoltageAngleLimit">
+        <xs:sequence>
+            <xs:element name="from" type="iidm:TerminalRef"/>
+            <xs:element name="to" type="iidm:TerminalRef"/>
+        </xs:sequence>
+		<xs:attribute name="id" use="required" type="xs:string"/>
+        <xs:attribute name="highLimit" use="optional" type="xs:double"/>
+        <xs:attribute name="lowLimit" use="optional" type="xs:double"/>
+    </xs:complexType>
+    <xs:complexType name="Ground">
+        <xs:complexContent>
+            <xs:extension base="iidm:Injection">
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/EquipmentXsdTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/EquipmentXsdTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.serde;
+
+import com.google.common.io.ByteStreams;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Node;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.ComparisonType;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.Difference;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+/**
+ * @author Olivier Perrin {@literal <olivier.perrin at rte-france.com>}
+ */
+class EquipmentXsdTest extends AbstractIidmSerDeTest {
+
+    @Test
+    void xsdConsistenceTest() {
+        testForAllVersionsSince(IidmVersion.V_1_12, this::checkXsdConsistence);
+    }
+
+    private void checkXsdConsistence(IidmVersion iidmVersion) {
+        try (InputStream is = getClass().getResourceAsStream(getXsdPath("iidm_equipment", iidmVersion))) {
+            // Load the "iidm_equipment" xsd
+            String equipmentXsd = new String(ByteStreams.toByteArray(is));
+            // Change the namespaces to match the ones in the "iidm" xsd
+            String modifiedEquipmentXsd = equipmentXsd.replaceAll("schema/iidm/equipment/", "schema/iidm/");
+            // Compare the modified "iidm_equipment" xsd with the "iidm" xsd
+            try (InputStream equipmentIs = IOUtils.toInputStream(modifiedEquipmentXsd, "UTF-8");
+                 InputStream iidmIs = getClass().getResourceAsStream(getXsdPath("iidm", iidmVersion))) {
+                Diff myDiffs = DiffBuilder.compare(iidmIs).withTest(equipmentIs).ignoreWhitespace().ignoreComments().build();
+                // For each difference, check that it is a "use" attribute change from "required" to "optional" or the reverse.
+                for (Difference diff : myDiffs.getDifferences()) {
+                    Assertions.assertTrue(isAcceptable(diff), diff.toString());
+                }
+            }
+        } catch (IOException exc) {
+            throw new UncheckedIOException(exc);
+        }
+    }
+
+    private static boolean isAcceptable(Difference diff) {
+        // Check that the difference is a "use" attribute change from "required" to "optional" or the reverse.
+        var c = diff.getComparison();
+        Node controlNode = c.getControlDetails().getTarget();
+        Node targetNode = c.getTestDetails().getTarget();
+        return c.getType() == ComparisonType.ATTR_VALUE
+                && "use".equals(controlNode.getLocalName())
+                && "use".equals(targetNode.getLocalName())
+                && ("required".equals(controlNode.getNodeValue()) && "optional".equals(targetNode.getNodeValue())
+                    || "optional".equals(controlNode.getNodeValue()) && "required".equals(targetNode.getNodeValue()));
+    }
+
+    private static String getXsdPath(String prefix, IidmVersion iidmVersion) {
+        return String.format("/xsd/%s_V%s.xsd", prefix, iidmVersion.toString("_"));
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`equipment_V1_12.xsd` is inconsistent with `iidm_V1_12.xsd`: operational limits are not correctly modelled.


**What is the new behavior (if this is a feature change)?**
The operational limits model in `equipment_V1_12.xsd` is consistent with `iidm_V1_12.xsd`.

Other problems were fixed:
- missing `ground` element in `VoltageLevel`;
- missing `regulatingTerminal` element in `VscConverterStation`;
- missing `property` element in `CalculatedBus`;
- missing `voltageAngleLimit` in `Network`.

Add a unit test to check the consistence of "equipment_iidm" XSD with "iidm" XSD.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
