### PR TITLE
Add overload management system removal (missing method)

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AutomationSystem.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AutomationSystem.java
@@ -23,4 +23,9 @@ public interface AutomationSystem<I extends AutomationSystem<I>> extends Identif
      * @param enabled <code>true</code> to enable the automation system
      */
     void setEnabled(boolean enabled);
+
+    /**
+     * Remove the automation system from the network.
+     */
+    void remove();
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubstationImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubstationImpl.java
@@ -240,11 +240,23 @@ class SubstationImpl extends AbstractIdentifiable<Substation> implements Substat
             vl.remove();
         }
 
+        // Remove the overload management systems
+        removeOverloadManagementSystems();
+
         // Remove this substation from the network
         network.getIndex().remove(this);
 
         network.getListeners().notifyAfterRemoval(id);
         removed = true;
+    }
+
+    void removeOverloadManagementSystems() {
+        overloadManagementSystems.forEach(OverloadManagementSystem::remove);
+    }
+
+    void remove(OverloadManagementSystemImpl overloadManagementSystem) {
+        Objects.requireNonNull(overloadManagementSystem);
+        overloadManagementSystems.remove(overloadManagementSystem);
     }
 
     void remove(VoltageLevelExt voltageLevelExt) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
There is no way to remove an overload management system from a network. The `OverloadManagementSystem.remove()` method was forgotten.


**What is the new behavior (if this is a feature change)?**
Add the missing `OverloadManagementSystem.remove()` method.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

Not a breaking change since the `OverloadManagementSystem` class is not yet in a production release, but custom IIDM maintainers should implement `OverloadManagementSystem.remove()`.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
