### PR TITLE
CGMES: Correct neutral step calculation for tap changers

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -802,10 +802,12 @@ public final class EquipmentExport {
 
     private static int getPhaseTapChangerNeutralStep(PhaseTapChanger ptc) {
         int neutralStep = ptc.getLowTapPosition();
-        while (ptc.getStep(neutralStep).getAlpha() != 0.0) {
-            neutralStep++;
-            if (neutralStep > ptc.getHighTapPosition()) {
-                return ptc.getHighTapPosition();
+        double minAlpha = Math.abs(ptc.getStep(neutralStep).getAlpha());
+        for (Map.Entry<Integer, PhaseTapChangerStep> step : ptc.getAllSteps().entrySet()) {
+            double tempAlpha = Math.abs(1 - step.getValue().getAlpha());
+            if (tempAlpha < minAlpha) {
+                minAlpha = tempAlpha;
+                neutralStep = step.getKey();
             }
         }
         return neutralStep;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -851,10 +851,12 @@ public final class EquipmentExport {
 
     private static int getRatioTapChangerNeutralStep(RatioTapChanger rtc) {
         int neutralStep = rtc.getLowTapPosition();
-        while (rtc.getStep(neutralStep).getRho() != 1.0) {
-            neutralStep++;
-            if (neutralStep > rtc.getHighTapPosition()) {
-                return rtc.getHighTapPosition();
+        double minRatio = Math.abs(1 - rtc.getStep(neutralStep).getRho());
+        for (Map.Entry<Integer, RatioTapChangerStep> step : rtc.getAllSteps().entrySet()) {
+            double tempRatio = Math.abs(1 - step.getValue().getRho());
+            if (tempRatio < minRatio) {
+                minRatio = tempRatio;
+                neutralStep = step.getKey();
             }
         }
         return neutralStep;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -804,7 +804,7 @@ public final class EquipmentExport {
         int neutralStep = ptc.getLowTapPosition();
         double minAlpha = Math.abs(ptc.getStep(neutralStep).getAlpha());
         for (Map.Entry<Integer, PhaseTapChangerStep> step : ptc.getAllSteps().entrySet()) {
-            double tempAlpha = Math.abs(1 - step.getValue().getAlpha());
+            double tempAlpha = Math.abs(step.getValue().getAlpha());
             if (tempAlpha < minAlpha) {
                 minAlpha = tempAlpha;
                 neutralStep = step.getKey();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
If no step has alpha or rho equal to 1 then the step with the highest position is returned.


**What is the new behavior (if this is a feature change)?**
Now the function returns the step where rho or alpha is the closest to 1.
