### PR TITLE
Fix vsc replacement by regulating generator

### DIFF
--- a/iidm/iidm-reducer/pom.xml
+++ b/iidm/iidm-reducer/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>powsybl-iidm-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-extensions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
@@ -273,21 +273,21 @@ public class DefaultNetworkReducer extends AbstractNetworkReducer {
 
         if (stationLimits != null) {
             if (stationLimits.getKind() == ReactiveLimitsKind.MIN_MAX) {
-                MinMaxReactiveLimits minMaxlimits = (MinMaxReactiveLimits) stationLimits;
+                MinMaxReactiveLimits minMaxLimits = (MinMaxReactiveLimits) stationLimits;
                 generator.newMinMaxReactiveLimits()
-                        .setMinQ(minMaxlimits.getMinQ())
-                        .setMaxQ(minMaxlimits.getMaxQ())
+                        .setMinQ(minMaxLimits.getMinQ())
+                        .setMaxQ(minMaxLimits.getMaxQ())
                         .add();
             } else if (stationLimits.getKind() == ReactiveLimitsKind.CURVE) {
                 ReactiveCapabilityCurve reactiveCurve = (ReactiveCapabilityCurve) stationLimits;
                 ReactiveCapabilityCurveAdder curveAdder = generator.newReactiveCapabilityCurve();
-                reactiveCurve.getPoints().forEach(point -> {
+                reactiveCurve.getPoints().forEach(point ->
                     curveAdder.beginPoint()
                             .setP(point.getP())
                             .setMinQ(point.getMinQ())
                             .setMaxQ(point.getMaxQ())
-                            .endPoint();
-                });
+                            .endPoint()
+                );
                 curveAdder.add();
             }
         }

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
@@ -285,7 +285,7 @@ public class DefaultNetworkReducer extends AbstractNetworkReducer {
                         .setMinQ(point.getMinQ())
                         .setMaxQ(point.getMaxQ())
                         .endPoint();
-                    });
+            });
             curveAdder.add();
         }
         observers.forEach(o -> o.hvdcLineReplaced(hvdcLine, generator));

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
@@ -265,6 +265,7 @@ class DefaultNetworkReducerTest {
 
         NetworkReducerObserverImpl observerVsc = new NetworkReducerObserverImpl();
         Network networkVsc = HvdcTestNetwork.createVsc();
+        double targetV = networkVsc.getVscConverterStation("C1").getVoltageSetpoint();
         assertEquals(0, networkVsc.getGeneratorCount());
         assertEquals(2, networkVsc.getHvdcConverterStationCount());
         NetworkReducer reducerVsc = NetworkReducer.builder()
@@ -279,7 +280,8 @@ class DefaultNetworkReducerTest {
         Generator gen = networkVsc.getGenerator("L");
         assertEquals(300, gen.getMaxP());
         assertEquals(-300, gen.getMinP());
-
+        assertTrue(gen.isVoltageRegulatorOn());
+        assertEquals(targetV, gen.getTargetV());
     }
 
     @Test

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
@@ -265,7 +265,10 @@ class DefaultNetworkReducerTest {
 
         NetworkReducerObserverImpl observerVsc = new NetworkReducerObserverImpl();
         Network networkVsc = HvdcTestNetwork.createVsc();
-        double targetV = networkVsc.getVscConverterStation("C1").getVoltageSetpoint();
+        VscConverterStation station = networkVsc.getVscConverterStation("C1");
+        double targetV = station.getVoltageSetpoint();
+        station.newMinMaxReactiveLimits().setMaxQ(200).setMinQ(-200).add();
+        double p = station.getTerminal().getP();
         assertEquals(0, networkVsc.getGeneratorCount());
         assertEquals(2, networkVsc.getHvdcConverterStationCount());
         NetworkReducer reducerVsc = NetworkReducer.builder()
@@ -280,8 +283,10 @@ class DefaultNetworkReducerTest {
         Generator gen = networkVsc.getGenerator("L");
         assertEquals(300, gen.getMaxP());
         assertEquals(-300, gen.getMinP());
+        assertEquals(-p, gen.getTargetP());
         assertTrue(gen.isVoltageRegulatorOn());
         assertEquals(targetV, gen.getTargetV());
+        assertEquals(200, gen.getReactiveLimits(MinMaxReactiveLimits.class).getMaxQ());
     }
 
     @Test

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/DefaultNetworkReducerTest.java
@@ -15,6 +15,7 @@ import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.Iterator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -249,21 +250,29 @@ class DefaultNetworkReducerTest {
 
     @Test
     void testHvdcReplacement() {
+        testHvdcReplacementLcc();
+        testHvdcReplacementVscWithMinMaxReactiveLimits();
+        tetHvdcReplacementVscWithReactiveCapabilityCurve();
+    }
+
+    private static void testHvdcReplacementLcc() {
         NetworkReducerObserverImpl observerLcc = new NetworkReducerObserverImpl();
         Network networkLcc = HvdcTestNetwork.createLcc();
         assertEquals(0, networkLcc.getLoadCount());
         assertEquals(2, networkLcc.getHvdcConverterStationCount());
         NetworkReducer reducerLcc = NetworkReducer.builder()
-                    .withNetworkPredicate(IdentifierNetworkPredicate.of("VL1"))
-                    .withObservers(observerLcc)
-                    .build();
+                .withNetworkPredicate(IdentifierNetworkPredicate.of("VL1"))
+                .withObservers(observerLcc)
+                .build();
         reducerLcc.reduce(networkLcc);
         assertEquals(0, networkLcc.getHvdcLineCount());
         assertEquals(1, observerLcc.getHvdcLineReplacedCount());
         assertEquals(1, observerLcc.getHvdcLineRemovedCount());
         assertEquals(1, networkLcc.getLoadCount());
         assertEquals(0, networkLcc.getHvdcConverterStationCount());
+    }
 
+    private static void testHvdcReplacementVscWithMinMaxReactiveLimits() {
         NetworkReducerObserverImpl observerVsc = new NetworkReducerObserverImpl();
         Network networkVsc = HvdcTestNetwork.createVsc();
         VscConverterStation station = networkVsc.getVscConverterStation("C1");
@@ -289,7 +298,9 @@ class DefaultNetworkReducerTest {
         assertEquals(targetV, gen.getTargetV());
         assertEquals(200, gen.getReactiveLimits(MinMaxReactiveLimits.class).getMaxQ());
         assertFalse(gen.getExtension(ActivePowerControl.class).isParticipate());
+    }
 
+    private static void tetHvdcReplacementVscWithReactiveCapabilityCurve() {
         NetworkReducerObserverImpl observerVsc2 = new NetworkReducerObserverImpl();
         Network networkVsc2 = HvdcTestNetwork.createVsc();
         VscConverterStation station2 = networkVsc2.getVscConverterStation("C1");
@@ -304,6 +315,15 @@ class DefaultNetworkReducerTest {
         reducerVsc2.reduce(networkVsc2);
         Generator gen2 = networkVsc2.getGenerator("L");
         assertEquals(2, gen2.getReactiveLimits(ReactiveCapabilityCurve.class).getPointCount());
+        Iterator<ReactiveCapabilityCurve.Point> pointIt = gen2.getReactiveLimits(ReactiveCapabilityCurve.class).getPoints().iterator();
+        ReactiveCapabilityCurve.Point point = pointIt.next();
+        assertEquals(0.0, point.getP(), 0.001);
+        assertEquals(-200.0, point.getMinQ(), 0.001);
+        assertEquals(200.0, point.getMaxQ(), 0.001);
+        point = pointIt.next();
+        assertEquals(100.0, point.getP(), 0.001);
+        assertEquals(-200.0, point.getMinQ(), 0.001);
+        assertEquals(200.0, point.getMaxQ(), 0.001);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix multiple issues regarding the replacement of VSC stations regulating voltage by generators when reducing HVDC lines : generator voltage regulation status and targetV, reactive limits, sign of P and Q 


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
