### PR TITLE
CGMES export mRID only for CGMES 3 (CIM 100) or greater

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -181,7 +181,7 @@ public final class CgmesExportUtil {
         // Only classes extending IdentifiedObject have an mRID
         // points of tables and curve data objects do not have mRID, although they have an RDF:ID
         writer.writeAttribute(RDF_NAMESPACE, CgmesNames.ID, toRdfId(id, context));
-        if (writeMasterResourceId) {
+        if (writeMasterResourceId && context.getCim().getVersion() >= 100) {
             writer.writeStartElement(cimNamespace, "IdentifiedObject.mRID");
             writer.writeCharacters(toMasterResourceId(id, context));
             writer.writeEndElement();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Identified objects in CGMES export have the attribute `mRID` for all CGMES versions.


**What is the new behavior (if this is a feature change)?**
The `mRID` attribute is only exported for output of `IdentifiedObject`s in CGMES 3 or greater. Export to CGMES 2.4.15 (CIM16) will not contain `mRID`s.



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

