### PR TITLE
CGMES post-processor to remove grounds

### DIFF
--- a/cgmes/cgmes-conversion/pom.xml
+++ b/cgmes/cgmes-conversion/pom.xml
@@ -70,6 +70,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>powsybl-iidm-modification</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.gdata</artifactId>
         </dependency>

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RemoveGroundsPostProcessor.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RemoveGroundsPostProcessor.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.config.PlatformConfig;
+import com.powsybl.iidm.modification.topology.RemoveFeederBay;
+import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.triplestore.api.TripleStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Luma Zamarreño {@literal <zamarrenolm@aia.es>}
+ */
+@AutoService(CgmesImportPostProcessor.class)
+public class RemoveGroundsPostProcessor implements CgmesImportPostProcessor {
+
+    public static final String NAME = "RemoveGrounds";
+    private static final Logger LOG = LoggerFactory.getLogger(RemoveGroundsPostProcessor.class);
+
+    public RemoveGroundsPostProcessor() {
+        this(PlatformConfig.defaultConfig());
+    }
+
+    public RemoveGroundsPostProcessor(PlatformConfig platformConfig) {
+        Objects.requireNonNull(platformConfig);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public void process(Network network, TripleStore tripleStore) {
+        Objects.requireNonNull(network);
+        LOG.info("Execute {} post processor on network {}", getName(), network.getId());
+        List<String> grounds = network.getGroundStream().map(Identifiable::getId).toList();
+        grounds.forEach(g -> new RemoveFeederBay(g).apply(network));
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/GroundConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/GroundConversionTest.java
@@ -8,9 +8,18 @@
 
 package com.powsybl.cgmes.conversion.test;
 
+import com.powsybl.cgmes.conversion.CgmesImport;
+import com.powsybl.commons.datasource.ResourceDataSource;
+import com.powsybl.commons.datasource.ResourceSet;
+import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.iidm.network.Ground;
 import com.powsybl.iidm.network.Network;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -18,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
  */
 
-class GroundConversionTest {
+class GroundConversionTest extends AbstractSerDeTest {
 
     @Test
     void groundConversionTest() {
@@ -39,5 +48,57 @@ class GroundConversionTest {
         assertNotNull(groundCV.getTerminal());
         assertTrue(groundCV.getTerminal().isConnected());
         assertEquals("S", groundCV.getTerminal().getVoltageLevel().getId());
+    }
+
+    @Test
+    void groundConversionRemoveTest() {
+        Properties importParams = new Properties();
+        importParams.put(CgmesImport.POST_PROCESSORS, "RemoveGrounds");
+        Network network = Network.read(
+                new ResourceDataSource("groundTest.xml", new ResourceSet("/", "groundTest.xml")),
+                importParams);
+
+        assertEquals(0, network.getGroundCount());
+
+        // Check also the exported GraphViz
+        // Some edges have been removed, ensure it is exported properly
+        String actual = graphVizClean(graphViz(network, "S"));
+        String expected = graphVizClean("""
+                digraph G {
+                \tnode [shape=box];
+                \tcompound=true;
+                \tn0 [label="0",shape="ellipse",style="filled",fillcolor="#8F7AF3"];
+                \tn2 [label="5\\lBUSBAR_SECTION\\lAX\\lEF",shape="ellipse",style="filled",fillcolor="#8F7AF3"];
+                \tn3 [label="8\\lGENERATOR\\lZX\\lZY",shape="ellipse",style="filled",fillcolor="#8F7AF3"];
+                \tn2 -> n0 [];
+                \tn3 -> n0 [];
+                \tsubgraph cluster_c1 {
+                \t\t// scope=1392570698
+                \t\tcluster_c1 [label="",shape=point,style=invis];
+                \t\tpencolor="transparent";
+                \t\tn0;
+                \t\tn2;
+                \t\tn3;
+                \t}
+                }
+                """);
+        assertEquals(expected, actual);
+    }
+
+    private String graphViz(Network network, String voltageLevelId) {
+        try {
+            Path gv = tmpDir.resolve(voltageLevelId + ".gv");
+            network.getVoltageLevel(voltageLevelId).exportTopology(gv);
+            return Files.readString(gv);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String graphVizClean(String gv) {
+        // Remove all colors (they are assigned randomly each time a graphviz is exported)
+        String r = gv.replaceAll("color=\"#[^\"]+\"", "color=\"---\"");
+        // Remove all comments
+        return r.replaceAll("([\\n\\r])(\\s+)//.*([\\n\\r])", "$1$2//$3");
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerVoltageLevel.java
@@ -1485,7 +1485,8 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     }
 
     private void exportEdges(GraphVizGraph gvGraph, GraphVizScope scope) {
-        for (int e = 0; e < graph.getEdgeCount(); e++) {
+        // Iterate over non-removed edges
+        for (int e : graph.getEdges()) {
             GraphVizEdge edge = gvGraph.edge(scope, graph.getEdgeVertex1(e), graph.getEdgeVertex2(e));
             SwitchImpl aSwitch = graph.getEdgeObject(e);
             if (aSwitch != null) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
CGMES `Ground` objects are always imported and left in the IIDM `Network`.


**What is the new behavior (if this is a feature change)?**
Some users may not want to have `Ground` objects imported.
A post-processor to remove all `Ground` objects has been added. 
The `Ground` objects and their paths connecting them to the rest of the network will be removed, including potential CGMES `GroundDisconnector` objects that were imported as switches of kind `Disconnector`.
To activate the feature configure a post-processor with name `RemoveGrounds`.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
To activate the feature configure a post-processor with name `RemoveGrounds`.


