### PR TITLE
CGMES import. Remove obsolete parameter and methods from config

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -398,12 +398,6 @@ public class CgmesImport implements Importer {
 
     private Conversion.Config config(Properties p) {
         Conversion.Config config = new Conversion.Config()
-                .setAllowUnsupportedTapChangers(
-                        Parameter.readBoolean(
-                                getFormat(),
-                                p,
-                                ALLOW_UNSUPPORTED_TAP_CHANGERS_PARAMETER,
-                                defaultValueConfig))
                 .setChangeSignForShuntReactivePowerFlowInitialState(
                         Parameter.readBoolean(
                                 getFormat(),
@@ -540,7 +534,6 @@ public class CgmesImport implements Importer {
 
     private static final String FORMAT = "CGMES";
 
-    public static final String ALLOW_UNSUPPORTED_TAP_CHANGERS = "iidm.import.cgmes.allow-unsupported-tap-changers";
     public static final String BOUNDARY_LOCATION = "iidm.import.cgmes.boundary-location";
     public static final String CHANGE_SIGN_FOR_SHUNT_REACTIVE_POWER_FLOW_INITIAL_STATE = "iidm.import.cgmes.change-sign-for-shunt-reactive-power-flow-initial-state";
     public static final String CONVERT_BOUNDARY = "iidm.import.cgmes.convert-boundary";
@@ -568,11 +561,6 @@ public class CgmesImport implements Importer {
     public static final String SOURCE_FOR_IIDM_ID_MRID = "mRID";
     public static final String SOURCE_FOR_IIDM_ID_RDFID = "rdfID";
 
-    private static final Parameter ALLOW_UNSUPPORTED_TAP_CHANGERS_PARAMETER = new Parameter(
-            ALLOW_UNSUPPORTED_TAP_CHANGERS,
-            ParameterType.BOOLEAN,
-            "Allow import of potentially unsupported tap changers",
-            Boolean.TRUE);
     private static final Parameter CHANGE_SIGN_FOR_SHUNT_REACTIVE_POWER_FLOW_INITIAL_STATE_PARAMETER = new Parameter(
             CHANGE_SIGN_FOR_SHUNT_REACTIVE_POWER_FLOW_INITIAL_STATE,
             ParameterType.BOOLEAN,
@@ -689,7 +677,6 @@ public class CgmesImport implements Importer {
             100.);
 
     private static final List<Parameter> STATIC_PARAMETERS = List.of(
-            ALLOW_UNSUPPORTED_TAP_CHANGERS_PARAMETER,
             CHANGE_SIGN_FOR_SHUNT_REACTIVE_POWER_FLOW_INITIAL_STATE_PARAMETER,
             CONVERT_BOUNDARY_PARAMETER,
             CONVERT_SV_INJECTIONS_PARAMETER,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -423,12 +423,6 @@ public class CgmesImport implements Importer {
 
     private Conversion.Config config(Properties p) {
         Conversion.Config config = new Conversion.Config()
-                .setChangeSignForShuntReactivePowerFlowInitialState(
-                        Parameter.readBoolean(
-                                getFormat(),
-                                p,
-                                CHANGE_SIGN_FOR_SHUNT_REACTIVE_POWER_FLOW_INITIAL_STATE_PARAMETER,
-                                defaultValueConfig))
                 .setConvertBoundary(
                         Parameter.readBoolean(
                                 getFormat(),
@@ -560,7 +554,6 @@ public class CgmesImport implements Importer {
     private static final String FORMAT = "CGMES";
 
     public static final String BOUNDARY_LOCATION = "iidm.import.cgmes.boundary-location";
-    public static final String CHANGE_SIGN_FOR_SHUNT_REACTIVE_POWER_FLOW_INITIAL_STATE = "iidm.import.cgmes.change-sign-for-shunt-reactive-power-flow-initial-state";
     public static final String CONVERT_BOUNDARY = "iidm.import.cgmes.convert-boundary";
     public static final String CONVERT_SV_INJECTIONS = "iidm.import.cgmes.convert-sv-injections";
     public static final String CREATE_ACTIVE_POWER_CONTROL_EXTENSION = "iidm.import.cgmes.create-active-power-control-extension";
@@ -586,12 +579,6 @@ public class CgmesImport implements Importer {
     public static final String SOURCE_FOR_IIDM_ID_MRID = "mRID";
     public static final String SOURCE_FOR_IIDM_ID_RDFID = "rdfID";
 
-    private static final Parameter CHANGE_SIGN_FOR_SHUNT_REACTIVE_POWER_FLOW_INITIAL_STATE_PARAMETER = new Parameter(
-            CHANGE_SIGN_FOR_SHUNT_REACTIVE_POWER_FLOW_INITIAL_STATE,
-            ParameterType.BOOLEAN,
-            "Change the sign of the reactive power flow for shunt in initial state",
-            Boolean.FALSE)
-            .addAdditionalNames("changeSignForShuntReactivePowerFlowInitialState");
     private static final Parameter CONVERT_BOUNDARY_PARAMETER = new Parameter(
             CONVERT_BOUNDARY,
             ParameterType.BOOLEAN,
@@ -702,7 +689,6 @@ public class CgmesImport implements Importer {
             100.);
 
     private static final List<Parameter> STATIC_PARAMETERS = List.of(
-            CHANGE_SIGN_FOR_SHUNT_REACTIVE_POWER_FLOW_INITIAL_STATE_PARAMETER,
             CONVERT_BOUNDARY_PARAMETER,
             CONVERT_SV_INJECTIONS_PARAMETER,
             CREATE_BUSBAR_SECTION_FOR_EVERY_CONNECTIVITY_NODE_PARAMETER,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -636,7 +636,7 @@ public class CgmesImport implements Importer {
             CREATE_ACTIVE_POWER_CONTROL_EXTENSION,
             ParameterType.BOOLEAN,
             "Create active power control extension during import",
-            Boolean.FALSE);
+            Boolean.TRUE);
     private static final Parameter CREATE_FICTITIOUS_SWITCHES_FOR_DISCONNECTED_TERMINALS_MODE_PARAMETER = new Parameter(
             CREATE_FICTITIOUS_SWITCHES_FOR_DISCONNECTED_TERMINALS_MODE,
             ParameterType.STRING,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -787,15 +787,6 @@ public class Conversion {
             return false;
         }
 
-        public boolean allowUnsupportedTapChangers() {
-            return allowUnsupportedTapChangers;
-        }
-
-        public Config setAllowUnsupportedTapChangers(boolean allowUnsupportedTapChangers) {
-            this.allowUnsupportedTapChangers = allowUnsupportedTapChangers;
-            return this;
-        }
-
         public boolean importNodeBreakerAsBusBreaker() {
             return importNodeBreakerAsBusBreaker;
         }
@@ -803,14 +794,6 @@ public class Conversion {
         public Config setImportNodeBreakerAsBusBreaker(boolean importNodeBreakerAsBusBreaker) {
             this.importNodeBreakerAsBusBreaker = importNodeBreakerAsBusBreaker;
             return this;
-        }
-
-        public double lowImpedanceLineR() {
-            return lowImpedanceLineR;
-        }
-
-        public double lowImpedanceLineX() {
-            return lowImpedanceLineX;
         }
 
         public boolean convertBoundary() {
@@ -1001,11 +984,8 @@ public class Conversion {
             return disconnectNetworkSideOfDanglingLinesIfBoundaryIsDisconnected;
         }
 
-        private boolean allowUnsupportedTapChangers = true;
         private boolean convertBoundary = false;
         private boolean changeSignForShuntReactivePowerFlowInitialState = false;
-        private double lowImpedanceLineR = 7.0E-5;
-        private double lowImpedanceLineX = 7.0E-5;
 
         private boolean createBusbarSectionForEveryConnectivityNode = false;
         private boolean convertSvInjections = true;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -805,15 +805,6 @@ public class Conversion {
             return this;
         }
 
-        public boolean changeSignForShuntReactivePowerFlowInitialState() {
-            return changeSignForShuntReactivePowerFlowInitialState;
-        }
-
-        public Config setChangeSignForShuntReactivePowerFlowInitialState(boolean b) {
-            changeSignForShuntReactivePowerFlowInitialState = b;
-            return this;
-        }
-
         public boolean computeFlowsAtBoundaryDanglingLines() {
             return true;
         }
@@ -985,7 +976,6 @@ public class Conversion {
         }
 
         private boolean convertBoundary = false;
-        private boolean changeSignForShuntReactivePowerFlowInitialState = false;
 
         private boolean createBusbarSectionForEveryConnectivityNode = false;
         private boolean convertSvInjections = true;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
@@ -81,9 +81,6 @@ public class ShuntConversion extends AbstractConductingEquipmentConversion {
         addAliasesAndProperties(shunt);
 
         PowerFlow f = powerFlowSV();
-        if (f.defined() && context.config().changeSignForShuntReactivePowerFlowInitialState()) {
-            f = new PowerFlow(-f.p(), -f.q());
-        }
         context.convertedTerminal(terminalId(), shunt.getTerminal(), 1, f);
         context.regulatingControlMapping().forShuntCompensators().add(shunt.getId(), p);
     }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
@@ -116,23 +116,6 @@ class CgmesConformity1ConversionTest {
     }
 
     @Test
-    void microGridBaseCaseBEWithoutUnsupportedTapChangersRoundtrip() throws IOException {
-        // TODO When we convert boundaries values for P0, Q0 at dangling lines
-        // are recalculated and we need to increase the tolerance
-        Properties exportParams = new Properties();
-        exportParams.put(CgmesExport.PROFILES, "SSH,SV");
-        exportParams.put(CgmesExport.MODELING_AUTHORITY_SET, "http://elia.be/CGMES/2.4.15");
-        importParams.put(CgmesImport.ALLOW_UNSUPPORTED_TAP_CHANGERS, "false");
-        importParams.put(CgmesImport.IMPORT_CGM_WITH_SUBNETWORKS, "false");
-        ConversionTester t = new ConversionTester(
-            importParams, exportParams,
-            TripleStoreFactory.onlyDefaultImplementation(),
-            new ComparisonConfig().tolerance(1e-5).checkNetworkId(false).incrementVersions(true));
-        t.setTestExportImportCgmes(true);
-        t.testConversion(CgmesConformity1NetworkCatalog.microBaseCaseBE(), CgmesConformity1Catalog.microGridBaseCaseBE());
-    }
-
-    @Test
     void microGridBaseCaseBEBusBalanceValidation() throws IOException {
         // Check bus balance mismatches are low if we use SV voltages
         // MicroGrid BaseCase BE contains an RTC defined at transformerEnd1

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
@@ -313,7 +313,9 @@ class CgmesConformity1ConversionTest {
     }
 
     @Test
-    void microNLActivePowerControlNoExtensionByDefault() {
+    void microNLActivePowerControlExtensionByDefault() {
+        // We need to explicitly set that the extension does not have to be created
+        importParams.put(CgmesImport.CREATE_ACTIVE_POWER_CONTROL_EXTENSION, "false");
         Network network = new CgmesImport().importData(CgmesConformity1Catalog.microGridBaseCaseNL().dataSource(), NetworkFactory.findDefault(), importParams);
         Generator g = network.getGenerator("9c3b8f97-7972-477d-9dc8-87365cc0ad0e");
         ActivePowerControl<Generator> ext = g.getExtension(ActivePowerControl.class);
@@ -322,7 +324,7 @@ class CgmesConformity1ConversionTest {
 
     @Test
     void microNLActivePowerControlExtension() {
-        importParams.put(CgmesImport.CREATE_ACTIVE_POWER_CONTROL_EXTENSION, "true");
+        // The extension is created by default
         Network network = new CgmesImport().importData(CgmesConformity1Catalog.microGridBaseCaseNL().dataSource(), NetworkFactory.findDefault(), importParams);
         Generator g = network.getGenerator("9c3b8f97-7972-477d-9dc8-87365cc0ad0e");
         ActivePowerControl<Generator> ext = g.getExtension(ActivePowerControl.class);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
CGMES import code contains references to parameters that are not used anymore.


**What is the new behavior (if this is a feature change)?**
The code handling the parameter `iidm.import.cgmes.allow-unsupported-tap-changers` have been removed. This parameter is not used in the current conversion from CGMES to IIDM.


Internal parameters containing low impedance threshold in conversion config have also been removed.

The parameter `change-sign-for-shunt-reactive-power-flow-initial-state` has also been removed.

The default value for parameter `create-active-power-control-extension` has been set to `true`.

The documentation has already been updated.

