### PR TITLE
CGMES. Updated export of busbar section terminals

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -1051,4 +1051,5 @@ public class Conversion {
     public static final String PROPERTY_IS_CREATED_FOR_DISCONNECTED_TERMINAL = CGMES_PREFIX_ALIAS_PROPERTIES + "isCreatedForDisconnectedTerminal";
     public static final String PROPERTY_IS_EQUIVALENT_SHUNT = CGMES_PREFIX_ALIAS_PROPERTIES + "isEquivalentShunt";
     public static final String PROPERTY_CGMES_ORIGINAL_CLASS = CGMES_PREFIX_ALIAS_PROPERTIES + "originalClass";
+    public static final String PROPERTY_BUSBAR_SECTION_TERMINALS = CGMES_PREFIX_ALIAS_PROPERTIES + "busbarSectionTerminals";
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
@@ -25,6 +25,12 @@ public class BusbarSectionConversion extends AbstractConductingEquipmentConversi
     }
 
     @Override
+    public boolean valid() {
+        // Always try to convert busbar sections, even if located at invalid o
+        return true;
+    }
+
+    @Override
     public void convert() {
         if (context.nodeBreaker()) {
             BusbarSectionAdder bbsAdder = voltageLevel().getNodeBreakerView().newBusbarSection()

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
@@ -26,7 +26,7 @@ public class BusbarSectionConversion extends AbstractConductingEquipmentConversi
 
     @Override
     public boolean valid() {
-        // Always try to convert busbar sections, even if located at invalid o
+        // Always try to convert busbar sections, even if located at invalid nodes or voltage levels
         return true;
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
@@ -124,11 +124,14 @@ public final class SteadyStateHypothesisExport {
                 writeTerminal(context.getNamingStrategy().getCgmesIdFromAlias(dl, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "Terminal_Boundary"), true, cimNamespace, writer, context);
             }
         }
-        for (Bus b : network.getBusBreakerView().getBuses()) {
-            String bbsTerminals = b.getProperty(PROPERTY_BUSBAR_SECTION_TERMINALS, "");
-            if (!bbsTerminals.isEmpty()) {
-                for (String bbsTerminal : bbsTerminals.split(",")) {
-                    writeTerminal(bbsTerminal, true, cimNamespace, writer, context);
+        // If we are performing an updated export, write recorded busbar section terminals as connected
+        if (!context.isExportEquipment()) {
+            for (Bus b : network.getBusBreakerView().getBuses()) {
+                String bbsTerminals = b.getProperty(PROPERTY_BUSBAR_SECTION_TERMINALS, "");
+                if (!bbsTerminals.isEmpty()) {
+                    for (String bbsTerminal : bbsTerminals.split(",")) {
+                        writeTerminal(bbsTerminal, true, cimNamespace, writer, context);
+                    }
                 }
             }
         }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
@@ -25,6 +25,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import java.util.*;
 
+import static com.powsybl.cgmes.conversion.Conversion.PROPERTY_BUSBAR_SECTION_TERMINALS;
 import static com.powsybl.cgmes.model.CgmesNamespace.RDF_NAMESPACE;
 
 /**
@@ -121,6 +122,14 @@ public final class SteadyStateHypothesisExport {
             // Terminal for boundary side of original line/switch is always connected
             if (dl.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "Terminal_Boundary").isPresent()) {
                 writeTerminal(context.getNamingStrategy().getCgmesIdFromAlias(dl, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "Terminal_Boundary"), true, cimNamespace, writer, context);
+            }
+        }
+        for (Bus b : network.getBusBreakerView().getBuses()) {
+            String bbsTerminals = b.getProperty(PROPERTY_BUSBAR_SECTION_TERMINALS, "");
+            if (!bbsTerminals.isEmpty()) {
+                for (String bbsTerminal : bbsTerminals.split(",")) {
+                    writeTerminal(bbsTerminal, true, cimNamespace, writer, context);
+                }
             }
         }
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
@@ -60,7 +60,10 @@ public final class TopologyExport {
         writeBoundaryTerminals(network, cimNamespace, writer, context);
         writeSwitchesTerminals(network, cimNamespace, writer, context);
         writeDcTerminals(network, cimNamespace, writer, context);
-        writeBusbarSectionTerminalsFromBusBranchCgmesModel(network, cimNamespace, writer, context);
+        // Only if it is an updated export
+        if (!context.isExportEquipment()) {
+            writeBusbarSectionTerminalsFromBusBranchCgmesModel(network, cimNamespace, writer, context);
+        }
     }
 
     private static void writeBusbarSectionTerminalsFromBusBranchCgmesModel(Network network, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/TopologyExport.java
@@ -20,6 +20,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import java.util.*;
 
+import static com.powsybl.cgmes.conversion.Conversion.PROPERTY_BUSBAR_SECTION_TERMINALS;
 import static com.powsybl.cgmes.conversion.naming.CgmesObjectReference.Part.DC_TOPOLOGICAL_NODE;
 import static com.powsybl.cgmes.conversion.naming.CgmesObjectReference.Part.TOPOLOGICAL_NODE;
 import static com.powsybl.cgmes.conversion.naming.CgmesObjectReference.refTyped;
@@ -59,6 +60,19 @@ public final class TopologyExport {
         writeBoundaryTerminals(network, cimNamespace, writer, context);
         writeSwitchesTerminals(network, cimNamespace, writer, context);
         writeDcTerminals(network, cimNamespace, writer, context);
+        writeBusbarSectionTerminalsFromBusBranchCgmesModel(network, cimNamespace, writer, context);
+    }
+
+    private static void writeBusbarSectionTerminalsFromBusBranchCgmesModel(Network network, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
+        for (Bus b : network.getBusBreakerView().getBuses()) {
+            String topologicalNodeId = context.getNamingStrategy().getCgmesId(b);
+            String bbsTerminals = b.getProperty(PROPERTY_BUSBAR_SECTION_TERMINALS, "");
+            if (!bbsTerminals.isEmpty()) {
+                for (String bbsTerminal : bbsTerminals.split(",")) {
+                    writeTerminal(bbsTerminal, topologicalNodeId, cimNamespace, writer, context);
+                }
+            }
+        }
     }
 
     private static void writeConnectableTerminals(Network network, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/issues/BusbarSectionTerminalsExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/issues/BusbarSectionTerminalsExportTest.java
@@ -3,21 +3,23 @@ package com.powsybl.cgmes.conversion.test.export.issues;
 import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conversion.CgmesExport;
 import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.cgmes.model.CgmesSubset;
 import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.iidm.network.Network;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class BusbarSectionTerminalsExportTest extends AbstractSerDeTest {
     @Test
-    void testMicroGridBe2() throws IOException {
+    void testMicroGridBEUpdate() throws IOException {
         Network network = Network.read(CgmesConformity1Catalog.microGridBaseCaseBE().dataSource());
+        network.setName("microGridBE-test-update");
 
         // Test case is bus/branch, CGMES contains busbar sections, but they are not present in the IIDM model
         assertEquals(0, network.getBusbarSectionCount());
@@ -40,12 +42,58 @@ class BusbarSectionTerminalsExportTest extends AbstractSerDeTest {
         });
     }
 
+    @Test
+    void testMicroGridBEFull() throws IOException {
+        Network network = Network.read(CgmesConformity1Catalog.microGridBaseCaseBE().dataSource());
+        network.setName("microGridBE-test-full");
+
+        // Test case is bus/branch, CGMES contains busbar sections, but they are not present in the IIDM model
+        assertEquals(0, network.getBusbarSectionCount());
+
+        // Export EQ, SSH, TP to CGMES and check that terminals from busbar sections are NOT present in the output
+        // This is a full export, the EQ will not contain definitions for original busbar sections or its terminals
+        Map<String, String> files = export(network);
+        String eq = files.get("EQ");
+        String ssh = files.get("SSH");
+        String tp = files.get("TP");
+        assertTrue(eq.contains(CgmesSubset.EQUIPMENT.getProfile()));
+        assertTrue(ssh.contains(CgmesSubset.STEADY_STATE_HYPOTHESIS.getProfile()));
+        assertTrue(tp.contains(CgmesSubset.TOPOLOGY.getProfile()));
+        network.getBusBreakerView().getBusStream().forEach(bus -> {
+            String bbsTerminals = bus.getProperty(Conversion.PROPERTY_BUSBAR_SECTION_TERMINALS, "");
+            if (bbsTerminals.isEmpty()) {
+                // Only this bus is missing a busbar in CGMES input (it is a Topological Node without busbar)
+                assertEquals("f96d552a-618d-4d0c-a39a-2dea3c411dee", bus.getId());
+            } else {
+                for (String bbsTerminal : bbsTerminals.split(",")) {
+                    assertFalse(eq.contains(bbsTerminal));
+                    assertFalse(ssh.contains(bbsTerminal));
+                    assertFalse(tp.contains(bbsTerminal));
+                }
+            }
+        });
+    }
+
     private String export(Network network, String profile) throws IOException {
         Properties exportParams = new Properties();
         exportParams.put(CgmesExport.PROFILES, profile);
         String basename = network.getNameOrId();
         network.write("CGMES", exportParams, tmpDir.resolve(basename));
+        return read(basename, profile);
+    }
+
+    private String read(String basename, String profile) throws IOException {
         String instanceFile = String.format("%s_%s.xml", basename, profile);
         return Files.readString(tmpDir.resolve(instanceFile));
+    }
+
+    private Map<String, String> export(Network network) throws IOException {
+        Properties exportParams = new Properties();
+        String basename = network.getNameOrId();
+        network.write("CGMES", exportParams, tmpDir.resolve(basename));
+
+        return Map.of("EQ", read(basename, "EQ"),
+                "SSH", read(basename, "SSH"),
+                "TP", read(basename, "TP"));
     }
 }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/issues/BusbarSectionTerminalsExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/issues/BusbarSectionTerminalsExportTest.java
@@ -1,0 +1,51 @@
+package com.powsybl.cgmes.conversion.test.export.issues;
+
+import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
+import com.powsybl.cgmes.conversion.CgmesExport;
+import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.commons.test.AbstractSerDeTest;
+import com.powsybl.iidm.network.Network;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BusbarSectionTerminalsExportTest extends AbstractSerDeTest {
+    @Test
+    void testMicroGridBe2() throws IOException {
+        Network network = Network.read(CgmesConformity1Catalog.microGridBaseCaseBE().dataSource());
+
+        // Test case is bus/branch, CGMES contains busbar sections, but they are not present in the IIDM model
+        assertEquals(0, network.getBusbarSectionCount());
+
+        // Export SSH, TP to CGMES and check that terminals from busbar sections are present in the output
+        // Even if the busbar themselves have not been included in the IIDM model
+        String ssh = export(network, "SSH");
+        String tp = export(network, "TP");
+        network.getBusBreakerView().getBusStream().forEach(bus -> {
+            String bbsTerminals = bus.getProperty(Conversion.PROPERTY_BUSBAR_SECTION_TERMINALS, "");
+            if (bbsTerminals.isEmpty()) {
+                // Only this bus is missing a busbar in CGMES input (it is a Topological Node without busbar)
+                assertEquals("f96d552a-618d-4d0c-a39a-2dea3c411dee", bus.getId());
+            } else {
+                for (String bbsTerminal : bbsTerminals.split(",")) {
+                    assertTrue(ssh.contains(bbsTerminal));
+                    assertTrue(tp.contains(bbsTerminal));
+                }
+            }
+        });
+    }
+
+    private String export(Network network, String profile) throws IOException {
+        Properties exportParams = new Properties();
+        exportParams.put(CgmesExport.PROFILES, profile);
+        String basename = network.getNameOrId();
+        network.write("CGMES", exportParams, tmpDir.resolve(basename));
+        String instanceFile = String.format("%s_%s.xml", basename, profile);
+        return Files.readString(tmpDir.resolve(instanceFile));
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #2885

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
When CGMES data is imported to IIDM bus/breaker model the terminals of all busbar sections inside a given CGMES Topological Node are stored in a property of the corresponding IIDM bus. The SSH and TP export modules use this property to write data about the busbar sections that have not been explicitly modelled in IIDM.