### PR TITLE
Add name in contingency for open rao

### DIFF
--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
@@ -8,9 +8,9 @@ package com.powsybl.contingency;
 
 import com.powsybl.commons.extensions.AbstractExtendable;
 import com.powsybl.contingency.contingency.list.ContingencyList;
-import com.powsybl.iidm.network.*;
-import com.powsybl.iidm.modification.NetworkModificationList;
 import com.powsybl.iidm.modification.NetworkModification;
+import com.powsybl.iidm.modification.NetworkModificationList;
+import com.powsybl.iidm.network.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,13 +30,24 @@ public class Contingency extends AbstractExtendable<Contingency> {
 
     private final List<ContingencyElement> elements;
 
-    public Contingency(String id, ContingencyElement... elements) {
-        this(id, Arrays.asList(elements));
+    private final String name;
+
+    public Contingency(String id, String name, List<ContingencyElement> elements) {
+        this.id = Objects.requireNonNull(id);
+        this.name = name;
+        this.elements = new ArrayList<>(Objects.requireNonNull(elements));
+    }
+
+    public Contingency(String id, String name, ContingencyElement... elements) {
+        this(id, name, Arrays.asList(elements));
     }
 
     public Contingency(String id, List<ContingencyElement> elements) {
-        this.id = Objects.requireNonNull(id);
-        this.elements = new ArrayList<>(Objects.requireNonNull(elements));
+        this(id, null, elements);
+    }
+
+    public Contingency(String id, ContingencyElement... elements) {
+        this(id, Arrays.asList(elements));
     }
 
     public String getId() {
@@ -58,6 +69,10 @@ public class Contingency extends AbstractExtendable<Contingency> {
             return id.equals(other.id) && elements.equals(other.elements);
         }
         return false;
+    }
+
+    public Optional<String> getName() {
+        return Optional.ofNullable(name);
     }
 
     public void addElement(ContingencyElement element) {

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingencyBuilder.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingencyBuilder.java
@@ -24,13 +24,15 @@ public class ContingencyBuilder {
 
     private final List<ContingencyElement> elements;
 
+    private String name;
+
     ContingencyBuilder(String id) {
         this.id = Objects.requireNonNull(id);
         this.elements = new ArrayList<>();
     }
 
     public Contingency build() {
-        return new Contingency(id, elements);
+        return new Contingency(id, name, elements);
     }
 
     public ContingencyBuilder addBattery(String id) {
@@ -143,6 +145,11 @@ public class ContingencyBuilder {
 
     public ContingencyBuilder addIdentifiable(Identifiable<?> identifiable) {
         elements.add(ContingencyElement.of(identifiable));
+        return this;
+    }
+
+    public ContingencyBuilder addName(String name) {
+        this.name = name;
         return this;
     }
 }

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ContingencyDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ContingencyDeserializer.java
@@ -40,6 +40,7 @@ public class ContingencyDeserializer extends StdDeserializer<Contingency> {
     @Override
     public Contingency deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
         String id = null;
+        String name = null;
         List<ContingencyElement> elements = Collections.emptyList();
 
         List<Extension<Contingency>> extensions = Collections.emptyList();
@@ -47,6 +48,7 @@ public class ContingencyDeserializer extends StdDeserializer<Contingency> {
         while (parser.nextToken() != JsonToken.END_OBJECT) {
             switch (parser.getCurrentName()) {
                 case "id" -> id = parser.nextTextValue();
+                case "name" -> name = parser.nextTextValue();
                 case "elements" -> {
                     parser.nextToken();
                     elements = JsonUtil.readList(deserializationContext, parser, ContingencyElement.class);
@@ -58,8 +60,7 @@ public class ContingencyDeserializer extends StdDeserializer<Contingency> {
                 default -> throw new IllegalStateException("Unexpected field: " + parser.getCurrentName());
             }
         }
-
-        Contingency contingency = new Contingency(id, elements);
+        Contingency contingency = new Contingency(id, name, elements);
         SUPPLIER.get().addExtensions(contingency, extensions);
 
         return contingency;

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ContingencySerializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ContingencySerializer.java
@@ -13,6 +13,7 @@ import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.contingency.Contingency;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * @author Teofil Calin BANC {@literal <teofil-calin.banc at rte-france.com>}
@@ -28,6 +29,10 @@ public class ContingencySerializer extends StdSerializer<Contingency> {
         jsonGenerator.writeStartObject();
 
         jsonGenerator.writeStringField("id", contingency.getId());
+        Optional<String> contingencyName = contingency.getName();
+        if (contingencyName.isPresent()) {
+            jsonGenerator.writeStringField("name", contingencyName.get());
+        }
         serializerProvider.defaultSerializeField("elements", contingency.getElements(), jsonGenerator);
 
         JsonUtil.writeExtensions(contingency, jsonGenerator, serializerProvider);

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
@@ -224,5 +224,11 @@ class ContingencyTest {
 
         Contingency contingency2 = new Contingency("test2", "testName2");
         assertEquals("testName2", contingency2.getName().orElse(null));
+
+        Contingency contingency3 = Contingency.builder("test3").addName("testName3").build();
+        assertEquals("testName3", contingency3.getName().orElse(null));
+
+        Contingency contingency4 = Contingency.builder("test4").addGenerator("GEN").addName("testName4").build();
+        assertEquals("testName4", contingency4.getName().orElse(null));
     }
 }

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/ContingencyTest.java
@@ -12,11 +12,7 @@ import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.modification.NetworkModificationList;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.test.DanglingLineNetworkFactory;
-import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
-import com.powsybl.iidm.network.test.HvdcTestNetwork;
-import com.powsybl.iidm.network.test.SvcTestCaseFactory;
-import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
+import com.powsybl.iidm.network.test.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -24,9 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
@@ -220,5 +214,15 @@ class ContingencyTest {
         ContingencyBuilder contingencyBuilder = Contingency.builder("Invalid contingency");
         PowsyblException exception = assertThrows(PowsyblException.class, () -> contingencyBuilder.addIdentifiable("Unknown", network));
         assertEquals("Element Unknown has not been found in the network", exception.getMessage());
+    }
+
+    @Test
+    void testWithName() {
+        ContingencyElement bbsElement = new BusbarSectionContingency("bbs");
+        Contingency contingency = new Contingency("test", "testName", bbsElement);
+        assertEquals("testName", contingency.getName().orElse(null));
+
+        Contingency contingency2 = new Contingency("test2", "testName2");
+        assertEquals("testName2", contingency2.getName().orElse(null));
     }
 }

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/ContingencyJsonTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/ContingencyJsonTest.java
@@ -13,11 +13,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.auto.service.AutoService;
-import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.commons.extensions.Extension;
 import com.powsybl.commons.extensions.ExtensionJsonSerializer;
 import com.powsybl.commons.json.JsonUtil;
-import com.powsybl.contingency.*;
+import com.powsybl.commons.test.AbstractSerDeTest;
+import com.powsybl.contingency.Contingency;
 import com.powsybl.contingency.contingency.list.ContingencyList;
 import com.powsybl.contingency.contingency.list.DefaultContingencyList;
 import com.powsybl.iidm.network.Network;
@@ -48,6 +48,7 @@ class ContingencyJsonTest extends AbstractSerDeTest {
         super.setUp();
 
         Files.copy(getClass().getResourceAsStream("/contingencies.json"), fileSystem.getPath("/contingencies.json"));
+        Files.copy(getClass().getResourceAsStream("/contingenciesWithOptionalName.json"), fileSystem.getPath("/contingenciesWithOptionalName.json"));
     }
 
     private static Contingency create() {
@@ -130,6 +131,24 @@ class ContingencyJsonTest extends AbstractSerDeTest {
         assertEquals(1, contingencies.get(1).getElements().size());
 
         roundTripTest(contingencyList, ContingencyJsonTest::write, ContingencyJsonTest::readContingencyList, "/contingencies.json");
+    }
+
+    @Test
+    void readJsonListContingenciesWithOptionalName() throws IOException {
+        Network network = EurostagTutorialExample1Factory.create();
+
+        DefaultContingencyList contingencyList = (DefaultContingencyList) ContingencyList.load(fileSystem.getPath("/contingenciesWithOptionalName.json"));
+        assertEquals("list", contingencyList.getName());
+
+        List<Contingency> contingencies = contingencyList.getContingencies(network);
+        assertEquals(2, contingencies.size());
+        assertEquals("contingency", contingencies.get(0).getId());
+        assertEquals("contingency name", contingencies.get(0).getName().get());
+        assertEquals(2, contingencies.get(0).getElements().size());
+        assertEquals("contingency2", contingencies.get(1).getId());
+        assertEquals(1, contingencies.get(1).getElements().size());
+
+        roundTripTest(contingencyList, ContingencyJsonTest::write, ContingencyJsonTest::readContingencyList, "/contingenciesWithOptionalName.json");
     }
 
     static class DummyExtension implements Extension<Contingency> {

--- a/contingency/contingency-api/src/test/resources/contingenciesWithOptionalName.json
+++ b/contingency/contingency-api/src/test/resources/contingenciesWithOptionalName.json
@@ -1,0 +1,22 @@
+{
+  "type" : "default",
+  "version" : "1.0",
+  "name" : "list",
+  "contingencies" : [ {
+    "id" : "contingency",
+    "name" : "contingency name",
+    "elements" : [ {
+      "id" : "NHV1_NHV2_1",
+      "type" : "BRANCH"
+    }, {
+      "id" : "NHV1_NHV2_2",
+      "type" : "BRANCH"
+    } ]
+  }, {
+    "id" : "contingency2",
+    "elements" : [ {
+      "id" : "GEN",
+      "type" : "GENERATOR"
+    } ]
+  } ]
+}


### PR DESCRIPTION
This PR add an optional Name in core Contingency for powsybl-open-rao to be able to use directly core Contingency knowing that a name is mandatory for rao. 

This is part of the issue: https://github.com/powsybl/powsybl-core/issues/2868

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
