### PR TITLE
[AMPL Converter] Add export sorting option

### DIFF
--- a/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplExportConfig.java
+++ b/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplExportConfig.java
@@ -136,4 +136,9 @@ public class AmplExportConfig {
         return exportSorted;
     }
 
+    public AmplExportConfig setExportSorted(boolean exportSorted) {
+        this.exportSorted = exportSorted;
+        return this;
+    }
+
 }

--- a/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplExportConfig.java
+++ b/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplExportConfig.java
@@ -50,25 +50,32 @@ public class AmplExportConfig {
 
     private boolean twtSplitShuntAdmittance;
 
+    private boolean exportSorted;
+
     public AmplExportConfig(ExportScope exportScope, boolean exportXNodes, ExportActionType actionType) {
-        this(exportScope, exportXNodes, actionType, false, false, AmplExportVersion.defaultVersion());
+        this(exportScope, exportXNodes, actionType, false, false, AmplExportVersion.defaultVersion(), false);
     }
 
     public AmplExportConfig(ExportScope exportScope, boolean exportXNodes, ExportActionType actionType,
                             boolean exportRatioTapChangerVoltageTarget, boolean twtSplitShuntAdmittance) {
         this(exportScope, exportXNodes, actionType, exportRatioTapChangerVoltageTarget, twtSplitShuntAdmittance,
-            AmplExportVersion.defaultVersion());
+            AmplExportVersion.defaultVersion(), false);
     }
 
     public AmplExportConfig(ExportScope exportScope, boolean exportXNodes, ExportActionType actionType,
                             boolean exportRatioTapChangerVoltageTarget, boolean twtSplitShuntAdmittance,
                             AmplExportVersion version) {
+        this(exportScope, exportXNodes, actionType, exportRatioTapChangerVoltageTarget, twtSplitShuntAdmittance, version, false);
+    }
+
+    public AmplExportConfig(ExportScope exportScope, boolean exportXNodes, ExportActionType actionType, boolean exportRatioTapChangerVoltageTarget, boolean twtSplitShuntAdmittance, AmplExportVersion version, boolean exportSorted) {
         this.exportScope = Objects.requireNonNull(exportScope);
         this.exportXNodes = exportXNodes;
         this.actionType = Objects.requireNonNull(actionType);
         this.exportRatioTapChangerVoltageTarget = exportRatioTapChangerVoltageTarget;
         this.twtSplitShuntAdmittance = twtSplitShuntAdmittance;
         this.version = Objects.requireNonNull(version);
+        this.exportSorted = exportSorted;
     }
 
     public ExportScope getExportScope() {
@@ -123,6 +130,10 @@ public class AmplExportConfig {
     public AmplExportConfig setVersion(AmplExportVersion version) {
         this.version = Objects.requireNonNull(version);
         return this;
+    }
+
+    public boolean isExportSorted() {
+        return exportSorted;
     }
 
 }

--- a/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplExporter.java
+++ b/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplExporter.java
@@ -60,7 +60,6 @@ public class AmplExporter implements Exporter {
 
     private static final Parameter EXPORT_SORTED_PARAMETER = new Parameter(EXPORT_SORTED, ParameterType.BOOLEAN, "Export alphabetically sorted by equipment id", Boolean.FALSE);
 
-
     private static final List<Parameter> STATIC_PARAMETERS = List.of(EXPORT_SCOPE_PARAMETER, EXPORT_XNODES_PARAMETER,
         EXPORT_ACTION_TYPE_PARAMETER, EXPORT_RATIOTAPCHANGER_VT_PARAMETER, TWT_SPLIT_SHUNT_ADMITTANCE_PARAMETER,
         EXPORT_VERSION_PARAMETER, EXPORT_SORTED_PARAMETER);

--- a/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplExporter.java
+++ b/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplExporter.java
@@ -35,6 +35,7 @@ public class AmplExporter implements Exporter {
     public static final String EXPORT_RATIOTAPCHANGER_VT = "iidm.export.ampl.export-ratio-tap-changer-voltage-target";
     public static final String TWT_SPLIT_SHUNT_ADMITTANCE = "iidm.export.ampl.twt-split-shunt-admittance";
     public static final String EXPORT_VERSION = "iidm.export.ampl.export-version";
+    public static final String EXPORT_SORTED = "iidm.export.ampl.export-sorted";
 
     private static final Parameter EXPORT_SCOPE_PARAMETER = new Parameter(EXPORT_SCOPE, ParameterType.STRING, "Export scope",
             AmplExportConfig.ExportScope.ALL.name(),
@@ -52,15 +53,17 @@ public class AmplExporter implements Exporter {
         ParameterType.BOOLEAN, "Export twt split shunt admittance", Boolean.FALSE)
         .addAdditionalNames("iidm.export.ampl.specific-compatibility")
         .addAdditionalNames("iidm.export.ampl.specificCompatibility");
-
     private static final Parameter EXPORT_VERSION_PARAMETER = new Parameter(EXPORT_VERSION, ParameterType.STRING,
         "The version of the export.",
             AmplExportVersion.defaultVersion().getExporterId(),
             new ArrayList<>(AmplExportVersion.exporterIdValues()));
 
+    private static final Parameter EXPORT_SORTED_PARAMETER = new Parameter(EXPORT_SORTED, ParameterType.BOOLEAN, "Export alphabetically sorted by equipment id", Boolean.FALSE);
+
+
     private static final List<Parameter> STATIC_PARAMETERS = List.of(EXPORT_SCOPE_PARAMETER, EXPORT_XNODES_PARAMETER,
         EXPORT_ACTION_TYPE_PARAMETER, EXPORT_RATIOTAPCHANGER_VT_PARAMETER, TWT_SPLIT_SHUNT_ADMITTANCE_PARAMETER,
-        EXPORT_VERSION_PARAMETER);
+        EXPORT_VERSION_PARAMETER, EXPORT_SORTED_PARAMETER);
 
     private final ParameterDefaultValueConfig defaultValueConfig;
 
@@ -95,10 +98,22 @@ public class AmplExporter implements Exporter {
                 TWT_SPLIT_SHUNT_ADMITTANCE_PARAMETER, defaultValueConfig);
             AmplExportVersion exportVersion = AmplExportVersion.fromExporterId(
                 Parameter.readString(getFormat(), parameters, EXPORT_VERSION_PARAMETER, defaultValueConfig));
+            boolean exportSorted = Parameter.readBoolean(getFormat(), parameters, EXPORT_SORTED_PARAMETER, defaultValueConfig);
 
             AmplExportConfig config = new AmplExportConfig(scope, exportXnodes, actionType,
-                exportRatioTapChangerVoltageTarget, twtSplitShuntAdmittance, exportVersion);
+                exportRatioTapChangerVoltageTarget, twtSplitShuntAdmittance, exportVersion, exportSorted);
 
+            new AmplNetworkWriter(network, dataSource, config).write();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void export(Network network, AmplExportConfig config, DataSource dataSource) {
+        Objects.requireNonNull(network);
+        Objects.requireNonNull(dataSource);
+        Objects.requireNonNull(config);
+        try {
             new AmplNetworkWriter(network, dataSource, config).write();
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/ampl-converter/src/test/java/com/powsybl/ampl/converter/AmplNetworkWriterTest.java
+++ b/ampl-converter/src/test/java/com/powsybl/ampl/converter/AmplNetworkWriterTest.java
@@ -41,7 +41,7 @@ class AmplNetworkWriterTest extends AbstractSerDeTest {
         AmplExporter exporter = new AmplExporter();
         assertEquals("AMPL", exporter.getFormat());
         assertEquals("IIDM to AMPL converter", exporter.getComment());
-        assertEquals(6, exporter.getParameters().size());
+        assertEquals(7, exporter.getParameters().size());
     }
 
     @Test

--- a/ampl-converter/src/test/java/com/powsybl/ampl/converter/AmplNetworkWriterTest.java
+++ b/ampl-converter/src/test/java/com/powsybl/ampl/converter/AmplNetworkWriterTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.ampl.converter;
 
+import com.powsybl.ampl.converter.version.AmplExportVersion;
 import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.commons.datasource.DataSource;
 import com.powsybl.commons.datasource.MemDataSource;
@@ -49,7 +50,8 @@ class AmplNetworkWriterTest extends AbstractSerDeTest {
 
         MemDataSource dataSource = new MemDataSource();
         AmplExporter exporter = new AmplExporter();
-        exporter.export(network, new Properties(), dataSource);
+        AmplExportConfig amplExportConfig = new AmplExportConfig(AmplExportConfig.ExportScope.ALL, false, AmplExportConfig.ExportActionType.CURATIVE, false, false, AmplExportVersion.defaultVersion(), true);
+        exporter.export(network, amplExportConfig, dataSource);
 
         assertEqualsToRef(dataSource, "_network_substations", "inputs/eurostag-tutorial-example1-substations.txt");
         assertEqualsToRef(dataSource, "_network_buses", "inputs/eurostag-tutorial-example1-buses.txt");

--- a/ampl-executor/src/main/java/com/powsybl/ampl/executor/AmplModelExecutionHandler.java
+++ b/ampl-executor/src/main/java/com/powsybl/ampl/executor/AmplModelExecutionHandler.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * This executionHandler will run an ampl model on a network.
@@ -96,7 +97,11 @@ public class AmplModelExecutionHandler extends AbstractExecutionHandler<AmplResu
 
     private void exportNetworkAsAmpl(Path workingDir) {
         DataSource networkExportDataSource = new FileDataSource(workingDir, this.model.getNetworkDataPrefix());
-        new AmplExporter().export(network, null, networkExportDataSource);
+        if (parameters.getAmplExportConfig() != null) {
+            new AmplExporter().export(network, parameters.getAmplExportConfig(), networkExportDataSource);
+        } else {
+            new AmplExporter().export(network, new Properties(), networkExportDataSource);
+        }
     }
 
     /**

--- a/ampl-executor/src/main/java/com/powsybl/ampl/executor/AmplParameters.java
+++ b/ampl-executor/src/main/java/com/powsybl/ampl/executor/AmplParameters.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.ampl.executor;
 
+import com.powsybl.ampl.converter.AmplExportConfig;
+
 import java.util.Collection;
 
 /**
@@ -32,4 +34,9 @@ public interface AmplParameters {
      * @return true if debug mode is on, else otherwise
      */
     boolean isDebug();
+
+    /**
+     * Configuration for AmplExporter
+     */
+    AmplExportConfig getAmplExportConfig();
 }

--- a/ampl-executor/src/main/java/com/powsybl/ampl/executor/EmptyAmplParameters.java
+++ b/ampl-executor/src/main/java/com/powsybl/ampl/executor/EmptyAmplParameters.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.ampl.executor;
 
+import com.powsybl.ampl.converter.AmplExportConfig;
+
 import java.util.Collection;
 import java.util.Collections;
 
@@ -28,4 +30,10 @@ public class EmptyAmplParameters implements AmplParameters {
     public boolean isDebug() {
         return false;
     }
+
+    @Override
+    public AmplExportConfig getAmplExportConfig() {
+        return null;
+    }
+
 }

--- a/ampl-executor/src/test/java/com/powsybl/ampl/executor/SimpleAmplParameters.java
+++ b/ampl-executor/src/test/java/com/powsybl/ampl/executor/SimpleAmplParameters.java
@@ -6,7 +6,9 @@
  */
 package com.powsybl.ampl.executor;
 
+import com.powsybl.ampl.converter.AmplExportConfig;
 import com.powsybl.ampl.converter.AmplSubset;
+import com.powsybl.ampl.converter.version.AmplExportVersion;
 import com.powsybl.commons.util.StringToIntMapper;
 
 import java.io.BufferedReader;
@@ -69,4 +71,10 @@ public class SimpleAmplParameters implements AmplParameters {
     public boolean isDebug() {
         return true;
     }
+
+    @Override
+    public AmplExportConfig getAmplExportConfig() {
+        return new AmplExportConfig(AmplExportConfig.ExportScope.ALL, false, AmplExportConfig.ExportActionType.CURATIVE, false, false, AmplExportVersion.defaultVersion(), false);
+    }
+
 }


### PR DESCRIPTION
Signed-off-by: Hugo Marcellin <hugo.marcelin@rte-france.com>

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
It allows to tune AMPL Converter network export in order write equipments alphabetically sorted in the output, the feature is optional and is enabled through a new parameter added to AmplExportConfig
This PR also adds the ability to tune AMPL Converter network export by passing the desired configuration through AMPL Executor 

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently the output order of AMPL Converter is inconsistent 


**What is the new behavior (if this is a feature change)?**
Equipments may be alphabetically sorted by their id through the AMPL export configuration


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
