### PR TITLE
CGMES. UUIDs with a leading underscore are considered valid master resource ids

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -54,7 +54,7 @@ public final class CgmesExportUtil {
     private static final DecimalFormat SCIENTIFIC_FORMAT = new DecimalFormat("0.######E0", DOUBLE_FORMAT_SYMBOLS);
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyy-MM-dd'T'HH:mm:ssXXX").withZone(ZoneOffset.UTC);
 
-    private static final Pattern CIM_MRID_PATTERN = Pattern.compile("(?i)_*[a-f\\d]{8}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{12}");
+    private static final Pattern CIM_MRID_PATTERN = Pattern.compile("(?i)_?[a-f\\d]{8}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{12}");
     private static final Pattern URN_UUID_PATTERN = Pattern.compile("(?i)urn:uuid:[a-f\\d]{8}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{12}");
     private static final Pattern ENTSOE_BD_EXCEPTIONS_PATTERN1 = Pattern.compile("(?i)[a-f\\d]{8}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{7}");
     private static final Pattern ENTSOE_BD_EXCEPTIONS_PATTERN2 = Pattern.compile("(?i)[a-f\\d]{8}[a-f\\d]{4}[a-f\\d]{4}[a-f\\d]{4}[a-f\\d]{12}");

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -54,7 +54,7 @@ public final class CgmesExportUtil {
     private static final DecimalFormat SCIENTIFIC_FORMAT = new DecimalFormat("0.######E0", DOUBLE_FORMAT_SYMBOLS);
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyy-MM-dd'T'HH:mm:ssXXX").withZone(ZoneOffset.UTC);
 
-    private static final Pattern CIM_MRID_PATTERN = Pattern.compile("(?i)[a-f\\d]{8}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{12}");
+    private static final Pattern CIM_MRID_PATTERN = Pattern.compile("(?i)_*[a-f\\d]{8}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{12}");
     private static final Pattern URN_UUID_PATTERN = Pattern.compile("(?i)urn:uuid:[a-f\\d]{8}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{12}");
     private static final Pattern ENTSOE_BD_EXCEPTIONS_PATTERN1 = Pattern.compile("(?i)[a-f\\d]{8}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{4}-[a-f\\d]{7}");
     private static final Pattern ENTSOE_BD_EXCEPTIONS_PATTERN2 = Pattern.compile("(?i)[a-f\\d]{8}[a-f\\d]{4}[a-f\\d]{4}[a-f\\d]{4}[a-f\\d]{12}");

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/issues/ConsiderValidMasterRIDWithLeadingUnderscoreTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/issues/ConsiderValidMasterRIDWithLeadingUnderscoreTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.test.export.issues;
+
+import com.powsybl.cgmes.conversion.CgmesExport;
+import com.powsybl.cgmes.conversion.export.CgmesExportUtil;
+import com.powsybl.commons.test.AbstractSerDeTest;
+import com.powsybl.iidm.network.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
+ */
+class ConsiderValidMasterRIDWithLeadingUnderscoreTest extends AbstractSerDeTest {
+    @Test
+    void testSshWithCgmesNamingStrategyPreservesIdentifiers() throws IOException {
+        // Create a very simple network with two loads:
+        // One load will have a UUID as identifier,
+        // The other one a UUID prefixed with an underscore
+        Network network = NetworkFactory.findDefault().createNetwork("minimal-network", "test");
+        Substation substation1 = network.newSubstation()
+                .setId(newUuid())
+                .setCountry(Country.AQ).add();
+        VoltageLevel voltageLevel = substation1.newVoltageLevel()
+                .setId(newUuid())
+                .setNominalV(400).setTopologyKind(TopologyKind.BUS_BREAKER).add();
+        Bus bus = voltageLevel.getBusBreakerView().newBus()
+                .setId(newUuid()).add();
+        Load loadUuid = voltageLevel.newLoad()
+                .setId(newUuid())
+                .setBus(bus.getId()).setP0(0).setQ0(0).add();
+        Load loadUnderscoreUuid = voltageLevel.newLoad()
+                .setId("_" + newUuid())
+                .setBus(bus.getId()).setP0(0).setQ0(0).add();
+
+        // Export SSH using the "cgmes" naming strategy
+        Set<String> exportedRdfAbouts = exportedSshRdfAboutsWithCgmesNamingStrategy(network);
+
+        // And check that both load identifiers have been preserved in the output
+        // All exported identifiers must be valid
+        assertTrue(exportedRdfAbouts.stream().allMatch(CgmesExportUtil::isValidCimMasterRID));
+        // Both IIDM load identifiers must be found in the exported data
+        // The load with the leading underscore will be found directly as and rdf:about
+        assertTrue(exportedRdfAbouts.contains(loadUnderscoreUuid.getId()));
+        // The load without the leading underscore must have been exported as a rdf:about that has a leading underscore
+        assertTrue(exportedRdfAbouts.contains("_" + loadUuid.getId()));
+    }
+
+    String newUuid() {
+        return UUID.randomUUID().toString();
+    }
+
+    private Set<String> exportedSshRdfAboutsWithCgmesNamingStrategy(Network network) throws IOException {
+        String basename = network.getNameOrId();
+
+        Properties exportParams = new Properties();
+        exportParams.put(CgmesExport.NAMING_STRATEGY, "cgmes");
+        exportParams.put(CgmesExport.PROFILES, "SSH");
+        network.write("CGMES", exportParams, tmpDir.resolve(basename));
+
+        String instanceFile = String.format("%s_%s.xml", basename, "SSH");
+        String instanceFileContent = Files.readString(tmpDir.resolve(instanceFile));
+
+        return extractRdfAbouts(instanceFileContent);
+    }
+
+    private static final Pattern REGEX_RDF_ABOUT = Pattern.compile(" rdf:about=\"[#]*(.*?)\"");
+
+    private Set<String> extractRdfAbouts(String xml) {
+        Set<String> ids = new HashSet<>();
+        Matcher matcher = REGEX_RDF_ABOUT.matcher(xml);
+        while (matcher.find()) {
+            ids.add(matcher.group(1));
+        }
+        return ids;
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The issue was raised when exporting an updated SSH of an IIDM network that had valid UUID in its identifiables, but prefixed with an underscore. When the SSH was exported using the `cgmes` naming strategy, these prefixed identifiers were considered not valid and "fixed": replaced by newly created ones. This meant that the references to the original objects in the CGMES EQ instance file were lost.


**What is the new behavior (if this is a feature change)?**
UUIDs with a leading `"_"` character are considered valid Master Resource Identifiers.
A specific unit test to check the scenario where the issue was first raised has been added.


