### PR TITLE
LoadScalable: Do not apply constant power factor if P0 is zero

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/LoadScalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/LoadScalable.java
@@ -150,7 +150,7 @@ class LoadScalable extends AbstractInjectionScalable {
         LOGGER.info("Change active power setpoint of {} from {} to {} ",
                 l.getId(), oldP0, l.getP0());
 
-        if (parameters.isConstantPowerFactor()) {
+        if (parameters.isConstantPowerFactor() && oldP0 != 0) {
             l.setQ0(l.getP0() * oldQ0 / oldP0);
             LOGGER.info("Change reactive power setpoint of {} from {} to {} ",
                     l.getId(), oldQ0, l.getQ0());

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/scalable/LoadScalableTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/scalable/LoadScalableTest.java
@@ -185,6 +185,13 @@ class LoadScalableTest {
         ls1.scale(network, 20, parameters);
         assertEquals(60, load.getP0(), 1e-3);
         assertEquals(7.5, load.getQ0(), 1e-3);
+
+        ls1.reset(network);
+        assertEquals(0.0, load.getP0(), 1e-3);
+        assertEquals(7.5, load.getQ0(), 1e-3);
+        ls1.scale(network, -20, parameters);
+        assertEquals(20.0, load.getP0(), 1e-3);
+        assertEquals(7.5, load.getQ0(), 1e-3);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix (handle the case when Scaling a load with P0=0 and constantPowerFactor = true).


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The calculated new Q0 value will be NaN because of dividing by P0=0. Which will make setQ0() throw an error.


**What is the new behavior (if this is a feature change)?**
The value of Q0 is not updated ant stays as is, instead of throwing an error.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
