### PR TITLE
Add a pairing key setter for unpaired dangling line

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DanglingLine.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DanglingLine.java
@@ -279,6 +279,12 @@ public interface DanglingLine extends Injection<DanglingLine>, FlowsLimitsHolder
      */
     String getPairingKey();
 
+    /**
+     * Set a pairing key corresponding to this dangling line only if the dangling line is not paired,
+     * throw exception otherwise.
+     */
+    DanglingLine setPairingKey(String pairingKey);
+
     Boundary getBoundary();
 
     default Optional<TieLine> getTieLine() {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DanglingLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DanglingLineImpl.java
@@ -246,7 +246,7 @@ class DanglingLineImpl extends AbstractConnectable<DanglingLine> implements Dang
 
     private double b;
 
-    private final String pairingKey;
+    private String pairingKey;
 
     private final GenerationImpl generation;
 
@@ -414,6 +414,18 @@ class DanglingLineImpl extends AbstractConnectable<DanglingLine> implements Dang
     @Override
     public String getPairingKey() {
         return pairingKey;
+    }
+
+    @Override
+    public DanglingLine setPairingKey(String pairingKey) {
+        if (this.isPaired()) {
+            throw new ValidationException(this, "pairing key cannot be set if dangling line is paired.");
+        } else {
+            String oldValue = this.pairingKey;
+            this.pairingKey = pairingKey;
+            notifyUpdate("pairing_key", oldValue, pairingKey);
+        }
+        return this;
     }
 
     @Override

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractDanglingLineTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractDanglingLineTest.java
@@ -64,6 +64,7 @@ public abstract class AbstractDanglingLineTest {
         String id = "danglingId";
         String name = "danlingName";
         String pairingKey = "code";
+        String newPairingKey = "new_code";
         voltageLevel.newDanglingLine()
                         .setId(id)
                         .setName(name)
@@ -111,6 +112,8 @@ public abstract class AbstractDanglingLineTest {
         assertEquals(p02, danglingLine.getP0(), 0.0);
         danglingLine.setQ0(q02);
         assertEquals(q02, danglingLine.getQ0(), 0.0);
+        danglingLine.setPairingKey(newPairingKey);
+        assertEquals(newPairingKey, danglingLine.getPairingKey());
 
         danglingLine.newCurrentLimits()
                 .setPermanentLimit(100.0)

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTieLineTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTieLineTest.java
@@ -187,6 +187,10 @@ public abstract class AbstractTieLineTest {
         Optional<DanglingLine> otherSide2 = TieLineUtil.getPairedDanglingLine(danglingLine2);
         assertTrue(otherSide2.isPresent());
         assertEquals(danglingLine1, otherSide2.orElseThrow());
+
+        // try to change pairing key, but not allowed.
+        assertThrows(ValidationException.class, () -> danglingLine1.setPairingKey("new_code"),
+                "Dangling line 'hl1': pairing key cannot be set if dangling line is paired.");
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Once a dangling line is created, it is not possible to change its pairing key.


**What is the new behavior (if this is a feature change)?**
A setter is available to change the pairing key of a dangling line after its creation.

In this PR, the setter throws an exception if the dangling line is already paired.

In a future PR, if the dangling line is already paired, changing its pairing key will unpair it and possibly pair it with another dangling line having the same pairing key. But this raises a lot of questions and the wanted behavior should be clarified before.


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes, for custom IIDM implementations
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

Custom IIDM implementation maintainers should define the following method in their `DanglingLine` implementation:
```java
DanglingLine setPairingKey(String pairingKey);
```

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
