### PR TITLE
AbstractMinMaxNodeCalc extends AbstractSingleChildNodeCalc

### DIFF
--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/AbstractMinMaxNodeCalc.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/ast/AbstractMinMaxNodeCalc.java
@@ -12,28 +12,17 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.powsybl.timeseries.TimeSeriesException;
 
 import java.io.IOException;
-import java.util.Objects;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
-public abstract class AbstractMinMaxNodeCalc implements NodeCalc {
-
-    protected NodeCalc child;
+public abstract class AbstractMinMaxNodeCalc extends AbstractSingleChildNodeCalc {
 
     protected final double value;
 
     protected AbstractMinMaxNodeCalc(NodeCalc child, double value) {
-        this.child = Objects.requireNonNull(child);
+        super(child);
         this.value = value;
-    }
-
-    public NodeCalc getChild() {
-        return child;
-    }
-
-    public void setChild(NodeCalc child) {
-        this.child = Objects.requireNonNull(child);
     }
 
     protected abstract String getJsonName();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature


**What is the current behavior?**
AbstractMinMaxNodeCalc implements directly NodeCalc


**What is the new behavior (if this is a feature change)?**
AbstractMinMaxNodeCalc now extends AbstractSingleChildNodeCalc


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
