### PR TITLE
CGMES. Fix access to busbar section container in bus/breaker import

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
@@ -11,6 +11,7 @@ import com.powsybl.cgmes.conversion.Context;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.BusbarSection;
 import com.powsybl.iidm.network.BusbarSectionAdder;
+import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.triplestore.api.PropertyBag;
 
 import static com.powsybl.cgmes.conversion.Conversion.PROPERTY_BUSBAR_SECTION_TERMINALS;
@@ -50,7 +51,11 @@ public class BusbarSectionConversion extends AbstractConductingEquipmentConversi
     }
 
     private void addBusbarSectionTerminalToBus() {
-        Bus bus = voltageLevel().getBusBreakerView().getBus(busId());
+        // voltageLevel() assumes voltage level is present, throws an exception if not available
+        // voltageLevel(1) returns the (optional) voltage level of the first terminal
+        // Some isolated busbar sections may not have a topological node, so we need to check
+        // if the voltage level is present before trying to access the bus
+        Bus bus = voltageLevel(1).map(VoltageLevel::getBusBreakerView).map(bbv -> bbv.getBus(busId())).orElse(null);
         if (bus != null) {
             String busbarSectionTerminals = bus.getProperty(PROPERTY_BUSBAR_SECTION_TERMINALS, "");
             if (!busbarSectionTerminals.isEmpty()) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
@@ -51,10 +51,11 @@ public class BusbarSectionConversion extends AbstractConductingEquipmentConversi
     }
 
     private void addBusbarSectionTerminalToBus() {
+        // Some isolated busbar sections may not have a topological node.
+        // This means that we can not determine the voltage level of the busbar section in bus/branch model,
+        // So we need to check if the voltage level is present before trying to access the bus
         // voltageLevel() assumes voltage level is present, throws an exception if not available
-        // voltageLevel(1) returns the (optional) voltage level of the first terminal
-        // Some isolated busbar sections may not have a topological node, so we need to check
-        // if the voltage level is present before trying to access the bus
+        // voltageLevel(1) returns the optional voltage level of the first terminal
         Bus bus = voltageLevel(1).map(VoltageLevel::getBusBreakerView).map(bbv -> bbv.getBus(busId())).orElse(null);
         if (bus != null) {
             String busbarSectionTerminals = bus.getProperty(PROPERTY_BUSBAR_SECTION_TERMINALS, "");

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/BusbarSectionConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/BusbarSectionConversionTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.powsybl.cgmes.conversion.test;
+
+import com.powsybl.commons.datasource.ResourceDataSource;
+import com.powsybl.commons.datasource.ResourceSet;
+import com.powsybl.commons.test.AbstractSerDeTest;
+import com.powsybl.iidm.network.Network;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
+ */
+
+class BusbarSectionConversionTest extends AbstractSerDeTest {
+
+    @Test
+    void isolatedBusbarSectionWithoutTopologicalNodeInBusBreakerModelTest() {
+        Network network = Network.read("bbs-busbreaker_EQ.xml", getClass().getResourceAsStream("/bbs-busbreaker_EQ.xml"));
+        // The network can be imported without any issue
+        assertNotNull(network);
+        assertEquals(1, network.getSubstationCount());
+        assertEquals(1, network.getSubstations().iterator().next().getVoltageLevelStream().count());
+        // But it does not contain any busbar section
+        assertEquals(0, network.getBusbarSectionCount());
+        // And no bus has been created
+        assertEquals(0, network.getBusBreakerView().getBusCount());
+    }
+
+    @Test
+    void isolatedBusbarSectionWithTopologicalNodeInBusBreakerModelTest() {
+        Network network = Network.read(
+                new ResourceDataSource("bbs-busbreaker",
+                new ResourceSet("/", "bbs-busbreaker_EQ.xml", "bbs-busbreaker_TP.xml")));
+        // The network can be imported without any issue
+        assertNotNull(network);
+        assertEquals(1, network.getSubstationCount());
+        assertEquals(1, network.getSubstations().iterator().next().getVoltageLevelStream().count());
+        // It does not contain busbar sections
+        assertEquals(0, network.getBusbarSectionCount());
+        // But a bus has been created and the busbar section terminal has been kept as a property
+        assertEquals(1, network.getBusBreakerView().getBusCount());
+        assertEquals("bbs_t", network.getBusBreakerView().getBus("bbs_tn").getProperty("CGMES.busbarSectionTerminals"));
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/BusbarSectionConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/BusbarSectionConversionTest.java
@@ -24,15 +24,32 @@ class BusbarSectionConversionTest extends AbstractSerDeTest {
 
     @Test
     void isolatedBusbarSectionWithoutTopologicalNodeInBusBreakerModelTest() {
-        Network network = Network.read("bbs-busbreaker_EQ.xml", getClass().getResourceAsStream("/bbs-busbreaker_EQ.xml"));
+        Network network = Network.read(
+                new ResourceDataSource("bbs-busbreaker",
+                new ResourceSet("/", "bbs-busbreaker_EQ.xml", "bbs-busbreaker_TP_withoutTN.xml")));
         // The network can be imported without any issue
         assertNotNull(network);
         assertEquals(1, network.getSubstationCount());
         assertEquals(1, network.getSubstations().iterator().next().getVoltageLevelStream().count());
-        // But it does not contain any busbar section
-        assertEquals(0, network.getBusbarSectionCount());
-        // And no bus has been created
+        // No Bus nor BusbarSection has been created since this is a busbreaker topology kind with no TopologicalNode
         assertEquals(0, network.getBusBreakerView().getBusCount());
+        assertEquals(0, network.getBusbarSectionCount());
+    }
+
+    @Test
+    void isolatedBusbarSectionWithoutLinkToTopologicalNodeInBusBreakerModelTest() {
+        Network network = Network.read(
+                new ResourceDataSource("bbs-busbreaker",
+                        new ResourceSet("/", "bbs-busbreaker_EQ.xml", "bbs-busbreaker_TP_withoutLinkToTN.xml")));
+        // The network can be imported without any issue
+        assertNotNull(network);
+        assertEquals(1, network.getSubstationCount());
+        assertEquals(1, network.getSubstations().iterator().next().getVoltageLevelStream().count());
+        // A Bus but no BusbarSection has been created in busbreaker topology kind
+        assertEquals(1, network.getBusBreakerView().getBusCount());
+        assertEquals(0, network.getBusbarSectionCount());
+        // The BusbasSection terminal couldn't be kept since the link to its topological node is missing
+        assertNull(network.getBusBreakerView().getBus("bbs_tn").getProperty("CGMES.busbarSectionTerminals"));
     }
 
     @Test
@@ -44,10 +61,10 @@ class BusbarSectionConversionTest extends AbstractSerDeTest {
         assertNotNull(network);
         assertEquals(1, network.getSubstationCount());
         assertEquals(1, network.getSubstations().iterator().next().getVoltageLevelStream().count());
-        // It does not contain busbar sections
-        assertEquals(0, network.getBusbarSectionCount());
-        // But a bus has been created and the busbar section terminal has been kept as a property
+        // A Bus but no BusbarSection has been created in busbreaker topology kind
         assertEquals(1, network.getBusBreakerView().getBusCount());
+        assertEquals(0, network.getBusbarSectionCount());
+        // The BusbasSection terminal has been kept as a property since the link to its topological node is present
         assertEquals("bbs_t", network.getBusBreakerView().getBus("bbs_tn").getProperty("CGMES.busbarSectionTerminals"));
     }
 }

--- a/cgmes/cgmes-conversion/src/test/resources/bbs-busbreaker_EQ.xml
+++ b/cgmes/cgmes-conversion/src/test/resources/bbs-busbreaker_EQ.xml
@@ -16,7 +16,6 @@
 		<cim:Terminal.ConductingEquipment rdf:resource="#_bbs"/>
 		<cim:Terminal.ConnectivityNode rdf:resource="#_bbs_cn"/>
 		<cim:IdentifiedObject.name>T1</cim:IdentifiedObject.name>
-		<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
 	</cim:Terminal>
 	<cim:ConnectivityNode rdf:ID="_bbs_cn">
 		<cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_bbs_vl"/>

--- a/cgmes/cgmes-conversion/src/test/resources/bbs-busbreaker_EQ.xml
+++ b/cgmes/cgmes-conversion/src/test/resources/bbs-busbreaker_EQ.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF  xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<md:FullModel rdf:about="urn:uuid:test">
+		<md:Model.scenarioTime>2024-02-26T00:00:00Z</md:Model.scenarioTime>
+		<md:Model.created>2024-02-26T00:00:00Z</md:Model.created>
+		<md:Model.description>test busbarsection without TN</md:Model.description>
+		<md:Model.version>1</md:Model.version>
+		<md:Model.profile>http://entsoe.eu/CIM/EquipmentCore/3/1</md:Model.profile>
+		<md:Model.modelingAuthoritySet>http://powsybl.org</md:Model.modelingAuthoritySet>
+	</md:FullModel>
+	<cim:BusbarSection rdf:ID="_bbs">
+		<cim:Equipment.EquipmentContainer rdf:resource="#_bbs_vl"/>
+		<cim:IdentifiedObject.name>BBS152</cim:IdentifiedObject.name>
+	</cim:BusbarSection>
+	<cim:Terminal rdf:ID="_bbs_t">
+		<cim:Terminal.ConductingEquipment rdf:resource="#_bbs"/>
+		<cim:Terminal.ConnectivityNode rdf:resource="#_bbs_cn"/>
+		<cim:IdentifiedObject.name>T1</cim:IdentifiedObject.name>
+		<cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+	</cim:Terminal>
+	<cim:ConnectivityNode rdf:ID="_bbs_cn">
+		<cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_bbs_vl"/>
+		<cim:IdentifiedObject.name>BBS152    </cim:IdentifiedObject.name>
+	</cim:ConnectivityNode>
+	<cim:Substation rdf:ID="_bbs_s">
+		<cim:Substation.Region rdf:resource="#_bbs_sgr"/>
+		<cim:IdentifiedObject.name>BBS152</cim:IdentifiedObject.name>
+	</cim:Substation>
+	<cim:VoltageLevel rdf:ID="_bbs_vl">
+		<cim:VoltageLevel.BaseVoltage rdf:resource="#_b8e17237e0ca4fca9e4e285b80ab30d0"/>
+		<cim:VoltageLevel.Substation rdf:resource="#_bbs_s"/>
+		<cim:IdentifiedObject.name>BBS_110</cim:IdentifiedObject.name>
+	</cim:VoltageLevel>
+	<cim:SubGeographicalRegion rdf:ID="_bbs_sgr">
+		<cim:SubGeographicalRegion.Region rdf:resource="#_bbs_gr"/>
+		<cim:IdentifiedObject.name>Subgeographical Region</cim:IdentifiedObject.name>
+	</cim:SubGeographicalRegion>
+	<cim:GeographicalRegion rdf:ID="_bbs_gr">
+		<cim:IdentifiedObject.name>AQ</cim:IdentifiedObject.name>
+	</cim:GeographicalRegion>
+	<cim:BaseVoltage rdf:ID="_b8e17237e0ca4fca9e4e285b80ab30d0">
+		<cim:BaseVoltage.nominalVoltage>110</cim:BaseVoltage.nominalVoltage>
+		<cim:IdentifiedObject.name>AC-110</cim:IdentifiedObject.name>
+		<cim:IdentifiedObject.description>Base voltage for 110 kV</cim:IdentifiedObject.description>
+	</cim:BaseVoltage>
+</rdf:RDF>

--- a/cgmes/cgmes-conversion/src/test/resources/bbs-busbreaker_TP.xml
+++ b/cgmes/cgmes-conversion/src/test/resources/bbs-busbreaker_TP.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF  xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<md:FullModel rdf:about="urn:uuid:test">
+		<md:Model.scenarioTime>2024-02-26T00:00:00Z</md:Model.scenarioTime>
+		<md:Model.created>2024-02-26T00:00:00Z</md:Model.created>
+		<md:Model.description>test busbarsection with TN</md:Model.description>
+		<md:Model.version>1</md:Model.version>
+		<md:Model.profile>http://entsoe.eu/CIM/Topology/4/1</md:Model.profile>
+		<md:Model.modelingAuthoritySet>http://powsybl.org</md:Model.modelingAuthoritySet>
+	</md:FullModel>
+	<cim:ConnectivityNode rdf:about="#_bbs_cn">
+		<cim:ConnectivityNode.TopologicalNode rdf:resource="#_bbs_tn"/>
+	</cim:ConnectivityNode>
+	<cim:Terminal rdf:about="#_bbs_t">
+		<cim:Terminal.TopologicalNode rdf:resource="#_bbs_tn"/>
+	</cim:Terminal>
+	<cim:TopologicalNode rdf:ID="_bbs_tn">
+		<cim:IdentifiedObject.name>BBS TN</cim:IdentifiedObject.name>
+		<cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_bbs_vl"/>
+		<cim:TopologicalNode.BaseVoltage rdf:resource="#_b8e17237e0ca4fca9e4e285b80ab30d0"/>
+	</cim:TopologicalNode>
+</rdf:RDF>

--- a/cgmes/cgmes-conversion/src/test/resources/bbs-busbreaker_TP_withoutLinkToTN.xml
+++ b/cgmes/cgmes-conversion/src/test/resources/bbs-busbreaker_TP_withoutLinkToTN.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF  xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<md:FullModel rdf:about="urn:uuid:test">
+		<md:Model.scenarioTime>2024-02-26T00:00:00Z</md:Model.scenarioTime>
+		<md:Model.created>2024-02-26T00:00:00Z</md:Model.created>
+		<md:Model.description>test busbarsection with TN</md:Model.description>
+		<md:Model.version>1</md:Model.version>
+		<md:Model.profile>http://entsoe.eu/CIM/Topology/4/1</md:Model.profile>
+		<md:Model.modelingAuthoritySet>http://powsybl.org</md:Model.modelingAuthoritySet>
+	</md:FullModel>
+	<cim:TopologicalNode rdf:ID="_bbs_tn">
+		<cim:IdentifiedObject.name>BBS TN</cim:IdentifiedObject.name>
+		<cim:TopologicalNode.ConnectivityNodeContainer rdf:resource="#_bbs_vl"/>
+		<cim:TopologicalNode.BaseVoltage rdf:resource="#_b8e17237e0ca4fca9e4e285b80ab30d0"/>
+	</cim:TopologicalNode>
+</rdf:RDF>

--- a/cgmes/cgmes-conversion/src/test/resources/bbs-busbreaker_TP_withoutTN.xml
+++ b/cgmes/cgmes-conversion/src/test/resources/bbs-busbreaker_TP_withoutTN.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF  xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<md:FullModel rdf:about="urn:uuid:test">
+		<md:Model.scenarioTime>2024-02-26T00:00:00Z</md:Model.scenarioTime>
+		<md:Model.created>2024-02-26T00:00:00Z</md:Model.created>
+		<md:Model.description>test busbarsection with TN</md:Model.description>
+		<md:Model.version>1</md:Model.version>
+		<md:Model.profile>http://entsoe.eu/CIM/Topology/4/1</md:Model.profile>
+		<md:Model.modelingAuthoritySet>http://powsybl.org</md:Model.modelingAuthoritySet>
+	</md:FullModel>
+</rdf:RDF>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Import of bus/branch models containing busbar sections without an association to a topological node raise an exception because no container can be determined for the busbar section.
The container is needed to find a bus where we could store the identifier of the busbar section terminal, that is required in SSH, TP files for updated exports.

**What is the new behavior (if this is a feature change)?**
If we can not determine the container for a busbar section we will ignore it, and we will not store its terminal. If the busbar section is missing a topological node, there will be no bus where we could store it.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Problem was raised during the update of CIMdesk to the latest PowSyBl release, testing power flow calculations for a TYNDP European network.