### PR TITLE
Fix build timestamp when displaying powsybl version

### DIFF
--- a/tools/src/main/java/com/powsybl/tools/AbstractVersion.java
+++ b/tools/src/main/java/com/powsybl/tools/AbstractVersion.java
@@ -8,8 +8,6 @@ package com.powsybl.tools;
 
 import com.google.common.collect.ImmutableMap;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.Objects;
 
@@ -66,7 +64,7 @@ public abstract class AbstractVersion implements Version {
                                "mavenProjectVersion", mavenProjectVersion,
                                "gitVersion", gitVersion,
                                "gitBranch", gitBranch,
-                               "buildTimestamp", Instant.ofEpochSecond(buildTimestamp).atZone(ZoneOffset.UTC).toString());
+                               "buildTimestamp", Version.convertBuildTimestamp(buildTimestamp));
     }
 
     @Override

--- a/tools/src/main/java/com/powsybl/tools/Version.java
+++ b/tools/src/main/java/com/powsybl/tools/Version.java
@@ -48,7 +48,7 @@ public interface Version {
                                  .writeCell(version.getMavenProjectVersion())
                                  .writeCell(version.getGitBranch())
                                  .writeCell(version.getGitVersion())
-                                 .writeCell(Instant.ofEpochSecond(version.getBuildTimestamp()).atZone(ZoneOffset.UTC).toString());
+                                 .writeCell(convertBuildTimestamp(version.getBuildTimestamp()));
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
                     }
@@ -58,6 +58,10 @@ public interface Version {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    static String convertBuildTimestamp(Long buildTimestamp) {
+        return Instant.ofEpochMilli(buildTimestamp).atZone(ZoneOffset.UTC).toString();
     }
 
     String getRepositoryName();

--- a/tools/src/test/java/com/powsybl/tools/VersionTest.java
+++ b/tools/src/test/java/com/powsybl/tools/VersionTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.tools;
+
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Antoine Bouhours {@literal <antoine.bouhours at rte-france.com>}
+ */
+class VersionTest {
+    @Test
+    void testVersionMap() {
+        String repositoryName = "Sample Repository";
+        String mavenProjectVersion = "1.0.0";
+        String gitVersion = "abc123";
+        String gitBranch = "main";
+        long buildTimestamp = 1707312507024L; // no formatting is done but the raw number value (milliseconds since January 1, 1970, 00:00:00 GMT) is used (https://www.mojohaus.org/buildnumber-maven-plugin/create-timestamp-mojo.html#timestampFormat)
+        AbstractVersion version = new AbstractVersion(repositoryName, mavenProjectVersion, gitVersion, gitBranch, buildTimestamp) { };
+        Map<String, String> versionMap = version.toMap();
+
+        assertEquals(repositoryName, versionMap.get("repositoryName"));
+        assertEquals(mavenProjectVersion, versionMap.get("mavenProjectVersion"));
+        assertEquals(gitVersion, versionMap.get("gitVersion"));
+        assertEquals(gitBranch, versionMap.get("gitBranch"));
+        assertEquals("2024-02-07T13:28:27.024Z", versionMap.get("buildTimestamp"));
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
https://github.com/powsybl/powsybl-core/pull/2778 introduced a regression when displaying the Powsybl versions. 

**What is the current behavior?**
<!-- You can also link to an open issue here -->
For example, when running the network-store-server, it displays: 
```
2024-02-27T15:17:48.777+01:00  INFO 522297 --- [           main] c.p.n.s.s.NetworkStoreStartupRunner      : Powsybl versions:
+-----------------------+-----------------------+------------+------------------------------------------+------------------------+
| Repository name       | Maven project version | Git branch | Git version                              | Build timestamp        |
+-----------------------+-----------------------+------------+------------------------------------------+------------------------+
| powsybl-network-store | 1.8.0                 | UNKNOWN    | b05b4893bc334768b5e8651578179672be872150 | +56050-12-11T11:59:15Z |
| powsybl-core          | 6.1.2                 | UNKNOWN    | 2c718501f831c24059fd54f15240544e0d7c045c | +56031-03-09T20:10:56Z |
+-----------------------+-----------------------+------------+------------------------------------------+------------------------+
```
with an incorrect build timestamp.

**What is the new behavior (if this is a feature change)?**
When changing the conversion expecting a timestamp in milliseconds as described in https://www.mojohaus.org/buildnumber-maven-plugin/create-timestamp-mojo.html#timestampFormat, the timestamp displays correctly: 
```
2024-02-27T15:07:20.904+01:00  INFO 512615 --- [           main] c.p.n.s.s.NetworkStoreStartupRunner      : Powsybl versions:
+-----------------------+-----------------------+------------+------------------------------------------+--------------------------+
| Repository name       | Maven project version | Git branch | Git version                              | Build timestamp          |
+-----------------------+-----------------------+------------+------------------------------------------+--------------------------+
| powsybl-network-store | 1.8.0                 | UNKNOWN    | b05b4893bc334768b5e8651578179672be872150 | 2024-01-30T15:49:40.755Z |
| powsybl-core          | 6.3.0-SNAPSHOT        | main       | 88eaca4bef31e5a334ffa27c6c5b68c4ff511d3d | 2024-02-27T14:00:00.212Z |
+-----------------------+-----------------------+------------+------------------------------------------+--------------------------+
```

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No