### PR TITLE
Add a new enum value for sensitivity function (bus reactive power)

### DIFF
--- a/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFunctionType.java
+++ b/sensitivity-analysis-api/src/main/java/com/powsybl/sensitivity/SensitivityFunctionType.java
@@ -20,6 +20,7 @@ import java.util.OptionalInt;
  *     <li>{@link #BRANCH_REACTIVE_POWER_1} and {@link #BRANCH_REACTIVE_POWER_2} if you want to monitor the reactive power in MVar of a network branch (lines,
  * two windings transformer, dangling lines, etc.). Use 1 for side 1 and use 2 for side 2. In case of a three windings transformer,
  * use {@link #BRANCH_REACTIVE_POWER_3} to monitor the reactive power in MVar of the leg 3 (network side).</li>
+ *     <li>{@link #BUS_REACTIVE_POWER} if you want to monitor the reactive power injection in MVar of a specific network bus</li>
  *     <li>{@link #BUS_VOLTAGE} if you want to monitor the voltage in KV of a specific network bus.</li>
  * </ul>
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -44,6 +45,8 @@ public enum SensitivityFunctionType {
     BRANCH_CURRENT_3(3),
     /** in MVar */
     BRANCH_REACTIVE_POWER_3(3),
+    /** In MVar */
+    BUS_REACTIVE_POWER,
     /** in kV */
     BUS_VOLTAGE;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
Extend the sensitivity API by adding a new enum in SensitivityFunctionType, BUS_REACTIVE_POWER
It can be used to request the sensitivity of the total  reactive injection at a bus, for example to a change in a targetV in the network.



**What is the current behavior?**
<!-- You can also link to an open issue here -->
DQInj/DtargetV cannot be implemented at this time because the enum is missing.


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes   -> switch statements on SensitivityFunctionType that don't have a default case will no longer compile.
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Developers using the SensitivityFunctionType in switch statement should either add a case for the new value or a default case. 


