### PR TITLE
Use double format for limit reduction values

### DIFF
--- a/action/action-dsl/src/main/java/com/powsybl/action/dsl/ast/AbstractBranchActionExpressionNode.java
+++ b/action/action-dsl/src/main/java/com/powsybl/action/dsl/ast/AbstractBranchActionExpressionNode.java
@@ -16,9 +16,9 @@ public abstract class AbstractBranchActionExpressionNode extends AbstractActionE
 
     private final List<String> branchIds;
 
-    private final float limitReduction;
+    private final double limitReduction;
 
-    public AbstractBranchActionExpressionNode(List<String> branchIds, float limitReduction) {
+    public AbstractBranchActionExpressionNode(List<String> branchIds, double limitReduction) {
         this.branchIds = Objects.requireNonNull(branchIds);
         if (branchIds.isEmpty()) {
             throw new IllegalArgumentException("The list of branch Ids should not be empty");
@@ -33,7 +33,7 @@ public abstract class AbstractBranchActionExpressionNode extends AbstractActionE
         return branchIds;
     }
 
-    public float getLimitReduction() {
+    public double getLimitReduction() {
         return limitReduction;
     }
 }

--- a/action/action-dsl/src/main/java/com/powsybl/action/dsl/ast/ActionExpressionEvaluator.java
+++ b/action/action-dsl/src/main/java/com/powsybl/action/dsl/ast/ActionExpressionEvaluator.java
@@ -209,7 +209,7 @@ public class ActionExpressionEvaluator extends ExpressionEvaluator implements Ac
 
     @Override
     public Object visitIsOverloaded(IsOverloadedNode isOverloadedNode, Void arg) {
-        float limitReduction = isOverloadedNode.getLimitReduction();
+        double limitReduction = isOverloadedNode.getLimitReduction();
 
         // Iterate over all the branch Ids to be sure that all the branches exist in the network
         return isOverloadedNode.getBranchIds().stream()
@@ -219,7 +219,7 @@ public class ActionExpressionEvaluator extends ExpressionEvaluator implements Ac
 
     @Override
     public Object visitAllOverloaded(AllOverloadedNode allOverloadedNode, Void arg) {
-        float limitReduction = allOverloadedNode.getLimitReduction();
+        double limitReduction = allOverloadedNode.getLimitReduction();
 
         // Iterate over all the branch Ids to be sure that all the branches exist in the network
         return allOverloadedNode.getBranchIds().stream()

--- a/action/action-dsl/src/main/java/com/powsybl/action/dsl/ast/ActionExpressionHelper.java
+++ b/action/action-dsl/src/main/java/com/powsybl/action/dsl/ast/ActionExpressionHelper.java
@@ -46,11 +46,11 @@ public final class ActionExpressionHelper {
         return new MostLoadedNode(branchIds);
     }
 
-    public static IsOverloadedNode newIsOverloadedNode(List<String> branchIds, float limitReduction) {
+    public static IsOverloadedNode newIsOverloadedNode(List<String> branchIds, double limitReduction) {
         return new IsOverloadedNode(branchIds, limitReduction);
     }
 
-    public static AllOverloadedNode newAllOverloadedNode(List<String> branchIds, float limitReduction) {
+    public static AllOverloadedNode newAllOverloadedNode(List<String> branchIds, double limitReduction) {
         return new AllOverloadedNode(branchIds, limitReduction);
     }
 

--- a/action/action-dsl/src/main/java/com/powsybl/action/dsl/ast/AllOverloadedNode.java
+++ b/action/action-dsl/src/main/java/com/powsybl/action/dsl/ast/AllOverloadedNode.java
@@ -13,7 +13,7 @@ import java.util.List;
  */
 public class AllOverloadedNode extends AbstractBranchActionExpressionNode {
 
-    public AllOverloadedNode(List<String> branchIds, float limitReduction) {
+    public AllOverloadedNode(List<String> branchIds, double limitReduction) {
         super(branchIds, limitReduction);
     }
 

--- a/action/action-dsl/src/main/java/com/powsybl/action/dsl/ast/IsOverloadedNode.java
+++ b/action/action-dsl/src/main/java/com/powsybl/action/dsl/ast/IsOverloadedNode.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public class IsOverloadedNode extends AbstractBranchActionExpressionNode {
 
-    public IsOverloadedNode(List<String> branchIds, float limitReduction) {
+    public IsOverloadedNode(List<String> branchIds, double limitReduction) {
         super(branchIds, limitReduction);
     }
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Branch.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Branch.java
@@ -471,31 +471,31 @@ public interface Branch<I extends Branch<I>> extends Identifiable<I> {
     /**
      * Only checks overloading for LimitType.Current and permanent limits
      */
-    boolean isOverloaded(float limitReductionValue);
+    boolean isOverloaded(double limitReductionValue);
 
     int getOverloadDuration();
 
-    boolean checkPermanentLimit(TwoSides side, float limitReductionValue, LimitType type);
+    boolean checkPermanentLimit(TwoSides side, double limitReductionValue, LimitType type);
 
     boolean checkPermanentLimit(TwoSides side, LimitType type);
 
-    boolean checkPermanentLimit1(float limitReductionValue, LimitType type);
+    boolean checkPermanentLimit1(double limitReductionValue, LimitType type);
 
     boolean checkPermanentLimit1(LimitType type);
 
-    boolean checkPermanentLimit2(float limitReductionValue, LimitType type);
+    boolean checkPermanentLimit2(double limitReductionValue, LimitType type);
 
     boolean checkPermanentLimit2(LimitType type);
 
-    Overload checkTemporaryLimits(TwoSides side, float limitReductionValue, LimitType type);
+    Overload checkTemporaryLimits(TwoSides side, double limitReductionValue, LimitType type);
 
     Overload checkTemporaryLimits(TwoSides side, LimitType type);
 
-    Overload checkTemporaryLimits1(float limitReductionValue, LimitType type);
+    Overload checkTemporaryLimits1(double limitReductionValue, LimitType type);
 
     Overload checkTemporaryLimits1(LimitType type);
 
-    Overload checkTemporaryLimits2(float limitReductionValue, LimitType type);
+    Overload checkTemporaryLimits2(double limitReductionValue, LimitType type);
 
     Overload checkTemporaryLimits2(LimitType type);
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ThreeWindingsTransformer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ThreeWindingsTransformer.java
@@ -367,39 +367,39 @@ public interface ThreeWindingsTransformer extends Connectable<ThreeWindingsTrans
     /**
      * Only checks overloading for LimitType.Current and permanent limits
      */
-    boolean isOverloaded(float limitReductionValue);
+    boolean isOverloaded(double limitReductionValue);
 
     int getOverloadDuration();
 
-    boolean checkPermanentLimit(ThreeSides side, float limitReductionValue, LimitType type);
+    boolean checkPermanentLimit(ThreeSides side, double limitReductionValue, LimitType type);
 
     boolean checkPermanentLimit(ThreeSides side, LimitType type);
 
-    boolean checkPermanentLimit1(float limitReductionValue, LimitType type);
+    boolean checkPermanentLimit1(double limitReductionValue, LimitType type);
 
     boolean checkPermanentLimit1(LimitType type);
 
-    boolean checkPermanentLimit2(float limitReductionValue, LimitType type);
+    boolean checkPermanentLimit2(double limitReductionValue, LimitType type);
 
     boolean checkPermanentLimit2(LimitType type);
 
-    boolean checkPermanentLimit3(float limitReductionValue, LimitType type);
+    boolean checkPermanentLimit3(double limitReductionValue, LimitType type);
 
     boolean checkPermanentLimit3(LimitType type);
 
-    Overload checkTemporaryLimits(ThreeSides side, float limitReductionValue, LimitType type);
+    Overload checkTemporaryLimits(ThreeSides side, double limitReductionValue, LimitType type);
 
     Overload checkTemporaryLimits(ThreeSides side, LimitType type);
 
-    Overload checkTemporaryLimits1(float limitReductionValue, LimitType type);
+    Overload checkTemporaryLimits1(double limitReductionValue, LimitType type);
 
     Overload checkTemporaryLimits1(LimitType type);
 
-    Overload checkTemporaryLimits2(float limitReductionValue, LimitType type);
+    Overload checkTemporaryLimits2(double limitReductionValue, LimitType type);
 
     Overload checkTemporaryLimits2(LimitType type);
 
-    Overload checkTemporaryLimits3(float limitReductionValue, LimitType type);
+    Overload checkTemporaryLimits3(double limitReductionValue, LimitType type);
 
     Overload checkTemporaryLimits3(LimitType type);
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/LimitViolationUtils.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/LimitViolationUtils.java
@@ -25,7 +25,7 @@ public final class LimitViolationUtils {
     private LimitViolationUtils() {
     }
 
-    public static Overload checkTemporaryLimits(Branch<?> branch, TwoSides side, float limitReductionValue, double i, LimitType type) {
+    public static Overload checkTemporaryLimits(Branch<?> branch, TwoSides side, double limitReductionValue, double i, LimitType type) {
         Objects.requireNonNull(branch);
         Objects.requireNonNull(side);
         return getLimits(branch, side, type)
@@ -33,7 +33,7 @@ public final class LimitViolationUtils {
                 .orElse(null);
     }
 
-    public static Overload checkTemporaryLimits(ThreeWindingsTransformer transformer, ThreeSides side, float limitReductionValue, double i, LimitType type) {
+    public static Overload checkTemporaryLimits(ThreeWindingsTransformer transformer, ThreeSides side, double limitReductionValue, double i, LimitType type) {
         Objects.requireNonNull(transformer);
         Objects.requireNonNull(side);
         return getLimits(transformer, side, type)
@@ -41,7 +41,7 @@ public final class LimitViolationUtils {
                 .orElse(null);
     }
 
-    private static OverloadImpl getOverload(LoadingLimits limits, double i, float limitReductionValue) {
+    private static OverloadImpl getOverload(LoadingLimits limits, double i, double limitReductionValue) {
         double permanentLimit = limits.getPermanentLimit();
         if (Double.isNaN(i) || Double.isNaN(permanentLimit)) {
             return null;
@@ -59,7 +59,7 @@ public final class LimitViolationUtils {
         return null;
     }
 
-    private static boolean checkPermanentLimitIfAny(LoadingLimits limits, double i, float limitReductionValue) {
+    private static boolean checkPermanentLimitIfAny(LoadingLimits limits, double i, double limitReductionValue) {
         double permanentLimit = limits.getPermanentLimit();
         if (Double.isNaN(i) || Double.isNaN(permanentLimit)) {
             return false;
@@ -67,13 +67,13 @@ public final class LimitViolationUtils {
         return i >= permanentLimit * limitReductionValue;
     }
 
-    public static boolean checkPermanentLimit(Branch<?> branch, TwoSides side, float limitReductionValue, double i, LimitType type) {
+    public static boolean checkPermanentLimit(Branch<?> branch, TwoSides side, double limitReductionValue, double i, LimitType type) {
         return getLimits(branch, side, type)
                 .map(l -> checkPermanentLimitIfAny(l, i, limitReductionValue))
                 .orElse(false);
     }
 
-    public static boolean checkPermanentLimit(ThreeWindingsTransformer transformer, ThreeSides side, float limitReductionValue, double i, LimitType type) {
+    public static boolean checkPermanentLimit(ThreeWindingsTransformer transformer, ThreeSides side, double limitReductionValue, double i, LimitType type) {
         return getLimits(transformer, side, type)
                 .map(l -> checkPermanentLimitIfAny(l, i, limitReductionValue))
                 .orElse(false);
@@ -89,11 +89,11 @@ public final class LimitViolationUtils {
         };
     }
 
-    public static boolean checkPermanentLimit(ThreeWindingsTransformer transformer, ThreeSides side, float limitReductionValue, LimitType type) {
+    public static boolean checkPermanentLimit(ThreeWindingsTransformer transformer, ThreeSides side, double limitReductionValue, LimitType type) {
         return checkPermanentLimit(transformer, side, limitReductionValue, getValueForLimit(transformer.getTerminal(side), type), type);
     }
 
-    public static Overload checkTemporaryLimits(ThreeWindingsTransformer transformer, ThreeSides side, float limitReductionValue, LimitType type) {
+    public static Overload checkTemporaryLimits(ThreeWindingsTransformer transformer, ThreeSides side, double limitReductionValue, LimitType type) {
         return checkTemporaryLimits(transformer, side, limitReductionValue, getValueForLimit(transformer.getTerminal(side), type), type);
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectableBranch.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectableBranch.java
@@ -191,7 +191,7 @@ abstract class AbstractConnectableBranch<I extends Branch<I> & Connectable<I>> e
     }
 
     @Override
-    public boolean isOverloaded(float limitReductionValue) {
+    public boolean isOverloaded(double limitReductionValue) {
         return checkPermanentLimit1(limitReductionValue, LimitType.CURRENT) || checkPermanentLimit2(limitReductionValue, LimitType.CURRENT);
     }
 
@@ -201,7 +201,7 @@ abstract class AbstractConnectableBranch<I extends Branch<I> & Connectable<I>> e
     }
 
     @Override
-    public boolean checkPermanentLimit(TwoSides side, float limitReductionValue, LimitType type) {
+    public boolean checkPermanentLimit(TwoSides side, double limitReductionValue, LimitType type) {
         return BranchUtil.getFromSide(side,
             () -> checkPermanentLimit1(limitReductionValue, type),
             () -> checkPermanentLimit2(limitReductionValue, type));
@@ -213,7 +213,7 @@ abstract class AbstractConnectableBranch<I extends Branch<I> & Connectable<I>> e
     }
 
     @Override
-    public boolean checkPermanentLimit1(float limitReductionValue, LimitType type) {
+    public boolean checkPermanentLimit1(double limitReductionValue, LimitType type) {
         return LimitViolationUtils.checkPermanentLimit(this, TwoSides.ONE, limitReductionValue, getValueForLimit(getTerminal1(), type), type);
     }
 
@@ -223,7 +223,7 @@ abstract class AbstractConnectableBranch<I extends Branch<I> & Connectable<I>> e
     }
 
     @Override
-    public boolean checkPermanentLimit2(float limitReductionValue, LimitType type) {
+    public boolean checkPermanentLimit2(double limitReductionValue, LimitType type) {
         return LimitViolationUtils.checkPermanentLimit(this, TwoSides.TWO, limitReductionValue, getValueForLimit(getTerminal2(), type), type);
     }
 
@@ -233,7 +233,7 @@ abstract class AbstractConnectableBranch<I extends Branch<I> & Connectable<I>> e
     }
 
     @Override
-    public Overload checkTemporaryLimits(TwoSides side, float limitReductionValue, LimitType type) {
+    public Overload checkTemporaryLimits(TwoSides side, double limitReductionValue, LimitType type) {
         return BranchUtil.getFromSide(side,
             () -> checkTemporaryLimits1(limitReductionValue, type),
             () -> checkTemporaryLimits2(limitReductionValue, type));
@@ -245,7 +245,7 @@ abstract class AbstractConnectableBranch<I extends Branch<I> & Connectable<I>> e
     }
 
     @Override
-    public Overload checkTemporaryLimits1(float limitReductionValue, LimitType type) {
+    public Overload checkTemporaryLimits1(double limitReductionValue, LimitType type) {
         return LimitViolationUtils.checkTemporaryLimits(this, TwoSides.ONE, limitReductionValue, getValueForLimit(getTerminal1(), type), type);
     }
 
@@ -255,7 +255,7 @@ abstract class AbstractConnectableBranch<I extends Branch<I> & Connectable<I>> e
     }
 
     @Override
-    public Overload checkTemporaryLimits2(float limitReductionValue, LimitType type) {
+    public Overload checkTemporaryLimits2(double limitReductionValue, LimitType type) {
         return LimitViolationUtils.checkTemporaryLimits(this, TwoSides.TWO, limitReductionValue, getValueForLimit(getTerminal2(), type), type);
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerImpl.java
@@ -450,7 +450,7 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public boolean isOverloaded(float limitReductionValue) {
+    public boolean isOverloaded(double limitReductionValue) {
         return checkPermanentLimit1(limitReductionValue, LimitType.CURRENT)
                 || checkPermanentLimit2(limitReductionValue, LimitType.CURRENT)
                 || checkPermanentLimit3(limitReductionValue, LimitType.CURRENT);
@@ -468,7 +468,7 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public boolean checkPermanentLimit(ThreeSides side, float limitReductionValue, LimitType type) {
+    public boolean checkPermanentLimit(ThreeSides side, double limitReductionValue, LimitType type) {
         return LimitViolationUtils.checkPermanentLimit(this, side, limitReductionValue, type);
     }
 
@@ -478,7 +478,7 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public boolean checkPermanentLimit1(float limitReductionValue, LimitType type) {
+    public boolean checkPermanentLimit1(double limitReductionValue, LimitType type) {
         return checkPermanentLimit(ThreeSides.ONE, limitReductionValue, type);
     }
 
@@ -488,7 +488,7 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public boolean checkPermanentLimit2(float limitReductionValue, LimitType type) {
+    public boolean checkPermanentLimit2(double limitReductionValue, LimitType type) {
         return checkPermanentLimit(ThreeSides.TWO, limitReductionValue, type);
     }
 
@@ -498,7 +498,7 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public boolean checkPermanentLimit3(float limitReductionValue, LimitType type) {
+    public boolean checkPermanentLimit3(double limitReductionValue, LimitType type) {
         return checkPermanentLimit(ThreeSides.THREE, limitReductionValue, type);
     }
 
@@ -508,7 +508,7 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public Overload checkTemporaryLimits(ThreeSides side, float limitReductionValue, LimitType type) {
+    public Overload checkTemporaryLimits(ThreeSides side, double limitReductionValue, LimitType type) {
         return LimitViolationUtils.checkTemporaryLimits(this, side, limitReductionValue, type);
     }
 
@@ -518,7 +518,7 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public Overload checkTemporaryLimits1(float limitReductionValue, LimitType type) {
+    public Overload checkTemporaryLimits1(double limitReductionValue, LimitType type) {
         return checkTemporaryLimits(ThreeSides.ONE, limitReductionValue, type);
     }
 
@@ -528,7 +528,7 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public Overload checkTemporaryLimits2(float limitReductionValue, LimitType type) {
+    public Overload checkTemporaryLimits2(double limitReductionValue, LimitType type) {
         return checkTemporaryLimits(ThreeSides.TWO, limitReductionValue, type);
     }
 
@@ -538,7 +538,7 @@ class ThreeWindingsTransformerImpl extends AbstractConnectable<ThreeWindingsTran
     }
 
     @Override
-    public Overload checkTemporaryLimits3(float limitReductionValue, LimitType type) {
+    public Overload checkTemporaryLimits3(double limitReductionValue, LimitType type) {
         return checkTemporaryLimits(ThreeSides.THREE, limitReductionValue, type);
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TieLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TieLineImpl.java
@@ -316,7 +316,7 @@ class TieLineImpl extends AbstractIdentifiable<TieLine> implements TieLine {
     }
 
     @Override
-    public boolean isOverloaded(float limitReductionValue) {
+    public boolean isOverloaded(double limitReductionValue) {
         return checkPermanentLimit1(limitReductionValue, LimitType.CURRENT) || checkPermanentLimit2(limitReductionValue, LimitType.CURRENT);
     }
 
@@ -326,7 +326,7 @@ class TieLineImpl extends AbstractIdentifiable<TieLine> implements TieLine {
     }
 
     @Override
-    public boolean checkPermanentLimit(TwoSides side, float limitReductionValue, LimitType type) {
+    public boolean checkPermanentLimit(TwoSides side, double limitReductionValue, LimitType type) {
         return BranchUtil.getFromSide(side,
             () -> checkPermanentLimit1(limitReductionValue, type),
             () -> checkPermanentLimit2(limitReductionValue, type));
@@ -338,7 +338,7 @@ class TieLineImpl extends AbstractIdentifiable<TieLine> implements TieLine {
     }
 
     @Override
-    public boolean checkPermanentLimit1(float limitReductionValue, LimitType type) {
+    public boolean checkPermanentLimit1(double limitReductionValue, LimitType type) {
         return LimitViolationUtils.checkPermanentLimit(this, TwoSides.ONE, limitReductionValue, getValueForLimit(getTerminal1(), type), type);
     }
 
@@ -348,7 +348,7 @@ class TieLineImpl extends AbstractIdentifiable<TieLine> implements TieLine {
     }
 
     @Override
-    public boolean checkPermanentLimit2(float limitReductionValue, LimitType type) {
+    public boolean checkPermanentLimit2(double limitReductionValue, LimitType type) {
         return LimitViolationUtils.checkPermanentLimit(this, TwoSides.TWO, limitReductionValue, getValueForLimit(getTerminal2(), type), type);
     }
 
@@ -358,7 +358,7 @@ class TieLineImpl extends AbstractIdentifiable<TieLine> implements TieLine {
     }
 
     @Override
-    public Overload checkTemporaryLimits(TwoSides side, float limitReductionValue, LimitType type) {
+    public Overload checkTemporaryLimits(TwoSides side, double limitReductionValue, LimitType type) {
         return BranchUtil.getFromSide(side,
             () -> checkTemporaryLimits1(limitReductionValue, type),
             () -> checkTemporaryLimits2(limitReductionValue, type));
@@ -370,7 +370,7 @@ class TieLineImpl extends AbstractIdentifiable<TieLine> implements TieLine {
     }
 
     @Override
-    public Overload checkTemporaryLimits1(float limitReductionValue, LimitType type) {
+    public Overload checkTemporaryLimits1(double limitReductionValue, LimitType type) {
         return LimitViolationUtils.checkTemporaryLimits(this, TwoSides.ONE, limitReductionValue, getValueForLimit(getTerminal1(), type), type);
     }
 
@@ -380,7 +380,7 @@ class TieLineImpl extends AbstractIdentifiable<TieLine> implements TieLine {
     }
 
     @Override
-    public Overload checkTemporaryLimits2(float limitReductionValue, LimitType type) {
+    public Overload checkTemporaryLimits2(double limitReductionValue, LimitType type) {
         return LimitViolationUtils.checkTemporaryLimits(this, TwoSides.TWO, limitReductionValue, getValueForLimit(getTerminal2(), type), type);
     }
 

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolation.java
@@ -33,7 +33,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
 
     private final int acceptableDuration;
 
-    private final float limitReduction;
+    private final double limitReduction;
 
     private final double value;
 
@@ -55,7 +55,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
      */
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
-                          double limit, float limitReduction, double value, @Nullable ThreeSides side) {
+                          double limit, double limitReduction, double value, @Nullable ThreeSides side) {
         this.subjectId = Objects.requireNonNull(subjectId);
         this.subjectName = subjectName;
         this.limitType = Objects.requireNonNull(limitType);
@@ -82,7 +82,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      */
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
-                          double limit, float limitReduction, double value) {
+                          double limit, double limitReduction, double value) {
         this(subjectId, subjectName, limitType, limitName, acceptableDuration, limit, limitReduction, value, (ThreeSides) null);
 
     }
@@ -103,7 +103,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
      */
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
-                          double limit, float limitReduction, double value, TwoSides side) {
+                          double limit, double limitReduction, double value, TwoSides side) {
         this(subjectId, subjectName, limitType, limitName, acceptableDuration, limit, limitReduction, value, Objects.requireNonNull(side).toThreeSides());
     }
 
@@ -122,7 +122,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
      */
     public LimitViolation(String subjectId, LimitViolationType limitType, String limitName, int acceptableDuration,
-                          double limit, float limitReduction, double value, TwoSides side) {
+                          double limit, double limitReduction, double value, TwoSides side) {
         this(subjectId, null, limitType, limitName, acceptableDuration, limit, limitReduction, value, Objects.requireNonNull(side).toThreeSides());
     }
 
@@ -140,7 +140,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      */
     public LimitViolation(String subjectId, LimitViolationType limitType, String limitName, int acceptableDuration,
-                          double limit, float limitReduction, double value) {
+                          double limit, double limitReduction, double value) {
         this(subjectId, null, limitType, limitName, acceptableDuration, limit, limitReduction, value, (ThreeSides) null);
     }
 
@@ -156,7 +156,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction The limit reduction factor used for violation detection.
      * @param value          The actual value of the physical value which triggered the detection of a violation.
      */
-    public LimitViolation(String subjectId, String subjectName, LimitViolationType limitType, double limit, float limitReduction, double value) {
+    public LimitViolation(String subjectId, String subjectName, LimitViolationType limitType, double limit, double limitReduction, double value) {
         this(subjectId, subjectName, limitType, null, Integer.MAX_VALUE, limit, limitReduction, value, (ThreeSides) null);
     }
 
@@ -171,7 +171,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction The limit reduction factor used for violation detection.
      * @param value          The actual value of the physical value which triggered the detection of a violation.
      */
-    public LimitViolation(String subjectId, LimitViolationType limitType, double limit, float limitReduction, double value) {
+    public LimitViolation(String subjectId, LimitViolationType limitType, double limit, double limitReduction, double value) {
         this(subjectId, null, limitType, null, Integer.MAX_VALUE, limit, limitReduction, value, (ThreeSides) null);
     }
 
@@ -235,11 +235,11 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
 
     /**
      * The limit reduction factor used for violation detection.
-     * For example when monitoring values above 95% of a given limit, this will return {@code 0.95f}
+     * For example when monitoring values above 95% of a given limit, this will return {@code 0.95}
      *
      * @return the limit reduction factor used for violation detection.
      */
-    public float getLimitReduction() {
+    public double getLimitReduction() {
         return limitReduction;
     }
 

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationDetector.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationDetector.java
@@ -446,7 +446,7 @@ public interface LimitViolationDetector {
     /**
      * Generic implementation for permanent limit checks
      */
-    default void checkPermanentLimit(Branch<?> branch, TwoSides side, float limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
+    default void checkPermanentLimit(Branch<?> branch, TwoSides side, double limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
         if (LimitViolationUtils.checkPermanentLimit(branch, side, limitReductionValue, value, type)) {
             double limit = branch.getLimits(type, side).map(LoadingLimits::getPermanentLimit).orElseThrow(PowsyblException::new);
             consumer.accept(new LimitViolation(branch.getId(),
@@ -464,7 +464,7 @@ public interface LimitViolationDetector {
     /**
      * Generic implementation for permanent limit checks
      */
-    default void checkPermanentLimit(ThreeWindingsTransformer transformer, ThreeSides side, float limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
+    default void checkPermanentLimit(ThreeWindingsTransformer transformer, ThreeSides side, double limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
         if (LimitViolationUtils.checkPermanentLimit(transformer, side, limitReductionValue, value, type)) {
             double limit = transformer.getLeg(side).getLimits(type).map(LoadingLimits::getPermanentLimit).orElseThrow(PowsyblException::new);
             consumer.accept(new LimitViolation(transformer.getId(),
@@ -482,7 +482,7 @@ public interface LimitViolationDetector {
     /**
      * Generic implementation for temporary limit checks
      */
-    default void checkTemporary(Branch<?> branch, TwoSides side, float limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
+    default void checkTemporary(Branch<?> branch, TwoSides side, double limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
         Overload overload = LimitViolationUtils.checkTemporaryLimits(branch, side, limitReductionValue, value, type);
         if (overload != null) {
             consumer.accept(new LimitViolation(branch.getId(),
@@ -500,7 +500,7 @@ public interface LimitViolationDetector {
     /**
      * Generic implementation for temporary limit checks
      */
-    default void checkTemporary(ThreeWindingsTransformer transformer, ThreeSides side, float limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
+    default void checkTemporary(ThreeWindingsTransformer transformer, ThreeSides side, double limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
         Overload overload = LimitViolationUtils.checkTemporaryLimits(transformer, side, limitReductionValue, value, type);
         if (overload != null) {
             consumer.accept(new LimitViolation(transformer.getId(),

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/Security.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/Security.java
@@ -51,16 +51,16 @@ public final class Security {
         return checkLimits(network, EnumSet.allOf(LoadingLimitType.class), 1f);
     }
 
-    public static List<LimitViolation> checkLimits(Network network, float limitReductionValue) {
+    public static List<LimitViolation> checkLimits(Network network, double limitReductionValue) {
         return checkLimits(network, EnumSet.allOf(LoadingLimitType.class), limitReductionValue);
     }
 
-    public static List<LimitViolation> checkLimits(Network network, LoadingLimitType currentLimitType, float limitReductionValue) {
+    public static List<LimitViolation> checkLimits(Network network, LoadingLimitType currentLimitType, double limitReductionValue) {
         Objects.requireNonNull(currentLimitType);
         return checkLimits(network, EnumSet.of(currentLimitType), limitReductionValue);
     }
 
-    public static List<LimitViolation> checkLimits(Network network, Set<LoadingLimitType> currentLimitTypes, float limitReductionValue) {
+    public static List<LimitViolation> checkLimits(Network network, Set<LoadingLimitType> currentLimitTypes, double limitReductionValue) {
         Objects.requireNonNull(network);
         Objects.requireNonNull(currentLimitTypes);
         // allow to increase the limits
@@ -72,7 +72,7 @@ public final class Security {
         return violations;
     }
 
-    public static List<LimitViolation> checkLimitsDc(Network network, float limitReductionValue, double dcPowerFactor) {
+    public static List<LimitViolation> checkLimitsDc(Network network, double limitReductionValue, double dcPowerFactor) {
         Objects.requireNonNull(network);
         // allow to increase the limits
         if (limitReductionValue <= 0) {

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/detectors/DefaultLimitViolationDetector.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/detectors/DefaultLimitViolationDetector.java
@@ -24,10 +24,10 @@ import java.util.function.Consumer;
  */
 public class DefaultLimitViolationDetector extends AbstractContingencyBlindDetector {
 
-    private final float limitReductionValue;
+    private final double limitReductionValue;
     private final Set<LoadingLimitType> currentLimitTypes;
 
-    public DefaultLimitViolationDetector(float limitReductionValue, Collection<LoadingLimitType> currentLimitTypes) {
+    public DefaultLimitViolationDetector(double limitReductionValue, Collection<LoadingLimitType> currentLimitTypes) {
         if (limitReductionValue <= 0) {
             throw new IllegalArgumentException("Bad limit reduction " + limitReductionValue);
         }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/LimitViolationDeserializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/LimitViolationDeserializer.java
@@ -44,7 +44,7 @@ public class LimitViolationDeserializer extends StdDeserializer<LimitViolation> 
         String limitName = null;
         int acceptableDuration = Integer.MAX_VALUE;
         double limit = Double.NaN;
-        float limitReduction = Float.NaN;
+        double limitReduction = Double.NaN;
         double value = Double.NaN;
         ThreeSides side = null;
 

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/limitreduction/LimitReduction.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/limitreduction/LimitReduction.java
@@ -23,7 +23,7 @@ import java.util.Objects;
  */
 public class LimitReduction {
     private final LimitType limitType;
-    private final float value;
+    private final double value;
     private final boolean monitoringOnly;
     private final ContingencyContext contingencyContext;
     private final List<NetworkElementCriterion> networkElementCriteria;
@@ -35,11 +35,11 @@ public class LimitReduction {
                 || limitType == LimitType.APPARENT_POWER;
     }
 
-    public LimitReduction(LimitType limitType, float value, boolean monitoringOnly) {
+    public LimitReduction(LimitType limitType, double value, boolean monitoringOnly) {
         this(limitType, value, monitoringOnly, ContingencyContext.all(), Collections.emptyList(), Collections.emptyList());
     }
 
-    public LimitReduction(LimitType limitType, float value, boolean monitoringOnly,
+    public LimitReduction(LimitType limitType, double value, boolean monitoringOnly,
                           ContingencyContext contingencyContext,
                           List<NetworkElementCriterion> networkElementCriteria,
                           List<LimitDurationCriterion> limitDurationCriteria) {
@@ -62,7 +62,7 @@ public class LimitReduction {
         return limitType;
     }
 
-    public float getValue() {
+    public double getValue() {
         return value;
     }
 

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/detectors/LimitViolationDetectorForThreeWindingsTransformerTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/detectors/LimitViolationDetectorForThreeWindingsTransformerTest.java
@@ -175,7 +175,7 @@ class LimitViolationDetectorForThreeWindingsTransformerTest {
             }
 
             @Override
-            public void checkPermanentLimit(Branch<?> branch, TwoSides side, float limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
+            public void checkPermanentLimit(Branch<?> branch, TwoSides side, double limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
                 throw new UnsupportedOperationException("Not used in this test!");
 
             }

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/detectors/LimitViolationDetectorTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/detectors/LimitViolationDetectorTest.java
@@ -198,7 +198,7 @@ class LimitViolationDetectorTest {
             }
 
             @Override
-            public void checkPermanentLimit(Branch<?> branch, TwoSides side, float limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
+            public void checkPermanentLimit(Branch<?> branch, TwoSides side, double limitReductionValue, double value, Consumer<LimitViolation> consumer, LimitType type) {
 
             }
         };

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/limitreduction/LimitReductionListTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/limitreduction/LimitReductionListTest.java
@@ -69,8 +69,8 @@ class LimitReductionListTest {
 
     @Test
     void limitReductionGetValue() {
-        assertEquals(0.9f, limitReduction1.getValue());
-        assertEquals(0.8f, limitReduction2.getValue());
+        assertEquals(0.9, limitReduction1.getValue(), 0.001);
+        assertEquals(0.8, limitReduction2.getValue(), 0.001);
     }
 
     @Test

--- a/security-analysis/security-analysis-api/src/test/resources/LimitReductions.json
+++ b/security-analysis/security-analysis-api/src/test/resources/LimitReductions.json
@@ -1,7 +1,7 @@
 {
   "version" : "1.0",
   "limitReductions" : [ {
-    "value" : 0.9,
+    "value" : 0.8999999761581421,
     "limitType" : "CURRENT",
     "monitoringOnly" : false,
     "contingencyContext" : {
@@ -96,14 +96,14 @@
       "highClosed" : true
     } ]
   }, {
-    "value" : 0.8,
+    "value" : 0.800000011920929,
     "limitType" : "ACTIVE_POWER",
     "monitoringOnly" : true,
     "contingencyContext" : {
       "contextType" : "ALL"
     }
   }, {
-    "value" : 0.9,
+    "value" : 0.8999999761581421,
     "limitType" : "CURRENT",
     "monitoringOnly" : false,
     "contingencyContext" : {

--- a/security-analysis/security-analysis-api/src/test/resources/PostContingencyResultTest.json
+++ b/security-analysis/security-analysis-api/src/test/resources/PostContingencyResultTest.json
@@ -9,7 +9,7 @@
       "subjectId" : "violation",
       "limitType" : "HIGH_VOLTAGE",
       "limit" : 420.0,
-      "limitReduction" : 0.1,
+      "limitReduction" : 0.10000000149011612,
       "value" : 500.0
     } ],
     "actionsTaken" : [ ]

--- a/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisResult.json
+++ b/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisResult.json
@@ -13,7 +13,7 @@
         "subjectId" : "NHV1_NHV2_1",
         "limitType" : "CURRENT",
         "limit" : 100.0,
-        "limitReduction" : 0.95,
+        "limitReduction" : 0.949999988079071,
         "value" : 110.0,
         "side" : "ONE",
         "extensions" : {
@@ -105,13 +105,13 @@
         "subjectId" : "GEN",
         "limitType" : "HIGH_VOLTAGE",
         "limit" : 100.0,
-        "limitReduction" : 0.9,
+        "limitReduction" : 0.8999999761581421,
         "value" : 110.0
       }, {
         "subjectId" : "GEN2",
         "limitType" : "LOW_VOLTAGE",
         "limit" : 100.0,
-        "limitReduction" : 0.7,
+        "limitReduction" : 0.699999988079071,
         "value" : 115.0,
         "extensions" : {
           "Voltage" : {

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/TestingResultFactory.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/TestingResultFactory.java
@@ -43,7 +43,7 @@ public final class TestingResultFactory {
     public static FortescueFaultResult createFaultResult(String faultId, LimitViolationType limitType, float limit, float value) {
         Fault fault = new BusFault(faultId, "BusId", 0.0, 0.0);
         List<LimitViolation> limitViolations = new ArrayList<>();
-        float limitReductionValue = 1;
+        double limitReductionValue = 1;
         LimitViolation limitViolation1 = new LimitViolation("VLGEN", limitType, limit, limitReductionValue, value);
         limitViolations.add(limitViolation1);
         LimitViolation limitViolation2 = new LimitViolation("VLGEN", limitType, limit, limitReductionValue, value);
@@ -57,7 +57,7 @@ public final class TestingResultFactory {
         String subjectId = "id";
         LimitViolationType limitType = LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT;
         float limit = 2000;
-        float limitReductionValue = 1;
+        double limitReductionValue = 1;
         float value = 2500;
         LimitViolation limitViolation = new LimitViolation(subjectId, limitType, limit, limitReductionValue, value);
         limitViolations.add(limitViolation);
@@ -75,7 +75,7 @@ public final class TestingResultFactory {
         String subjectId = "vlId";
         LimitViolationType limitType = LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT;
         float limit = 2000;
-        float limitReductionValue = 1;
+        double limitReductionValue = 1;
         float value = 2500;
         LimitViolation limitViolation = new LimitViolation(subjectId, limitType, limit, limitReductionValue, value);
         limitViolation.addExtension(DummyLimitViolationExtension.class, new DummyLimitViolationExtension());
@@ -98,7 +98,7 @@ public final class TestingResultFactory {
         String subjectId = "vlId";
         LimitViolationType limitType = LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT;
         float limit = 2000;
-        float limitReductionValue = 1;
+        double limitReductionValue = 1;
         float value = 2500;
         LimitViolation limitViolation = new LimitViolation(subjectId, limitType, limit, limitReductionValue, value);
         limitViolation.addExtension(DummyLimitViolationExtension.class, new DummyLimitViolationExtension());
@@ -119,7 +119,7 @@ public final class TestingResultFactory {
         String subjectId = "vlId";
         LimitViolationType limitType = LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT;
         float limit = 2000;
-        float limitReductionValue = 1;
+        double limitReductionValue = 1;
         float value = 2500;
         LimitViolation limitViolation = new LimitViolation(subjectId, limitType, limit, limitReductionValue, value);
         limitViolation.addExtension(DummyLimitViolationExtension.class, new DummyLimitViolationExtension());
@@ -144,7 +144,7 @@ public final class TestingResultFactory {
         String subjectId = "vlId";
         LimitViolationType limitType = LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT;
         float limit = 2000;
-        float limitReductionValue = 1;
+        double limitReductionValue = 1;
         float value = 2500;
         LimitViolation limitViolation = new LimitViolation(subjectId, limitType, limit, limitReductionValue, value);
         limitViolation.addExtension(DummyLimitViolationExtension.class, new DummyLimitViolationExtension());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Limit reduction values are in **float** format in:
- `LimitViolation`;
- `LimitReduction`;
- the methods taking a limit reduction value in `LimitViolationUtils`, the action DSL and in the API's equipment classes.


**What is the new behavior (if this is a feature change)?**
Limit reduction values are in **double** format.


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

- `LimitViolation.getLimitReduction` now returns a `double` instead of a `float`;

- If you have defined your own IIDM implementation, you should change the type of the `limitReductionValue` parameter from `float` to `double` in the `checkPermanentLimit…` and `checkTemporaryLimit…` methods of your `Branch`'s and `ThreeWindingTransformer`'s implementations;

- If you have a custom `LimitViolationDetector`'s implementation, you should change the type of the `limitReductionValue` parameter from `float` to `double` in the `checkPermanentLimit` and `checkTemporaryLimit` methods;

- `AbstractBranchActionExpressionNode.getLimitReduction()` now returns a `double` instead of a `float`.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
The `PR: do-not-merge` tag was added since this PR relies on #2760. This latter should be merged prior to the current one.