### PR TITLE
Reject null values for IdentifiableCriterion

### DIFF
--- a/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/IdentifiableCriterion.java
+++ b/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/IdentifiableCriterion.java
@@ -7,6 +7,8 @@
  */
 package com.powsybl.iidm.criteria;
 
+import java.util.Objects;
+
 /**
  * <p>{@link NetworkElementCriterion} on identifiables of a network.</p>
  * @author Olivier Perrin {@literal <olivier.perrin at rte-france.com>}
@@ -17,14 +19,34 @@ public class IdentifiableCriterion extends AbstractNetworkElementEquipmentCriter
     private final AtLeastOneCountryCriterion atLeastOneCountryCriterion;
     private final AtLeastOneNominalVoltageCriterion atLeastOneNominalVoltageCriterion;
 
+    public IdentifiableCriterion(AtLeastOneCountryCriterion atLeastOneCountryCriterion) {
+        this(null, atLeastOneCountryCriterion);
+    }
+
+    public IdentifiableCriterion(String name, AtLeastOneCountryCriterion atLeastOneCountryCriterion) {
+        super(name);
+        this.atLeastOneCountryCriterion = Objects.requireNonNull(atLeastOneCountryCriterion);
+        this.atLeastOneNominalVoltageCriterion = null;
+    }
+
+    public IdentifiableCriterion(AtLeastOneNominalVoltageCriterion atLeastOneNominalVoltageCriterion) {
+        this((String) null, atLeastOneNominalVoltageCriterion);
+    }
+
+    public IdentifiableCriterion(String name, AtLeastOneNominalVoltageCriterion atLeastOneNominalVoltageCriterion) {
+        super(name);
+        this.atLeastOneCountryCriterion = null;
+        this.atLeastOneNominalVoltageCriterion = Objects.requireNonNull(atLeastOneNominalVoltageCriterion);
+    }
+
     public IdentifiableCriterion(AtLeastOneCountryCriterion atLeastOneCountryCriterion, AtLeastOneNominalVoltageCriterion atLeastOneNominalVoltageCriterion) {
         this(null, atLeastOneCountryCriterion, atLeastOneNominalVoltageCriterion);
     }
 
     public IdentifiableCriterion(String name, AtLeastOneCountryCriterion atLeastOneCountryCriterion, AtLeastOneNominalVoltageCriterion atLeastOneNominalVoltageCriterion) {
         super(name);
-        this.atLeastOneCountryCriterion = atLeastOneCountryCriterion;
-        this.atLeastOneNominalVoltageCriterion = atLeastOneNominalVoltageCriterion;
+        this.atLeastOneCountryCriterion = Objects.requireNonNull(atLeastOneCountryCriterion);
+        this.atLeastOneNominalVoltageCriterion = Objects.requireNonNull(atLeastOneNominalVoltageCriterion);
     }
 
     @Override

--- a/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/json/IdentifiableCriterionDeserializer.java
+++ b/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/json/IdentifiableCriterionDeserializer.java
@@ -9,11 +9,13 @@ package com.powsybl.iidm.criteria.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.iidm.criteria.AtLeastOneCountryCriterion;
 import com.powsybl.iidm.criteria.AtLeastOneNominalVoltageCriterion;
 import com.powsybl.iidm.criteria.Criterion.CriterionType;
 import com.powsybl.iidm.criteria.IdentifiableCriterion;
+import com.powsybl.iidm.criteria.NetworkElementCriterion;
 
 import java.io.IOException;
 
@@ -32,8 +34,21 @@ public class IdentifiableCriterionDeserializer extends AbstractNetworkElementCri
         JsonUtil.parsePolymorphicObject(parser, name -> deserializeAttributes(parser, deserializationContext, parsingContext, name,
                 IdentifiableCriterion.TYPE, CriterionType.AT_LEAST_ONE_COUNTRY, CriterionType.AT_LEAST_ONE_NOMINAL_VOLTAGE));
 
-        return new IdentifiableCriterion(parsingContext.name,
-                (AtLeastOneCountryCriterion) parsingContext.countryCriterion,
-                (AtLeastOneNominalVoltageCriterion) parsingContext.nominalVoltageCriterion);
+        if (parsingContext.countryCriterion != null) {
+            if (parsingContext.nominalVoltageCriterion != null) {
+                return new IdentifiableCriterion(parsingContext.name,
+                        (AtLeastOneCountryCriterion) parsingContext.countryCriterion,
+                        (AtLeastOneNominalVoltageCriterion) parsingContext.nominalVoltageCriterion);
+            } else {
+                return new IdentifiableCriterion(parsingContext.name,
+                        (AtLeastOneCountryCriterion) parsingContext.countryCriterion);
+            }
+        } else if (parsingContext.nominalVoltageCriterion != null) {
+            return new IdentifiableCriterion(parsingContext.name,
+                    (AtLeastOneNominalVoltageCriterion) parsingContext.nominalVoltageCriterion);
+        } else {
+            throw new PowsyblException("Criterion of type '" + NetworkElementCriterion.NetworkElementCriterionType.IDENTIFIABLE.getName() + "'" +
+                    " should have at least one sub-criterion");
+        }
     }
 }

--- a/iidm/iidm-criteria/src/test/java/com/powsybl/iidm/criteria/IdentifiableCriterionTest.java
+++ b/iidm/iidm-criteria/src/test/java/com/powsybl/iidm/criteria/IdentifiableCriterionTest.java
@@ -11,7 +11,6 @@ import com.powsybl.iidm.criteria.translation.NetworkElement;
 import com.powsybl.iidm.network.Country;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.List;
 
@@ -54,30 +53,30 @@ public class IdentifiableCriterionTest {
     @Test
     void typeTest() {
         assertEquals(NetworkElementCriterion.NetworkElementCriterionType.IDENTIFIABLE,
-                new IdentifiableCriterion(null, null).getNetworkElementCriterionType());
+                new IdentifiableCriterion(new AtLeastOneCountryCriterion(List.of(Country.BE))).getNetworkElementCriterionType());
     }
 
     @Test
-    void emptyCriterionTest() {
-        IdentifiableCriterion criterion = new IdentifiableCriterion(null, null);
-        assertTrue(criterion.accept(new NetworkElementVisitor(danglingLine1)));
-        assertTrue(criterion.accept(new NetworkElementVisitor(danglingLine2)));
-        assertTrue(criterion.accept(new NetworkElementVisitor(line1)));
-        assertTrue(criterion.accept(new NetworkElementVisitor(line2)));
-        assertTrue(criterion.accept(new NetworkElementVisitor(tieLine1)));
-        assertTrue(criterion.accept(new NetworkElementVisitor(tieLine2)));
-        assertTrue(criterion.accept(new NetworkElementVisitor(twoWt1)));
-        assertTrue(criterion.accept(new NetworkElementVisitor(twoWt2)));
-        assertTrue(criterion.accept(new NetworkElementVisitor(threeWt1)));
-        assertTrue(criterion.accept(new NetworkElementVisitor(threeWt2)));
+    void creationErrorsTest() {
+        AtLeastOneCountryCriterion countryCriterion = new AtLeastOneCountryCriterion(List.of(Country.DE));
+        AtLeastOneNominalVoltageCriterion nominalVoltageCriterion = new AtLeastOneNominalVoltageCriterion(
+                new SingleNominalVoltageCriterion.VoltageInterval(40., 100., true, true));
+        assertThrows(NullPointerException.class, () -> new IdentifiableCriterion("test1", null, null));
+        assertThrows(NullPointerException.class, () -> new IdentifiableCriterion("test2", countryCriterion, null));
+        assertThrows(NullPointerException.class, () -> new IdentifiableCriterion("test3", null, nominalVoltageCriterion));
+        assertThrows(NullPointerException.class, () -> new IdentifiableCriterion((AtLeastOneCountryCriterion) null, null));
+        assertThrows(NullPointerException.class, () -> new IdentifiableCriterion(countryCriterion, null));
+        assertThrows(NullPointerException.class, () -> new IdentifiableCriterion((AtLeastOneCountryCriterion) null, nominalVoltageCriterion));
+        assertThrows(NullPointerException.class, () -> new IdentifiableCriterion("test7", (AtLeastOneCountryCriterion) null));
+        assertThrows(NullPointerException.class, () -> new IdentifiableCriterion(null, (AtLeastOneCountryCriterion) null));
+        assertThrows(NullPointerException.class, () -> new IdentifiableCriterion("test8", (AtLeastOneNominalVoltageCriterion) null));
+        assertThrows(NullPointerException.class, () -> new IdentifiableCriterion((String) null, (AtLeastOneNominalVoltageCriterion) null));
 
-        NetworkElement anotherTypeElement = Mockito.mock(NetworkElement.class);
-        assertFalse(criterion.accept(new NetworkElementVisitor(anotherTypeElement)));
     }
 
     @Test
     void nominalVoltageTest() {
-        IdentifiableCriterion criterion = new IdentifiableCriterion(null, new AtLeastOneNominalVoltageCriterion(
+        IdentifiableCriterion criterion = new IdentifiableCriterion(new AtLeastOneNominalVoltageCriterion(
                 new SingleNominalVoltageCriterion.VoltageInterval(40., 100., true, true)));
         assertTrue(criterion.accept(new NetworkElementVisitor(danglingLine1)));
         assertFalse(criterion.accept(new NetworkElementVisitor(danglingLine2)));
@@ -93,7 +92,7 @@ public class IdentifiableCriterionTest {
 
     @Test
     void countriesTest() {
-        IdentifiableCriterion criterion = new IdentifiableCriterion(new AtLeastOneCountryCriterion(List.of(Country.FR)), null);
+        IdentifiableCriterion criterion = new IdentifiableCriterion(new AtLeastOneCountryCriterion(List.of(Country.FR)));
         assertFalse(criterion.accept(new NetworkElementVisitor(danglingLine1)));
         assertTrue(criterion.accept(new NetworkElementVisitor(danglingLine2)));
         assertFalse(criterion.accept(new NetworkElementVisitor(line1)));
@@ -105,7 +104,7 @@ public class IdentifiableCriterionTest {
         assertFalse(criterion.accept(new NetworkElementVisitor(threeWt1)));
         assertTrue(criterion.accept(new NetworkElementVisitor(threeWt2)));
 
-        criterion = new IdentifiableCriterion(new AtLeastOneCountryCriterion(List.of(Country.FR, Country.BE)), null);
+        criterion = new IdentifiableCriterion(new AtLeastOneCountryCriterion(List.of(Country.FR, Country.BE)));
         assertTrue(criterion.accept(new NetworkElementVisitor(danglingLine1)));
         assertTrue(criterion.accept(new NetworkElementVisitor(danglingLine2)));
         assertTrue(criterion.accept(new NetworkElementVisitor(line1)));

--- a/iidm/iidm-criteria/src/test/resources/criterion/identifiable-criteria.json
+++ b/iidm/iidm-criteria/src/test/resources/criterion/identifiable-criteria.json
@@ -17,5 +17,21 @@
   }
 }, {
   "type" : "identifiableCriterion",
-  "version" : "1.0"
+  "version" : "1.0",
+  "countryCriterion" : {
+    "type" : "AT_LEAST_ONE_COUNTRY",
+    "countries" : [ "BE" ]
+  }
+}, {
+  "type" : "identifiableCriterion",
+  "version" : "1.0",
+  "nominalVoltageCriterion" : {
+    "type" : "AT_LEAST_ONE_NOMINAL_VOLTAGE",
+    "voltageInterval" : {
+      "nominalVoltageLowBound" : 80.0,
+      "nominalVoltageHighBound" : 100.0,
+      "lowClosed" : true,
+      "highClosed" : true
+    }
+  }
 } ]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature / bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
- When creating an `IdentifiableCriterion` without criterion on network elements or limit durations, you have no choice but to use `null` values (there's only one constructor taking both parameters);
- It is thus possible to create an empty `IdentifiableCriterion` valid for every network element.


**What is the new behavior (if this is a feature change)?**
- New constructors were introduce taking one or both of criteria. A `null` value could not be used anymore for the criterion parameters.
- It is thus not possible anymore to create an `IdentifiableCriterion` valid for every network element.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
