### PR TITLE
`TemporaryDurationCriterion` improvements

### DIFF
--- a/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/duration/EqualityTemporaryDurationCriterion.java
+++ b/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/duration/EqualityTemporaryDurationCriterion.java
@@ -21,8 +21,8 @@ public final class EqualityTemporaryDurationCriterion extends AbstractTemporaryD
      * @param durationEqualityValue duration in seconds
      */
     public EqualityTemporaryDurationCriterion(int durationEqualityValue) {
-        if (durationEqualityValue <= 0) {
-            throw new IllegalArgumentException("Invalid value (must be > 0).");
+        if (durationEqualityValue < 0) {
+            throw new IllegalArgumentException("Invalid value (must be >= 0).");
         }
         this.durationEqualityValue = durationEqualityValue;
     }

--- a/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/duration/IntervalTemporaryDurationCriterion.java
+++ b/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/duration/IntervalTemporaryDurationCriterion.java
@@ -7,6 +7,8 @@
  */
 package com.powsybl.iidm.criteria.duration;
 
+import org.apache.commons.lang3.IntegerRange;
+
 import java.util.Optional;
 
 /**
@@ -38,8 +40,8 @@ public final class IntervalTemporaryDurationCriterion extends AbstractTemporaryD
     public static class Builder {
         private Integer lowBound = null;
         private Integer highBound = null;
-        private boolean lowClosed = false;
-        private boolean highClosed = false;
+        private boolean lowClosed = true;
+        private boolean highClosed = true;
 
         /**
          * Define the lower bound of the interval.
@@ -49,7 +51,7 @@ public final class IntervalTemporaryDurationCriterion extends AbstractTemporaryD
          */
         public Builder setLowBound(int value, boolean closed) {
             checkValue(value);
-            checkBounds(value, highBound);
+            checkBounds(value, highBound, closed, highClosed);
             this.lowBound = value;
             this.lowClosed = closed;
             return this;
@@ -63,21 +65,26 @@ public final class IntervalTemporaryDurationCriterion extends AbstractTemporaryD
          */
         public Builder setHighBound(int value, boolean closed) {
             checkValue(value);
-            checkBounds(lowBound, value);
+            checkBounds(lowBound, value, lowClosed, closed);
             this.highBound = value;
             this.highClosed = closed;
             return this;
         }
 
         private void checkValue(int value) {
-            if (value <= 0) {
-                throw new IllegalArgumentException("Invalid bound value (must be > 0).");
+            if (value < 0) {
+                throw new IllegalArgumentException("Invalid bound value (must be >= 0).");
             }
         }
 
-        private void checkBounds(Integer low, Integer high) {
+        private void checkBounds(Integer low, Integer high, boolean closedLow, boolean closedHigh) {
             if (low != null && high != null && low > high) {
                 throw new IllegalArgumentException("Invalid interval bounds values (low must be <= high).");
+            }
+            int l = low != null ? low : 0;
+            int h = high != null ? high : Integer.MAX_VALUE;
+            if (l == h && (!closedLow || !closedHigh)) {
+                throw new IllegalArgumentException("Invalid interval: it should not be empty");
             }
         }
 
@@ -104,6 +111,9 @@ public final class IntervalTemporaryDurationCriterion extends AbstractTemporaryD
 
     @Override
     public boolean filter(int acceptableDuration) {
+        if (acceptableDuration < 0) {
+            return false;
+        }
         boolean lowBoundOk = lowBound == null || acceptableDuration > lowBound
                 || lowClosed && acceptableDuration == lowBound;
         boolean highBoundOk = highBound == null || acceptableDuration < highBound
@@ -141,5 +151,27 @@ public final class IntervalTemporaryDurationCriterion extends AbstractTemporaryD
      */
     public boolean isHighClosed() {
         return highClosed;
+    }
+
+    /**
+     * <p>Return an {@link IntegerRange} representation corresponding to the criterion's interval.</p>
+     * @return the criterion's interval as an {@link IntegerRange}
+     */
+    public IntegerRange asRange() {
+        int min = 0;
+        if (lowBound != null) {
+            min = lowBound;
+            if (!lowClosed) {
+                min++;
+            }
+        }
+        int max = Integer.MAX_VALUE;
+        if (highBound != null) {
+            max = highBound;
+            if (!highClosed) {
+                max--;
+            }
+        }
+        return IntegerRange.of(min, max);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
- `TemporaryDurationCriterion` sub-classes don't accept 0 value as a valid acceptable duration;
- When not using the `filter(...)` method, `IntervalTemporaryDurationCriterion` processing can be unpractical.


**What is the new behavior (if this is a feature change)?**
- `TemporaryDurationCriterion` sub-classes now accept 0 value as a valid acceptable duration;
- `IntervalTemporaryDurationCriterion` has now a `asRange()` method returning an Apache commons-lang3 `IntegerRange` representation of its range.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
