### PR TITLE
Add a builder for LimitReductions

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/limitreduction/LimitReductionDeserializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/limitreduction/LimitReductionDeserializer.java
@@ -12,13 +12,12 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.powsybl.commons.json.JsonUtil;
 import com.powsybl.contingency.ContingencyContext;
-import com.powsybl.iidm.network.LimitType;
 import com.powsybl.iidm.criteria.NetworkElementCriterion;
-import com.powsybl.security.limitreduction.LimitReduction;
 import com.powsybl.iidm.criteria.duration.LimitDurationCriterion;
+import com.powsybl.iidm.network.LimitType;
+import com.powsybl.security.limitreduction.LimitReduction;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -76,9 +75,17 @@ public class LimitReductionDeserializer extends StdDeserializer<LimitReduction> 
                 }
             }
         });
-        return new LimitReduction(context.limitType, context.value, context.monitoringOnly,
-                context.contingencyContext,
-                context.networkElementCriteria != null ? context.networkElementCriteria : Collections.emptyList(),
-                context.durationCriteria != null ? context.durationCriteria : Collections.emptyList());
+        LimitReduction.Builder builder = LimitReduction.builder(context.limitType, context.value)
+                .withMonitoringOnly(context.monitoringOnly);
+        if (context.contingencyContext != null) {
+            builder.withContingencyContext(context.contingencyContext);
+        }
+        if (context.networkElementCriteria != null) {
+            builder.withNetworkElementCriteria(context.networkElementCriteria);
+        }
+        if (context.durationCriteria != null) {
+            builder.withLimitDurationCriteria(context.durationCriteria);
+        }
+        return builder.build();
     }
 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/limitreduction/LimitReductionDeserializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/limitreduction/LimitReductionDeserializer.java
@@ -19,6 +19,7 @@ import com.powsybl.security.limitreduction.LimitReduction;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Olivier Perrin {@literal <olivier.perrin@rte-france.com>}
@@ -31,7 +32,7 @@ public class LimitReductionDeserializer extends StdDeserializer<LimitReduction> 
     private static class ParsingContext {
         float value;
         LimitType limitType;
-        boolean monitoringOnly;
+        Boolean monitoringOnly;
         ContingencyContext contingencyContext;
         List<NetworkElementCriterion> networkElementCriteria;
         List<LimitDurationCriterion> durationCriteria;
@@ -75,11 +76,10 @@ public class LimitReductionDeserializer extends StdDeserializer<LimitReduction> 
                 }
             }
         });
-        LimitReduction.Builder builder = LimitReduction.builder(context.limitType, context.value)
-                .withMonitoringOnly(context.monitoringOnly);
-        if (context.contingencyContext != null) {
-            builder.withContingencyContext(context.contingencyContext);
-        }
+        LimitReduction.Builder builder = LimitReduction.builder(checkAttribute(context.limitType, "limitType"),
+                        checkAttribute(context.value, "value"))
+                .withMonitoringOnly(checkAttribute(context.monitoringOnly, "monitoringOnly"))
+                .withContingencyContext(checkAttribute(context.contingencyContext, "contingencyContext"));
         if (context.networkElementCriteria != null) {
             builder.withNetworkElementCriteria(context.networkElementCriteria);
         }
@@ -87,5 +87,9 @@ public class LimitReductionDeserializer extends StdDeserializer<LimitReduction> 
             builder.withLimitDurationCriteria(context.durationCriteria);
         }
         return builder.build();
+    }
+
+    private static <T> T checkAttribute(T object, String attributeName) {
+        return Objects.requireNonNull(object, String.format("'%s' attribute is missing (or null)", attributeName));
     }
 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/limitreduction/LimitReduction.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/limitreduction/LimitReduction.java
@@ -19,18 +19,18 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * <p>This class represents a reduction that should be applied to limits of a certain type.</p>
+ * <p>This class represents a reduction that should be applied to operational limits of a certain type.</p>
  * <p>A reduced limit is computed as <code>original limit * limitReduction.value</code>.</p>
- * <p>It may also contain restrictions indicating in which conditions it should be applied. If no restrictions are defined
- * the limit reduction will apply to all limits of the defined type.</p>
+ * <p>It may also contain restrictions indicating in which conditions it should be applied. If no restriction is defined
+ * the limit reduction is applied to all limits of the defined type.</p>
  * <p>The possible restrictions are:
  *     <ul>
- *         <li><code>monitoringOnly</code>: Does the restriction applies for monitoring use case only (<code>true</code>),
- *              or for both monitoring and action use cases (<code>false</code>)?</li>
- *         <li><code>contingencyContext</code>: The contingency context for which the limit reduction applies (in pre-contingency only, after every contingency, ...);</li>
- *         <li><code>networkElementCriteria</code>: Criteria that a network element should respect for the limit reduction to apply on its limits;</li>
- *         <li><code>limitDurationCriteria</code>: Criteria on a duration aspect that a limit should respect for the limit reduction to apply on it
- *              (permanent limit, temporary limits with an acceptable duration defined within a specific range, ...).</li>
+ *         <li><code>monitoringOnly</code>: use <code>true</code> if the limit reduction is applied when reporting the limit violations only.
+ *              Use <code>false</code> if it is applied also inside the conditions of operator strategies. The default value is <code>false</code>.</li>
+ *         <li><code>contingencyContext</code>: the contingency context in which the limit reduction is applied (in pre-contingency only, after every contingency, etc.);</li>
+ *         <li><code>networkElementCriteria</code>: criteria a network element should respect for the limit reduction to be applied on its limits;</li>
+ *         <li><code>limitDurationCriteria</code>: criteria based on limit overload acceptable durations. Through these criteria, we can defined if
+ *         the reduction is applied on the permanent limit and/or on a temporary limit if it acceptable duration is within a specific range.</li>
  *     </ul>
  * </p>
  * @author Olivier Perrin {@literal <olivier.perrin at rte-france.com>}
@@ -50,11 +50,11 @@ public class LimitReduction {
     }
 
     /**
-     * <p>Create a limit reduction applying on each limits of a given type.</p>
-     * <p>This reduction will apply for every contingency context, and for monitoring and action use cases.</p>
+     * <p>Create a limit reduction applying on each operational limits of a given type.</p>
+     * <p>This reduction is applied for a contingency context ALL and for limit violations reporting and operator strategy conditions.</p>
      *
-     * @param limitType the type of the limits to reduce
-     * @param value the value of the reduction (reduced limits will be equal to <code>original limit * reduction value</code>).
+     * @param limitType the type of the limits to reduce.
+     * @param value the value of the reduction (reduced limits are equal to <code>original limit * reduction value</code>).
      */
     public LimitReduction(LimitType limitType, double value) {
         this(limitType, value, false);
@@ -62,24 +62,24 @@ public class LimitReduction {
 
     /**
      * <p>Create a limit reduction applying on each limits of a given type, for monitoring only or monitoring/action
-     * use cases depending on the <code>monitoringOnly</code> parameter.</p>
-     * <p>This reduction will apply for every contingency context.</p>
+     * depending on the <code>monitoringOnly</code> parameter.</p>
+     * <p>This reduction is applied for a contingency context ALL.</p>
      *
      * @param limitType the type of the limits to reduce
-     * @param value the value of the reduction (reduced limits will be equal to <code>original limit * reduction value</code>).
-     * @param monitoringOnly <code>true</code> if the reduction should apply only for monitoring use case, <code>false</code> otherwise.
+     * @param value the value of the reduction (reduced limits are equal to <code>original limit * reduction value</code>).
+     * @param monitoringOnly <code>true</code> if the reduction is applied only for monitoring only, <code>false</code> otherwise.
      */
     public LimitReduction(LimitType limitType, double value, boolean monitoringOnly) {
         this(limitType, value, monitoringOnly, ContingencyContext.all(), Collections.emptyList(), Collections.emptyList());
     }
 
     /**
-     * <p>Initiate a builder for creating more specific limit reductions (indicate a contingency context or criteria
-     * on network elements or limit durations).</p>
+     * <p>Initialize a builder for creating more specific limit reductions (indicate a contingency context or criteria
+     * on network elements or on limit durations).</p>
      *
-     * @param limitType the type of the limits to reduce
-     * @param value the value of the reduction (reduced limits will be equal to <code>original limit * reduction value</code>).
-     * @return a builder to use to create a {@link LimitReduction}.
+     * @param limitType the type of the limits to reduce.
+     * @param value the value of the reduction (reduced limits are equal to <code>original limit * reduction value</code>).
+     * @return a builder used to create a {@link LimitReduction}.
      */
     public static LimitReduction.Builder builder(LimitType limitType, double value) {
         return new Builder(limitType, value);
@@ -87,12 +87,12 @@ public class LimitReduction {
 
     /**
      * <p>Builder used to create a {@link LimitReduction}.</p>
-     * <p>The default values for the {@link LimitReduction} to create are the following:
+     * <p>The default values for the {@link LimitReduction} are the following:
      *     <ul>
-     *         <li><code>monitoringOnly</code>: <code>false</code>. The limit reduction will apply for all use cases (monitoring and action);</li>
-     *         <li><code>contingencyContext</code>: {@link ContingencyContext#all()}. The limit reduction will apply in pre-contingency and after every contingency.</li>
-     *         <li><code>networkElementCriteria</code>: {@link Collections#emptyList()}. The limit reduction will apply for every network element.</li>
-     *         <li><code>limitDurationCriteria</code>: {@link Collections#emptyList()}. The limit reduction will apply for all permanent and temporary limits.</li>
+     *         <li><code>monitoringOnly</code>: <code>false</code>. The limit reduction is applied for monitoring limit violations and conditions of operator strategies;</li>
+     *         <li><code>contingencyContext</code>: {@link ContingencyContext#all()}. The limit reduction is used on pre-contingency state and after each contingency state.</li>
+     *         <li><code>networkElementCriteria</code>: {@link Collections#emptyList()}. The limit reduction is applied on each network element (that holds a limit on this type).</li>
+     *         <li><code>limitDurationCriteria</code>: {@link Collections#emptyList()}. The limit reduction is applied for all permanent and temporary limits.</li>
      *     </ul>
      * </p>
      */
@@ -110,10 +110,10 @@ public class LimitReduction {
         }
 
         /**
-         * <p>Define for which use cases the limit reduction should apply.</p>
-         * <p>By default, the limit reduction will apply for all use cases (monitoring and action).</p>
+         * <p>Define if the limit reduction is applied only for limit violations report or also inside conditions of operator strategies.</p>
+         * <p>By default, the limit reduction is apply for both steps.</p>
          *
-         * @param monitoringOnly <code>true</code> if the limit reduction should only apply for monitoring use case, <code>false</code> otherwise.
+         * @param monitoringOnly <code>true</code> if the limit reduction is applied for monitoring only, <code>false</code> otherwise.
          * @return the current {@link Builder}
          */
         public Builder withMonitoringOnly(boolean monitoringOnly) {
@@ -122,11 +122,10 @@ public class LimitReduction {
         }
 
         /**
-         * <p>Define for which contingency context the limit reduction should apply.</p>
-         * <p>By default, the limit reduction will apply in pre-contingency and after every contingency.</p>
+         * <p>Define in which contingency context the limit reduction is applied.</p>
+         * <p>By default, the limit reduction is used in pre-contingency state and after each contingency state.</p>
          *
-         * @param contingencyContext the contingency context for which contingency context the limit reduction should apply.
-         *                           It could not be null.
+         * @param contingencyContext the contingency context of the limit reduction to be applied.
          * @return the current {@link Builder}
          */
         public Builder withContingencyContext(ContingencyContext contingencyContext) {
@@ -135,11 +134,11 @@ public class LimitReduction {
         }
 
         /**
-         * <p>Define criteria to use to define the network elements for which the limit reduction should apply.</p>
-         * <p>By default, the limit reduction will apply for every network element.</p>
-         * <p>This method replace all the previously network element criteria by the given ones.</p>
+         * <p>Define criteria on network elements.</p>
+         * <p>By default, the limit reduction is applied on each network element that holds a limit of the good type.</p>
+         * <p>This method is not cumulative and clean previous definitions.</p>
          *
-         * @param networkElementCriteria criteria to use to restrict the limit reduction to certain network elements.
+         * @param networkElementCriteria criteria on network elements on which the limit reduction is applied.
          * @return the current {@link Builder}
          */
         public Builder withNetworkElementCriteria(NetworkElementCriterion... networkElementCriteria) {
@@ -147,11 +146,11 @@ public class LimitReduction {
         }
 
         /**
-         * <p>Define criteria to use to define the network elements for which the limit reduction should apply.</p>
-         * <p>By default, the limit reduction will apply for every network element.</p>
-         * <p>This method replace all the previously network element criteria by the given ones.</p>
+         * <p>Define criteria on network elements.</p>
+         * <p>By default, the limit reduction is applied on each network element that holds a limit of the good type.</p>
+         * <p>This method is not cumulative and clean previous definitions.</p>
          *
-         * @param networkElementCriteria criteria to use to restrict the limit reduction to certain network elements.
+         * @param networkElementCriteria criteria on network elements on which the limit reduction is applied.
          * @return the current {@link Builder}
          */
         public Builder withNetworkElementCriteria(List<NetworkElementCriterion> networkElementCriteria) {
@@ -160,12 +159,11 @@ public class LimitReduction {
         }
 
         /**
-         * <p>Define criteria to use to define if the limit reduction should apply on permanent limits,
-         * temporary limits (with possible restrictions) or both.</p>
-         * <p>By default, the limit reduction will apply for all permanent and temporary limits.</p>
-         * <p>This method replace all the previously limit duration criteria by the given ones.</p>
+         * <p>Define criteria on permanent limit and/or on acceptable durations of temporary limits within a specific range.</p>
+         * <p>By default, the limit reduction is applied for all permanent and temporary limits of the good type.</p>
+         * <p>This method is not cumulative and clean previous definitions.</p>
          *
-         * @param limitDurationCriteria criteria to use to restrict the limit reduction to certain durations.
+         * @param limitDurationCriteria criteria to restrict the limit reduction to specific durations.
          * @return the current {@link Builder}
          */
         public Builder withLimitDurationCriteria(LimitDurationCriterion... limitDurationCriteria) {
@@ -173,12 +171,11 @@ public class LimitReduction {
         }
 
         /**
-         * <p>Define criteria to use to define if the limit reduction should apply on permanent limits,
-         * temporary limits (with possible restrictions) or both.</p>
-         * <p>By default, the limit reduction will apply for all permanent and temporary limits.</p>
-         * <p>This method replace all the previously limit duration criteria by the given ones.</p>
+         * <p>Define criteria on permanent limit and/or on acceptable durations of temporary limits within a specific range.</p>
+         * <p>By default, the limit reduction is applied for all permanent and temporary limits of the good type.</p>
+         * <p>This method is not cumulative and clean previous definitions.</p>
          *
-         * @param limitDurationCriteria criteria to use to restrict the limit reduction to certain durations.
+         * @param limitDurationCriteria criteria to restrict the limit reduction to specific durations.
          * @return the current {@link Builder}
          */
         public Builder withLimitDurationCriteria(List<LimitDurationCriterion> limitDurationCriteria) {
@@ -224,17 +221,17 @@ public class LimitReduction {
     }
 
     /**
-     * <p>Indicate if the limit reduction applies only for monitoring use case (<code>true</code>),
-     * or for monitoring and action use cases (<code>false</code>).</p>
+     * <p>Indicate if the limit reduction is applied only to report limit violations (<code>true</code>),
+     * or if also affects the conditions of operator strategies (<code>false</code>).</p>
      *
-     * @return <code>true</code> if the limit reduction applies only for monitoring use case, <code>false</code> otherwise.
+     * @return <code>true</code> if the limit reduction is applied only for monitoring, <code>false</code> otherwise.
      */
     public boolean isMonitoringOnly() {
         return monitoringOnly;
     }
 
     /**
-     * <p>Indicate for which contingency context the limit reduction applies.</p>
+     * <p>Indicate the limit reduction contingency context.</p>
      *
      * @return the {@link ContingencyContext} of the limit reduction.
      */
@@ -243,16 +240,16 @@ public class LimitReduction {
     }
 
     /**
-     * <p>Indicate the criteria used to define the network elements for which the limit reduction applies.</p>
+     * <p>Indicate the criteria on network elements candidate for the limit reduction.</p>
      *
-     * @return the list of the {@link NetworkElementCriterion} of the limit reduction.
+     * @return the list of the {@link NetworkElementCriterion} candidate for the limit reduction.
      */
     public List<NetworkElementCriterion> getNetworkElementCriteria() {
         return networkElementCriteria;
     }
 
     /**
-     * <p>Indicate criteria used to restrict the limit reduction to certain durations.</p>
+     * <p>Indicate criteria on operational limit acceptable durations.</p>
      *
      * @return the list of the {@link LimitDurationCriterion} of the limit reduction.
      */

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/limitreduction/LimitReduction.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/limitreduction/LimitReduction.java
@@ -19,6 +19,20 @@ import java.util.List;
 import java.util.Objects;
 
 /**
+ * <p>This class represents a reduction that should be applied to limits of a certain type.</p>
+ * <p>A reduced limit is computed as <code>original limit * limitReduction.value</code>.</p>
+ * <p>It may also contain restrictions indicating in which conditions it should be applied. If no restrictions are defined
+ * the limit reduction will apply to all limits of the defined type.</p>
+ * <p>The possible restrictions are:
+ *     <ul>
+ *         <li><code>monitoringOnly</code>: Does the restriction applies for monitoring use case only (<code>true</code>),
+ *              or for both monitoring and action use cases (<code>false</code>)?</li>
+ *         <li><code>contingencyContext</code>: The contingency context for which the limit reduction applies (in pre-contingency only, after every contingency, ...);</li>
+ *         <li><code>networkElementCriteria</code>: Criteria that a network element should respect for the limit reduction to apply on its limits;</li>
+ *         <li><code>limitDurationCriteria</code>: Criteria on a duration aspect that a limit should respect for the limit reduction to apply on it
+ *              (permanent limit, temporary limits with an acceptable duration defined within a specific range, ...).</li>
+ *     </ul>
+ * </p>
  * @author Olivier Perrin {@literal <olivier.perrin at rte-france.com>}
  */
 public class LimitReduction {
@@ -35,11 +49,154 @@ public class LimitReduction {
                 || limitType == LimitType.APPARENT_POWER;
     }
 
+    /**
+     * <p>Create a limit reduction applying on each limits of a given type.</p>
+     * <p>This reduction will apply for every contingency context, and for monitoring and action use cases.</p>
+     *
+     * @param limitType the type of the limits to reduce
+     * @param value the value of the reduction (reduced limits will be equal to <code>original limit * reduction value</code>).
+     */
+    public LimitReduction(LimitType limitType, double value) {
+        this(limitType, value, false);
+    }
+
+    /**
+     * <p>Create a limit reduction applying on each limits of a given type, for monitoring only or monitoring/action
+     * use cases depending on the <code>monitoringOnly</code> parameter.</p>
+     * <p>This reduction will apply for every contingency context.</p>
+     *
+     * @param limitType the type of the limits to reduce
+     * @param value the value of the reduction (reduced limits will be equal to <code>original limit * reduction value</code>).
+     * @param monitoringOnly <code>true</code> if the reduction should apply only for monitoring use case, <code>false</code> otherwise.
+     */
     public LimitReduction(LimitType limitType, double value, boolean monitoringOnly) {
         this(limitType, value, monitoringOnly, ContingencyContext.all(), Collections.emptyList(), Collections.emptyList());
     }
 
-    public LimitReduction(LimitType limitType, double value, boolean monitoringOnly,
+    /**
+     * <p>Initiate a builder for creating more specific limit reductions (indicate a contingency context or criteria
+     * on network elements or limit durations).</p>
+     *
+     * @param limitType the type of the limits to reduce
+     * @param value the value of the reduction (reduced limits will be equal to <code>original limit * reduction value</code>).
+     * @return a builder to use to create a {@link LimitReduction}.
+     */
+    public static LimitReduction.Builder builder(LimitType limitType, double value) {
+        return new Builder(limitType, value);
+    }
+
+    /**
+     * <p>Builder used to create a {@link LimitReduction}.</p>
+     * <p>The default values for the {@link LimitReduction} to create are the following:
+     *     <ul>
+     *         <li><code>monitoringOnly</code>: <code>false</code>. The limit reduction will apply for all use cases (monitoring and action);</li>
+     *         <li><code>contingencyContext</code>: {@link ContingencyContext#all()}. The limit reduction will apply in pre-contingency and after every contingency.</li>
+     *         <li><code>networkElementCriteria</code>: {@link Collections#emptyList()}. The limit reduction will apply for every network element.</li>
+     *         <li><code>limitDurationCriteria</code>: {@link Collections#emptyList()}. The limit reduction will apply for all permanent and temporary limits.</li>
+     *     </ul>
+     * </p>
+     */
+    public static class Builder {
+        private final LimitType limitType;
+        private final double value;
+        private boolean monitoringOnly = false;
+        private ContingencyContext contingencyContext = ContingencyContext.all();
+        private List<NetworkElementCriterion> networkElementCriteria = Collections.emptyList();
+        private List<LimitDurationCriterion> limitDurationCriteria = Collections.emptyList();
+
+        protected Builder(LimitType limitType, double value) {
+            this.limitType = limitType;
+            this.value = value;
+        }
+
+        /**
+         * <p>Define for which use cases the limit reduction should apply.</p>
+         * <p>By default, the limit reduction will apply for all use cases (monitoring and action).</p>
+         *
+         * @param monitoringOnly <code>true</code> if the limit reduction should only apply for monitoring use case, <code>false</code> otherwise.
+         * @return the current {@link Builder}
+         */
+        public Builder withMonitoringOnly(boolean monitoringOnly) {
+            this.monitoringOnly = monitoringOnly;
+            return this;
+        }
+
+        /**
+         * <p>Define for which contingency context the limit reduction should apply.</p>
+         * <p>By default, the limit reduction will apply in pre-contingency and after every contingency.</p>
+         *
+         * @param contingencyContext the contingency context for which contingency context the limit reduction should apply.
+         *                           It could not be null.
+         * @return the current {@link Builder}
+         */
+        public Builder withContingencyContext(ContingencyContext contingencyContext) {
+            this.contingencyContext = Objects.requireNonNull(contingencyContext);
+            return this;
+        }
+
+        /**
+         * <p>Define criteria to use to define the network elements for which the limit reduction should apply.</p>
+         * <p>By default, the limit reduction will apply for every network element.</p>
+         * <p>This method replace all the previously network element criteria by the given ones.</p>
+         *
+         * @param networkElementCriteria criteria to use to restrict the limit reduction to certain network elements.
+         * @return the current {@link Builder}
+         */
+        public Builder withNetworkElementCriteria(NetworkElementCriterion... networkElementCriteria) {
+            return withNetworkElementCriteria(List.of(networkElementCriteria));
+        }
+
+        /**
+         * <p>Define criteria to use to define the network elements for which the limit reduction should apply.</p>
+         * <p>By default, the limit reduction will apply for every network element.</p>
+         * <p>This method replace all the previously network element criteria by the given ones.</p>
+         *
+         * @param networkElementCriteria criteria to use to restrict the limit reduction to certain network elements.
+         * @return the current {@link Builder}
+         */
+        public Builder withNetworkElementCriteria(List<NetworkElementCriterion> networkElementCriteria) {
+            this.networkElementCriteria = ImmutableList.copyOf(Objects.requireNonNull(networkElementCriteria));
+            return this;
+        }
+
+        /**
+         * <p>Define criteria to use to define if the limit reduction should apply on permanent limits,
+         * temporary limits (with possible restrictions) or both.</p>
+         * <p>By default, the limit reduction will apply for all permanent and temporary limits.</p>
+         * <p>This method replace all the previously limit duration criteria by the given ones.</p>
+         *
+         * @param limitDurationCriteria criteria to use to restrict the limit reduction to certain durations.
+         * @return the current {@link Builder}
+         */
+        public Builder withLimitDurationCriteria(LimitDurationCriterion... limitDurationCriteria) {
+            return withLimitDurationCriteria(List.of(limitDurationCriteria));
+        }
+
+        /**
+         * <p>Define criteria to use to define if the limit reduction should apply on permanent limits,
+         * temporary limits (with possible restrictions) or both.</p>
+         * <p>By default, the limit reduction will apply for all permanent and temporary limits.</p>
+         * <p>This method replace all the previously limit duration criteria by the given ones.</p>
+         *
+         * @param limitDurationCriteria criteria to use to restrict the limit reduction to certain durations.
+         * @return the current {@link Builder}
+         */
+        public Builder withLimitDurationCriteria(List<LimitDurationCriterion> limitDurationCriteria) {
+            this.limitDurationCriteria = ImmutableList.copyOf(Objects.requireNonNull(limitDurationCriteria));
+            return this;
+        }
+
+        /**
+         * <p>Build the {@link LimitReduction} with the defined parameters.</p>
+         * @return a new {@link LimitReduction}
+         */
+        public LimitReduction build() {
+            return new LimitReduction(limitType, value, monitoringOnly, contingencyContext,
+                    networkElementCriteria, limitDurationCriteria);
+        }
+    }
+
+    private LimitReduction(LimitType limitType, double value, boolean monitoringOnly,
                           ContingencyContext contingencyContext,
                           List<NetworkElementCriterion> networkElementCriteria,
                           List<LimitDurationCriterion> limitDurationCriteria) {
@@ -53,9 +210,9 @@ public class LimitReduction {
         }
         this.value = value;
         this.monitoringOnly = monitoringOnly;
-        this.contingencyContext = Objects.requireNonNull(contingencyContext);
-        this.networkElementCriteria = ImmutableList.copyOf(Objects.requireNonNull(networkElementCriteria));
-        this.durationCriteria = ImmutableList.copyOf(Objects.requireNonNull(limitDurationCriteria));
+        this.contingencyContext = contingencyContext;
+        this.networkElementCriteria = networkElementCriteria;
+        this.durationCriteria = limitDurationCriteria;
     }
 
     public LimitType getLimitType() {
@@ -66,18 +223,39 @@ public class LimitReduction {
         return value;
     }
 
+    /**
+     * <p>Indicate if the limit reduction applies only for monitoring use case (<code>true</code>),
+     * or for monitoring and action use cases (<code>false</code>).</p>
+     *
+     * @return <code>true</code> if the limit reduction applies only for monitoring use case, <code>false</code> otherwise.
+     */
     public boolean isMonitoringOnly() {
         return monitoringOnly;
     }
 
+    /**
+     * <p>Indicate for which contingency context the limit reduction applies.</p>
+     *
+     * @return the {@link ContingencyContext} of the limit reduction.
+     */
     public ContingencyContext getContingencyContext() {
         return contingencyContext;
     }
 
+    /**
+     * <p>Indicate the criteria used to define the network elements for which the limit reduction applies.</p>
+     *
+     * @return the list of the {@link NetworkElementCriterion} of the limit reduction.
+     */
     public List<NetworkElementCriterion> getNetworkElementCriteria() {
         return networkElementCriteria;
     }
 
+    /**
+     * <p>Indicate criteria used to restrict the limit reduction to certain durations.</p>
+     *
+     * @return the list of the {@link LimitDurationCriterion} of the limit reduction.
+     */
     public List<LimitDurationCriterion> getDurationCriteria() {
         return durationCriteria;
     }

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandlersTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/distributed/SecurityAnalysisExecutionHandlersTest.java
@@ -121,7 +121,7 @@ class SecurityAnalysisExecutionHandlersTest {
     void forwardedBeforeWithCompleteInput() throws IOException {
         Action action = new SwitchAction("action", "switch", false);
         OperatorStrategy strategy = new OperatorStrategy("strat", ContingencyContext.specificContingency("cont"), new TrueCondition(), List.of("action"));
-        LimitReduction limitReduction = new LimitReduction(LimitType.CURRENT, 0.9f, false);
+        LimitReduction limitReduction = new LimitReduction(LimitType.CURRENT, 0.9);
 
         SecurityAnalysisExecutionInput input = new SecurityAnalysisExecutionInput()
                 .setParameters(new SecurityAnalysisParameters())

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/limitreduction/LimitReductionModuleTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/limitreduction/LimitReductionModuleTest.java
@@ -43,29 +43,32 @@ class LimitReductionModuleTest extends AbstractSerDeTest {
                         new DanglingLineCriterion(null, new SingleNominalVoltageCriterion(
                                 new SingleNominalVoltageCriterion.VoltageInterval(80., 100., true, false))));
         List<LimitDurationCriterion> durationCriteria1 = List.of(new PermanentDurationCriterion(), new AllTemporaryDurationCriterion());
-        LimitReduction limitReduction1 = new LimitReduction(LimitType.CURRENT, 0.9f, false,
-                contingencyContext1, networkElementCriteria1, durationCriteria1);
+        LimitReduction limitReduction1 = LimitReduction.builder(LimitType.CURRENT, 0.9)
+                .withContingencyContext(contingencyContext1)
+                .withNetworkElementCriteria(networkElementCriteria1)
+                .withLimitDurationCriteria(durationCriteria1)
+                .build();
 
-        LimitReduction limitReduction2 = new LimitReduction(LimitType.APPARENT_POWER, 0.5f, false,
-                ContingencyContext.all(),
-                List.of(new NetworkElementIdListCriterion(Set.of("NHV1_NHV2_2"))),
-                List.of(IntervalTemporaryDurationCriterion.builder()
+        LimitReduction limitReduction2 = LimitReduction.builder(LimitType.APPARENT_POWER, 0.5)
+                .withNetworkElementCriteria(new NetworkElementIdListCriterion(Set.of("NHV1_NHV2_2")))
+                .withLimitDurationCriteria(IntervalTemporaryDurationCriterion.builder()
                         .setLowBound(10 * 60, true)
                         .setHighBound(20 * 60, true)
-                        .build()));
-        LimitReduction limitReduction3 = new LimitReduction(LimitType.ACTIVE_POWER, 0.8f, true);
+                        .build())
+                .build();
+        LimitReduction limitReduction3 = new LimitReduction(LimitType.ACTIVE_POWER, 0.8, true);
 
-        LimitReduction limitReduction4 = new LimitReduction(LimitType.CURRENT, 0.9f, false,
-                ContingencyContext.all(),
-                List.of(new IdentifiableCriterion(
+        LimitReduction limitReduction4 = LimitReduction.builder(LimitType.CURRENT, 0.9)
+                .withNetworkElementCriteria(new IdentifiableCriterion(
                         new AtLeastOneCountryCriterion(List.of(Country.FR)),
                         new AtLeastOneNominalVoltageCriterion(
                                 new SingleNominalVoltageCriterion.VoltageInterval(380., 410., true, true)
-                        ))),
-                List.of(IntervalTemporaryDurationCriterion.builder()
+                        )))
+                .withLimitDurationCriteria(IntervalTemporaryDurationCriterion.builder()
                         .setLowBound(300, true)
                         .setHighBound(600, false)
-                        .build()));
+                        .build())
+                .build();
 
         LimitReductionList limitReductionList = new LimitReductionList(List.of(limitReduction1, limitReduction2, limitReduction3, limitReduction4));
 

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/limitreduction/LimitReductionBuilderTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/limitreduction/LimitReductionBuilderTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.security.limitreduction;
+
+import com.powsybl.contingency.ContingencyContext;
+import com.powsybl.iidm.criteria.LineCriterion;
+import com.powsybl.iidm.criteria.NetworkElementCriterion;
+import com.powsybl.iidm.criteria.TieLineCriterion;
+import com.powsybl.iidm.criteria.TwoWindingsTransformerCriterion;
+import com.powsybl.iidm.criteria.duration.AbstractTemporaryDurationCriterion;
+import com.powsybl.iidm.criteria.duration.EqualityTemporaryDurationCriterion;
+import com.powsybl.iidm.criteria.duration.LimitDurationCriterion;
+import com.powsybl.iidm.criteria.duration.PermanentDurationCriterion;
+import com.powsybl.iidm.network.LimitType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Olivier Perrin {@literal <olivier.perrin at rte-france.com>}
+ */
+class LimitReductionBuilderTest {
+
+    @Test
+    void defaultValuesTest() {
+        LimitReduction limitReduction = LimitReduction.builder(LimitType.APPARENT_POWER, 0.5).build();
+        assertEquals(LimitType.APPARENT_POWER, limitReduction.getLimitType());
+        assertEquals(0.5, limitReduction.getValue(), 0.01);
+        assertFalse(limitReduction.isMonitoringOnly());
+        assertEquals(ContingencyContext.all(), limitReduction.getContingencyContext());
+        assertTrue(limitReduction.getNetworkElementCriteria().isEmpty());
+        assertTrue(limitReduction.getDurationCriteria().isEmpty());
+    }
+
+    @Test
+    void allValuesTest() {
+        NetworkElementCriterion nec0 = new TieLineCriterion(null, null);
+        NetworkElementCriterion nec1 = new LineCriterion(null, null);
+        NetworkElementCriterion nec2 = new TwoWindingsTransformerCriterion(null, null);
+        LimitDurationCriterion ldc0 = new PermanentDurationCriterion();
+        LimitDurationCriterion ldc1 = new EqualityTemporaryDurationCriterion(300);
+        LimitReduction limitReduction = LimitReduction.builder(LimitType.CURRENT, 0.9)
+                .withMonitoringOnly(true)
+                .withContingencyContext(ContingencyContext.none())
+                .withNetworkElementCriteria(nec0)
+                .withNetworkElementCriteria(nec1, nec2) // replace previously defined NetworkElementCriteria
+                .withLimitDurationCriteria(ldc0)
+                .withLimitDurationCriteria(ldc1) // replace previously defined LimitDurationCriterion
+                .build();
+        assertEquals(LimitType.CURRENT, limitReduction.getLimitType());
+        assertEquals(0.9, limitReduction.getValue(), 0.01);
+        assertTrue(limitReduction.isMonitoringOnly());
+        assertEquals(ContingencyContext.none(), limitReduction.getContingencyContext());
+        assertEquals(2, limitReduction.getNetworkElementCriteria().size());
+        assertEquals(NetworkElementCriterion.NetworkElementCriterionType.LINE,
+                limitReduction.getNetworkElementCriteria().get(0).getNetworkElementCriterionType());
+        assertEquals(NetworkElementCriterion.NetworkElementCriterionType.TWO_WINDINGS_TRANSFORMER,
+                limitReduction.getNetworkElementCriteria().get(1).getNetworkElementCriterionType());
+        assertEquals(1, limitReduction.getDurationCriteria().size());
+        assertEquals(AbstractTemporaryDurationCriterion.TemporaryDurationCriterionType.EQUALITY,
+                ((AbstractTemporaryDurationCriterion) limitReduction.getDurationCriteria().get(0)).getComparisonType());
+    }
+}

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/limitreduction/LimitReductionListTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/limitreduction/LimitReductionListTest.java
@@ -47,12 +47,13 @@ class LimitReductionListTest {
                 new SingleNominalVoltageCriterion.VoltageInterval(350., 410., true, false), null));
 
         contingencyContext1 = ContingencyContext.specificContingency("contingency1");
-        limitReduction1 = new LimitReduction(LimitType.CURRENT, 0.9f, false,
-                contingencyContext1,
-                List.of(networkElementCriterion1, networkElementCriterion2,
-                        networkElementCriterion3, networkElementCriterion4, networkElementCriterion5),
-                List.of(new PermanentDurationCriterion(), new AllTemporaryDurationCriterion()));
-        limitReduction2 = new LimitReduction(LimitType.ACTIVE_POWER, 0.8f, true);
+        limitReduction1 = LimitReduction.builder(LimitType.CURRENT, 0.9)
+                .withContingencyContext(contingencyContext1)
+                .withNetworkElementCriteria(networkElementCriterion1, networkElementCriterion2,
+                        networkElementCriterion3, networkElementCriterion4, networkElementCriterion5)
+                .withLimitDurationCriteria(new PermanentDurationCriterion(), new AllTemporaryDurationCriterion())
+                .build();
+        limitReduction2 = new LimitReduction(LimitType.ACTIVE_POWER, 0.8, true);
     }
 
     @Test
@@ -103,17 +104,17 @@ class LimitReductionListTest {
 
     @Test
     void unsupportedLimitType() {
-        Exception e = assertThrows(PowsyblException.class, () -> new LimitReduction(LimitType.VOLTAGE, 0.9f, false));
+        Exception e = assertThrows(PowsyblException.class, () -> new LimitReduction(LimitType.VOLTAGE, 0.9));
         assertEquals("VOLTAGE is not a supported limit type for limit reduction", e.getMessage());
     }
 
     @Test
     void unsupportedLimitReductionValues() {
         String expectedMessage = "Limit reduction value should be in [0;1]";
-        Exception e = assertThrows(PowsyblException.class, () -> new LimitReduction(LimitType.CURRENT, -0.5f, true));
+        Exception e = assertThrows(PowsyblException.class, () -> new LimitReduction(LimitType.CURRENT, -0.5, true));
         assertEquals(expectedMessage, e.getMessage());
 
-        e = assertThrows(PowsyblException.class, () -> new LimitReduction(LimitType.CURRENT, 1.3f, false));
+        e = assertThrows(PowsyblException.class, () -> new LimitReduction(LimitType.CURRENT, 1.3));
         assertEquals(expectedMessage, e.getMessage());
     }
 }

--- a/security-analysis/security-analysis-api/src/test/resources/LimitReductions.json
+++ b/security-analysis/security-analysis-api/src/test/resources/LimitReductions.json
@@ -1,7 +1,7 @@
 {
   "version" : "1.0",
   "limitReductions" : [ {
-    "value" : 0.8999999761581421,
+    "value" : 0.9,
     "limitType" : "CURRENT",
     "monitoringOnly" : false,
     "contingencyContext" : {
@@ -96,14 +96,14 @@
       "highClosed" : true
     } ]
   }, {
-    "value" : 0.800000011920929,
+    "value" : 0.8,
     "limitType" : "ACTIVE_POWER",
     "monitoringOnly" : true,
     "contingencyContext" : {
       "contextType" : "ALL"
     }
   }, {
-    "value" : 0.8999999761581421,
+    "value" : 0.9,
     "limitType" : "CURRENT",
     "monitoringOnly" : false,
     "contingencyContext" : {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature + doc update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When creating a `LimitReduction` with either a contingency context or a criterion list, every characteristics of a `LimitReduction` must be given as parameter for the constructor. This forces the user to give empty lists to the constructor for the unneeded parameters. 

**What is the new behavior (if this is a feature change)?**
- Two small constructors are now present for simple cases:
  - `LimitReduction(LimitType limitType, double value)`;
  - `LimitReduction(LimitType limitType, double value, boolean monitoringOnly)`.
- For more complex cases, a builder was added.



**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

When you used the constructor with all the parameters to create a "LimitReduction", you should use the builder.
Default values for the characteristics are:
- `monitoringOnly`: false;
- `contingencyContext`: `ContingencyContext.all()`;
- `networkElementCriteria`: `Collections.emptyList()`;
- `limitDurationCriteria`: `Collections.emptyList()`.

Thus, you can omit setting one of the characteristics if you used its default value.

For instance:

```java
       LimitReduction limitReduction = new LimitReduction(LimitType.APPARENT_POWER, 0.5, false,
                ContingencyContext.all(),
                Collections.emptyList(),
                List.of(durationCriterion1, durationCriterion2));
```

could be rewritten in

```java
       LimitReduction limitReduction = LimitReduction.builder(LimitType.APPARENT_POWER, 0.5)
                .withLimitDurationCriteria(durationCriterion1, durationCriterion2)
                .build();
```

Note:
- `monitoringOnly`, `networkElementCriteria` and `contingencyContext` are not specified as their default values are used;
- the `with...Criteria(...)` methods take either a `List` or varArgs. You could thus omit the encapsulating `List.of()` for ease of use. But in either case, the previously definied criteria are replaced by the given ones. 


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
