### PR TITLE
Add convenient creation methods for IntervalTemporaryDurationCriterion

### DIFF
--- a/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/duration/IntervalTemporaryDurationCriterion.java
+++ b/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/duration/IntervalTemporaryDurationCriterion.java
@@ -107,39 +107,39 @@ public final class IntervalTemporaryDurationCriterion extends AbstractTemporaryD
     /**
      * <p>Convenient method to easily create an {@link IntervalTemporaryDurationCriterion} with only a lower bound.</p>
      * @param value the lower bound (in seconds) of the interval to create (it corresponds to the <code>lowBound</code> attribute of the interval)
-     * @param valueIncluded is the bound included in the interval (it corresponds to the <code>lowClosed</code> attribute of the interval)
+     * @param closed is the bound included in the interval (it corresponds to the <code>lowClosed</code> attribute of the interval)
      * @return an interval
      */
-    public static IntervalTemporaryDurationCriterion greaterThan(int value, boolean valueIncluded) {
+    public static IntervalTemporaryDurationCriterion greaterThan(int value, boolean closed) {
         return IntervalTemporaryDurationCriterion.builder()
-                .setLowBound(value, valueIncluded)
+                .setLowBound(value, closed)
                 .build();
     }
 
     /**
      * <p>Convenient method to easily create an {@link IntervalTemporaryDurationCriterion} with only a upper bound.</p>
      * @param value the upper bound (in seconds) of the interval to create (it corresponds to the <code>highBound</code> attribute of the interval)
-     * @param valueIncluded is the bound included in the interval (it corresponds to the <code>highClosed</code> attribute of the interval)
+     * @param closed is the bound included in the interval (it corresponds to the <code>highClosed</code> attribute of the interval)
      * @return an interval
      */
-    public static IntervalTemporaryDurationCriterion lowerThan(int value, boolean valueIncluded) {
+    public static IntervalTemporaryDurationCriterion lowerThan(int value, boolean closed) {
         return IntervalTemporaryDurationCriterion.builder()
-                .setHighBound(value, valueIncluded)
+                .setHighBound(value, closed)
                 .build();
     }
 
     /**
      * <p>Convenient method to easily create an {@link IntervalTemporaryDurationCriterion} with only a upper bound.</p>
      * @param lowBound the lower bound (in seconds) of the interval to create (it corresponds to the <code>lowBound</code> attribute of the interval)
-     * @param lowIncluded is the bound included in the interval (it corresponds to the <code>lowClosed</code> attribute of the interval)
+     * @param lowClosed is the bound included in the interval (it corresponds to the <code>lowClosed</code> attribute of the interval)
      * @param highBound the upper bound (in seconds) of the interval to create (it corresponds to the <code>highBound</code> attribute of the interval)
-     * @param highIncluded is the bound included in the interval (it corresponds to the <code>highClosed</code> attribute of the interval)
+     * @param highClosed is the bound included in the interval (it corresponds to the <code>highClosed</code> attribute of the interval)
      * @return an interval
      */
-    public static IntervalTemporaryDurationCriterion between(int lowBound, int highBound, boolean lowIncluded, boolean highIncluded) {
+    public static IntervalTemporaryDurationCriterion between(int lowBound, int highBound, boolean lowClosed, boolean highClosed) {
         return IntervalTemporaryDurationCriterion.builder()
-                .setLowBound(lowBound, lowIncluded)
-                .setHighBound(highBound, highIncluded)
+                .setLowBound(lowBound, lowClosed)
+                .setHighBound(highBound, highClosed)
                 .build();
     }
 

--- a/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/duration/IntervalTemporaryDurationCriterion.java
+++ b/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/duration/IntervalTemporaryDurationCriterion.java
@@ -104,6 +104,45 @@ public final class IntervalTemporaryDurationCriterion extends AbstractTemporaryD
         return new Builder();
     }
 
+    /**
+     * <p>Convenient method to easily create an {@link IntervalTemporaryDurationCriterion} with only a lower bound.</p>
+     * @param value the lower bound (in seconds) of the interval to create (it corresponds to the <code>lowBound</code> attribute of the interval)
+     * @param valueIncluded is the bound included in the interval (it corresponds to the <code>lowClosed</code> attribute of the interval)
+     * @return an interval
+     */
+    public static IntervalTemporaryDurationCriterion greaterThan(int value, boolean valueIncluded) {
+        return IntervalTemporaryDurationCriterion.builder()
+                .setLowBound(value, valueIncluded)
+                .build();
+    }
+
+    /**
+     * <p>Convenient method to easily create an {@link IntervalTemporaryDurationCriterion} with only a upper bound.</p>
+     * @param value the upper bound (in seconds) of the interval to create (it corresponds to the <code>highBound</code> attribute of the interval)
+     * @param valueIncluded is the bound included in the interval (it corresponds to the <code>highClosed</code> attribute of the interval)
+     * @return an interval
+     */
+    public static IntervalTemporaryDurationCriterion lowerThan(int value, boolean valueIncluded) {
+        return IntervalTemporaryDurationCriterion.builder()
+                .setHighBound(value, valueIncluded)
+                .build();
+    }
+
+    /**
+     * <p>Convenient method to easily create an {@link IntervalTemporaryDurationCriterion} with only a upper bound.</p>
+     * @param lowBound the lower bound (in seconds) of the interval to create (it corresponds to the <code>lowBound</code> attribute of the interval)
+     * @param lowIncluded is the bound included in the interval (it corresponds to the <code>lowClosed</code> attribute of the interval)
+     * @param highBound the upper bound (in seconds) of the interval to create (it corresponds to the <code>highBound</code> attribute of the interval)
+     * @param highIncluded is the bound included in the interval (it corresponds to the <code>highClosed</code> attribute of the interval)
+     * @return an interval
+     */
+    public static IntervalTemporaryDurationCriterion between(int lowBound, int highBound, boolean lowIncluded, boolean highIncluded) {
+        return IntervalTemporaryDurationCriterion.builder()
+                .setLowBound(lowBound, lowIncluded)
+                .setHighBound(highBound, highIncluded)
+                .build();
+    }
+
     @Override
     public TemporaryDurationCriterionType getComparisonType() {
         return TemporaryDurationCriterionType.INTERVAL;

--- a/iidm/iidm-criteria/src/test/java/com/powsybl/iidm/criteria/duration/IntervalTemporaryDurationCriterionTest.java
+++ b/iidm/iidm-criteria/src/test/java/com/powsybl/iidm/criteria/duration/IntervalTemporaryDurationCriterionTest.java
@@ -171,4 +171,45 @@ class IntervalTemporaryDurationCriterionTest {
         assertThrows(IllegalArgumentException.class, () -> builder5.setLowBound(Integer.MAX_VALUE, false));
         assertDoesNotThrow(() -> builder5.setLowBound(Integer.MAX_VALUE, true)); // [MAX_VALUE ; MAX_VALUE] is valid
     }
+
+    @Test
+    void betweenTest() {
+        IntervalTemporaryDurationCriterion interval = IntervalTemporaryDurationCriterion.between(300, 600, false, true);
+        assertFalse(interval.isLowClosed());
+        assertTrue(interval.isHighClosed());
+        assertEquals(300, interval.getLowBound().orElse(0));
+        assertEquals(600, interval.getHighBound().orElse(0));
+
+        interval = IntervalTemporaryDurationCriterion.between(900, 1200, true, false);
+        assertTrue(interval.isLowClosed());
+        assertFalse(interval.isHighClosed());
+        assertEquals(900, interval.getLowBound().orElse(0));
+        assertEquals(1200, interval.getHighBound().orElse(0));
+    }
+
+    @Test
+    void lowerThanTest() {
+        IntervalTemporaryDurationCriterion interval = IntervalTemporaryDurationCriterion.lowerThan(300, true);
+        assertTrue(interval.getLowBound().isEmpty());
+        assertEquals(300, interval.getHighBound().orElse(0));
+        assertTrue(interval.isHighClosed());
+
+        interval = IntervalTemporaryDurationCriterion.lowerThan(600, false);
+        assertTrue(interval.getLowBound().isEmpty());
+        assertEquals(600, interval.getHighBound().orElse(0));
+        assertFalse(interval.isHighClosed());
+    }
+
+    @Test
+    void greaterThanTest() {
+        IntervalTemporaryDurationCriterion interval = IntervalTemporaryDurationCriterion.greaterThan(60, false);
+        assertEquals(60, interval.getLowBound().orElse(0));
+        assertTrue(interval.getHighBound().isEmpty());
+        assertFalse(interval.isLowClosed());
+
+        interval = IntervalTemporaryDurationCriterion.greaterThan(300, true);
+        assertEquals(300, interval.getLowBound().orElse(0));
+        assertTrue(interval.getHighBound().isEmpty());
+        assertTrue(interval.isLowClosed());
+    }
 }

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/limitreduction/LimitReductionModuleTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/limitreduction/LimitReductionModuleTest.java
@@ -64,10 +64,7 @@ class LimitReductionModuleTest extends AbstractSerDeTest {
                         new AtLeastOneNominalVoltageCriterion(
                                 new SingleNominalVoltageCriterion.VoltageInterval(380., 410., true, true)
                         )))
-                .withLimitDurationCriteria(IntervalTemporaryDurationCriterion.builder()
-                        .setLowBound(300, true)
-                        .setHighBound(600, false)
-                        .build())
+                .withLimitDurationCriteria(IntervalTemporaryDurationCriterion.between(300, 600, true, false))
                 .build();
 
         LimitReductionList limitReductionList = new LimitReductionList(List.of(limitReduction1, limitReduction2, limitReduction3, limitReduction4));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The only way to create an `IntervalTemporaryDurationCriterion` is to use the builder (via `builder()` method).


**What is the new behavior (if this is a feature change)?**
3 convenient static methods `lowerThan(...)`, `greaterThan(...)` and `between(...)`, creating an `IntervalTemporaryDurationCriterion` with one or both bounds, were added.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

It is thus possible (but not mandatory) to replace:

```java
var criterion = IntervalTemporaryDurationCriterion.builder()
                                  .setLowBound(300, true)
                                  .setHighBound(600, false)
                                  .build();
```

with:

```java
var criterion = IntervalTemporaryDurationCriterion.between(300, 600, true, false);
```
