### PR TITLE
Fix flows, voltage and angle at Boundary if generation present

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/DanglingLineBoundaryImpl.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/DanglingLineBoundaryImpl.java
@@ -26,7 +26,7 @@ public class DanglingLineBoundaryImpl implements Boundary {
 
     @Override
     public double getV() {
-        if (!parent.isPaired() && valid(parent.getP0(), parent.getQ0())) {
+        if (useHypothesis(parent)) {
             DanglingLineData danglingLineData = new DanglingLineData(parent, true);
             return danglingLineData.getBoundaryBusU();
         }
@@ -38,7 +38,7 @@ public class DanglingLineBoundaryImpl implements Boundary {
 
     @Override
     public double getAngle() {
-        if (!parent.isPaired() && valid(parent.getP0(), parent.getQ0())) {
+        if (useHypothesis(parent)) {
             DanglingLineData danglingLineData = new DanglingLineData(parent, true);
             return Math.toDegrees(danglingLineData.getBoundaryBusTheta());
         }
@@ -49,7 +49,7 @@ public class DanglingLineBoundaryImpl implements Boundary {
 
     @Override
     public double getP() {
-        if (!parent.isPaired() && valid(parent.getP0(), parent.getQ0())) {
+        if (useHypothesis(parent)) {
             return -parent.getP0();
         }
         Terminal t = parent.getTerminal();
@@ -59,7 +59,7 @@ public class DanglingLineBoundaryImpl implements Boundary {
 
     @Override
     public double getQ() {
-        if (!parent.isPaired() && valid(parent.getP0(), parent.getQ0())) {
+        if (useHypothesis(parent)) {
             return -parent.getQ0();
         }
         Terminal t = parent.getTerminal();
@@ -87,5 +87,13 @@ public class DanglingLineBoundaryImpl implements Boundary {
 
     private static boolean valid(double p0, double q0) {
         return !Double.isNaN(p0) && !Double.isNaN(q0);
+    }
+
+    private static boolean useHypothesis(DanglingLine parent) {
+        // We prefer to use P0 and Q0 if the dangling line is not paired and P0 and Q0 are valid, but we cannot retrieve
+        // P, Q, angle and voltage at boundary if the dangling line has a generation part: a previous global load flow
+        // run is needed, especially if the generation is regulating voltage.
+        // This could be improved later.
+        return !parent.isPaired() && valid(parent.getP0(), parent.getQ0()) && parent.getGeneration() == null;
     }
 }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/util/SVTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/util/SVTest.java
@@ -8,8 +8,10 @@
 package com.powsybl.iidm.network.impl.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.test.DanglingLineNetworkFactory;
 import org.junit.jupiter.api.Test;
 
 import com.powsybl.iidm.network.util.SV;
@@ -248,5 +250,29 @@ class SVTest {
             .setNode(node)
             .setEnsureIdUnicity(false)
             .add();
+    }
+
+    @Test
+    void testWithGeneration() {
+        double tol = 0.001;
+        Network network = DanglingLineNetworkFactory.createWithGeneration();
+        DanglingLine danglingLine = network.getDanglingLine("DL");
+        assertTrue(Double.isNaN(danglingLine.getBoundary().getP())); // there is no good solution here.
+        // we run an DC load flow and fill state variable
+        danglingLine.getTerminal().setP(-298.937);
+        danglingLine.getTerminal().setQ(Double.NaN);
+        danglingLine.getTerminal().getBusView().getBus().setAngle(0.0);
+        danglingLine.getTerminal().getBusView().getBus().setV(Double.NaN);
+        assertEquals(298.937, danglingLine.getBoundary().getP(), tol);
+        assertEquals(1.712783, danglingLine.getBoundary().getAngle(), tol);
+        // we run an AC load flow
+        danglingLine.getTerminal().setP(-298.937);
+        danglingLine.getTerminal().setQ(-7.413);
+        danglingLine.getTerminal().getBusView().getBus().setAngle(0.0);
+        danglingLine.getTerminal().getBusView().getBus().setV(100.0);
+        assertEquals(389.999, danglingLine.getBoundary().getP(), tol);
+        assertEquals(16.250, danglingLine.getBoundary().getQ(), tol);
+        assertEquals(130.037, danglingLine.getBoundary().getV(), tol);
+        assertEquals(0.995, danglingLine.getBoundary().getAngle(), tol);
     }
 }

--- a/iidm/iidm-serde/src/test/resources/V1_10/danglingLineWithGeneration.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_10/danglingLineWithGeneration.xml
@@ -8,7 +8,7 @@
             <iidm:generator id="G" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="50.0" targetV="100.0" targetQ="30.0" bus="BUS" connectableBus="BUS">
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
             </iidm:generator>
-            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
+            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="101.0" bus="BUS" connectableBus="BUS">
                 <iidm:property name="test" value="test"/>
                 <iidm:reactiveCapabilityCurve>
                     <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_11/danglingLineWithGeneration.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_11/danglingLineWithGeneration.xml
@@ -8,7 +8,7 @@
             <iidm:generator id="G" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="50.0" targetV="100.0" targetQ="30.0" bus="BUS" connectableBus="BUS">
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
             </iidm:generator>
-            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
+            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="101.0" bus="BUS" connectableBus="BUS">
                 <iidm:property name="test" value="test"/>
                 <iidm:reactiveCapabilityCurve>
                     <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_12/danglingLineWithGeneration.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_12/danglingLineWithGeneration.xml
@@ -14,7 +14,7 @@
             </iidm:generator>
             <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0"
                                generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0"
-                               generationTargetV="400.0" bus="BUS" connectableBus="BUS" selectedOperationalLimitsGroupId="DEFAULT">
+                               generationTargetV="101.0" bus="BUS" connectableBus="BUS" selectedOperationalLimitsGroupId="DEFAULT">
                 <iidm:property name="test" value="test"/>
                 <iidm:reactiveCapabilityCurve>
                     <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_3/danglingLineWithGeneration.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_3/danglingLineWithGeneration.xml
@@ -8,7 +8,7 @@
             <iidm:generator id="G" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="50.0" targetV="100.0" targetQ="30.0" bus="BUS" connectableBus="BUS">
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
             </iidm:generator>
-            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
+            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="101.0" bus="BUS" connectableBus="BUS">
                 <iidm:property name="test" value="test"/>
                 <iidm:reactiveCapabilityCurve>
                     <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_4/danglingLineWithGeneration.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_4/danglingLineWithGeneration.xml
@@ -8,7 +8,7 @@
             <iidm:generator id="G" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="50.0" targetV="100.0" targetQ="30.0" bus="BUS" connectableBus="BUS">
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
             </iidm:generator>
-            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
+            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="101.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
                 <iidm:property name="test" value="test"/>
                 <iidm:reactiveCapabilityCurve>
                     <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_5/danglingLineWithGeneration.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_5/danglingLineWithGeneration.xml
@@ -8,7 +8,7 @@
             <iidm:generator id="G" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="50.0" targetV="100.0" targetQ="30.0" bus="BUS" connectableBus="BUS">
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
             </iidm:generator>
-            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
+            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="101.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
                 <iidm:property name="test" value="test"/>
                 <iidm:reactiveCapabilityCurve>
                     <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_6/danglingLineWithGeneration.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_6/danglingLineWithGeneration.xml
@@ -8,7 +8,7 @@
             <iidm:generator id="G" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="50.0" targetV="100.0" targetQ="30.0" bus="BUS" connectableBus="BUS">
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
             </iidm:generator>
-            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
+            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="101.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
                 <iidm:property name="test" value="test"/>
                 <iidm:reactiveCapabilityCurve>
                     <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_7/danglingLineWithGeneration.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_7/danglingLineWithGeneration.xml
@@ -8,7 +8,7 @@
             <iidm:generator id="G" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="50.0" targetV="100.0" targetQ="30.0" bus="BUS" connectableBus="BUS">
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
             </iidm:generator>
-            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
+            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="101.0" bus="BUS" connectableBus="BUS">
                 <iidm:property name="test" value="test"/>
                 <iidm:reactiveCapabilityCurve>
                     <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_8/danglingLineWithGeneration.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_8/danglingLineWithGeneration.xml
@@ -8,7 +8,7 @@
             <iidm:generator id="G" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="50.0" targetV="100.0" targetQ="30.0" bus="BUS" connectableBus="BUS">
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
             </iidm:generator>
-            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
+            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="101.0" bus="BUS" connectableBus="BUS">
                 <iidm:property name="test" value="test"/>
                 <iidm:reactiveCapabilityCurve>
                     <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_9/danglingLineWithGeneration.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_9/danglingLineWithGeneration.xml
@@ -8,7 +8,7 @@
             <iidm:generator id="G" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="50.0" targetV="100.0" targetQ="30.0" bus="BUS" connectableBus="BUS">
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
             </iidm:generator>
-            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="400.0" bus="BUS" connectableBus="BUS">
+            <iidm:danglingLine id="DL" p0="50.0" q0="30.0" r="10.0" x="1.0" g="1.0E-4" b="1.0E-5" generationMinP="0.0" generationMaxP="900.0" generationVoltageRegulationOn="true" generationTargetP="440.0" generationTargetV="101.0" bus="BUS" connectableBus="BUS">
                 <iidm:property name="test" value="test"/>
                 <iidm:reactiveCapabilityCurve>
                     <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/DanglingLineNetworkFactory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/DanglingLineNetworkFactory.java
@@ -58,7 +58,7 @@ public final class DanglingLineNetworkFactory {
                 .setTargetP(440)
                 .setMaxP(900)
                 .setMinP(0)
-                .setTargetV(400)
+                .setTargetV(101)
                 .setVoltageRegulationOn(true)
                 .add()
                 .add();

--- a/matpower/matpower-converter/src/test/resources/dangling-line-generation.json
+++ b/matpower/matpower-converter/src/test/resources/dangling-line-generation.json
@@ -61,7 +61,7 @@
     "reactivePowerOutput" : "NaN",
     "maximumReactivePowerOutput" : 46.25,
     "minimumReactivePowerOutput" : -54.55,
-    "voltageMagnitudeSetpoint" : 4.0,
+    "voltageMagnitudeSetpoint" : 1.01,
     "totalMbase" : 0.0,
     "status" : 1,
     "maximumRealPowerOutput" : 900.0,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

No, but it is a bug fix. In case of unpaired dangling line with a not null generation part, the `Boundary` P, Q, voltage and angle are totally wrong.

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This is a quick fix, not ideal. If the dangling line is not paired but with a generation file, we rely on power flow results at network side to retrieve the good value at boundary side.

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
