### PR TITLE
Add back static method parseCsv without ReportNode for TimeSeries

### DIFF
--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/TimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/TimeSeries.java
@@ -446,6 +446,10 @@ public interface TimeSeries<P extends AbstractPoint, T extends TimeSeries<P, T>>
         }
     }
 
+    static Map<Integer, List<TimeSeries>> parseCsv(BufferedReader reader, TimeSeriesCsvConfig timeSeriesCsvConfig) {
+        return parseCsv(reader, timeSeriesCsvConfig, ReportNode.NO_OP);
+    }
+
     static Map<Integer, List<TimeSeries>> parseCsv(BufferedReader reader, TimeSeriesCsvConfig timeSeriesCsvConfig,
                                                    ReportNode reportNode) {
         Objects.requireNonNull(reader);

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
@@ -11,6 +11,9 @@ import com.powsybl.commons.report.ReportNode;
 import com.powsybl.timeseries.TimeSeries.TimeFormat;
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
 import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -133,6 +136,26 @@ class TimeSeriesTest {
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv, timeSeriesCsvConfig);
 
         assertOnParsedTimeSeries(timeSeriesPerVersion, RegularTimeSeriesIndex.class);
+    }
+
+    @Test
+    void testParseCsvBuffered() {
+        String csv = String.join(System.lineSeparator(),
+            "Time;Version;ts1;ts2",
+            "0.000;1;1.0;",
+            "0.001;1;;a",
+            "0.002;1;3.0;b",
+            "0.000;2;4.0;c",
+            "0.001;2;5.0;",
+            "0.002;2;6.0;d") + System.lineSeparator();
+
+        TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', true, TimeFormat.FRACTIONS_OF_SECOND, true);
+        try (BufferedReader reader = new BufferedReader(new StringReader(csv))) {
+            Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(reader, timeSeriesCsvConfig);
+            assertOnParsedTimeSeries(timeSeriesPerVersion, RegularTimeSeriesIndex.class);
+        } catch (IOException e) {
+            fail();
+        }
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature/Bug fix

**What is the current behavior?**
Since v6.3.0, the `parseCsv(BufferedReader reader, TimeSeriesCsvConfig timeSeriesCsvConfig)` needed a ReportNode as third parameter.

**What is the new behavior (if this is a feature change)?**
For convenience, a static method `parseCsv(BufferedReader reader, TimeSeriesCsvConfig timeSeriesCsvConfig)` is again available.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No