### PR TITLE
Launch CI when new version tag is pushed

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,7 +7,7 @@ on:
       - 'release-v**'
       - 'full-sonar-analysis-**'
     tags:
-      - 'v*.*.*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
 
 permissions: {}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,8 @@ on:
       - 'main'
       - 'release-v**'
       - 'full-sonar-analysis-**'
+    tags:
+      - 'v*.*.*'
   pull_request:
 
 permissions: {}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
CI is often not launched on version commit, as the "prepare release" pull request contains two commits which are often pushed at once. The CI is then launched only at the latest commit ("Bump to X.Y.Z-SNAPSHOT version") and not the the first one ("Bump to X.Y.Z version")

**What is the new behavior (if this is a feature change)?**
The CI is launched when the added tag "vX.Y.Z" is pushed

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No