### PR TITLE
Fix hvdcAcEmulation option loading from a yaml config file

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
@@ -144,6 +144,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
                     parameters.setDcUseTransformerRatio(config.getBooleanProperty("dcUseTransformerRatio", DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT));
                     parameters.setCountriesToBalance(config.getEnumSetProperty("countriesToBalance", Country.class, DEFAULT_COUNTRIES_TO_BALANCE));
                     parameters.setConnectedComponentMode(config.getEnumProperty("connectedComponentMode", ConnectedComponentMode.class, DEFAULT_CONNECTED_COMPONENT_MODE));
+                    parameters.setHvdcAcEmulation(config.getBooleanProperty("hvdcAcEmulation", DEFAULT_HVDC_AC_EMULATION_ON));
                     parameters.setDcPowerFactor(config.getDoubleProperty("dcPowerFactor", DEFAULT_DC_POWER_FACTOR));
                 });
     }

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
@@ -107,7 +107,7 @@ class LoadFlowParametersTest {
         boolean dcUseTransformerRatio = true;
         Set<Country> countriesToBalance = new HashSet<>();
         LoadFlowParameters.ConnectedComponentMode computedConnectedComponent = LoadFlowParameters.ConnectedComponentMode.MAIN;
-        boolean hvdcAcEmulation = true;
+        boolean hvdcAcEmulation = false;
 
         MapModuleConfig moduleConfig = platformConfig.createModuleConfig("load-flow-default-parameters");
         moduleConfig.setStringProperty("voltageInitMode", "UNIFORM_VALUES");
@@ -294,7 +294,7 @@ class LoadFlowParametersTest {
         boolean dcUseTransformerRatio = true;
         Set<Country> countriesToBalance = new HashSet<>();
         LoadFlowParameters.ConnectedComponentMode computedConnectedComponent = LoadFlowParameters.ConnectedComponentMode.MAIN;
-        boolean hvdcAcEmulation = true;
+        boolean hvdcAcEmulation = false;
         LoadFlowParameters parameters = new LoadFlowParameters()
                 .setVoltageInitMode(voltageInitMode)
                 .setTransformerVoltageControlOn(transformerVoltageControlOn)

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/JsonLoadFlowParametersTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/JsonLoadFlowParametersTest.java
@@ -129,7 +129,7 @@ public class JsonLoadFlowParametersTest extends AbstractSerDeTest {
     void readJsonVersion17() {
         LoadFlowParameters parameters = JsonLoadFlowParameters
                 .read(getClass().getResourceAsStream("/LoadFlowParametersVersion17.json"));
-        assertTrue(parameters.isHvdcAcEmulation());
+        assertFalse(parameters.isHvdcAcEmulation());
     }
 
     @Test

--- a/loadflow/loadflow-api/src/test/resources/LoadFlowParametersVersion17.json
+++ b/loadflow/loadflow-api/src/test/resources/LoadFlowParametersVersion17.json
@@ -14,5 +14,5 @@
   "dcUseTransformerRatio" : true,
   "countriesToBalance" : [ "FR" , "KI" ],
   "connectedComponentMode" : "MAIN",
-  "hvdcAcEmulation" : true
+  "hvdcAcEmulation" : false
 }

--- a/loadflow/loadflow-api/src/test/resources/LoadFlowParametersVersion18.json
+++ b/loadflow/loadflow-api/src/test/resources/LoadFlowParametersVersion18.json
@@ -14,5 +14,5 @@
   "dcUseTransformerRatio" : true,
   "countriesToBalance" : [ "FR" , "KI" ],
   "connectedComponentMode" : "MAIN",
-  "hvdcAcEmulation" : true
+  "hvdcAcEmulation" : false
 }

--- a/loadflow/loadflow-api/src/test/resources/LoadFlowParametersVersion19.json
+++ b/loadflow/loadflow-api/src/test/resources/LoadFlowParametersVersion19.json
@@ -14,6 +14,6 @@
   "dcUseTransformerRatio" : true,
   "countriesToBalance" : [ "FR" , "KI" ],
   "connectedComponentMode" : "MAIN",
-  "hvdcAcEmulation" : true,
+  "hvdcAcEmulation" : false,
   "dcPowerFactor": 0.8
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The `hvdcAcEmulation` option is not read from the LF parameters **yaml** config file. The default value is always used.


**What is the new behavior (if this is a feature change)?**
The `hvdcAcEmulation` option is read from the LF parameters yaml config file.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
