### PR TITLE
Fix LoadFlowResult status for retro-compatibility and replace uses of deprecated isOk

### DIFF
--- a/action-ial/action-ial-simulator/src/main/java/com/powsybl/action/ial/simulator/loadflow/LoadFlowActionSimulator.java
+++ b/action-ial/action-ial-simulator/src/main/java/com/powsybl/action/ial/simulator/loadflow/LoadFlowActionSimulator.java
@@ -305,7 +305,7 @@ public class LoadFlowActionSimulator implements ActionSimulator {
         } catch (Exception e) {
             throw new PowsyblException(e);
         }
-        if (result.isPartiallyConverged() || result.isFullyConverged()) {
+        if (!result.isFailed()) {
             return checkViolations(actionDb, context);
         } else {
             LOGGER.warn("Loadflow diverged: {}", result.getMetrics());
@@ -359,7 +359,7 @@ public class LoadFlowActionSimulator implements ActionSimulator {
 
             LoadFlowResult testResult = runTest(context, networkForTest, action);
             context.addTested(actionId);
-            if (testResult.isPartiallyConverged() || testResult.isFullyConverged()) {
+            if (!testResult.isFailed()) {
                 List<LimitViolation> violationsInTest =
                         LIMIT_VIOLATION_FILTER.apply(Security.checkLimits(networkForTest, 1), networkForTest);
                 if (violationsInTest.isEmpty()) {

--- a/action-ial/action-ial-simulator/src/main/java/com/powsybl/action/ial/simulator/loadflow/LoadFlowActionSimulator.java
+++ b/action-ial/action-ial-simulator/src/main/java/com/powsybl/action/ial/simulator/loadflow/LoadFlowActionSimulator.java
@@ -305,7 +305,7 @@ public class LoadFlowActionSimulator implements ActionSimulator {
         } catch (Exception e) {
             throw new PowsyblException(e);
         }
-        if (result.isOk()) {
+        if (result.isPartiallyConverged() || result.isFullyConverged()) {
             return checkViolations(actionDb, context);
         } else {
             LOGGER.warn("Loadflow diverged: {}", result.getMetrics());
@@ -359,7 +359,7 @@ public class LoadFlowActionSimulator implements ActionSimulator {
 
             LoadFlowResult testResult = runTest(context, networkForTest, action);
             context.addTested(actionId);
-            if (testResult.isOk()) {
+            if (testResult.isPartiallyConverged() || testResult.isFullyConverged()) {
                 List<LimitViolation> violationsInTest =
                         LIMIT_VIOLATION_FILTER.apply(Security.checkLimits(networkForTest, 1), networkForTest);
                 if (violationsInTest.isEmpty()) {

--- a/action-ial/action-ial-simulator/src/test/java/com/powsybl/action/ial/simulator/LoadFlowProviderMock.java
+++ b/action-ial/action-ial-simulator/src/test/java/com/powsybl/action/ial/simulator/LoadFlowProviderMock.java
@@ -15,8 +15,12 @@ import com.powsybl.loadflow.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+
+import static com.powsybl.loadflow.LoadFlowResult.ComponentResult.Status.CONVERGED;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -39,6 +43,11 @@ public class LoadFlowProviderMock extends AbstractNoSpecificParametersLoadFlowPr
     @Override
     public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingStateId, LoadFlowParameters parameters, ReportNode reportNode) {
         LOGGER.warn("Running loadflow mock");
-        return CompletableFuture.completedFuture(new LoadFlowResultImpl(true, Collections.emptyMap(), ""));
+
+        // Add a converged ComponentResult
+        List<LoadFlowResult.ComponentResult> componentResults = new ArrayList<>();
+        componentResults.add(new LoadFlowResultImpl.ComponentResultImpl(1, 2, CONVERGED, 3, "id", 4d, 5d));
+
+        return CompletableFuture.completedFuture(new LoadFlowResultImpl(true, Collections.emptyMap(), "", componentResults));
     }
 }

--- a/action-ial/action-ial-simulator/src/test/java/com/powsybl/action/ial/simulator/LoadFlowProviderMock.java
+++ b/action-ial/action-ial-simulator/src/test/java/com/powsybl/action/ial/simulator/LoadFlowProviderMock.java
@@ -15,12 +15,8 @@ import com.powsybl.loadflow.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
-
-import static com.powsybl.loadflow.LoadFlowResult.ComponentResult.Status.CONVERGED;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -43,11 +39,6 @@ public class LoadFlowProviderMock extends AbstractNoSpecificParametersLoadFlowPr
     @Override
     public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingStateId, LoadFlowParameters parameters, ReportNode reportNode) {
         LOGGER.warn("Running loadflow mock");
-
-        // Add a converged ComponentResult
-        List<LoadFlowResult.ComponentResult> componentResults = new ArrayList<>();
-        componentResults.add(new LoadFlowResultImpl.ComponentResultImpl(1, 2, CONVERGED, 3, "id", 4d, 5d));
-
-        return CompletableFuture.completedFuture(new LoadFlowResultImpl(true, Collections.emptyMap(), "", componentResults));
+        return CompletableFuture.completedFuture(new LoadFlowResultImpl(true, Collections.emptyMap(), ""));
     }
 }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/LoadFlowBasedPhaseShifterOptimizer.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/LoadFlowBasedPhaseShifterOptimizer.java
@@ -46,7 +46,7 @@ public class LoadFlowBasedPhaseShifterOptimizer implements PhaseShifterOptimizer
             String loadFlowName = config.getLoadFlowName().orElse(null);
             LoadFlowResult result = LoadFlow.find(loadFlowName)
                                             .run(network, workingStateId, computationManager, LoadFlowParameters.load());
-            if (result.getStatus() == LoadFlowResult.Status.FAILED) {
+            if (result.isFailed()) {
                 throw new PowsyblException("Load flow diverged during phase shifter optimization");
             }
         } catch (Exception e) {

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/LoadFlowBasedPhaseShifterOptimizer.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/LoadFlowBasedPhaseShifterOptimizer.java
@@ -46,7 +46,7 @@ public class LoadFlowBasedPhaseShifterOptimizer implements PhaseShifterOptimizer
             String loadFlowName = config.getLoadFlowName().orElse(null);
             LoadFlowResult result = LoadFlow.find(loadFlowName)
                                             .run(network, workingStateId, computationManager, LoadFlowParameters.load());
-            if (!result.isOk()) {
+            if (result.getStatus() == LoadFlowResult.Status.FAILED) {
                 throw new PowsyblException("Load flow diverged during phase shifter optimization");
             }
         } catch (Exception e) {

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowResultImpl.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowResultImpl.java
@@ -175,6 +175,7 @@ public class LoadFlowResultImpl implements LoadFlowResult {
     private final Map<String, String> metrics;
     private final String logs;
     private final List<ComponentResult> componentResults;
+    private static final Status DEFAULT_OK_STATUS_FOR_RETROCOMPATIBILITY = Status.PARTIALLY_CONVERGED;
 
     public LoadFlowResultImpl(boolean ok, Map<String, String> metrics, String logs) {
         this(ok, metrics, logs, Collections.emptyList());
@@ -189,6 +190,11 @@ public class LoadFlowResultImpl implements LoadFlowResult {
     }
 
     private Status computeStatus(List<ComponentResult> componentResults) {
+        // Retro-compatibility
+        if (componentResults.isEmpty() && ok) {
+            return DEFAULT_OK_STATUS_FOR_RETROCOMPATIBILITY;
+        }
+
         int convergedCount = 0;
         int maxIterOrFailedCount = 0;
         for (ComponentResult componentResult : componentResults) {

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowResultSerializer.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowResultSerializer.java
@@ -40,7 +40,7 @@ public class LoadFlowResultSerializer extends StdSerializer<LoadFlowResult> {
     public void serialize(LoadFlowResult result, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         jsonGenerator.writeStartObject();
         jsonGenerator.writeStringField("version", VERSION);
-        jsonGenerator.writeBooleanField("isOK", result.getStatus() != LoadFlowResult.Status.FAILED);
+        jsonGenerator.writeBooleanField("isOK", !result.isFailed());
         serializerProvider.defaultSerializeField("metrics", result.getMetrics(), jsonGenerator);
         List<LoadFlowResult.ComponentResult> componentResults = result.getComponentResults();
         if (!componentResults.isEmpty()) {

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowResultSerializer.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/json/LoadFlowResultSerializer.java
@@ -40,7 +40,7 @@ public class LoadFlowResultSerializer extends StdSerializer<LoadFlowResult> {
     public void serialize(LoadFlowResult result, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         jsonGenerator.writeStartObject();
         jsonGenerator.writeStringField("version", VERSION);
-        jsonGenerator.writeBooleanField("isOK", result.isOk());
+        jsonGenerator.writeBooleanField("isOK", result.getStatus() != LoadFlowResult.Status.FAILED);
         serializerProvider.defaultSerializeField("metrics", result.getMetrics(), jsonGenerator);
         List<LoadFlowResult.ComponentResult> componentResults = result.getComponentResults();
         if (!componentResults.isEmpty()) {

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/tools/RunLoadFlowTool.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/tools/RunLoadFlowTool.java
@@ -193,7 +193,7 @@ public class RunLoadFlowTool implements Tool {
                 new Column("Ok"),
                 new Column("Status"),
                 new Column("Metrics"))) {
-            formatter.writeCell(result.isOk());
+            formatter.writeCell(result.getStatus() == LoadFlowResult.Status.FAILED);
             formatter.writeCell(result.getStatus().name());
             formatter.writeCell(result.getMetrics().toString());
         } catch (IOException e) {

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/tools/RunLoadFlowTool.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/tools/RunLoadFlowTool.java
@@ -193,7 +193,7 @@ public class RunLoadFlowTool implements Tool {
                 new Column("Ok"),
                 new Column("Status"),
                 new Column("Metrics"))) {
-            formatter.writeCell(result.getStatus() == LoadFlowResult.Status.FAILED);
+            formatter.writeCell(!result.isFailed());
             formatter.writeCell(result.getStatus().name());
             formatter.writeCell(result.getMetrics().toString());
         } catch (IOException e) {

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/LoadFlowResultJsonTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/LoadFlowResultJsonTest.java
@@ -182,10 +182,10 @@ class LoadFlowResultJsonTest extends AbstractSerDeTest {
     @Test
     void readJsonVersion11() throws IOException {
         LoadFlowResult result11 = LoadFlowResultDeserializer.read(getClass().getResourceAsStream("/LoadFlowResultVersion11.json"));
-        assertNotSame(LoadFlowResult.Status.FAILED, result11.getStatus());
+        assertFalse(result11.isFailed());
 
         LoadFlowResult result12 = createVersion12();
-        assertNotSame(LoadFlowResult.Status.FAILED, result12.getStatus());
+        assertFalse(result12.isFailed());
 
         LoadFlowResult.ComponentResult component11 = result11.getComponentResults().get(0);
         LoadFlowResult.ComponentResult component12 = result12.getComponentResults().get(0);
@@ -225,7 +225,7 @@ class LoadFlowResultJsonTest extends AbstractSerDeTest {
     void version10apiBackwardCompatibility() {
         LoadFlowResult result = createVersion10();
         assertTrue(result.getComponentResults().isEmpty());
-        assertTrue(result.isOk());
+        assertTrue(result.isPartiallyConverged());
         assertEquals("", result.getLogs());
     }
 

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/LoadFlowResultJsonTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/json/LoadFlowResultJsonTest.java
@@ -182,10 +182,10 @@ class LoadFlowResultJsonTest extends AbstractSerDeTest {
     @Test
     void readJsonVersion11() throws IOException {
         LoadFlowResult result11 = LoadFlowResultDeserializer.read(getClass().getResourceAsStream("/LoadFlowResultVersion11.json"));
-        assertTrue(result11.isOk());
+        assertNotSame(LoadFlowResult.Status.FAILED, result11.getStatus());
 
         LoadFlowResult result12 = createVersion12();
-        assertTrue(result12.isOk());
+        assertNotSame(LoadFlowResult.Status.FAILED, result12.getStatus());
 
         LoadFlowResult.ComponentResult component11 = result11.getComponentResults().get(0);
         LoadFlowResult.ComponentResult component12 = result12.getComponentResults().get(0);
@@ -197,7 +197,7 @@ class LoadFlowResultJsonTest extends AbstractSerDeTest {
     @Test
     void readJsonVersion10() throws IOException {
         LoadFlowResult result = LoadFlowResultDeserializer.read(getClass().getResourceAsStream("/LoadFlowResultVersion10.json"));
-        assertTrue(result.isOk());
+        assertNotEquals(LoadFlowResult.Status.FAILED, result.getStatus());
         assertEquals(createMetrics(), result.getMetrics());
         assertNull(result.getLogs());
         assertTrue(result.getComponentResults().isEmpty());

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/LoadFlowComputation.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/LoadFlowComputation.java
@@ -40,7 +40,7 @@ public class LoadFlowComputation implements CandidateComputation {
         String loadFlowName = ValidationConfig.load().getLoadFlowName().orElse(null);
         LoadFlowResult result = LoadFlow.find(loadFlowName)
                                         .run(network, VariantManagerConstants.INITIAL_VARIANT_ID, computationManager, parameters);
-        if (!result.isOk()) {
+        if (result.isFailed()) {
             throw new PowsyblException("Loadflow on network " + network.getId() + " does not converge");
         }
     }

--- a/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/ValidationTool.java
+++ b/loadflow/loadflow-validation/src/main/java/com/powsybl/loadflow/validation/ValidationTool.java
@@ -217,7 +217,7 @@ public class ValidationTool implements Tool {
         LoadFlow.find(loadFlowName)
                 .runAsync(network, VariantManagerConstants.INITIAL_VARIANT_ID, context.getShortTimeExecutionComputationManager(), parameters)
                 .thenAccept(loadFlowResult -> {
-                    if (!loadFlowResult.isOk()) {
+                    if (loadFlowResult.isFailed()) {
                         throw new PowsyblException("Loadflow on network " + network.getId() + " does not converge");
                     }
                 })

--- a/security-analysis/security-analysis-default/src/main/java/com/powsybl/security/impl/DefaultSecurityAnalysis.java
+++ b/security-analysis/security-analysis-default/src/main/java/com/powsybl/security/impl/DefaultSecurityAnalysis.java
@@ -129,7 +129,7 @@ public class DefaultSecurityAnalysis {
         return LoadFlow
             .runAsync(network, workingVariantId, computationManager, loadFlowParameters, reportNode)
             .thenCompose(loadFlowResult -> {
-                if (loadFlowResult.isOk()) {
+                if (!loadFlowResult.isFailed()) {
                     return CompletableFuture
                         .runAsync(() -> {
                             network.getVariantManager().setWorkingVariant(workingVariantId);
@@ -225,9 +225,9 @@ public class DefaultSecurityAnalysis {
         network.getVariantManager().setWorkingVariant(postContVariantId);
         SecurityAnalysisResultBuilder.PostContingencyResultBuilder builder =
                 resultBuilder.contingency(contingency)
-                        .setStatus(lfResult.isOk() ? PostContingencyComputationStatus.CONVERGED : PostContingencyComputationStatus.FAILED)
+                        .setStatus(!lfResult.isFailed() ? PostContingencyComputationStatus.CONVERGED : PostContingencyComputationStatus.FAILED)
                         .setConnectivityResult(new ConnectivityResult(0, 0, 0.0, 0.0, Collections.emptySet()));
-        if (lfResult.isOk()) {
+        if (!lfResult.isFailed()) {
             violationDetector.checkAll(contingency, network, builder::addViolation);
             addMonitorInfos(network, monitorIndex.getAllStateMonitor(), builder::addBranchResult, builder::addBusResult, builder::addThreeWindingsTransformerResult);
             StateMonitor stateMonitor = monitorIndex.getSpecificStateMonitors().get(contingency.getId());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
When initializing a new `LoadFlowResultImpl(boolean ok, Map<String, String> metrics, String logs)` with `ok` set to `true`, since no componentResults is given, the status is still set to FAILED. Therefore, there is an incoherence between `isOk` and `status`.
This case appears for example when deserializing an old loadflow result where no component result is defined.

**What is the new behavior (if this is a feature change)?**
If no component result is given during the initialisation of a new `LoadFlowResultImpl` and if `ok` is set to `true`, then `status` is set to `DEFAULT_OK_STATUS_FOR_RETROCOMPATIBILITY`, which has been defined equals to `PARTIALLY_CONVERGED`.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
