### PR TITLE
CGMES export fix: modelling authority must be preserved

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
@@ -113,11 +113,13 @@ public class CgmesExport implements Exporter {
         if (sourcingActor.containsKey("masUri") && masUri.equals(CgmesExportContext.DEFAULT_MODELING_AUTHORITY_SET_VALUE)) {
             masUri = sourcingActor.get("masUri");
         }
-
-        context.getExportedEQModel().setModelingAuthoritySet(masUri);
-        context.getExportedTPModel().setModelingAuthoritySet(masUri);
-        context.getExportedSSHModel().setModelingAuthoritySet(masUri);
-        context.getExportedSVModel().setModelingAuthoritySet(masUri);
+        // Only update if masUri is not the default value
+        if (!masUri.equals(CgmesExportContext.DEFAULT_MODELING_AUTHORITY_SET_VALUE)) {
+            context.getExportedEQModel().setModelingAuthoritySet(masUri);
+            context.getExportedTPModel().setModelingAuthoritySet(masUri);
+            context.getExportedSSHModel().setModelingAuthoritySet(masUri);
+            context.getExportedSVModel().setModelingAuthoritySet(masUri);
+        }
         String modelDescription = Parameter.readString(getFormat(), params, MODEL_DESCRIPTION_PARAMETER, defaultValueConfig);
         if (modelDescription != null) {
             context.getExportedEQModel().setDescription(modelDescription);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/LegacyCommonGridModelExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/LegacyCommonGridModelExportTest.java
@@ -76,9 +76,13 @@ class LegacyCommonGridModelExportTest extends AbstractSerDeTest {
         String exportBasename = "tmp-micro-bc-from-CGM";
         network.write("CGMES", exportParams, tmpDir.resolve(exportBasename));
 
-        Set<String> deps = findAll(REGEX_DEPENDENT_ON, Files.readString(tmpDir.resolve(exportBasename + "_SV.xml")));
+        String sv = Files.readString(tmpDir.resolve(exportBasename + "_SV.xml"));
+
+        Set<String> deps = findAll(REGEX_DEPENDENT_ON, sv);
         assertTrue(deps.containsAll(updatedSshIds));
         initialSshIds.forEach(initialSshId -> assertFalse(deps.contains(initialSshId)));
+
+        assertEquals("MAS1", findFirst(MODELING_AUTHORITY, sv));
     }
 
     private void buildSvDependenciesManaginMetadataModels(Network network, List<String> updateSshIds) {
@@ -139,5 +143,14 @@ class LegacyCommonGridModelExportTest extends AbstractSerDeTest {
         return found;
     }
 
+    private static String findFirst(Pattern pattern, String xml) {
+        Matcher matcher = pattern.matcher(xml);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
     private static final Pattern REGEX_DEPENDENT_ON = Pattern.compile("<md:Model.DependentOn rdf:resource=\"(.*?)\"");
+    private static final Pattern MODELING_AUTHORITY = Pattern.compile("<md:Model.modelingAuthoritySet>(.*?)</md:Model.modelingAuthoritySet>");
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Modelling authority set in the metadata models by an external user is always overwritten with the default value of the corresponding export parameter.


**What is the new behavior (if this is a feature change)?**
Modelling authority set in the metadata models is overwritten only if a specific value has been set through parameters. If the parameter has the default value, the metadata models are not modified, and its modelling authority will be used in the export.


