### PR TITLE
Replace OptionalDouble by Optional

### DIFF
--- a/action-api/src/main/java/com/powsybl/action/AbstractLoadAction.java
+++ b/action-api/src/main/java/com/powsybl/action/AbstractLoadAction.java
@@ -7,7 +7,7 @@
  */
 package com.powsybl.action;
 
-import java.util.OptionalDouble;
+import java.util.Optional;
 
 /**
  * An action to:
@@ -41,11 +41,11 @@ public abstract class AbstractLoadAction extends AbstractAction {
         return relativeValue;
     }
 
-    public OptionalDouble getActivePowerValue() {
-        return activePowerValue == null ? OptionalDouble.empty() : OptionalDouble.of(activePowerValue);
+    public Optional<Double> getActivePowerValue() {
+        return activePowerValue == null ? Optional.empty() : Optional.of(activePowerValue);
     }
 
-    public OptionalDouble getReactivePowerValue() {
-        return reactivePowerValue == null ? OptionalDouble.empty() : OptionalDouble.of(reactivePowerValue);
+    public Optional<Double> getReactivePowerValue() {
+        return reactivePowerValue == null ? Optional.empty() : Optional.of(reactivePowerValue);
     }
 }


### PR DESCRIPTION
Replace OptionalDouble by Optional to be able to easily replace it by 'null', for instance to use on a constructor which allows null parameters

It will be used for NetworkModification constructor with null parameters like ShuntCompensatorModification.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
