### PR TITLE
[Draft] Asymmetrical line and two windings transformer extensions

### DIFF
--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/LineAsymmetrical.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/LineAsymmetrical.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network.extensions;
+
+import com.powsybl.commons.extensions.Extension;
+import com.powsybl.iidm.network.Line;
+import com.powsybl.math.matrix.ComplexMatrix;
+
+/**
+ * An asymmetrical line is modeled by:
+ * - the connection status of each phase A, B and C.
+ * - its physical characteristics Rz, Xz, Rn and Zn (knowing that Rp and Rp, balanced characteristics, are present in
+ * the line attributes). From these values, we compute the Fortescue admittance matrix admittanceMatrixABC for computation engine.
+ *
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
+ */
+public interface LineAsymmetrical extends Extension<Line> {
+
+    String NAME = "lineAsymmetrical";
+
+    @Override
+    default String getName() {
+        return NAME;
+    }
+
+    boolean isOpenPhaseA();
+
+    void setOpenPhaseA(boolean openPhaseA);
+
+    boolean isOpenPhaseB();
+
+    void setOpenPhaseB(boolean openPhaseB);
+
+    boolean isOpenPhaseC();
+
+    void setOpenPhaseC(boolean openPhaseC);
+
+    ComplexMatrix getAdmittanceMatrixABC();
+
+    void setAdmittanceMatrixABC(ComplexMatrix admittanceMatrixABC);
+}

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/LineAsymmetricalAdder.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/LineAsymmetricalAdder.java
@@ -7,33 +7,18 @@
  */
 package com.powsybl.iidm.network.extensions;
 
-import com.powsybl.commons.extensions.Extension;
+import com.powsybl.commons.extensions.ExtensionAdder;
 import com.powsybl.iidm.network.Line;
 
 /**
  * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
-public interface LineFortescue extends Extension<Line> {
+public interface LineAsymmetricalAdder extends ExtensionAdder<Line, LineAsymmetrical> {
 
-    String NAME = "lineFortescue";
+    LineAsymmetricalAdder withOpenPhaseA(boolean openPhaseA);
 
-    @Override
-    default String getName() {
-        return NAME;
-    }
+    LineAsymmetricalAdder withOpenPhaseB(boolean openPhaseB);
 
-    /**
-     * The zero sequence resistance of the line.
-     */
-    double getRz();
-
-    void setRz(double rz);
-
-    /**
-     * The zero sequence reactance of the line.
-     */
-    double getXz();
-
-    void setXz(double xz);
+    LineAsymmetricalAdder withOpenPhaseC(boolean openPhaseC);
 }

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/LineFortescueAdder.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/LineFortescueAdder.java
@@ -19,10 +19,4 @@ public interface LineFortescueAdder extends ExtensionAdder<Line, LineFortescue> 
     LineFortescueAdder withRz(double rz);
 
     LineFortescueAdder withXz(double xz);
-
-    LineFortescueAdder withOpenPhaseA(boolean openPhaseA);
-
-    LineFortescueAdder withOpenPhaseB(boolean openPhaseB);
-
-    LineFortescueAdder withOpenPhaseC(boolean openPhaseC);
 }

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/TwoWindingsTransformerAsymmetrical.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/TwoWindingsTransformerAsymmetrical.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network.extensions;
+
+import com.powsybl.commons.extensions.Extension;
+import com.powsybl.iidm.network.TwoWindingsTransformer;
+import com.powsybl.math.matrix.ComplexMatrix;
+
+/**
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
+ */
+public interface TwoWindingsTransformerAsymmetrical extends Extension<TwoWindingsTransformer> {
+
+    String NAME = "twoWindingsTransformerAsymmetrical";
+
+    @Override
+    default String getName() {
+        return NAME;
+    }
+
+    boolean isOpenPhaseA1();
+
+    void setOpenPhaseA1(boolean openPhaseA1);
+
+    boolean isOpenPhaseB1();
+
+    void setOpenPhaseB1(boolean openPhaseB1);
+
+    boolean isOpenPhaseC1();
+
+    void setOpenPhaseC1(boolean openPhaseC1);
+
+    boolean isOpenPhaseA2();
+
+    void setOpenPhaseA2(boolean openPhaseA2);
+
+    boolean isOpenPhaseB2();
+
+    void setOpenPhaseB2(boolean openPhaseB2);
+
+    boolean isOpenPhaseC2();
+
+    void setOpenPhaseC2(boolean openPhaseC2);
+
+    /**
+     * Get admittance complex matrix for phase A.
+     */
+    ComplexMatrix getAdmittanceMatrixA();
+
+    void setAdmittanceMatrixA(ComplexMatrix admittanceMatrixA);
+
+    /**
+     * Get admittance complex matrix for phase B.
+     */
+    ComplexMatrix getAdmittanceMatrixB();
+
+    void setAdmittanceMatrixB(ComplexMatrix admittanceMatrixB);
+
+    /**
+     * Get admittance complex matrix for phase C.
+     */
+    ComplexMatrix getAdmittanceMatrixC();
+
+    void setAdmittanceMatrixC(ComplexMatrix admittanceMatrixC);
+}

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/TwoWindingsTransformerAsymmetricalAdder.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/TwoWindingsTransformerAsymmetricalAdder.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network.extensions;
+
+import com.powsybl.commons.extensions.ExtensionAdder;
+import com.powsybl.iidm.network.TwoWindingsTransformer;
+import com.powsybl.math.matrix.ComplexMatrix;
+
+/**
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ */
+public interface TwoWindingsTransformerAsymmetricalAdder extends ExtensionAdder<TwoWindingsTransformer, TwoWindingsTransformerAsymmetrical> {
+
+    TwoWindingsTransformerAsymmetricalAdder withOpenPhaseA1(boolean openPhaseA1);
+
+    TwoWindingsTransformerAsymmetricalAdder withOpenPhaseB1(boolean openPhaseB1);
+
+    TwoWindingsTransformerAsymmetricalAdder withOpenPhaseC1(boolean openPhaseC1);
+
+    TwoWindingsTransformerAsymmetricalAdder withOpenPhaseA2(boolean openPhaseA2);
+
+    TwoWindingsTransformerAsymmetricalAdder withOpenPhaseB2(boolean openPhaseB2);
+
+    TwoWindingsTransformerAsymmetricalAdder withOpenPhaseC2(boolean openPhaseC2);
+
+    TwoWindingsTransformerAsymmetricalAdder withYA(ComplexMatrix yA);
+
+    TwoWindingsTransformerAsymmetricalAdder withYB(ComplexMatrix yB);
+
+    TwoWindingsTransformerAsymmetricalAdder withYC(ComplexMatrix yC);
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/LineAsymmetricalAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/LineAsymmetricalAdderImpl.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network.impl.extensions;
+
+import com.powsybl.commons.extensions.AbstractExtensionAdder;
+import com.powsybl.iidm.network.Line;
+import com.powsybl.iidm.network.extensions.LineAsymmetrical;
+import com.powsybl.iidm.network.extensions.LineAsymmetricalAdder;
+import com.powsybl.math.matrix.ComplexMatrix;
+
+/**
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
+ */
+public class LineAsymmetricalAdderImpl extends AbstractExtensionAdder<Line, LineAsymmetrical> implements LineAsymmetricalAdder {
+
+    private boolean openPhaseA = false;
+    private boolean openPhaseB = false;
+    private boolean openPhaseC = false;
+
+    private ComplexMatrix admittanceMatrixABC = null;
+
+    public LineAsymmetricalAdderImpl(Line line) {
+        super(line);
+    }
+
+    @Override
+    public Class<? super LineAsymmetrical> getExtensionClass() {
+        return LineAsymmetrical.class;
+    }
+
+    @Override
+    protected LineAsymmetricalImpl createExtension(Line line) {
+        return new LineAsymmetricalImpl(line, openPhaseA, openPhaseB, openPhaseC, admittanceMatrixABC);
+    }
+
+    @Override
+    public LineAsymmetricalAdder withOpenPhaseA(boolean openPhaseA) {
+        this.openPhaseA = openPhaseA;
+        return this;
+    }
+
+    @Override
+    public LineAsymmetricalAdder withOpenPhaseB(boolean openPhaseB) {
+        this.openPhaseB = openPhaseB;
+        return this;
+    }
+
+    @Override
+    public LineAsymmetricalAdder withOpenPhaseC(boolean openPhaseC) {
+        this.openPhaseC = openPhaseC;
+        return this;
+    }
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/LineAsymmetricalImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/LineAsymmetricalImpl.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network.impl.extensions;
+
+import com.powsybl.commons.extensions.AbstractExtension;
+import com.powsybl.iidm.network.Line;
+import com.powsybl.iidm.network.extensions.LineAsymmetrical;
+import com.powsybl.math.matrix.ComplexMatrix;
+
+/**
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Jean-Baptiste Heyberger {@literal <jbheyberger at gmail.com>}
+ */
+public class LineAsymmetricalImpl extends AbstractExtension<Line> implements LineAsymmetrical {
+
+    private boolean openPhaseA;
+    private boolean openPhaseB;
+    private boolean openPhaseC;
+
+    private ComplexMatrix admittanceMatrixABC;
+
+    public LineAsymmetricalImpl(Line line, boolean openPhaseA, boolean openPhaseB, boolean openPhaseC,
+                                ComplexMatrix admittanceMatrixABC) {
+        super(line);
+        this.openPhaseA = openPhaseA;
+        this.openPhaseB = openPhaseB;
+        this.openPhaseC = openPhaseC;
+        this.admittanceMatrixABC = admittanceMatrixABC;
+    }
+
+    @Override
+    public boolean isOpenPhaseA() {
+        return openPhaseA;
+    }
+
+    @Override
+    public void setOpenPhaseA(boolean openPhaseA) {
+        this.openPhaseA = openPhaseA;
+    }
+
+    @Override
+    public boolean isOpenPhaseB() {
+        return openPhaseB;
+    }
+
+    @Override
+    public void setOpenPhaseB(boolean openPhaseB) {
+        this.openPhaseB = openPhaseB;
+    }
+
+    @Override
+    public boolean isOpenPhaseC() {
+        return openPhaseC;
+    }
+
+    @Override
+    public void setOpenPhaseC(boolean openPhaseC) {
+        this.openPhaseC = openPhaseC;
+    }
+
+    @Override
+    public ComplexMatrix getAdmittanceMatrixABC() {
+        return admittanceMatrixABC;
+    }
+
+    @Override
+    public void setAdmittanceMatrixABC(ComplexMatrix admittanceMatrixABC) {
+        this.admittanceMatrixABC = admittanceMatrixABC;
+    }
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/LineFortescueAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/LineFortescueAdderImpl.java
@@ -22,10 +22,6 @@ public class LineFortescueAdderImpl extends AbstractExtensionAdder<Line, LineFor
 
     private double xz = Double.NaN;
 
-    private boolean openPhaseA = false;
-    private boolean openPhaseB = false;
-    private boolean openPhaseC = false;
-
     public LineFortescueAdderImpl(Line line) {
         super(line);
     }
@@ -37,7 +33,7 @@ public class LineFortescueAdderImpl extends AbstractExtensionAdder<Line, LineFor
 
     @Override
     protected LineFortescueImpl createExtension(Line line) {
-        return new LineFortescueImpl(line, rz, xz, openPhaseA, openPhaseB, openPhaseC);
+        return new LineFortescueImpl(line, rz, xz);
     }
 
     @Override
@@ -49,24 +45,6 @@ public class LineFortescueAdderImpl extends AbstractExtensionAdder<Line, LineFor
     @Override
     public LineFortescueAdderImpl withXz(double xz) {
         this.xz = xz;
-        return this;
-    }
-
-    @Override
-    public LineFortescueAdder withOpenPhaseA(boolean openPhaseA) {
-        this.openPhaseA = openPhaseA;
-        return this;
-    }
-
-    @Override
-    public LineFortescueAdder withOpenPhaseB(boolean openPhaseB) {
-        this.openPhaseB = openPhaseB;
-        return this;
-    }
-
-    @Override
-    public LineFortescueAdder withOpenPhaseC(boolean openPhaseC) {
-        this.openPhaseC = openPhaseC;
         return this;
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/LineFortescueImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/LineFortescueImpl.java
@@ -20,17 +20,10 @@ public class LineFortescueImpl extends AbstractExtension<Line> implements LineFo
     private double rz;
     private double xz;
 
-    private boolean openPhaseA;
-    private boolean openPhaseB;
-    private boolean openPhaseC;
-
-    public LineFortescueImpl(Line line, double rz, double xz, boolean openPhaseA, boolean openPhaseB, boolean openPhaseC) {
+    public LineFortescueImpl(Line line, double rz, double xz) {
         super(line);
         this.rz = rz;
         this.xz = xz;
-        this.openPhaseA = openPhaseA;
-        this.openPhaseB = openPhaseB;
-        this.openPhaseC = openPhaseC;
     }
 
     @Override
@@ -51,35 +44,5 @@ public class LineFortescueImpl extends AbstractExtension<Line> implements LineFo
     @Override
     public void setXz(double xz) {
         this.xz = xz;
-    }
-
-    @Override
-    public boolean isOpenPhaseA() {
-        return openPhaseA;
-    }
-
-    @Override
-    public void setOpenPhaseA(boolean openPhaseA) {
-        this.openPhaseA = openPhaseA;
-    }
-
-    @Override
-    public boolean isOpenPhaseB() {
-        return openPhaseB;
-    }
-
-    @Override
-    public void setOpenPhaseB(boolean openPhaseB) {
-        this.openPhaseB = openPhaseB;
-    }
-
-    @Override
-    public boolean isOpenPhaseC() {
-        return openPhaseC;
-    }
-
-    @Override
-    public void setOpenPhaseC(boolean openPhaseC) {
-        this.openPhaseC = openPhaseC;
     }
 }

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/LineFortescueSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/LineFortescueSerDe.java
@@ -33,25 +33,16 @@ public class LineFortescueSerDe extends AbstractExtensionSerDe<Line, LineFortesc
     public void write(LineFortescue lineFortescue, SerializerContext context) {
         context.getWriter().writeDoubleAttribute("rz", lineFortescue.getRz(), Double.NaN);
         context.getWriter().writeDoubleAttribute("xz", lineFortescue.getXz(), Double.NaN);
-        context.getWriter().writeBooleanAttribute("openPhaseA", lineFortescue.isOpenPhaseA(), false);
-        context.getWriter().writeBooleanAttribute("openPhaseB", lineFortescue.isOpenPhaseB(), false);
-        context.getWriter().writeBooleanAttribute("openPhaseC", lineFortescue.isOpenPhaseC(), false);
     }
 
     @Override
     public LineFortescue read(Line line, DeserializerContext context) {
         double rz = context.getReader().readDoubleAttribute("rz");
         double xz = context.getReader().readDoubleAttribute("xz");
-        boolean openPhaseA = context.getReader().readBooleanAttribute("openPhaseA", false);
-        boolean openPhaseB = context.getReader().readBooleanAttribute("openPhaseB", false);
-        boolean openPhaseC = context.getReader().readBooleanAttribute("openPhaseC", false);
         context.getReader().readEndNode();
         return line.newExtension(LineFortescueAdder.class)
                 .withRz(rz)
                 .withXz(xz)
-                .withOpenPhaseA(openPhaseA)
-                .withOpenPhaseB(openPhaseB)
-                .withOpenPhaseC(openPhaseC)
                 .add();
     }
 }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/LineFortescueXmlSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/LineFortescueXmlSerDeTest.java
@@ -34,8 +34,6 @@ class LineFortescueXmlSerDeTest extends AbstractIidmSerDeTest {
         LineFortescue fortescue = l.newExtension(LineFortescueAdder.class)
                 .withRz(0.1d)
                 .withXz(2d)
-                .withOpenPhaseA(true)
-                .withOpenPhaseC(true)
                 .add();
 
         Network network2 = allFormatsRoundTripTest(network, "/fortescue/lineFortescueRef.xml");
@@ -47,8 +45,5 @@ class LineFortescueXmlSerDeTest extends AbstractIidmSerDeTest {
 
         assertEquals(fortescue.getRz(), fortescue2.getRz(), 0);
         assertEquals(fortescue.getXz(), fortescue2.getXz(), 0);
-        assertTrue(fortescue2.isOpenPhaseA());
-        assertFalse(fortescue2.isOpenPhaseB());
-        assertTrue(fortescue2.isOpenPhaseC());
     }
 }

--- a/iidm/iidm-serde/src/test/resources/fortescue/lineFortescueRef.xml
+++ b/iidm/iidm-serde/src/test/resources/fortescue/lineFortescueRef.xml
@@ -40,6 +40,6 @@
     <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
     <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
     <iidm:extension id="NHV1_NHV2_1">
-        <lf:lineFortescue rz="0.1" xz="2.0" openPhaseA="true" openPhaseC="true"/>
+        <lf:lineFortescue rz="0.1" xz="2.0"/>
     </iidm:extension>
 </iidm:network>

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractFortescueExtensionTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractFortescueExtensionTest.java
@@ -64,23 +64,16 @@ public abstract class AbstractFortescueExtensionTest {
         LineFortescue fortescue = l.newExtension(LineFortescueAdder.class)
                 .withRz(0.1d)
                 .withXz(2d)
-                .withOpenPhaseA(true)
-                .withOpenPhaseC(true)
                 .add();
 
         assertEquals(0.1d, fortescue.getRz());
         assertEquals(2d, fortescue.getXz());
-        assertTrue(fortescue.isOpenPhaseA());
-        assertFalse(fortescue.isOpenPhaseB());
-        assertTrue(fortescue.isOpenPhaseC());
 
         fortescue.setRz(0.11d);
         fortescue.setXz(2.03d);
-        fortescue.setOpenPhaseA(false);
 
         assertEquals(0.11d, fortescue.getRz());
         assertEquals(2.03d, fortescue.getXz());
-        assertFalse(fortescue.isOpenPhaseA());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

Yes, a PR on open-loadlfow side: https://github.com/powsybl/powsybl-open-loadflow/pull/806/

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

For the moment, we have two types of line and two windings transformer extensions: one for Fortescue data and another one for three phase data (called "asymmetrical"). 
One all needed data are modeled, a nice solution should be to have only one extension for Fortescue data and for three phase data, each object `Fortescue` and `` ThreePhase` seen as an optional object. But first, focus on modeling.

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
