### PR TITLE
Fix SlackTerminal.isEmpty misuses

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
@@ -169,7 +169,7 @@ public final class StateVariablesExport {
 
         static boolean isSlack(Bus bus) {
             SlackTerminal st = bus.getVoltageLevel().getExtension(SlackTerminal.class);
-            return st != null && !st.isEmpty() && st.getTerminal().getBusView().getBus() == bus;
+            return st != null && st.getTerminal() != null && st.getTerminal().getBusView().getBus() == bus;
         }
 
         static void logDetail(Bus bus) {
@@ -331,7 +331,7 @@ public final class StateVariablesExport {
         if (context.isExportSvInjectionsForSlacks()) {
             for (VoltageLevel vl : network.getVoltageLevels()) {
                 SlackTerminal st = vl.getExtension(SlackTerminal.class);
-                if (st != null && !st.isEmpty()) {
+                if (st != null && st.getTerminal() != null) {
                     Bus bus = st.getTerminal().getBusBreakerView().getBus();
                     Optional<Bus> optionalBusViewBus = BusTools.getBusViewBus(bus);
                     if (optionalBusViewBus.isPresent()) {
@@ -401,7 +401,7 @@ public final class StateVariablesExport {
 
     private static void writePowerFlowForSwitchesInVoltageLevel(VoltageLevel vl, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) {
         SlackTerminal st = vl.getExtension(SlackTerminal.class);
-        Terminal slackTerminal = st != null && !st.isEmpty() ? st.getTerminal() : null;
+        Terminal slackTerminal = st != null ? st.getTerminal() : null;
         SwitchesFlow swflows = new SwitchesFlow(vl, slackTerminal);
         vl.getSwitches().forEach(sw -> {
             if (context.isExportedEquipment(sw)) {

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/SlackTerminal.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/SlackTerminal.java
@@ -101,7 +101,9 @@ public interface SlackTerminal extends Extension<VoltageLevel> {
     }
 
     /**
-     * Returns true if the current SlackTerminal is empty, meaning that this extension is unused
+     * <p>Returns <code>true</code> if the current SlackTerminal is empty, meaning that this extension is unused.</p>
+     * <p>Note that this method returns <code>true</code> only when the terminal is <code>null</code> <b>for all the variants</b>.
+     * Thus, when it returns <code>false</code>, the current variant's terminal may still be <code>null</code>.</p>
      */
     boolean isEmpty();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`SlackTerminal.isEmpty()` is used in some places to check if the terminal is present for the current variant. But when this method returns `false`, the terminal may still be `null` since this method's purpose is to check if the extension is used for at least one variant (see [SlackTerminal.setTerminal(Terminal terminal, boolean cleanIfEmpty)](https://github.com/powsybl/powsybl-core/blob/f8ef9c6cc61ab4ad521fdaa347092b2b6b39b15e/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/SlackTerminal.java#L95)).


**What is the new behavior (if this is a feature change)?**
- `!extension.isEmpty()` was replaced by `extension.getTerminal != null` when it was used to check the terminal presence.
- The javadoc was improved to clearly state this particularity.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
