### PR TITLE
Refactoring of newRootReportNode from ReportNode interface

### DIFF
--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/FunctionalLogsTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/FunctionalLogsTest.java
@@ -12,6 +12,7 @@ import com.powsybl.cgmes.conformity.CgmesConformity1ModifiedCatalog;
 import com.powsybl.cgmes.conversion.CgmesImport;
 import com.powsybl.cgmes.model.GridModelReference;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.network.Importers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,7 +63,7 @@ class FunctionalLogsTest {
     }
 
     private ReportNode importReport(GridModelReference testCase) {
-        ReportNode reportNode = ReportNode.newRootReportNode()
+        ReportNode reportNode = new ReportNodeRootBuilderImpl()
                 .withMessageTemplate("testFunctionalLogs", "Test importing ${name}")
                 .withUntypedValue("name", testCase.name())
                 .build();

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportProfilesConsistencyTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportProfilesConsistencyTest.java
@@ -13,6 +13,7 @@ import com.powsybl.cgmes.conversion.CgmesImport;
 import com.powsybl.cgmes.conversion.naming.NamingStrategyFactory;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.iidm.network.ExportersServiceLoader;
 import com.powsybl.iidm.network.Importers;
@@ -34,11 +35,11 @@ class ExportProfilesConsistencyTest extends AbstractSerDeTest {
     void testSVSmallGridNodeBreaker() {
         Network network = importNetwork(CgmesConformity1Catalog.smallNodeBreaker().dataSource());
 
-        ReportNode reportNodeOnlySv = ReportNode.newRootReportNode().withMessageTemplate("onlySV", "").build();
+        ReportNode reportNodeOnlySv = new ReportNodeRootBuilderImpl().withMessageTemplate("onlySV", "").build();
         exportProfiles(List.of("SV"), network, reportNodeOnlySv);
         assertTrue(inconsistentProfilesReported(reportNodeOnlySv));
 
-        ReportNode reportNodeSvAndTp = ReportNode.newRootReportNode().withMessageTemplate("SVandTP", "").build();
+        ReportNode reportNodeSvAndTp = new ReportNodeRootBuilderImpl().withMessageTemplate("SVandTP", "").build();
         exportProfiles(List.of("SV", "TP"), network, reportNodeSvAndTp);
         assertFalse(inconsistentProfilesReported(reportNodeSvAndTp));
     }

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNode.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNode.java
@@ -58,9 +58,7 @@ public interface ReportNode {
      * Create a new builder for creating a root <code>ReportNode</code>.
      * @return a {@link ReportNodeBuilder}
      */
-    static ReportNodeBuilder newRootReportNode() {
-        return new ReportNodeRootBuilderImpl();
-    }
+    ReportNodeBuilder newRootReportNode();
 
     /**
      * Get the message key for current node.

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeImpl.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeImpl.java
@@ -92,6 +92,11 @@ public final class ReportNodeImpl implements ReportNode {
     }
 
     @Override
+    public ReportNodeBuilder newRootReportNode() {
+        return new ReportNodeRootBuilderImpl();
+    }
+
+    @Override
     public String getMessageKey() {
         return messageKey;
     }

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeNoOp.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeNoOp.java
@@ -30,6 +30,11 @@ public class ReportNodeNoOp implements ReportNode {
     }
 
     @Override
+    public ReportNodeBuilder newRootReportNode() {
+        return new ReportNodeRootBuilderNoOp();
+    }
+
+    @Override
     public String getMessageKey() {
         return null;
     }

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeRootBuilderNoOp.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeRootBuilderNoOp.java
@@ -11,16 +11,17 @@ package com.powsybl.commons.report;
  * An adder to create a {@link ReportNode} object as a child of given {@link ReportRoot} parent.
  *
  * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
+ * @author Caio Luke {@literal <caio.luke at artelys.com>}
  */
-public class ReportNodeRootBuilderImpl extends AbstractReportNodeAdderOrBuilder<ReportNodeBuilder> implements ReportNodeBuilder {
+public class ReportNodeRootBuilderNoOp extends AbstractReportNodeAdderOrBuilder<ReportNodeBuilder> implements ReportNodeBuilder {
 
-    public ReportNodeRootBuilderImpl() {
+    public ReportNodeRootBuilderNoOp() {
         // Empty constructor
     }
 
     @Override
     public ReportNode build() {
-        return ReportNodeImpl.createRootReportNode(key, messageTemplate, values);
+        return new ReportNodeNoOp();
     }
 
     @Override

--- a/commons/src/test/java/com/powsybl/commons/report/NoOpTest.java
+++ b/commons/src/test/java/com/powsybl/commons/report/NoOpTest.java
@@ -48,7 +48,7 @@ class NoOpTest {
         assertNull(reportNode.getMessageTemplate());
         assertNull(reportNode.getMessageKey());
 
-        reportNode.include(ReportNode.newRootReportNode().withMessageTemplate("k", "Real root reportNode").build());
+        reportNode.include(new ReportNodeRootBuilderImpl().withMessageTemplate("k", "Real root reportNode").build());
         assertEquals(Collections.emptyList(), reportNode.getChildren());
 
         StringWriter sw = new StringWriter();

--- a/commons/src/test/java/com/powsybl/commons/report/ReportNodeTest.java
+++ b/commons/src/test/java/com/powsybl/commons/report/ReportNodeTest.java
@@ -23,14 +23,14 @@ class ReportNodeTest extends AbstractSerDeTest {
 
     @Test
     void testInclude() throws IOException {
-        ReportNode root = ReportNode.newRootReportNode()
+        ReportNode root = new ReportNodeRootBuilderImpl()
                 .withMessageTemplate("rootTemplate", "Root message")
                 .build();
 
         PowsyblException e1 = assertThrows(PowsyblException.class, () -> root.include(root));
         assertEquals("Cannot add a reportNode in itself", e1.getMessage());
 
-        ReportNode otherRoot = ReportNode.newRootReportNode()
+        ReportNode otherRoot = new ReportNodeRootBuilderImpl()
                 .withMessageTemplate("includedRoot", "Included root message")
                 .build();
         otherRoot.newReportNode()

--- a/commons/src/test/java/com/powsybl/commons/report/TypedValueTest.java
+++ b/commons/src/test/java/com/powsybl/commons/report/TypedValueTest.java
@@ -28,7 +28,7 @@ class TypedValueTest {
         assertEquals(TypedValue.SEVERITY, TypedValue.ERROR_SEVERITY.getType());
 
         // Check that is not possible to add a Severity attribute with a TypedValue that is not a severity
-        ReportNode root = ReportNode.newRootReportNode().withMessageTemplate("root", "Root reportNode").build();
+        ReportNode root = new ReportNodeRootBuilderImpl().withMessageTemplate("root", "Root reportNode").build();
         ReportNodeAdder r1 = root.newReportNode().withMessageTemplate("key", "defaultMessage");
         TypedValue illegalSeverity = new TypedValue("error", "OTHER_TYPE");
         assertThrows(IllegalArgumentException.class, () -> r1.withSeverity(illegalSeverity));

--- a/dynamic-simulation/dynamic-simulation-tool/src/main/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationTool.java
+++ b/dynamic-simulation/dynamic-simulation-tool/src/main/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationTool.java
@@ -11,6 +11,7 @@ import com.google.auto.service.AutoService;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.io.table.*;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.dynamicsimulation.*;
 import com.powsybl.dynamicsimulation.groovy.*;
 import com.powsybl.dynamicsimulation.json.DynamicSimulationResultSerializer;
@@ -156,7 +157,7 @@ public class DynamicSimulationTool implements Tool {
             JsonDynamicSimulationParameters.update(params, parametersFile);
         }
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("dynamicSimulationTool", "Dynamic Simulation Tool").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("dynamicSimulationTool", "Dynamic Simulation Tool").build();
         DynamicSimulationResult result = runner.run(network, dynamicModelsSupplier, eventSupplier, curvesSupplier, VariantManagerConstants.INITIAL_VARIANT_ID, context.getShortTimeExecutionComputationManager(), params, reportNode);
 
         Path outputLogFile = line.hasOption(OUTPUT_LOG_FILE) ? context.getFileSystem().getPath(line.getOptionValue(OUTPUT_LOG_FILE)) : null;

--- a/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/ExportersTest.java
+++ b/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/ExportersTest.java
@@ -11,6 +11,7 @@ import com.google.common.io.ByteStreams;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.datasource.DataSource;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.commons.test.TestUtil;
 import com.powsybl.iidm.network.tools.ExporterMockWithReportNode;
 import org.junit.jupiter.api.Test;
@@ -120,7 +121,7 @@ class ExportersTest extends AbstractConvertersTest {
     void exportWithReportNode() throws Exception {
         Exporter testExporter = new ExporterMockWithReportNode();
         DataSource dataSource = Exporters.createDataSource(path);
-        ReportNode rootReportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTest", "Testing exporter reporting").build();
+        ReportNode rootReportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTest", "Testing exporter reporting").build();
         testExporter.export(null, null, dataSource, rootReportNode);
         Optional<ReportNode> reportNode = rootReportNode.getChildren().stream().findFirst();
         assertTrue(reportNode.isPresent());

--- a/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/ImportersTest.java
+++ b/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/ImportersTest.java
@@ -10,6 +10,7 @@ package com.powsybl.iidm.network;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.datasource.DataSource;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.commons.test.TestUtil;
 import com.powsybl.computation.ComputationManager;
 import org.junit.jupiter.api.Assertions;
@@ -91,7 +92,7 @@ class ImportersTest extends AbstractConvertersTest {
     @Test
     void getImporterWithImportConfigAndReportNode() throws IOException {
         Importer importer = Importer.find(loader, TEST_FORMAT, computationManager, importConfigWithPostProcessor);
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("testFunctionalLog", "testFunctionalLogs").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("testFunctionalLog", "testFunctionalLogs").build();
         assertNotNull(importer);
         Network network = importer.importData(null, networkFactory, null, reportNode);
         assertNotNull(network);

--- a/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/PostProcessorReportNodeTest.java
+++ b/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/PostProcessorReportNodeTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.network;
 
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.commons.report.ReportNodeDeserializer;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.commons.report.ReportNodeSerializer;
 import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.computation.ComputationManager;
@@ -36,7 +37,7 @@ class PostProcessorReportNodeTest extends AbstractSerDeTest {
     @Test
     void postProcessorWithReportNode() throws IOException {
 
-        ReportNode reportRoot = ReportNode.newRootReportNode().withMessageTemplate("testPostProcessor", "Test importer post processor").build();
+        ReportNode reportRoot = new ReportNodeRootBuilderImpl().withMessageTemplate("testPostProcessor", "Test importer post processor").build();
         Network network1 = importer1.importData(null, new NetworkFactoryMock(), null, reportRoot);
         assertNotNull(network1);
 

--- a/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/ReportNodeContextTest.java
+++ b/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/ReportNodeContextTest.java
@@ -8,6 +8,7 @@
 package com.powsybl.iidm.network;
 
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,12 +52,12 @@ class ReportNodeContextTest {
     @MethodSource("getReportNodeContextStream")
     void pushAndGetReportNodeTest(String desc, Supplier<ReportNodeContext> contextSupplier) {
         ReportNodeContext reportNodeContext = contextSupplier.get();
-        ReportNode reportNode0 = ReportNode.newRootReportNode().withMessageTemplate("task0", "name0").build();
+        ReportNode reportNode0 = new ReportNodeRootBuilderImpl().withMessageTemplate("task0", "name0").build();
         reportNodeContext.pushReportNode(reportNode0);
         assertEquals(reportNode0, reportNodeContext.getReportNode());
         assertEquals(reportNode0, reportNodeContext.peekReportNode());
 
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("task1", "name1").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("task1", "name1").build();
         reportNodeContext.pushReportNode(reportNode1);
         assertEquals(reportNode1, reportNodeContext.getReportNode());
         assertEquals(reportNode1, reportNodeContext.peekReportNode());
@@ -71,8 +72,8 @@ class ReportNodeContextTest {
     void popReportNodeTest(String desc, Supplier<ReportNodeContext> contextSupplier) {
         ReportNodeContext reportNodeContext = contextSupplier.get();
 
-        ReportNode reportNode0 = ReportNode.newRootReportNode().withMessageTemplate("task0", "name0").build();
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("task1", "name1").build();
+        ReportNode reportNode0 = new ReportNodeRootBuilderImpl().withMessageTemplate("task0", "name0").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("task1", "name1").build();
         reportNodeContext.pushReportNode(reportNode0);
         reportNodeContext.pushReportNode(reportNode1);
         assertEquals(reportNode1, reportNodeContext.getReportNode());
@@ -125,11 +126,11 @@ class ReportNodeContextTest {
         assert ReportNode.NO_OP.equals(reportNodeContext.getReportNode());
 
         // Push reportNodes in the context
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("1", "1").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("1", "1").build();
         reportNodeContext.pushReportNode(reportNode1);
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("2", "2").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("2", "2").build();
         reportNodeContext.pushReportNode(reportNode2);
-        ReportNode reportNode3 = ReportNode.newRootReportNode().withMessageTemplate("3", "3").build();
+        ReportNode reportNode3 = new ReportNodeRootBuilderImpl().withMessageTemplate("3", "3").build();
         reportNodeContext.pushReportNode(reportNode3);
 
         // Create copies

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/ConnectionAndDisconnectionsTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/ConnectionAndDisconnectionsTest.java
@@ -8,6 +8,7 @@
 package com.powsybl.iidm.modification;
 
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.modification.topology.AbstractModificationTest;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.BusbarSectionPositionAdder;
@@ -310,7 +311,7 @@ class ConnectionAndDisconnectionsTest extends AbstractModificationTest {
         Network network = createNetwork();
 
         // Network modification
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportPlannedDisconnectionComplete", "Testing reportNode for connectable disconnection").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportPlannedDisconnectionComplete", "Testing reportNode for connectable disconnection").build();
         PlannedDisconnection modification = new PlannedDisconnectionBuilder()
             .withConnectableId("L1")
             .withFictitiousSwitchesOperable(true)
@@ -329,7 +330,7 @@ class ConnectionAndDisconnectionsTest extends AbstractModificationTest {
         network.getSwitch("D1").setFictitious(true);
 
         // Network modification
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestConnectionNoDisconnection", "Testing reportNode for connectable disconnection").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestConnectionNoDisconnection", "Testing reportNode for connectable disconnection").build();
         PlannedDisconnection modification = new PlannedDisconnectionBuilder()
             .withConnectableId("L1")
             .withFictitiousSwitchesOperable(false)
@@ -345,7 +346,7 @@ class ConnectionAndDisconnectionsTest extends AbstractModificationTest {
         Network network = createNetwork();
 
         // Network modification
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestConnectionDisconnection", "Testing reportNode for connectable disconnection").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestConnectionDisconnection", "Testing reportNode for connectable disconnection").build();
         UnplannedDisconnection modification = new UnplannedDisconnectionBuilder()
             .withConnectableId("L1")
             .withFictitiousSwitchesOperable(true)
@@ -361,7 +362,7 @@ class ConnectionAndDisconnectionsTest extends AbstractModificationTest {
         Network network = createNetwork();
 
         // Network modification
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestConnectionNoDisconnection", "Testing reportNode for connectable disconnection").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestConnectionNoDisconnection", "Testing reportNode for connectable disconnection").build();
         UnplannedDisconnection modification = new UnplannedDisconnectionBuilder()
             .withConnectableId("L1")
             .withFictitiousSwitchesOperable(false)
@@ -377,7 +378,7 @@ class ConnectionAndDisconnectionsTest extends AbstractModificationTest {
         Network network = createNetwork();
 
         // Network modification
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestConnection", "Testing reportNode for connectable connection").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestConnection", "Testing reportNode for connectable connection").build();
         ConnectableConnection modification = new ConnectableConnectionBuilder()
             .withConnectableId("L2")
             .withFictitiousSwitchesOperable(true)
@@ -394,7 +395,7 @@ class ConnectionAndDisconnectionsTest extends AbstractModificationTest {
         Network network = createNetwork();
 
         // Network modification
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestConnectionNoConnection", "Testing reportNode for connectable connection").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestConnectionNoConnection", "Testing reportNode for connectable connection").build();
         ConnectableConnection modification = new ConnectableConnectionBuilder()
             .withConnectableId("L2")
             .withFictitiousSwitchesOperable(false)

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/scalable/ProportionalScalableTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/scalable/ProportionalScalableTest.java
@@ -10,6 +10,7 @@ package com.powsybl.iidm.modification.scalable;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -74,7 +75,7 @@ class ProportionalScalableTest {
 
     @Test
     void testOnInjections() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Injection<?>> injectionsList = Arrays.asList(network.getLoad("l1"), network.getLoad("l2"), network.getDanglingLine("dl1"));
         ProportionalScalable proportionalScalable;
         double variationDone;
@@ -114,7 +115,7 @@ class ProportionalScalableTest {
 
     @Test
     void testOnGenerator() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, RESPECT_OF_VOLUME_ASKED, true, DELTA_P);
@@ -180,7 +181,7 @@ class ProportionalScalableTest {
 
     @Test
     void testScaleOnGeneratorsUsedPower() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, RESPECT_OF_VOLUME_ASKED, true, DELTA_P);
@@ -204,7 +205,7 @@ class ProportionalScalableTest {
 
     @Test
     void testScaleOnGeneratorsWithTargetPScalingType() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, RESPECT_OF_VOLUME_ASKED, true, TARGET_P);
@@ -228,7 +229,7 @@ class ProportionalScalableTest {
 
     @Test
     void testScaleOnLoadsWithTargetPScalingType() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Load> loadList = Arrays.asList(network.getLoad("l1"), network.getLoad("l2"), network.getLoad("l3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, false, RESPECT_OF_VOLUME_ASKED, true, TARGET_P);
@@ -252,7 +253,7 @@ class ProportionalScalableTest {
 
     @Test
     void testScaleOnGeneratorsVentilationPriority() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, RESPECT_OF_DISTRIBUTION, true, DELTA_P);
@@ -369,7 +370,7 @@ class ProportionalScalableTest {
         network.getGenerator("g2").setTargetP(0.0);
         network.getGenerator("g3").setTargetP(0.0);
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, RESPECT_OF_VOLUME_ASKED, true, DELTA_P);
@@ -398,7 +399,7 @@ class ProportionalScalableTest {
         network.getGenerator("g2").setTargetP(network.getGenerator("g2").getMinP());
         network.getGenerator("g3").setTargetP(network.getGenerator("g3").getMinP());
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, RESPECT_OF_VOLUME_ASKED, true, DELTA_P);
@@ -427,7 +428,7 @@ class ProportionalScalableTest {
         network.getGenerator("g2").setTargetP(network.getGenerator("g2").getMaxP());
         network.getGenerator("g3").setTargetP(network.getGenerator("g3").getMaxP());
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, RESPECT_OF_VOLUME_ASKED, true, DELTA_P);
@@ -514,7 +515,7 @@ class ProportionalScalableTest {
 
     @Test
     void testMaxValueBoundsScalingUpGenConvention() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Injection<?>> injectionsList = Arrays.asList(network.getLoad("l1"), network.getLoad("l2"), network.getDanglingLine("dl1"));
         ProportionalScalable proportionalScalable;
         double variationDone;
@@ -551,7 +552,7 @@ class ProportionalScalableTest {
 
     @Test
     void testMaxValueBoundsScalingDownLoadConvention() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Injection<?>> injectionsList = Arrays.asList(network.getLoad("l1"), network.getLoad("l2"), network.getDanglingLine("dl1"));
         ProportionalScalable proportionalScalable;
         double variationDone;
@@ -588,7 +589,7 @@ class ProportionalScalableTest {
 
     @Test
     void testMinValueBoundsScalingDownGenConvention() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Injection<?>> injectionsList = Arrays.asList(network.getLoad("l1"), network.getLoad("l2"), network.getDanglingLine("dl1"));
         ProportionalScalable proportionalScalable;
         double variationDone;
@@ -625,7 +626,7 @@ class ProportionalScalableTest {
 
     @Test
     void testMinValueBoundsScalingUpLoadConvention() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Injection<?>> injectionsList = Arrays.asList(network.getLoad("l1"), network.getLoad("l2"), network.getDanglingLine("dl1"));
         ProportionalScalable proportionalScalable;
         double variationDone;

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/scalable/StackScalableTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/scalable/StackScalableTest.java
@@ -9,6 +9,7 @@
 package com.powsybl.iidm.modification.scalable;
 
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Network;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,7 +67,7 @@ class StackScalableTest {
 
     @Test
     void testScaleOnGeneratorsStackingUp() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, ONESHOT, true, DELTA_P);
@@ -87,7 +88,7 @@ class StackScalableTest {
 
     @Test
     void testScaleOnGeneratorsStackingTargetPMoreThanCurrent() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, ONESHOT, true, TARGET_P);
@@ -108,7 +109,7 @@ class StackScalableTest {
 
     @Test
     void testScaleOnGeneratorsStackingTargetPLessThanCurrent() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, ONESHOT, true, TARGET_P);
@@ -129,7 +130,7 @@ class StackScalableTest {
 
     @Test
     void testMaxValueBoundsScalingUp() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, ONESHOT, true, DELTA_P);
@@ -153,7 +154,7 @@ class StackScalableTest {
 
     @Test
     void testMinValueBoundsScalingDown() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("scaling", "default").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("scaling", "default").build();
         List<Generator> generatorList = Arrays.asList(network.getGenerator("g1"), network.getGenerator("g2"), network.getGenerator("g3"));
         ScalingParameters scalingParameters = new ScalingParameters(Scalable.ScalingConvention.GENERATOR,
             true, true, ONESHOT, true, DELTA_P);

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ConnectVoltageLevelOnLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ConnectVoltageLevelOnLineTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.BusbarSection;
@@ -32,7 +33,7 @@ class ConnectVoltageLevelOnLineTest extends AbstractModificationTest {
     @Test
     void attachVoltageLevelOnLineNbTest() throws IOException {
         Network network = createNbNetworkWithBusbarSection();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportAttachVoltageLevelOnLineNbTest", "Testing reportNode for Attaching voltage level on line - Node breaker").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportAttachVoltageLevelOnLineNbTest", "Testing reportNode for Attaching voltage level on line - Node breaker").build();
         NetworkModification modification = new ConnectVoltageLevelOnLineBuilder()
                 .withBusbarSectionOrBusId(BBS)
                 .withLine(network.getLine("CJ"))
@@ -44,7 +45,7 @@ class ConnectVoltageLevelOnLineTest extends AbstractModificationTest {
     @Test
     void connectVoltageLevelOnLineNbBbTest() throws IOException {
         Network network = createNbBbNetwork();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportConnectVoltageLevelOnLineNbBbTest", "Testing reportNode for connecting voltage level on line - Node breaker").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportConnectVoltageLevelOnLineNbBbTest", "Testing reportNode for connecting voltage level on line - Node breaker").build();
         NetworkModification modification = new ConnectVoltageLevelOnLineBuilder()
                 .withBusbarSectionOrBusId(BBS)
                 .withLine(network.getLine("NHV1_NHV2_1"))
@@ -56,7 +57,7 @@ class ConnectVoltageLevelOnLineTest extends AbstractModificationTest {
     @Test
     void connectVoltageLevelOnLineBbTest() throws IOException {
         Network network = createBbNetwork();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportConnectVoltageLevelOnLineBbTest", "Testing reportNode for connecting voltage level on line - Bus breaker").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportConnectVoltageLevelOnLineBbTest", "Testing reportNode for connecting voltage level on line - Bus breaker").build();
         NetworkModification modification = new ConnectVoltageLevelOnLineBuilder()
                 .withBusbarSectionOrBusId("bus")
                 .withLine(network.getLine("NHV1_NHV2_1"))
@@ -132,7 +133,7 @@ class ConnectVoltageLevelOnLineTest extends AbstractModificationTest {
     void testExceptions() {
         Network network1 = createNbNetworkWithBusbarSection();
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestUndefinedBbs", "Testing reportNode with undefined busbar section").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestUndefinedBbs", "Testing reportNode with undefined busbar section").build();
         NetworkModification modification2 = new ConnectVoltageLevelOnLineBuilder()
                 .withBusbarSectionOrBusId("NOT_EXISTING")
                 .withLine(network1.getLine("CJ"))
@@ -176,7 +177,7 @@ class ConnectVoltageLevelOnLineTest extends AbstractModificationTest {
     @Test
     void testWithReportNode() throws IOException {
         Network network = createNbNetworkWithBusbarSection();
-        ReportNode report = ReportNode.newRootReportNode().withMessageTemplate("reportTestConnectVoltageLevelOnLine", "Testing reportNode for connecting voltage level on line").build();
+        ReportNode report = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestConnectVoltageLevelOnLine", "Testing reportNode for connecting voltage level on line").build();
         new ConnectVoltageLevelOnLineBuilder()
                 .withBusbarSectionOrBusId(BBS)
                 .withLine(network.getLine("CJ"))

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateBranchFeederBaysTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.Line;
 import com.powsybl.iidm.network.LineAdder;
@@ -208,7 +209,7 @@ class CreateBranchFeederBaysTest extends AbstractModificationTest {
                 .setB2(0.0);
 
         //wrong network
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("reportTestWrongNetwork", "Testing creating line reportNode with wrong network").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestWrongNetwork", "Testing creating line reportNode with wrong network").build();
         Network network1 = Network.read("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
         CreateBranchFeederBays modification0 = new CreateBranchFeederBaysBuilder().
                 withBranchAdder(lineAdder)
@@ -224,7 +225,7 @@ class CreateBranchFeederBaysTest extends AbstractModificationTest {
         assertEquals("networkMismatch", reportNode1.getChildren().get(0).getMessageKey());
 
         // not found id
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("reportTestUndefinedId", "Testing creating line reportNode with wrong busbar section ID").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestUndefinedId", "Testing creating line reportNode with wrong busbar section ID").build();
         CreateBranchFeederBays modification1 = new CreateBranchFeederBaysBuilder().
                 withBranchAdder(lineAdder)
                 .withBusOrBusbarSectionId1("bbs")
@@ -239,7 +240,7 @@ class CreateBranchFeederBaysTest extends AbstractModificationTest {
         assertEquals("notFoundBusOrBusbarSection", reportNode2.getChildren().get(0).getMessageKey());
 
         // wrong identifiable type
-        ReportNode reportNode3 = ReportNode.newRootReportNode().withMessageTemplate("reportTestWrongBbsType", "Testing creating line reportNode with wrong bbs type").build();
+        ReportNode reportNode3 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestWrongBbsType", "Testing creating line reportNode with wrong bbs type").build();
         CreateBranchFeederBays modification2 = new CreateBranchFeederBaysBuilder().
                 withBranchAdder(lineAdder)
                 .withBusOrBusbarSectionId1("gen1")
@@ -341,7 +342,7 @@ class CreateBranchFeederBaysTest extends AbstractModificationTest {
                 .setG2(0.0)
                 .setB1(0.0)
                 .setB2(0.0);
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestCreateLine", "Testing creating line reportNode").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestCreateLine", "Testing creating line reportNode").build();
         new CreateBranchFeederBaysBuilder()
                 .withBranchAdder(lineAdder)
                 .withBusOrBusbarSectionId1("bbs5")
@@ -367,7 +368,7 @@ class CreateBranchFeederBaysTest extends AbstractModificationTest {
                 .setG2(0.0)
                 .setB1(0.0)
                 .setB2(0.0);
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestCreateLineWithoutExtensions", "Testing creating line reportNode without extensions").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestCreateLineWithoutExtensions", "Testing creating line reportNode without extensions").build();
         new CreateBranchFeederBaysBuilder()
                 .withBranchAdder(lineAdder)
                 .withBusOrBusbarSectionId1("bbs5")

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateCouplingDeviceTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateCouplingDeviceTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.NetworkFactory;
@@ -58,7 +59,7 @@ class CreateCouplingDeviceTest extends AbstractModificationTest {
     void createCouplingDeviceThrowsException() {
         Network network = Network.read("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
 
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("testReportNodeWrongBbs", "Testing reportNode with wrong busbar section ID").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("testReportNodeWrongBbs", "Testing reportNode with wrong busbar section ID").build();
         NetworkModification couplingDeviceModifWrongBbs = new CreateCouplingDeviceBuilder()
                 .withBusOrBusbarSectionId1("bbs")
                 .withBusOrBusbarSectionId2("bbs2")
@@ -67,7 +68,7 @@ class CreateCouplingDeviceTest extends AbstractModificationTest {
         assertEquals("Bus or busbar section bbs not found", e0.getMessage());
         assertEquals("notFoundBusOrBusbarSection", reportNode1.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("testReportNodeBbsInDifferentVl", "Testing reportNode with busbar sections in different voltage levels").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("testReportNodeBbsInDifferentVl", "Testing reportNode with busbar sections in different voltage levels").build();
         NetworkModification couplingDeviceModifBbsInDifferentVl = new CreateCouplingDeviceBuilder()
                 .withBusOrBusbarSectionId1("bbs1")
                 .withBusOrBusbarSectionId2("bbs5")
@@ -76,7 +77,7 @@ class CreateCouplingDeviceTest extends AbstractModificationTest {
         assertEquals("bbs1 and bbs5 are in two different voltage levels.", e1.getMessage());
         assertEquals("unexpectedDifferentVoltageLevels", reportNode2.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode3 = ReportNode.newRootReportNode().withMessageTemplate("testReportNodeSameBbs", "Testing reportNode with same busbar section").build();
+        ReportNode reportNode3 = new ReportNodeRootBuilderImpl().withMessageTemplate("testReportNodeSameBbs", "Testing reportNode with same busbar section").build();
         NetworkModification sameBusbarSection = new CreateCouplingDeviceBuilder()
                 .withBusOrBusbarSectionId1("bbs1")
                 .withBusOrBusbarSectionId2("bbs1")
@@ -123,7 +124,7 @@ class CreateCouplingDeviceTest extends AbstractModificationTest {
     @Test
     void testWithReportNode() throws IOException {
         Network network = Network.read("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestCreateCouplingDevice", "Testing reportNode for coupling device creation").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestCreateCouplingDevice", "Testing reportNode for coupling device creation").build();
         new CreateCouplingDeviceBuilder()
                 .withBusOrBusbarSectionId1("bbs1")
                 .withBusOrBusbarSectionId2("bbs3")
@@ -136,7 +137,7 @@ class CreateCouplingDeviceTest extends AbstractModificationTest {
     @MethodSource("parameters")
     void createCouplingDeviceThrowsException(String bbs1, String bbs2, String message, String messageKey) {
         Network network = Network.read("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("ReportNodeTest", "Testing reportNode").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("ReportNodeTest", "Testing reportNode").build();
         NetworkModification modification = new CreateCouplingDeviceBuilder()
                 .withBusOrBusbarSectionId1(bbs1)
                 .withBusOrBusbarSectionId2(bbs2)

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateFeederBayTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.modification.NetworkModification;
@@ -132,7 +133,7 @@ class CreateFeederBayTest extends AbstractModificationTest {
     @Test
     void testException() {
         Network network = Network.read("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("reportTestInvalidNetwork", "Testing reportNode if network mismatch").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestInvalidNetwork", "Testing reportNode if network mismatch").build();
         LoadAdder loadAdder = network.getVoltageLevel("vl1").newLoad()
                 .setId("newLoad")
                 .setLoadType(LoadType.UNDEFINED)
@@ -151,7 +152,7 @@ class CreateFeederBayTest extends AbstractModificationTest {
         assertEquals("networkMismatch", reportNode1.getChildren().get(0).getMessageKey());
 
         // not found id
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("reportTestInvalidId", "Testing reportNode if wrong feeder id").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestInvalidId", "Testing reportNode if wrong feeder id").build();
         CreateFeederBay modification1 = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
                 .withBusOrBusbarSectionId("bbs")
@@ -163,7 +164,7 @@ class CreateFeederBayTest extends AbstractModificationTest {
         assertEquals("notFoundBusOrBusbarSection", reportNode2.getChildren().get(0).getMessageKey());
 
         // wrong identifiable type
-        ReportNode reportNode3 = ReportNode.newRootReportNode().withMessageTemplate("reportTestInvalidType", "Testing reportNode if wrong feeder type").build();
+        ReportNode reportNode3 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestInvalidType", "Testing reportNode if wrong feeder type").build();
         CreateFeederBay modification2 = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
                 .withBusOrBusbarSectionId("gen1")
@@ -439,7 +440,7 @@ class CreateFeederBayTest extends AbstractModificationTest {
                 .setQ0(10);
 
         //negative order position
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("reportTestNegativeOrderPosition", "Testing reportNode for a load creation with negative position order").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestNegativeOrderPosition", "Testing reportNode for a load creation with negative position order").build();
         CreateFeederBay negativeOrderCreate = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
                 .withBusOrBusbarSectionId(bbs.getId())
@@ -450,7 +451,7 @@ class CreateFeederBayTest extends AbstractModificationTest {
         assertEquals("unexpectedNegativePositionOrder", reportNode1.getChildren().get(0).getMessageKey());
 
         //null order position
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("reportTestNullOrderPosition", "Testing reportNode for a load creation with null order position").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestNullOrderPosition", "Testing reportNode for a load creation with null order position").build();
         CreateFeederBay nullOrderCreate = new CreateFeederBayBuilder()
                 .withInjectionAdder(loadAdder)
                 .withBusOrBusbarSectionId(bbs.getId())
@@ -463,7 +464,7 @@ class CreateFeederBayTest extends AbstractModificationTest {
     @Test
     void testCreateLoadWithReportNode() throws IOException {
         Network network = Network.read("testNetworkNodeBreaker.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreaker.xiidm"));
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestCreateLoad", "Testing reportNode for a load creation").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestCreateLoad", "Testing reportNode for a load creation").build();
         LoadAdder loadAdder = network.getVoltageLevel("vl1").newLoad()
                 .setId("newLoad")
                 .setLoadType(LoadType.UNDEFINED)
@@ -482,7 +483,7 @@ class CreateFeederBayTest extends AbstractModificationTest {
     @Test
     void testCreateLoadWithReportNodeWithoutExtensions() throws IOException {
         Network network = Network.read("testNetworkNodeBreakerWithoutExtensions.xiidm", getClass().getResourceAsStream("/testNetworkNodeBreakerWithoutExtensions.xiidm"));
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestCreateLoadWithoutExtensions", "Testing reportNode for a load creation in a network without extensions").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestCreateLoadWithoutExtensions", "Testing reportNode for a load creation in a network without extensions").build();
         LoadAdder loadAdder = network.getVoltageLevel("vl1").newLoad()
                 .setId("newLoad")
                 .setLoadType(LoadType.UNDEFINED)

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateLineOnLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateLineOnLineTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.BusbarSection;
 import com.powsybl.iidm.network.Line;
@@ -136,7 +137,7 @@ class CreateLineOnLineTest extends AbstractModificationTest {
         Network network1 = createNbNetworkWithBusbarSection();
         Line line1 = network1.getLine("CJ");
         LineAdder adder1 = createLineAdder(line1, network1);
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("reportTestBbsNotExistingNB", "Testing reportNode if busbar section does not exist in node/breaker").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestBbsNotExistingNB", "Testing reportNode if busbar section does not exist in node/breaker").build();
         NetworkModification modification1 = new CreateLineOnLineBuilder()
                 .withBusbarSectionOrBusId("NOT_EXISTING")
                 .withLine(line1)
@@ -149,7 +150,7 @@ class CreateLineOnLineTest extends AbstractModificationTest {
         Network network2 = createBbNetwork();
         Line line2 = network2.getLine("NHV1_NHV2_1");
         LineAdder adder2 = createLineAdder(line2, network2);
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("reportTestBbsNotExistingBB", "Testing reportNode if busbar section does not exist in bus/breaker").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestBbsNotExistingBB", "Testing reportNode if busbar section does not exist in bus/breaker").build();
         NetworkModification modification2 = new CreateLineOnLineBuilder()
                 .withBusbarSectionOrBusId("NOT_EXISTING")
                 .withLine(line2)
@@ -159,7 +160,7 @@ class CreateLineOnLineTest extends AbstractModificationTest {
         assertEquals("Bus or busbar section NOT_EXISTING not found", exception2.getMessage());
         assertEquals("notFoundBusOrBusbarSection", reportNode2.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode3 = ReportNode.newRootReportNode().withMessageTemplate("reportTestWrongTypeBbs", "Testing reportNode if type of busbar section is wrong").build();
+        ReportNode reportNode3 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestWrongTypeBbs", "Testing reportNode if type of busbar section is wrong").build();
         NetworkModification modification3 = new CreateLineOnLineBuilder()
                 .withBusbarSectionOrBusId("LOAD")
                 .withLine(line2)
@@ -169,7 +170,7 @@ class CreateLineOnLineTest extends AbstractModificationTest {
         assertEquals("Unexpected type of identifiable LOAD: LOAD", exception3.getMessage());
         assertEquals("unexpectedIdentifiableType", reportNode3.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode4 = ReportNode.newRootReportNode().withMessageTemplate("reportTestNullFictitiousSubstationID", "Testing reportNode with null fictitious substation ID").build();
+        ReportNode reportNode4 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestNullFictitiousSubstationID", "Testing reportNode with null fictitious substation ID").build();
         NetworkModification modification4 = new CreateLineOnLineBuilder()
                 .withBusbarSectionOrBusId(BBS)
                 .withLine(network1.getLine("CJ"))
@@ -181,7 +182,7 @@ class CreateLineOnLineTest extends AbstractModificationTest {
         assertEquals("Fictitious substation ID must be defined if a fictitious substation is to be created", exception4.getMessage());
         assertEquals("undefinedFictitiousSubstationId", reportNode4.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode5 = ReportNode.newRootReportNode().withMessageTemplate("reportTestUndefinedPositionPercent", "Testing reportNode with undefined position percent").build();
+        ReportNode reportNode5 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestUndefinedPositionPercent", "Testing reportNode with undefined position percent").build();
         NetworkModification modification5 = new CreateLineOnLineBuilder()
                 .withBusbarSectionOrBusId(BBS)
                 .withLine(network1.getLine("CJ"))
@@ -197,7 +198,7 @@ class CreateLineOnLineTest extends AbstractModificationTest {
     @Test
     void testWithReportNode() throws IOException {
         Network network = createNbNetworkWithBusbarSection();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestCreateLineOnLine", "Testing reportNode for creation of a line on line").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestCreateLineOnLine", "Testing reportNode for creation of a line on line").build();
         Line line = network.getLine("CJ");
         LineAdder adder = createLineAdder(line, network);
         NetworkModification modification = new CreateLineOnLineBuilder().withBusbarSectionOrBusId(BBS).withLine(line).withLineAdder(adder).build();

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateVoltageLevelTopologyTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateVoltageLevelTopologyTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.BusbarSection;
@@ -62,7 +63,7 @@ class CreateVoltageLevelTopologyTest extends AbstractModificationTest {
     @Test
     void testWithNullSwitchKind() {
         Network network = createNbNetwork();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTest", "Testing reportNode").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTest", "Testing reportNode").build();
         CreateVoltageLevelTopology modification = new CreateVoltageLevelTopologyBuilder()
                 .withVoltageLevelId(VLTEST)
                 .withAlignedBusesOrBusbarCount(3)
@@ -81,7 +82,7 @@ class CreateVoltageLevelTopologyTest extends AbstractModificationTest {
     @Test
     void testWithUnsupportedSwitchKind() {
         Network network = createNbNetwork();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTest", "Testing reportNode").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTest", "Testing reportNode").build();
         CreateVoltageLevelTopology modification = new CreateVoltageLevelTopologyBuilder()
                 .withVoltageLevelId(VLTEST)
                 .withAlignedBusesOrBusbarCount(3)
@@ -100,7 +101,7 @@ class CreateVoltageLevelTopologyTest extends AbstractModificationTest {
     @Test
     void testWithNegativeCount() {
         Network network = createNbNetwork();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTest", "Testing reportNode").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTest", "Testing reportNode").build();
         NetworkModification modification = new CreateVoltageLevelTopologyBuilder()
                 .withVoltageLevelId(VLTEST)
                 .withAlignedBusesOrBusbarCount(-1)
@@ -146,7 +147,7 @@ class CreateVoltageLevelTopologyTest extends AbstractModificationTest {
     @Test
     void testWithUnexpectedSwitchKindsSize() {
         Network network = createNbNetwork();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTest", "Testing reportNode").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTest", "Testing reportNode").build();
         CreateVoltageLevelTopology modification = new CreateVoltageLevelTopologyBuilder()
                 .withVoltageLevelId(VLTEST)
                 .withAlignedBusesOrBusbarCount(3)
@@ -165,7 +166,7 @@ class CreateVoltageLevelTopologyTest extends AbstractModificationTest {
     @Test
     void testWithNotExistingVoltageLevel() {
         Network network = createNbNetwork();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTest", "Testing reportNode").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTest", "Testing reportNode").build();
         CreateVoltageLevelTopology modification = new CreateVoltageLevelTopologyBuilder()
                 .withVoltageLevelId("NOT_EXISTING")
                 .withAlignedBusesOrBusbarCount(3)
@@ -197,7 +198,7 @@ class CreateVoltageLevelTopologyTest extends AbstractModificationTest {
     @Test
     void testErrorIfNotSwitchKindsDefinedAndNodeBreaker() {
         Network network = createNbNetwork();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTest", "Testing reportNode").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTest", "Testing reportNode").build();
         CreateVoltageLevelTopology modification = new CreateVoltageLevelTopologyBuilder()
                 .withVoltageLevelId(VLTEST)
                 .withAlignedBusesOrBusbarCount(3)
@@ -211,7 +212,7 @@ class CreateVoltageLevelTopologyTest extends AbstractModificationTest {
     @Test
     void testWithReportNode() throws IOException {
         Network network = createNbNetwork();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestCreateVoltageLevelTopology", "Testing reportNode for voltage level topology creation").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestCreateVoltageLevelTopology", "Testing reportNode for voltage level topology creation").build();
         CreateVoltageLevelTopology modification = new CreateVoltageLevelTopologyBuilder()
                 .withVoltageLevelId(VLTEST)
                 .withAlignedBusesOrBusbarCount(3)

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveFeederBayTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveFeederBayTest.java
@@ -10,6 +10,7 @@ package com.powsybl.iidm.modification.topology;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportConstants;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.commons.report.TypedValue;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.*;
@@ -143,7 +144,7 @@ class RemoveFeederBayTest {
     @Test
     void testRemoveBbs() {
         Network network = createNetwork2Feeders();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestRemoveBbs", "Testing reportNode when trying to remove a busbar section").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestRemoveBbs", "Testing reportNode when trying to remove a busbar section").build();
         RemoveFeederBay removeBbs = new RemoveFeederBay("BBS_TEST_1_1");
         PowsyblException e = assertThrows(PowsyblException.class, () -> removeBbs.apply(network, true, reportNode));
         assertEquals("BusbarSection connectables are not allowed as RemoveFeederBay input: BBS_TEST_1_1", e.getMessage());

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveHvdcLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveHvdcLineTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.Substation;
@@ -70,7 +71,7 @@ class RemoveHvdcLineTest extends AbstractSerDeTest {
     @Test
     void testRemoveHvdcLineUnknownShunt() {
         Network network = HvdcTestNetwork.createLcc();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestRemoveHvdcLineWithUnknownShunt", "Testing reportNode on removing a HVDC line with unknown shunt").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestRemoveHvdcLineWithUnknownShunt", "Testing reportNode on removing a HVDC line with unknown shunt").build();
         RemoveHvdcLine removeHvdcLine = new RemoveHvdcLineBuilder().withHvdcLineId("L").withShuntCompensatorIds("UnknownShunt").build();
         PowsyblException e = assertThrows(PowsyblException.class, () -> removeHvdcLine.apply(network, true, reportNode));
         assertEquals("Shunt UnknownShunt not found", e.getMessage());
@@ -80,7 +81,7 @@ class RemoveHvdcLineTest extends AbstractSerDeTest {
     @Test
     void testRemoveHvdcLineUnknownLine() {
         Network network = Network.create("empty", "test");
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestRemoveHvdcLineUnknownLine", "Testing reportNode on removing a HVDC line with wrong line ID").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestRemoveHvdcLineUnknownLine", "Testing reportNode on removing a HVDC line with wrong line ID").build();
         RemoveHvdcLine removeHvdcLine = new RemoveHvdcLineBuilder().withHvdcLineId("L").build();
         PowsyblException e = assertThrows(PowsyblException.class, () -> removeHvdcLine.apply(network, true, reportNode));
         assertEquals("Hvdc Line L not found", e.getMessage());

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveSubstationTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveSubstationTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.network.DefaultNetworkListener;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
@@ -71,7 +72,7 @@ class RemoveSubstationTest extends AbstractModificationTest {
         RemoveSubstation removeUnknown = new RemoveSubstationBuilder()
                 .withSubstationId("UNKNOWN")
                 .build();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestRemoveUnknownSubstation", "Testing reportNode on removing unknown substation").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestRemoveUnknownSubstation", "Testing reportNode on removing unknown substation").build();
         Network network = EurostagTutorialExample1Factory.create();
         removeUnknown.apply(network, false, reportNode);
         PowsyblException e = assertThrows(PowsyblException.class, () -> removeUnknown.apply(network, true, reportNode));

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevelTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RemoveVoltageLevelTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.DefaultNetworkListener;
 import com.powsybl.iidm.network.Identifiable;
@@ -55,7 +56,7 @@ class RemoveVoltageLevelTest extends AbstractModificationTest {
     @Test
     void testRemoveVoltageLevel() {
         Network network = FourSubstationsNodeBreakerFactory.create();
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestRemoveVL", "Testing reportNode on remove voltage level").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestRemoveVL", "Testing reportNode on remove voltage level").build();
         addListener(network);
 
         new RemoveVoltageLevelBuilder().withVoltageLevelId("S1VL1").build().apply(network);

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.BusbarSectionPositionAdder;
@@ -52,7 +53,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
         vl.getNodeBreakerView().newSwitch().setId("breaker4").setName("breaker4").setKind(SwitchKind.BREAKER).setRetained(false).setOpen(true).setFictitious(false).setNode1(0).setNode2(1).add();
         network.newLine().setId("LINE34").setR(0.1).setX(0.1).setG1(0.0).setB1(0.0).setG2(0.0).setB2(0.0).setNode1(1).setVoltageLevel1("VL3").setNode2(1).setVoltageLevel2("VL4").add();
 
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("reportTestLineNotFound", "Testing reportNode with wrong line1 id").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestLineNotFound", "Testing reportNode with wrong line1 id").build();
         NetworkModification modificationWithError1 = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("line1NotFound")
                 .withTeePointLine2("CJ_2")
@@ -63,7 +64,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
         assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError1.apply(network, true, reportNode1)).getMessage().contains("Line line1NotFound is not found"));
         assertEquals("lineNotFound", reportNode1.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("reportTestLineNotFound2", "Testing reportNode with wrong line2 id").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestLineNotFound2", "Testing reportNode with wrong line2 id").build();
         NetworkModification modificationWithError2 = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("CJ_1")
                 .withTeePointLine2("line2NotFound")
@@ -74,7 +75,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
         assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError2.apply(network, true, reportNode2)).getMessage().contains("Line line2NotFound is not found"));
         assertEquals("lineNotFound", reportNode2.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode3 = ReportNode.newRootReportNode().withMessageTemplate("reportTestLineNotFound", "Testing reportNode with wrong tee point line").build();
+        ReportNode reportNode3 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestLineNotFound", "Testing reportNode with wrong tee point line").build();
         NetworkModification modificationWithError3 = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("CJ_1")
                 .withTeePointLine2("CJ_2")
@@ -85,7 +86,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
         assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError3.apply(network, true, reportNode3)).getMessage().contains("Line line3NotFound is not found"));
         assertEquals("lineNotFound", reportNode3.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode4 = ReportNode.newRootReportNode().withMessageTemplate("reportTestBbsNotFound", "Testing reportNode with wrong bbs").build();
+        ReportNode reportNode4 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestBbsNotFound", "Testing reportNode with wrong bbs").build();
         NetworkModification modificationWithError4 = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("CJ_1")
                 .withTeePointLine2("CJ_2")
@@ -96,7 +97,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
         assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError4.apply(network, true, reportNode4)).getMessage().contains("Busbar section notFoundBusbarSection is not found in voltage level VLTEST"));
         assertEquals("busbarSectionNotFound", reportNode4.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode5 = ReportNode.newRootReportNode().withMessageTemplate("reportTestWrongTeePoint", "Testing reportNode with wrong tee point").build();
+        ReportNode reportNode5 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestWrongTeePoint", "Testing reportNode with wrong tee point").build();
         NetworkModification modificationWithError5 = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("CJ_1")
                 .withTeePointLine2("CJ_2")
@@ -107,7 +108,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
         assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError5.apply(network, true, reportNode5)).getMessage().contains("Unable to find the tee point and the tapped voltage level from lines CJ_1, CJ_2 and LINE34"));
         assertEquals("noTeePointAndOrTappedVoltageLevel", reportNode5.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode6 = ReportNode.newRootReportNode().withMessageTemplate("reportTestBbsInWrongVL", "Testing reportNode with busbar section in wrong voltage level").build();
+        ReportNode reportNode6 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestBbsInWrongVL", "Testing reportNode with busbar section in wrong voltage level").build();
         NetworkModification modificationWithError6 = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("CJ_1")
                 .withTeePointLine2("CJ_2")
@@ -118,7 +119,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
         assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError6.apply(network, true, reportNode6)).getMessage().contains("Busbar section bbs3 is not found in voltage level VLTEST"));
         assertEquals("busbarSectionNotFound", reportNode6.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestReplaceTeePointByVoltageLevelOnLineNB", "Testing reportNode when replacing tee point by voltage level on line in Node/breaker network").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestReplaceTeePointByVoltageLevelOnLineNB", "Testing reportNode when replacing tee point by voltage level on line in Node/breaker network").build();
         modification = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("CJ_1")
                 .withTeePointLine2("CJ_2")
@@ -145,7 +146,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
             .withSectionIndex(1)
             .add();
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestReplaceTeePointByVoltageLevelOnLineNBBb", "Testing reportNode when replacing tee point by voltage level on line").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestReplaceTeePointByVoltageLevelOnLineNBBb", "Testing reportNode when replacing tee point by voltage level on line").build();
         modification = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("NHV1_NHV2_1_1")
                 .withTeePointLine2("NHV1_NHV2_1_2")
@@ -169,7 +170,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
         VoltageLevel vl = network.newVoltageLevel().setId("VL3").setNominalV(380).setTopologyKind(TopologyKind.BUS_BREAKER).add();
         vl.getBusBreakerView().newBus().setId("bus3").add();
 
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("reportTestUndefinedBus", "Testing reportNode with undefined bus").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestUndefinedBus", "Testing reportNode with undefined bus").build();
         NetworkModification modificationWithError1 = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("NHV1_NHV2_1_1")
                 .withTeePointLine2("NHV1_NHV2_1_2")
@@ -180,7 +181,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
         assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError1.apply(network, true, reportNode1)).getMessage().contains("Bus busNotFound is not found in voltage level " + VOLTAGE_LEVEL_ID));
         assertEquals("busNotFound", reportNode1.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("reportTestBusInWrongVl", "Testing reportNode with bus in wrong voltage level").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestBusInWrongVl", "Testing reportNode with bus in wrong voltage level").build();
         NetworkModification modificationWithError2 = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("NHV1_NHV2_1_1")
                 .withTeePointLine2("NHV1_NHV2_1_2")
@@ -191,7 +192,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
         assertTrue(assertThrows(PowsyblException.class, () -> modificationWithError2.apply(network, true, reportNode2)).getMessage().contains("Bus bus3 is not found in voltage level " + VOLTAGE_LEVEL_ID));
         assertEquals("busNotFound", reportNode2.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode3 = ReportNode.newRootReportNode().withMessageTemplate("reportTestReplaceTeePointByVoltageLevelOnLineBb", "Testing reportNode when replacing tee point by voltage level on line in bus/breaker network").build();
+        ReportNode reportNode3 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestReplaceTeePointByVoltageLevelOnLineBb", "Testing reportNode when replacing tee point by voltage level on line in bus/breaker network").build();
         modification = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("NHV1_NHV2_1_1")
                 .withTeePointLine2("NHV1_NHV2_1_2")

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RevertConnectVoltageLevelOnLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RevertConnectVoltageLevelOnLineTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,7 @@ class RevertConnectVoltageLevelOnLineTest extends AbstractModificationTest {
         vl.getNodeBreakerView().newSwitch().setId("breaker4").setName("breaker4").setKind(SwitchKind.BREAKER).setRetained(false).setOpen(true).setFictitious(false).setNode1(0).setNode2(1).add();
         network.newLine().setId("LINE34").setR(0.1).setX(0.1).setG1(0.0).setB1(0.0).setG2(0.0).setB2(0.0).setNode1(1).setVoltageLevel1("VL3").setNode2(1).setVoltageLevel2("VL4").add();
 
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("reportTestUndefinedLine", "Testing reportNode with undefined line1 ID").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestUndefinedLine", "Testing reportNode with undefined line1 ID").build();
         final NetworkModification modificationWithError1 = new RevertConnectVoltageLevelOnLineBuilder()
                 .withLine1Id("line1NotFound")
                 .withLine2Id("CJ_2")
@@ -50,7 +51,7 @@ class RevertConnectVoltageLevelOnLineTest extends AbstractModificationTest {
         assertThrows(PowsyblException.class, () -> modificationWithError1.apply(network, true, reportNode1), "Line line1NotFound is not found");
         assertEquals("lineNotFound", reportNode1.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("reportTestUndefinedLine", "Testing reportNode with undefined line2 ID").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestUndefinedLine", "Testing reportNode with undefined line2 ID").build();
         final NetworkModification modificationWithError2 = new RevertConnectVoltageLevelOnLineBuilder()
                 .withLine1Id("CJ_1")
                 .withLine2Id("line2NotFound")
@@ -59,7 +60,7 @@ class RevertConnectVoltageLevelOnLineTest extends AbstractModificationTest {
         assertThrows(PowsyblException.class, () -> modificationWithError2.apply(network, true, reportNode2), "Line line2NotFound is not found");
         assertEquals("lineNotFound", reportNode2.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode3 = ReportNode.newRootReportNode().withMessageTemplate("reportTestNoVLInCommon", "Testing reportNode with lines having no voltage level in common").build();
+        ReportNode reportNode3 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestNoVLInCommon", "Testing reportNode with lines having no voltage level in common").build();
         final NetworkModification modificationWithError3 = new RevertConnectVoltageLevelOnLineBuilder()
                 .withLine1Id("CJ_1")
                 .withLine2Id("LINE34")
@@ -79,7 +80,7 @@ class RevertConnectVoltageLevelOnLineTest extends AbstractModificationTest {
         line2.newApparentPowerLimits1().setPermanentLimit(800.).add();
         line2.newCurrentLimits1().setPermanentLimit(900.).beginTemporaryLimit().setName("limit6").setValue(400).setAcceptableDuration(1200).endTemporaryLimit().add();
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestRevertConnectVoltageLevelOnLine", "Testing reportNode to revert connecting a voltage level on a line in node/breaker network").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestRevertConnectVoltageLevelOnLine", "Testing reportNode to revert connecting a voltage level on a line in node/breaker network").build();
         modification = new RevertConnectVoltageLevelOnLineBuilder()
                 .withLine1Id("CJ_1")
                 .withLine2Id("CJ_2")
@@ -100,7 +101,7 @@ class RevertConnectVoltageLevelOnLineTest extends AbstractModificationTest {
 
         modification.apply(network);
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestRevertConnectVoltageLevelOnLineNbBb", "Testing reportNode to revert connecting a voltage level on a line").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestRevertConnectVoltageLevelOnLineNbBb", "Testing reportNode to revert connecting a voltage level on a line").build();
         modification = new RevertConnectVoltageLevelOnLineBuilder()
                 .withLine1Id("NHV1_NHV2_1_1")
                 .withLine2Id("NHV1_NHV2_1_2")
@@ -121,7 +122,7 @@ class RevertConnectVoltageLevelOnLineTest extends AbstractModificationTest {
 
         modification.apply(network);
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestRevertConnectVoltageLevelOnLineBb", "Testing reportNode to revert connecting a voltage level on a line in bus/breaker network").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestRevertConnectVoltageLevelOnLineBb", "Testing reportNode to revert connecting a voltage level on a line in bus/breaker network").build();
         modification = new RevertConnectVoltageLevelOnLineBuilder()
                 .withLine1Id("NHV1_NHV2_1_1")
                 .withLine2Id("NHV1_NHV2_1_2")

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RevertCreateLineOnLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/RevertCreateLineOnLineTest.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ class RevertCreateLineOnLineTest extends AbstractModificationTest {
         vl.getNodeBreakerView().newSwitch().setId("breaker4").setName("breaker4").setKind(SwitchKind.BREAKER).setRetained(false).setOpen(true).setFictitious(false).setNode1(0).setNode2(1).add();
         network.newLine().setId("LINE34").setR(0.1).setX(0.1).setG1(0.0).setB1(0.0).setG2(0.0).setB2(0.0).setNode1(1).setVoltageLevel1("VL3").setNode2(1).setVoltageLevel2("VL4").add();
 
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("reportTestUndefinedLine1", "Testing reportNode with undefined line1").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestUndefinedLine1", "Testing reportNode with undefined line1").build();
         final NetworkModification modificationWithError1 = new RevertCreateLineOnLineBuilder()
                 .withLineToBeMerged1Id("line1NotFound")
                 .withLineToBeMerged2Id("CJ_1")
@@ -61,7 +62,7 @@ class RevertCreateLineOnLineTest extends AbstractModificationTest {
         ReportNode reportNodeChild1b = reportNode1.getChildren().get(1);
         assertEquals("lineNotFound", reportNodeChild1b.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("reportTestUndefinedLine2", "Testing reportNode with undefined line2").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestUndefinedLine2", "Testing reportNode with undefined line2").build();
         final NetworkModification modificationWithError2 = new RevertCreateLineOnLineBuilder()
                 .withLineToBeMerged1Id("CJ_1")
                 .withLineToBeMerged2Id("line2NotFound")
@@ -83,7 +84,7 @@ class RevertCreateLineOnLineTest extends AbstractModificationTest {
         ReportNode reportNodeChild2b = reportNode2.getChildren().get(1);
         assertEquals("lineNotFound", reportNodeChild2b.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode3 = ReportNode.newRootReportNode().withMessageTemplate("reportTestUndefinedLineToBeDeleted", "Testing reportNode with undefined line to be deleted").build();
+        ReportNode reportNode3 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestUndefinedLineToBeDeleted", "Testing reportNode with undefined line to be deleted").build();
         final NetworkModification modificationWithError3 = new RevertCreateLineOnLineBuilder()
                 .withLineToBeMerged1Id("CJ_1")
                 .withLineToBeMerged2Id("CJ_2")
@@ -105,7 +106,7 @@ class RevertCreateLineOnLineTest extends AbstractModificationTest {
         ReportNode reportNodeChild3b = reportNode3.getChildren().get(1);
         assertEquals("lineNotFound", reportNodeChild3b.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode4 = ReportNode.newRootReportNode().withMessageTemplate("reportTestNoTeePointAndOrTappedVoltageLevel", "Testing reportNode without tee point").build();
+        ReportNode reportNode4 = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestNoTeePointAndOrTappedVoltageLevel", "Testing reportNode without tee point").build();
         final NetworkModification modificationWithError4 = new RevertCreateLineOnLineBuilder()
                 .withLineToBeMerged1Id("CJ_1")
                 .withLineToBeMerged2Id("CJ_2")
@@ -127,7 +128,7 @@ class RevertCreateLineOnLineTest extends AbstractModificationTest {
         ReportNode reportNodeChild4b = reportNode4.getChildren().get(1);
         assertEquals("noTeePointAndOrTappedVoltageLevel", reportNodeChild4b.getChildren().get(0).getMessageKey());
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportNodeTestRevertCreateLineOnLine", "Testing reportNode for reverting create line on line in node/breaker network").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportNodeTestRevertCreateLineOnLine", "Testing reportNode for reverting create line on line in node/breaker network").build();
         modification = new RevertCreateLineOnLineBuilder()
                 .withLineToBeMerged1Id("CJ_1")
                 .withLineToBeMerged2Id("CJ_2")
@@ -147,7 +148,7 @@ class RevertCreateLineOnLineTest extends AbstractModificationTest {
         NetworkModification modification = new CreateLineOnLineBuilder().withBusbarSectionOrBusId(BBS).withLine(line).withLineAdder(adder).build();
         modification.apply(network);
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportNodeTestRevertCreateLineOnLineNBBB", "Testing reportNode for reverting create line on line with mixed topology network").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportNodeTestRevertCreateLineOnLineNBBB", "Testing reportNode for reverting create line on line with mixed topology network").build();
         modification = new RevertCreateLineOnLineBuilder()
                 .withLineToBeMerged1Id("NHV1_NHV2_1_2")
                 .withLineToBeMerged2Id("NHV1_NHV2_1_1")
@@ -167,7 +168,7 @@ class RevertCreateLineOnLineTest extends AbstractModificationTest {
         NetworkModification modification = new CreateLineOnLineBuilder().withBusbarSectionOrBusId("bus").withLine(line).withLineAdder(adder).build();
         modification.apply(network);
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportNodeTestRevertCreateLineOnLineNBBB", "Testing reportNode for reverting create line on line in bus/breaker network").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportNodeTestRevertCreateLineOnLineNBBB", "Testing reportNode for reverting create line on line in bus/breaker network").build();
         modification = new RevertCreateLineOnLineBuilder()
                 .withLineToBeMerged1Id("NHV1_NHV2_1_1")
                 .withLineToBeMerged2Id("NHV1_NHV2_1_2")

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
@@ -14,6 +14,7 @@ import com.powsybl.commons.extensions.ExtensionSerDe;
 import com.powsybl.commons.io.DeserializerContext;
 import com.powsybl.commons.io.SerializerContext;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.commons.test.TestUtil;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.*;
@@ -53,7 +54,7 @@ class NetworkSerDeTest extends AbstractIidmSerDeTest {
     @Test
     void testSkippedExtension() throws IOException {
         // Read file with all extensions included (default ImportOptions)
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("root", "Root reportNode").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("root", "Root reportNode").build();
         Network networkReadExtensions = NetworkSerDe.read(getNetworkAsStream("/skippedExtensions.xml"),
                 new ImportOptions(), null, NetworkFactory.findDefault(), reportNode1);
         Load load1 = networkReadExtensions.getLoad("LOAD");
@@ -73,7 +74,7 @@ class NetworkSerDeTest extends AbstractIidmSerDeTest {
                 """, TestUtil.normalizeLineSeparator(sw1.toString()));
 
         // Read file with only terminalMockNoSerDe and loadZipModel extensions included
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("root", "Root reportNode").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("root", "Root reportNode").build();
         ImportOptions notAllExtensions = new ImportOptions().addExtension("terminalMockNoSerDe").addExtension("loadZipModel");
         Network networkSkippedExtensions = NetworkSerDe.read(getNetworkAsStream("/skippedExtensions.xml"),
                 notAllExtensions, null, NetworkFactory.findDefault(), reportNode2);

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/XMLImporterTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/XMLImporterTest.java
@@ -10,6 +10,7 @@ package com.powsybl.iidm.serde;
 import com.google.common.io.ByteStreams;
 import com.powsybl.commons.datasource.*;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.NetworkFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -257,7 +258,7 @@ class XMLImporterTest extends AbstractIidmSerDeTest {
     }
 
     private void importDataAndTestReportNode(String expectedContentFilename, ReadOnlyDataSource dataSource) throws IOException {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("test", "test reportNode").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("test", "test reportNode").build();
         assertNotNull(importer.importData(dataSource, NetworkFactory.findDefault(), null, reportNode));
 
         StringWriter sw = new StringWriter();

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractConnectableTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractConnectableTest.java
@@ -8,6 +8,7 @@
 package com.powsybl.iidm.network.tck;
 
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.BusbarSectionPositionAdder;
 import com.powsybl.iidm.network.util.SwitchPredicates;
@@ -313,7 +314,7 @@ public abstract class AbstractConnectableTest {
         line1.getTerminals().forEach(terminal -> assertFalse(terminal.isConnected()));
 
         // disconnect the already fully disconnected line 1
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTest", "Testing reportNode").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTest", "Testing reportNode").build();
         network.getReportNodeContext().pushReportNode(reportNode);
         assertFalse(line1.disconnect());
         network.getReportNodeContext().popReportNode();
@@ -363,7 +364,7 @@ public abstract class AbstractConnectableTest {
         line2.getTerminals().forEach(terminal -> assertTrue(terminal.isConnected()));
 
         // connect the already fully connected line 2
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTest", "Testing reportNode").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTest", "Testing reportNode").build();
         network.getReportNodeContext().pushReportNode(reportNode);
         assertFalse(line2.connect());
         network.getReportNodeContext().popReportNode();

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkReportNodeTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkReportNodeTest.java
@@ -8,6 +8,7 @@
 package com.powsybl.iidm.network.tck;
 
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ReportNodeContext;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
@@ -31,12 +32,12 @@ public abstract class AbstractNetworkReportNodeTest {
     public void executeWithReportNodeTest() {
         // Create a network and affect it a reportNode (reportNode1)
         Network network = EurostagTutorialExample1Factory.create();
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("key1", "name1").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("key1", "name1").build();
         network.getReportNodeContext().pushReportNode(reportNode1);
         assertTrue(reportNode1.getChildren().isEmpty());
 
         // Create another reportNode (reportNode2)
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("key2", "name2").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("key2", "name2").build();
         assertTrue(reportNode2.getChildren().isEmpty());
 
         // Execute a task using reportNode2
@@ -58,13 +59,13 @@ public abstract class AbstractNetworkReportNodeTest {
     public void multiThreadTest() throws InterruptedException {
         // Create a network and affect it a reportNode (reportNode1)
         Network network = EurostagTutorialExample1Factory.create();
-        ReportNode reportNode1 = ReportNode.newRootReportNode().withMessageTemplate("key1", "name1").build();
+        ReportNode reportNode1 = new ReportNodeRootBuilderImpl().withMessageTemplate("key1", "name1").build();
         network.getReportNodeContext().pushReportNode(reportNode1);
         assertTrue(reportNode1.getChildren().isEmpty());
 
         // Create 2 other reportNodes (reportNode2 and reportNode3)
-        ReportNode reportNode2 = ReportNode.newRootReportNode().withMessageTemplate("key2", "name2").build();
-        ReportNode reportNode3 = ReportNode.newRootReportNode().withMessageTemplate("key3", "name3").build();
+        ReportNode reportNode2 = new ReportNodeRootBuilderImpl().withMessageTemplate("key2", "name2").build();
+        ReportNode reportNode3 = new ReportNodeRootBuilderImpl().withMessageTemplate("key3", "name3").build();
         assertTrue(reportNode2.getChildren().isEmpty());
         assertTrue(reportNode3.getChildren().isEmpty());
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -10,6 +10,7 @@ package com.powsybl.iidm.network.tck;
 import com.google.common.collect.Iterables;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.VoltageLevel.NodeBreakerView;
 import com.powsybl.iidm.network.test.*;
@@ -600,7 +601,7 @@ public abstract class AbstractNetworkTest {
 
         assertEquals(ValidationLevel.EQUIPMENT, network.runValidationChecks(false));
 
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("testReportScadaNetwork", "Test reporting of SCADA network").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("testReportScadaNetwork", "Test reporting of SCADA network").build();
         assertEquals(ValidationLevel.EQUIPMENT, network.runValidationChecks(false, reportNode));
 
         List<ReportNode> children = reportNode.getChildren();

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisTest.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisTest.java
@@ -9,6 +9,7 @@ package com.powsybl.shortcircuit;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VariantManager;
@@ -119,7 +120,7 @@ class ShortCircuitAnalysisTest {
 
     @Test
     void testWithReportNode() {
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("testReportShortCircuit", "Test mock short circuit").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("testReportShortCircuit", "Test mock short circuit").build();
         ShortCircuitAnalysisResult result = ShortCircuitAnalysis.run(network, faults, shortCircuitParameters, computationManager, faultParameters, reportNode);
         assertNotNull(result);
         List<ReportNode> children = reportNode.getChildren();

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
@@ -8,6 +8,7 @@
 package com.powsybl.timeseries;
 
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.ReportNodeRootBuilderImpl;
 import com.powsybl.timeseries.TimeSeries.TimeFormat;
 import org.junit.jupiter.api.Test;
 
@@ -216,7 +217,7 @@ class TimeSeriesTest {
             "0.002;2;6.0;d") + System.lineSeparator();
 
         // Reporter
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestVersionedAtDefaultNumberNotStrictCSV", "Testing reportNode TimeSeriesImport with wrong version number").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestVersionedAtDefaultNumberNotStrictCSV", "Testing reportNode TimeSeriesImport with wrong version number").build();
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(ZoneId.of("UTC"), ';', true, TimeFormat.FRACTIONS_OF_SECOND, false);
         TimeSeries.parseCsv(csv, timeSeriesCsvConfig, reportNode);
@@ -243,7 +244,7 @@ class TimeSeriesTest {
             "0.002;2;6.0;d") + System.lineSeparator();
 
         // Reporter
-        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestVersionedAtDefaultNumberNotStrictCSV", "Testing reportNode TimeSeriesImport with wrong version number").build();
+        ReportNode reportNode = new ReportNodeRootBuilderImpl().withMessageTemplate("reportTestVersionedAtDefaultNumberNotStrictCSV", "Testing reportNode TimeSeriesImport with wrong version number").build();
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(ZoneId.of("UTC"), ';', true, TimeFormat.FRACTIONS_OF_SECOND, true);
         TimeSeriesException timeSeriesException = assertThrows(TimeSeriesException.class, () -> TimeSeries.parseCsv(csv, timeSeriesCsvConfig, reportNode));

--- a/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterReportNodeTest.java
+++ b/ucte/ucte-converter/src/test/java/com/powsybl/ucte/converter/UcteImporterReportNodeTest.java
@@ -44,7 +44,7 @@ class UcteImporterReportNodeTest extends AbstractSerDeTest {
     void testReportElementName() throws Exception {
         ReadOnlyDataSource dataSource = new ResourceDataSource("elementName", new ResourceSet("/", "elementName.uct"));
 
-        ReportNode rootReportNode = ReportNode.newRootReportNode()
+        ReportNode rootReportNode = new ReportNodeRootBuilderImpl()
                 .withMessageTemplate("testReportVoltageRegulatingXnode", "Test importing UCTE file ${file}")
                 .withTypedValue("file", "elementName.uct", TypedValue.FILENAME)
                 .build();
@@ -72,7 +72,7 @@ class UcteImporterReportNodeTest extends AbstractSerDeTest {
     @Test
     void roundTripReportNodeJsonTest() throws Exception {
         String filename = "frVoltageRegulatingXnode.uct";
-        ReportNode reportRoot = ReportNode.newRootReportNode().withMessageTemplate("roundTripReportNodeJsonTest", "Test importing UCTE file frVoltageRegulatingXnode.uct").build();
+        ReportNode reportRoot = new ReportNodeRootBuilderImpl().withMessageTemplate("roundTripReportNodeJsonTest", "Test importing UCTE file frVoltageRegulatingXnode.uct").build();
         reportRoot.newReportNode().withMessageTemplate("novalueReport", "No value report").add();
         Network.read(filename, getClass().getResourceAsStream("/" + filename), reportRoot);
         roundTripTest(reportRoot, ReportNodeSerializer::write, ReportNodeDeserializer::read, "/frVoltageRegulatingXnodeReport.json");
@@ -118,7 +118,7 @@ class UcteImporterReportNodeTest extends AbstractSerDeTest {
         Files.copy(getClass().getResourceAsStream("/germanTsos.uct"), fileSystem.getPath(WORK_DIR, "germanTsos.uct"));
 
         List<Network> networkList = Collections.synchronizedList(new ArrayList<>());
-        ReportNode reportRoot = ReportNode.newRootReportNode()
+        ReportNode reportRoot = new ReportNodeRootBuilderImpl()
                 .withMessageTemplate("importAllParallel", "Test importing UCTE files in parallel: ${file1}, ${file2}, ${file3}")
                 .withTypedValue("file1", "frVoltageRegulatingXnode.uct", TypedValue.FILENAME)
                 .withTypedValue("file2", "frTestGridForMerging.uct", TypedValue.FILENAME)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug (incoherence) fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently, the ReportNode interface allows the implementation of different reporters. However, ReportNode's static method [newRootReportNode ](https://github.com/powsybl/powsybl-core/blob/main/commons/src/main/java/com/powsybl/commons/report/ReportNode.java#L61) defines a default ReportNode builder (ReportNodeImpl) that cannot be overriden.


**What is the new behavior (if this is a feature change)?**
newRootReportNode is a method of the class ReportNode, therefore different types of ReportNodes can be created. Also, the builders now have a constructor.


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No


**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section


**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Instead of calling the previous static method from ReportNode, one would have to create an instance of a ReportNodeRootBuilder, e.g ReportNodeRootBuilderImpl, and then build.

Before:
```java
ReportNode root = ReportNode.newRootReportNode().build();
```

After:
```java
ReportNode root = new ReportNodeRootBuilderImpl().build();
```