### PR TITLE
Fix: the fictitious load SvInjection should refer to TopologicalNode UUID

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
@@ -448,7 +448,7 @@ public final class StateVariablesExport {
             LOG.warn("Fictitious load does not have a BusView bus. No SvInjection is written");
         } else {
             // SvInjection will be assigned to the first of the TNs mapped to the bus
-            String topologicalNode = bus.getId();
+            String topologicalNode = context.getNamingStrategy().getCgmesId(bus);
 
             // In this special case we use the original CGMES id,
             // to be able to keep track of it in the exported SV file

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/StateVariablesExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/StateVariablesExportTest.java
@@ -663,22 +663,27 @@ class StateVariablesExportTest extends AbstractSerDeTest {
     @Test
     void testDisconnectedTerminalForSlack() {
         Network network = EurostagTutorialExample1Factory.createWithLFResults();
-        Pattern svInjectionPattern = Pattern.compile("<cim:SvInjection rdf:ID=");
+        Pattern svInjectionPattern = Pattern.compile("cim:SvInjection.TopologicalNode rdf:resource=\"#(.*)\"/>");
 
         // Set slack terminal
         Terminal terminal = network.getGenerator("GEN").getTerminal();
         SlackTerminal.reset(network.getVoltageLevel("VLGEN"), terminal);
 
         // Export only the CGMES SV instance file and check that no SvInjection is present (slack bus is balanced)
-        String svBalanced = exportSv(network, "tmp-slackTerminal-balanced");
+        String svBalanced = export(network, "tmp-slackTerminal-balanced").sv;
         assertFalse(svInjectionPattern.matcher(svBalanced).find());
 
         // Introduce a mismatch in the slack bus
         terminal.setP(0);
 
         // Export again, now an SvInjection must be present in the SV output (slack has a mismatch)
-        String svMismatch = exportSv(network, "tmp-slackTerminal-mismatch");
-        assertTrue(svInjectionPattern.matcher(svMismatch).find());
+        // And it should refer to a TopologicalNode present in the TP output
+        ExportedContent exportedMismatch = export(network, "tmp-slackTerminal-mismatch");
+        Matcher m = svInjectionPattern.matcher(exportedMismatch.sv);
+        assertTrue(exportedMismatch.sv.contains("cim:SvInjection.TopologicalNode"));
+        assertTrue(m.find());
+        String svInjectionTopologicalNode = m.group(1);
+        assertTrue(exportedMismatch.tp.contains(svInjectionTopologicalNode));
 
         // Disconnect the generator
         terminal.disconnect();
@@ -686,17 +691,24 @@ class StateVariablesExportTest extends AbstractSerDeTest {
         assertNull(terminal.getBusView().getBus());
 
         // We still have a mismatch, but we do not have a slack bus to assign it, no SvInjection in the output
-        String svDisconnected = exportSv(network, "tmp-slackTerminal-disconnected");
+        String svDisconnected = export(network, "tmp-slackTerminal-disconnected").sv;
         assertFalse(svInjectionPattern.matcher(svDisconnected).find());
     }
 
-    private String exportSv(Network network, String basename) {
+    record ExportedContent(String sv, String tp) {
+    }
+
+    private ExportedContent export(Network network, String basename) {
         Path outputPath = tmpDir.resolve(basename);
         Properties exportParams = new Properties();
-        exportParams.put(CgmesExport.PROFILES, "SV");
+        exportParams.put(CgmesExport.PROFILES, "SV,TP");
+        exportParams.put(CgmesExport.NAMING_STRATEGY, "cgmes");
         network.write("CGMES", exportParams, outputPath);
         try {
-            return Files.readString(tmpDir.resolve(String.format("%s_SV.xml", basename)));
+            return new ExportedContent(
+                    Files.readString(tmpDir.resolve(String.format("%s_SV.xml", basename))),
+                    Files.readString(tmpDir.resolve(String.format("%s_TP.xml", basename)))
+            );
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When writing a SvInjection for a fictitious load, the Id of the bus is used for the topological node reference, without regards to the naming strategy.


**What is the new behavior (if this is a feature change)?**
The topological node reference is the one of the bus and takes into account the naming strategy.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No