### PR TITLE
Tie lines in network reduction

### DIFF
--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/AbstractNetworkReducer.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/AbstractNetworkReducer.java
@@ -23,9 +23,9 @@ public abstract class AbstractNetworkReducer implements NetworkReducer {
 
     private final NetworkPredicate predicate;
 
-    private Set<String> vlIds = new HashSet<>();
+    private final Set<String> vlIds = new HashSet<>();
 
-    public AbstractNetworkReducer(NetworkPredicate predicate) {
+    protected AbstractNetworkReducer(NetworkPredicate predicate) {
         this.predicate = Objects.requireNonNull(predicate);
     }
 
@@ -37,6 +37,12 @@ public abstract class AbstractNetworkReducer implements NetworkReducer {
                 .filter(l -> !test(l))
                 .toList();
         lines.forEach(this::reduce);
+
+        // Remove all unwanted tie lines
+        List<TieLine> tieLines = network.getTieLineStream()
+                .filter(l -> !test(l))
+                .toList();
+        tieLines.forEach(this::reduce);
 
         // Remove all unwanted two windings transformers
         List<TwoWindingsTransformer> twoWindingsTransformers = network.getTwoWindingsTransformerStream()
@@ -79,6 +85,8 @@ public abstract class AbstractNetworkReducer implements NetworkReducer {
 
     protected abstract void reduce(Line line);
 
+    protected abstract void reduce(TieLine tieLine);
+
     protected abstract void reduce(TwoWindingsTransformer transformer);
 
     protected abstract void reduce(ThreeWindingsTransformer transformer);
@@ -98,20 +106,27 @@ public abstract class AbstractNetworkReducer implements NetworkReducer {
      * Return true if the given {@link Line} should be kept in the network, false otherwise
      */
     protected boolean test(Line line) {
-        return test((Branch) line);
+        return test((Branch<?>) line);
+    }
+
+    /**
+     * Return true if the given {@link TieLine} should be kept in the network, false otherwise
+     */
+    protected boolean test(TieLine tieLine) {
+        return test((Branch<?>) tieLine);
     }
 
     /**
      * Return true if the given {@link TwoWindingsTransformer} should be kept in the network, false otherwise
      */
     protected boolean test(TwoWindingsTransformer transformer) {
-        return test((Branch) transformer);
+        return test((Branch<?>) transformer);
     }
 
     /**
      * Return true if the given {@link Branch} should be kept in the network, false otherwise
      */
-    private boolean test(Branch branch) {
+    private boolean test(Branch<?> branch) {
         Objects.requireNonNull(branch);
         VoltageLevel vl1 = branch.getTerminal1().getVoltageLevel();
         VoltageLevel vl2 = branch.getTerminal2().getVoltageLevel();

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
@@ -77,7 +77,7 @@ public class DefaultNetworkReducer extends AbstractNetworkReducer {
         VoltageLevel vl2 = terminal2.getVoltageLevel();
 
         // just remove the tie line if one of its voltage levels has to be removed
-        if (test(vl1) || test(vl2)) {
+        if (!test(vl1) || !test(vl2)) {
             tieLine.remove();
         }
 

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducer.java
@@ -70,6 +70,21 @@ public class DefaultNetworkReducer extends AbstractNetworkReducer {
     }
 
     @Override
+    protected void reduce(TieLine tieLine) {
+        Terminal terminal1 = tieLine.getTerminal1();
+        Terminal terminal2 = tieLine.getTerminal2();
+        VoltageLevel vl1 = terminal1.getVoltageLevel();
+        VoltageLevel vl2 = terminal2.getVoltageLevel();
+
+        // just remove the tie line if one of its voltage levels has to be removed
+        if (test(vl1) || test(vl2)) {
+            tieLine.remove();
+        }
+
+        observers.forEach(o -> o.tieLineRemoved(tieLine));
+    }
+
+    @Override
     protected void reduce(TwoWindingsTransformer transformer) {
         Terminal terminal1 = transformer.getTerminal1();
         Terminal terminal2 = transformer.getTerminal2();

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducerObserver.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/DefaultNetworkReducerObserver.java
@@ -35,6 +35,11 @@ public class DefaultNetworkReducerObserver implements NetworkReducerObserver {
     }
 
     @Override
+    public void tieLineRemoved(TieLine tieLine) {
+        // Nothing to do
+    }
+
+    @Override
     public void transformerReplaced(TwoWindingsTransformer transformer, Injection injection) {
         // Nothing to do
     }

--- a/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/NetworkReducerObserver.java
+++ b/iidm/iidm-reducer/src/main/java/com/powsybl/iidm/reducer/NetworkReducerObserver.java
@@ -22,6 +22,8 @@ public interface NetworkReducerObserver {
 
     void lineRemoved(Line line);
 
+    void tieLineRemoved(TieLine tieLine);
+
     void transformerReplaced(TwoWindingsTransformer transformer, Injection injection);
 
     void transformerRemoved(TwoWindingsTransformer transformer);

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/NetworkReducerObserverImpl.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/NetworkReducerObserverImpl.java
@@ -22,6 +22,8 @@ public class NetworkReducerObserverImpl extends DefaultNetworkReducerObserver {
 
     private int lineReplacedCount = 0;
 
+    private int tieLineRemovedCount = 0;
+
     private int twoWindingsTransformerRemovedCount = 0;
 
     private int twoWindingsTransformerReplacedCount = 0;
@@ -48,6 +50,10 @@ public class NetworkReducerObserverImpl extends DefaultNetworkReducerObserver {
 
     int getLineReplacedCount() {
         return lineReplacedCount;
+    }
+
+    public int getTieLineRemovedCount() {
+        return tieLineRemovedCount;
     }
 
     int getTwoWindingsTransformerRemovedCount() {
@@ -100,6 +106,13 @@ public class NetworkReducerObserverImpl extends DefaultNetworkReducerObserver {
         super.lineRemoved(line);
 
         lineRemovedCount++;
+    }
+
+    @Override
+    public void tieLineRemoved(TieLine tieLine) {
+        super.tieLineRemoved(tieLine);
+
+        tieLineRemovedCount++;
     }
 
     @Override

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/TieLineReductionTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/TieLineReductionTest.java
@@ -10,6 +10,7 @@ package com.powsybl.iidm.reducer;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -21,9 +22,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class TieLineReductionTest {
 
+    private Network network;
+
+    private NetworkReducerObserverImpl observer;
+
+    @BeforeEach
+    void setUp() {
+        network = EurostagTutorialExample1Factory.createWithTieLine();
+        observer = new NetworkReducerObserverImpl();
+    }
+
     @Test
-    void test() {
-        var observer = new NetworkReducerObserverImpl();
+    void testOneSideTieLineReduction() {
         Network network = EurostagTutorialExample1Factory.createWithTieLine();
         var reducer = NetworkReducer.builder()
                 .withNetworkPredicate(new IdentifierNetworkPredicate(List.of("VLGEN", "VLHV1", "VLLOAD")))
@@ -34,5 +44,29 @@ class TieLineReductionTest {
         assertEquals(2, observer.getTieLineRemovedCount());
         assertEquals(List.of("P1", "P2", "VLGEN", "LOAD", "NGEN", "NGEN_NHV1", "NHV2_NLOAD", "sim1", "VLLOAD", "NHV1", "GEN", "VLHV1", "NHV1_XNODE1", "NLOAD", "NVH1_XNODE2"),
                 network.getIdentifiables().stream().map(Identifiable::getId).toList());
+    }
+
+    @Test
+    void testTwoSidesTieLineReduction() {
+        var reducer = NetworkReducer.builder()
+                .withNetworkPredicate(new IdentifierNetworkPredicate(List.of("VLGEN", "VLLOAD")))
+                .withObservers(observer)
+                .build();
+        assertEquals(0, observer.getTieLineRemovedCount());
+        reducer.reduce(network);
+        assertEquals(2, observer.getTieLineRemovedCount());
+        assertEquals(List.of("P1", "P2", "VLGEN", "LOAD", "NGEN", "NGEN_NHV1", "NHV2_NLOAD", "sim1", "VLLOAD", "GEN", "NLOAD"),
+                network.getIdentifiables().stream().map(Identifiable::getId).toList());
+    }
+
+    @Test
+    void testNoTieLineReduction() {
+        var reducer = NetworkReducer.builder()
+                .withNetworkPredicate(new IdentifierNetworkPredicate(List.of("VLHV1", "VLHV2", "VLLOAD")))
+                .withObservers(observer)
+                .build();
+        assertEquals(0, observer.getTieLineRemovedCount());
+        reducer.reduce(network);
+        assertEquals(0, observer.getTieLineRemovedCount());
     }
 }

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/TieLineReductionTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/TieLineReductionTest.java
@@ -34,7 +34,6 @@ class TieLineReductionTest {
 
     @Test
     void testOneSideTieLineReduction() {
-        Network network = EurostagTutorialExample1Factory.createWithTieLine();
         var reducer = NetworkReducer.builder()
                 .withNetworkPredicate(new IdentifierNetworkPredicate(List.of("VLGEN", "VLHV1", "VLLOAD")))
                 .withObservers(observer)

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/TieLineReductionTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/TieLineReductionTest.java
@@ -9,13 +9,12 @@ package com.powsybl.iidm.reducer;
 
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.TieLine;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -24,21 +23,15 @@ class TieLineReductionTest {
 
     @Test
     void test() {
-        boolean[] tieLineRemoved = new boolean[1];
-        var observer = new DefaultNetworkReducerObserver() {
-            @Override
-            public void tieLineRemoved(TieLine tieLine) {
-                tieLineRemoved[0] = true;
-            }
-        };
+        var observer = new NetworkReducerObserverImpl();
         Network network = EurostagTutorialExample1Factory.createWithTieLine();
         var reducer = NetworkReducer.builder()
                 .withNetworkPredicate(new IdentifierNetworkPredicate(List.of("VLGEN", "VLHV1", "VLLOAD")))
                 .withObservers(observer)
                 .build();
-        assertFalse(tieLineRemoved[0]);
+        assertEquals(0, observer.getTieLineRemovedCount());
         reducer.reduce(network);
-        assertTrue(tieLineRemoved[0]);
+        assertEquals(2, observer.getTieLineRemovedCount());
         assertEquals(List.of("P1", "P2", "VLGEN", "LOAD", "NGEN", "NGEN_NHV1", "NHV2_NLOAD", "sim1", "VLLOAD", "NHV1", "GEN", "VLHV1", "NHV1_XNODE1", "NLOAD", "NVH1_XNODE2"),
                 network.getIdentifiables().stream().map(Identifiable::getId).toList());
     }

--- a/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/TieLineReductionTest.java
+++ b/iidm/iidm-reducer/src/test/java/com/powsybl/iidm/reducer/TieLineReductionTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.reducer;
+
+import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.TieLine;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ */
+class TieLineReductionTest {
+
+    @Test
+    void test() {
+        boolean[] tieLineRemoved = new boolean[1];
+        var observer = new DefaultNetworkReducerObserver() {
+            @Override
+            public void tieLineRemoved(TieLine tieLine) {
+                tieLineRemoved[0] = true;
+            }
+        };
+        Network network = EurostagTutorialExample1Factory.createWithTieLine();
+        var reducer = NetworkReducer.builder()
+                .withNetworkPredicate(new IdentifierNetworkPredicate(List.of("VLGEN", "VLHV1", "VLLOAD")))
+                .withObservers(observer)
+                .build();
+        assertFalse(tieLineRemoved[0]);
+        reducer.reduce(network);
+        assertTrue(tieLineRemoved[0]);
+        assertEquals(List.of("P1", "P2", "VLGEN", "LOAD", "NGEN", "NGEN_NHV1", "NHV2_NLOAD", "sim1", "VLLOAD", "NHV1", "GEN", "VLHV1", "NHV1_XNODE1", "NLOAD", "NVH1_XNODE2"),
+                network.getIdentifiables().stream().map(Identifiable::getId).toList());
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
#3026 


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the new behavior (if this is a feature change)?**
When network reduction impact the removal of one of a tie line voltage levels, we remove the tie line (so we un-merge the dangling lines). 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
