### PR TITLE
CGMES SvInjection for slack unit test: referred topological node must be defined

### DIFF
--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/StateVariablesExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/StateVariablesExportTest.java
@@ -683,7 +683,8 @@ class StateVariablesExportTest extends AbstractSerDeTest {
         assertTrue(exportedMismatch.sv.contains("cim:SvInjection.TopologicalNode"));
         assertTrue(m.find());
         String svInjectionTopologicalNode = m.group(1);
-        assertTrue(exportedMismatch.tp.contains(svInjectionTopologicalNode));
+        String tnDefinition = "cim:TopologicalNode rdf:ID=\"" + svInjectionTopologicalNode + "\"";
+        assertTrue(exportedMismatch.tp.contains(tnDefinition));
 
         // Disconnect the generator
         terminal.disconnect();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Completes the unit test for #3037. 
Checks that the `TopologicalNode` referred in the SV `SvInjection` for the slack bus mismatch is present in properly defined inside the exported TP instance file.