### PR TITLE
Add an optional category in parameters

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/parameters/Parameter.java
+++ b/commons/src/main/java/com/powsybl/commons/parameters/Parameter.java
@@ -34,14 +34,27 @@ public class Parameter {
 
     private final ParameterScope scope;
 
+    private final String categoryKey;
+
     public Parameter(String name, ParameterType type, String description, Object defaultValue,
-                     List<Object> possibleValues, ParameterScope scope) {
+                     List<Object> possibleValues, ParameterScope scope, String categoryKey) {
         names.add(Objects.requireNonNull(name));
         this.type = Objects.requireNonNull(type);
         this.description = Objects.requireNonNull(description);
         this.defaultValue = checkDefaultValue(type, defaultValue);
         this.possibleValues = checkPossibleValues(type, possibleValues, defaultValue);
         this.scope = scope;
+        this.categoryKey = categoryKey;
+    }
+
+    public Parameter(String name, ParameterType type, String description, Object defaultValue,
+                     List<Object> possibleValues, ParameterScope scope) {
+        this(name, type, description, defaultValue, possibleValues, scope, null);
+    }
+
+    public Parameter(String name, ParameterType type, String description, Object defaultValue, ParameterScope scope,
+                     String categoryKey) {
+        this(name, type, description, defaultValue, null, scope, categoryKey);
     }
 
     public Parameter(String name, ParameterType type, String description, Object defaultValue,
@@ -222,5 +235,9 @@ public class Parameter {
 
     public ParameterScope getScope() {
         return scope;
+    }
+
+    public String getCategoryKey() {
+        return categoryKey;
     }
 }

--- a/commons/src/test/java/com/powsybl/commons/parameters/ParameterTest.java
+++ b/commons/src/test/java/com/powsybl/commons/parameters/ParameterTest.java
@@ -138,4 +138,13 @@ class ParameterTest {
         PowsyblException e = assertThrows(PowsyblException.class, () -> new Parameter("i", ParameterType.INTEGER, "an integer", null));
         assertEquals("With Integer parameter you are not allowed to pass a null default value", e.getMessage());
     }
+
+    @Test
+    void getCategoryKeyTest() {
+        Parameter param0 = new Parameter("p0", ParameterType.BOOLEAN, "param0", Boolean.FALSE);
+        Parameter param1 = new Parameter("p1", ParameterType.BOOLEAN, "another param", Boolean.FALSE,
+                ParameterScope.FUNCTIONAL, "Category");
+        assertNull(param0.getCategoryKey());
+        assertEquals("Category", param1.getCategoryKey());
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**

`Parameter` class has now an new optional free-string attribute `categoryKey`, corresponding to a business key which is meant to group together the parameters concerning a same topic.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

This feature was extracted from #3032.
