### PR TITLE
Boundary P, Q, angle and voltage with zero impedance 

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/DanglingLineBoundaryImpl.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/DanglingLineBoundaryImpl.java
@@ -33,7 +33,11 @@ public class DanglingLineBoundaryImpl implements Boundary {
 
         Terminal t = parent.getTerminal();
         Bus b = t.getBusView().getBus();
-        return new SV(t.getP(), t.getQ(), getV(b), getAngle(b), TwoSides.ONE).otherSideU(parent, true);
+        if (zeroImpedance(parent)) {
+            return getV(b);
+        } else {
+            return new SV(t.getP(), t.getQ(), getV(b), getAngle(b), TwoSides.ONE).otherSideU(parent, true);
+        }
     }
 
     @Override
@@ -44,7 +48,11 @@ public class DanglingLineBoundaryImpl implements Boundary {
         }
         Terminal t = parent.getTerminal();
         Bus b = t.getBusView().getBus();
-        return new SV(t.getP(), t.getQ(), getV(b), getAngle(b), TwoSides.ONE).otherSideA(parent, true);
+        if (zeroImpedance(parent)) {
+            return getAngle(b);
+        } else {
+            return new SV(t.getP(), t.getQ(), getV(b), getAngle(b), TwoSides.ONE).otherSideA(parent, true);
+        }
     }
 
     @Override
@@ -54,7 +62,11 @@ public class DanglingLineBoundaryImpl implements Boundary {
         }
         Terminal t = parent.getTerminal();
         Bus b = t.getBusView().getBus();
-        return new SV(t.getP(), t.getQ(), getV(b), getAngle(b), TwoSides.ONE).otherSideP(parent, true);
+        if (zeroImpedance(parent)) {
+            return -t.getP();
+        } else {
+            return new SV(t.getP(), t.getQ(), getV(b), getAngle(b), TwoSides.ONE).otherSideP(parent, true);
+        }
     }
 
     @Override
@@ -64,7 +76,11 @@ public class DanglingLineBoundaryImpl implements Boundary {
         }
         Terminal t = parent.getTerminal();
         Bus b = t.getBusView().getBus();
-        return new SV(t.getP(), t.getQ(), getV(b), getAngle(b), TwoSides.ONE).otherSideQ(parent, true);
+        if (zeroImpedance(parent)) {
+            return -t.getQ();
+        } else {
+            return new SV(t.getP(), t.getQ(), getV(b), getAngle(b), TwoSides.ONE).otherSideQ(parent, true);
+        }
     }
 
     @Override
@@ -95,5 +111,10 @@ public class DanglingLineBoundaryImpl implements Boundary {
         // run is needed, especially if the generation is regulating voltage.
         // This could be improved later.
         return !parent.isPaired() && valid(parent.getP0(), parent.getQ0()) && parent.getGeneration() == null;
+    }
+
+    private static boolean zeroImpedance(DanglingLine parent) {
+        // Simple way to deal with zero impedance dangling line.
+        return parent.getR() == 0.0 && parent.getX() == 0.0;
     }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/DanglingLineBoundaryImpl.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/DanglingLineBoundaryImpl.java
@@ -11,6 +11,8 @@ import com.powsybl.iidm.network.*;
 
 import java.util.Objects;
 
+import static com.powsybl.iidm.network.util.DanglingLineData.zeroImpedance;
+
 /**
  * @author Miora Ralambotiana {@literal <miora.ralambotiana at rte-france.com>}
  */
@@ -111,10 +113,5 @@ public class DanglingLineBoundaryImpl implements Boundary {
         // run is needed, especially if the generation is regulating voltage.
         // This could be improved later.
         return !parent.isPaired() && valid(parent.getP0(), parent.getQ0()) && parent.getGeneration() == null;
-    }
-
-    private static boolean zeroImpedance(DanglingLine parent) {
-        // Simple way to deal with zero impedance dangling line.
-        return parent.getR() == 0.0 && parent.getX() == 0.0;
     }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/DanglingLineData.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/DanglingLineData.java
@@ -32,11 +32,6 @@ public class DanglingLineData {
     public DanglingLineData(DanglingLine danglingLine, boolean splitShuntAdmittance) {
         this.danglingLine = Objects.requireNonNull(danglingLine);
 
-        double g1 = splitShuntAdmittance ? danglingLine.getG() * 0.5 : danglingLine.getG();
-        double b1 = splitShuntAdmittance ? danglingLine.getB() * 0.5 : danglingLine.getB();
-        double g2 = splitShuntAdmittance ? danglingLine.getG() * 0.5 : 0.0;
-        double b2 = splitShuntAdmittance ? danglingLine.getB() * 0.5 : 0.0;
-
         double u1 = getV(danglingLine);
         double theta1 = getTheta(danglingLine);
 
@@ -45,6 +40,17 @@ public class DanglingLineData {
             boundaryBusTheta = Double.NaN;
             return;
         }
+
+        if (zeroImpedance(danglingLine)) {
+            boundaryBusU = u1;
+            boundaryBusTheta = theta1;
+            return;
+        }
+
+        double g1 = splitShuntAdmittance ? danglingLine.getG() * 0.5 : danglingLine.getG();
+        double b1 = splitShuntAdmittance ? danglingLine.getB() * 0.5 : danglingLine.getB();
+        double g2 = splitShuntAdmittance ? danglingLine.getG() * 0.5 : 0.0;
+        double b2 = splitShuntAdmittance ? danglingLine.getB() * 0.5 : 0.0;
 
         Complex v1 = ComplexUtils.polar2Complex(u1, theta1);
 
@@ -102,6 +108,11 @@ public class DanglingLineData {
 
     public double getBoundaryBusTheta() {
         return boundaryBusTheta;
+    }
+
+    public static boolean zeroImpedance(DanglingLine parent) {
+        // Simple way to deal with zero impedance dangling line.
+        return parent.getR() == 0.0 && parent.getX() == 0.0;
     }
 }
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TieLineUtil.java
@@ -278,13 +278,13 @@ public final class TieLineUtil {
     public static double getR(DanglingLine dl1, DanglingLine dl2) {
         LinkData.BranchAdmittanceMatrix adm = TieLineUtil.equivalentBranchAdmittanceMatrix(dl1, dl2);
         // Add 0.0 to avoid negative zero, tests where the R value is compared as text, fail
-        return adm.y12().negate().reciprocal().getReal() + 0.0;
+        return zeroImpedanceLine(adm) ? 0.0 : adm.y12().negate().reciprocal().getReal() + 0.0;
     }
 
     public static double getX(DanglingLine dl1, DanglingLine dl2) {
         LinkData.BranchAdmittanceMatrix adm = TieLineUtil.equivalentBranchAdmittanceMatrix(dl1, dl2);
         // Add 0.0 to avoid negative zero, tests where the X value is compared as text, fail
-        return adm.y12().negate().reciprocal().getImaginary() + 0.0;
+        return zeroImpedanceLine(adm) ? 0.0 : adm.y12().negate().reciprocal().getImaginary() + 0.0;
     }
 
     public static double getG1(DanglingLine dl1, DanglingLine dl2) {
@@ -326,7 +326,9 @@ public final class TieLineUtil {
         BranchAdmittanceMatrix adm2 = LinkData.calculateBranchAdmittance(dl2.getR(), dl2.getX(), 1.0, 0.0, 1.0, 0.0,
             new Complex(0.0, 0.0), new Complex(dl2.getG(), dl2.getB()));
 
-        if (zeroImpedanceLine(adm1)) {
+        if (zeroImpedanceLine(adm1) && zeroImpedanceLine(adm2)) {
+            return adm1;
+        } else if (zeroImpedanceLine(adm1)) {
             return adm2;
         } else if (zeroImpedanceLine(adm2)) {
             return adm1;
@@ -353,7 +355,15 @@ public final class TieLineUtil {
         BranchAdmittanceMatrix adm2 = LinkData.calculateBranchAdmittance(dl2.getR(), dl2.getX(), 1.0, 0.0, 1.0, 0.0,
                 new Complex(0.0, 0.0), new Complex(dl2.getG(), dl2.getB()));
 
-        return adm1.y21().multiply(v1).add(adm2.y12().multiply(v2)).negate().divide(adm1.y22().add(adm2.y11()));
+        if (zeroImpedanceLine(adm1) && zeroImpedanceLine(adm2)) {
+            return v1;
+        } else if (zeroImpedanceLine(adm1)) {
+            return v1;
+        } else if (zeroImpedanceLine(adm2)) {
+            return v2;
+        } else {
+            return adm1.y21().multiply(v1).add(adm2.y12().multiply(v2)).negate().divide(adm1.y22().add(adm2.y11()));
+        }
     }
 
     /**

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/TieLineTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/TieLineTest.java
@@ -10,6 +10,8 @@ package com.powsybl.iidm.network.impl;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.NoEquipmentNetworkFactory;
 import java.time.ZonedDateTime;
+
+import com.powsybl.iidm.network.util.TieLineUtil;
 import org.junit.jupiter.api.Test;
 
 import com.powsybl.iidm.network.util.LinkData;
@@ -271,6 +273,76 @@ class TieLineTest {
 
         assertSame(s1vl1, tieLine.getDanglingLine1().getTerminal().getVoltageLevel());
         assertSame(s2vl1, tieLine.getDanglingLine2().getTerminal().getVoltageLevel());
+    }
+
+    @Test
+    void tieLineTestZeroImpedanceDl1() {
+        // Line1 from node1 to boundaryNode, Line2 from node2 to boundaryNode
+        CaseSv caseSv0 = createCase0();
+        Network n = createNetworkWithTieLine(NetworkFactory.findDefault(), TwoSides.TWO, TwoSides.TWO, caseSv0);
+        Branch<?> branch = n.getBranch("TWO + TWO");
+        assertTrue(branch instanceof TieLine);
+
+        TieLine tieLine = (TieLine) branch;
+        tieLine.getDanglingLine1().setR(0.0).setX(0.0).setG(0.0).setB(0.0);
+
+        double tol = 1.0e-6;
+        assertEquals(tieLine.getDanglingLine2().getR(), tieLine.getR(), tol);
+        assertEquals(tieLine.getDanglingLine2().getX(), tieLine.getX(), tol);
+        assertEquals(tieLine.getDanglingLine2().getG(), tieLine.getG2(), tol);
+        assertEquals(tieLine.getDanglingLine2().getB(), tieLine.getB2(), tol);
+        assertEquals(0.0, tieLine.getG1(), tol);
+        assertEquals(0.0, tieLine.getB1(), tol);
+
+        assertEquals(tieLine.getDanglingLine1().getTerminal().getBusView().getBus().getV(), TieLineUtil.getBoundaryV(tieLine.getDanglingLine1(), tieLine.getDanglingLine2()), tol);
+        assertEquals(tieLine.getDanglingLine1().getTerminal().getBusView().getBus().getAngle(), TieLineUtil.getBoundaryAngle(tieLine.getDanglingLine1(), tieLine.getDanglingLine2()), tol);
+    }
+
+    @Test
+    void tieLineTestZeroImpedanceDl2() {
+        // Line1 from node1 to boundaryNode, Line2 from node2 to boundaryNode
+        CaseSv caseSv0 = createCase0();
+        Network n = createNetworkWithTieLine(NetworkFactory.findDefault(), TwoSides.TWO, TwoSides.TWO, caseSv0);
+        Branch<?> branch = n.getBranch("TWO + TWO");
+        assertTrue(branch instanceof TieLine);
+
+        TieLine tieLine = (TieLine) branch;
+        tieLine.getDanglingLine2().setR(0.0).setX(0.0).setG(0.0).setB(0.0);
+
+        double tol = 1.0e-6;
+        assertEquals(tieLine.getDanglingLine1().getR(), tieLine.getR(), tol);
+        assertEquals(tieLine.getDanglingLine1().getX(), tieLine.getX(), tol);
+        assertEquals(tieLine.getDanglingLine1().getG(), tieLine.getG1(), tol);
+        assertEquals(tieLine.getDanglingLine1().getB(), tieLine.getB1(), tol);
+        assertEquals(0.0, tieLine.getG2(), tol);
+        assertEquals(0.0, tieLine.getB2(), tol);
+
+        assertEquals(tieLine.getDanglingLine2().getTerminal().getBusView().getBus().getV(), TieLineUtil.getBoundaryV(tieLine.getDanglingLine1(), tieLine.getDanglingLine2()), tol);
+        assertEquals(tieLine.getDanglingLine2().getTerminal().getBusView().getBus().getAngle(), TieLineUtil.getBoundaryAngle(tieLine.getDanglingLine1(), tieLine.getDanglingLine2()), tol);
+    }
+
+    @Test
+    void tieLineTestZeroImpedanceDl1AndDl2() {
+        // Line1 from node1 to boundaryNode, Line2 from node2 to boundaryNode
+        CaseSv caseSv0 = createCase0();
+        Network n = createNetworkWithTieLine(NetworkFactory.findDefault(), TwoSides.TWO, TwoSides.TWO, caseSv0);
+        Branch<?> branch = n.getBranch("TWO + TWO");
+        assertTrue(branch instanceof TieLine);
+
+        TieLine tieLine = (TieLine) branch;
+        tieLine.getDanglingLine1().setR(0.0).setX(0.0).setG(0.0).setB(0.0);
+        tieLine.getDanglingLine2().setR(0.0).setX(0.0).setG(0.0).setB(0.0);
+
+        double tol = 1.0e-6;
+        assertEquals(0.0, tieLine.getR(), tol);
+        assertEquals(0.0, tieLine.getX(), tol);
+        assertEquals(0.0, tieLine.getG1(), tol);
+        assertEquals(0.0, tieLine.getB1(), tol);
+        assertEquals(0.0, tieLine.getG2(), tol);
+        assertEquals(0.0, tieLine.getB2(), tol);
+
+        assertEquals(tieLine.getDanglingLine1().getTerminal().getBusView().getBus().getV(), TieLineUtil.getBoundaryV(tieLine.getDanglingLine1(), tieLine.getDanglingLine2()), tol);
+        assertEquals(tieLine.getDanglingLine1().getTerminal().getBusView().getBus().getAngle(), TieLineUtil.getBoundaryAngle(tieLine.getDanglingLine1(), tieLine.getDanglingLine2()), tol);
     }
 
     private static Network createNetworkWithTieLine(NetworkFactory networkFactory,

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/util/SVTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/util/SVTest.java
@@ -275,4 +275,20 @@ class SVTest {
         assertEquals(130.037, danglingLine.getBoundary().getV(), tol);
         assertEquals(0.995, danglingLine.getBoundary().getAngle(), tol);
     }
+
+    @Test
+    void testWithZeroImpedanceDanglingLine() {
+        double tol = 0.001;
+        Network network = DanglingLineNetworkFactory.createWithGeneration();
+        DanglingLine danglingLine = network.getDanglingLine("DL");
+        danglingLine.setR(0.0).setX(0.0);
+        danglingLine.getTerminal().setP(-298.937);
+        danglingLine.getTerminal().setQ(-7.413);
+        danglingLine.getTerminal().getBusView().getBus().setAngle(0.0);
+        danglingLine.getTerminal().getBusView().getBus().setV(100.0);
+        assertEquals(298.937, danglingLine.getBoundary().getP(), tol);
+        assertEquals(7.413, danglingLine.getBoundary().getQ(), tol);
+        assertEquals(100.0, danglingLine.getBoundary().getV(), tol);
+        assertEquals(0.0, danglingLine.getBoundary().getAngle(), tol);
+    }
 }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/util/SVTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/util/SVTest.java
@@ -277,7 +277,7 @@ class SVTest {
     }
 
     @Test
-    void testWithZeroImpedanceDanglingLine() {
+    void testWithZeroImpedanceDanglingLineWithGeneration() {
         double tol = 0.001;
         Network network = DanglingLineNetworkFactory.createWithGeneration();
         DanglingLine danglingLine = network.getDanglingLine("DL");
@@ -288,6 +288,22 @@ class SVTest {
         danglingLine.getTerminal().getBusView().getBus().setV(100.0);
         assertEquals(298.937, danglingLine.getBoundary().getP(), tol);
         assertEquals(7.413, danglingLine.getBoundary().getQ(), tol);
+        assertEquals(100.0, danglingLine.getBoundary().getV(), tol);
+        assertEquals(0.0, danglingLine.getBoundary().getAngle(), tol);
+    }
+
+    @Test
+    void testWithZeroImpedanceDanglingLineWithoutGeneration() {
+        double tol = 0.001;
+        Network network = DanglingLineNetworkFactory.create();
+        DanglingLine danglingLine = network.getDanglingLine("DL");
+        danglingLine.setR(0.0).setX(0.0);
+        danglingLine.getTerminal().setP(50.0);
+        danglingLine.getTerminal().setQ(30.0);
+        danglingLine.getTerminal().getBusView().getBus().setAngle(0.0);
+        danglingLine.getTerminal().getBusView().getBus().setV(100.0);
+        assertEquals(-50.0, danglingLine.getBoundary().getP(), tol);
+        assertEquals(-30.0, danglingLine.getBoundary().getQ(), tol);
         assertEquals(100.0, danglingLine.getBoundary().getV(), tol);
         assertEquals(0.0, danglingLine.getBoundary().getAngle(), tol);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

No. We have:
- A dangling line (paired or unpaired)
- May have a generation part or not.
- Has zero impedance (X = 0, R = 0).

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Values at boundary are not calculated correctly when  dangling lines have zero impedance.


**What is the new behavior (if this is a feature change)?**
Calculations of boundary magnitudes in IIDM boundary implementation and `DanglingLineData` now have support for zero impedance.
Zero impedance check for dangling lines is kept at `DanglingLineData`.
Zero impedance paired dangling lines (inside tie lines) are also calculated correctly.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
