### PR TITLE
Allow OperatingStatus on busbar sections

### DIFF
--- a/docs/grid_model/extensions.md
+++ b/docs/grid_model/extensions.md
@@ -54,10 +54,6 @@ This extension contains the sub-object `ObservabilityQuality`.
 
 This extension is provided by the `com.powsybl:powsybl-iidm-extensions` module.
 
-## Branch status
-
-This extension models the status of a connectable. The status could be `IN_OPERATION`, `PLANNED_OUTAGE` or `FORCED_OUTAGE`.
-
 ## Busbar section position
 
 This extension gives positions information about a busbar section. The `busbarIndex` gives the position of the busbar section relatively to other busbars. The `sectionIndex` gives the position of the busbar section within the corresponding busbar. Note that a busbar is a set of busbar sections. Hence, the sections of a same busbar should have the same busbar index. The busbar indices induce an order of busbars within the voltage level, which usually reflects the busbars physical relative positions. Similarly, the section indices induce an order of sections of a same busbar, which usually reflects their physical relative position.
@@ -567,3 +563,11 @@ line.newExtension(LinePositionAdder.class)
     .withCoordinates(List.of(new Coordinate(48, 2), new Coordinate(48.1, 2.1)))
     .add();
 ```
+
+## Operating status
+
+This is an extension of `Identifiable`, but it is restricted to some identifiable types: busbar sections, all branches,
+three-winding transformers, HVDC line and a dangling line. The status could be:
+- `IN_OPERATION`: equipment in service. 
+- `PLANNED_OUTAGE`: outage due to an unscheduled putting out of service of the equipment.
+- `FORCED_OUTAGE`: outage due to a programmed taking out of service of the equipment.

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/OperatingStatus.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/OperatingStatus.java
@@ -13,10 +13,11 @@ import com.powsybl.iidm.network.Identifiable;
 import java.util.Objects;
 
 /**
- *  An extension to describe the operating status of an equipment. This is typically used in addition to an equipment
+ *  Extension to describe the operating status of some equipment. This is typically used in addition to an equipment
  *  disconnection (so using topological changes), to specify the reason of the disconnection: for instance a planned
- *  outage.
- * `Identifiable` is needed as generic type because we also have to support HVDC lines which are not `Connectable`
+ *  outage (or scheduled outage), i.e. an outage due to a programmed taking out of service of an equipment, or a forced
+ *  outage, i.e. an outage due to an unscheduled putting out of service of an equipment.
+ * `Identifiable` is needed as generic type because we support HVDC lines and tie lines which are not `Connectable`.
  * @author Nicolas Noir {@literal <nicolas.noir at rte-france.com>}
  */
 public interface OperatingStatus<I extends Identifiable<I>> extends Extension<I> {

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/OperatingStatus.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/OperatingStatus.java
@@ -32,7 +32,7 @@ public interface OperatingStatus<I extends Identifiable<I>> extends Extension<I>
     static boolean isAllowedIdentifiable(Identifiable<?> identifiable) {
         Objects.requireNonNull(identifiable);
         return switch (identifiable.getType()) {
-            case LINE, TWO_WINDINGS_TRANSFORMER, THREE_WINDINGS_TRANSFORMER, DANGLING_LINE, HVDC_LINE, TIE_LINE -> true;
+            case BUSBAR_SECTION, LINE, TWO_WINDINGS_TRANSFORMER, THREE_WINDINGS_TRANSFORMER, DANGLING_LINE, HVDC_LINE, TIE_LINE -> true;
             default -> false;
         };
     }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractOperatingStatusTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractOperatingStatusTest.java
@@ -47,6 +47,11 @@ public abstract class AbstractOperatingStatusTest {
                 .withStatus(OperatingStatus.Status.PLANNED_OUTAGE)
                 .add();
 
+        BusbarSection bbs = network.getBusbarSection("S1VL1_BBS");
+        bbs.newExtension(OperatingStatusAdder.class)
+                .withStatus(OperatingStatus.Status.FORCED_OUTAGE)
+                .add();
+
         Generator g = network.getGenerator("GH1");
         OperatingStatusAdder operatingStatusAdder = g.newExtension(OperatingStatusAdder.class)
                 .withStatus(OperatingStatus.Status.PLANNED_OUTAGE);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
OperatingStatus in-memory implementation cannot be added on a busbar section (no restriction at all on network-store implementation!)

**What is the new behavior (if this is a feature change)?**
OperatingStatus in-memory implementation can be added on a busbar section

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No