### PR TITLE
Fix exception for connectable not found in Network Modification connection and disconnection

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/AbstractDisconnection.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/AbstractDisconnection.java
@@ -7,7 +7,6 @@
  */
 package com.powsybl.iidm.modification;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.iidm.network.Connectable;
 import com.powsybl.iidm.network.Network;

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/AbstractDisconnection.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/AbstractDisconnection.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.iidm.modification;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.iidm.network.Connectable;
 import com.powsybl.iidm.network.Network;
@@ -35,12 +36,16 @@ public abstract class AbstractDisconnection extends AbstractNetworkModification 
         this.side = side;
     }
 
-    public void applyModification(Network network, boolean isPlanned, ReportNode reportNode) {
+    public void applyModification(Network network, boolean isPlanned, boolean throwException, ReportNode reportNode) {
         // Add the reportNode to the network reportNode context
         network.getReportNodeContext().pushReportNode(reportNode);
 
         // Get the connectable
         Connectable<?> connectable = network.getConnectable(connectableId);
+        if (connectable == null) {
+            logOrThrow(throwException, "Connectable '" + connectableId + "' not found");
+            return;
+        }
 
         // Disconnect the connectable
         boolean hasBeenDisconnected;

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ConnectableConnection.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ConnectableConnection.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.iidm.modification;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.modification.topology.NamingStrategy;
@@ -59,6 +60,10 @@ public class ConnectableConnection extends AbstractNetworkModification {
     public void apply(Network network, NamingStrategy namingStrategy, boolean throwException, ComputationManager computationManager, ReportNode reportNode) {
         // Get the connectable
         Connectable<?> connectable = network.getConnectable(connectableId);
+        if (connectable == null) {
+            logOrThrow(throwException, "Connectable '" + connectableId + "' not found");
+            return;
+        }
 
         // Add the reportNode to the network reportNode context
         network.getReportNodeContext().pushReportNode(reportNode);

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ConnectableConnection.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ConnectableConnection.java
@@ -7,7 +7,6 @@
  */
 package com.powsybl.iidm.modification;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.modification.topology.NamingStrategy;

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/PlannedDisconnection.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/PlannedDisconnection.java
@@ -28,6 +28,6 @@ public class PlannedDisconnection extends AbstractDisconnection {
     @Override
     public void apply(Network network, NamingStrategy namingStrategy, boolean throwException,
                       ComputationManager computationManager, ReportNode reportNode) {
-        applyModification(network, true, reportNode);
+        applyModification(network, true, throwException, reportNode);
     }
 }

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/UnplannedDisconnection.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/UnplannedDisconnection.java
@@ -28,6 +28,6 @@ public class UnplannedDisconnection extends AbstractDisconnection {
     @Override
     public void apply(Network network, NamingStrategy namingStrategy, boolean throwException,
                       ComputationManager computationManager, ReportNode reportNode) {
-        applyModification(network, false, reportNode);
+        applyModification(network, false, throwException, reportNode);
     }
 }

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/ConnectionAndDisconnectionsTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/ConnectionAndDisconnectionsTest.java
@@ -16,7 +16,6 @@ import com.powsybl.iidm.modification.topology.DefaultNamingStrategy;
 import com.powsybl.iidm.modification.topology.NamingStrategy;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.BusbarSectionPositionAdder;
-import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/ConnectionAndDisconnectionsTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/ConnectionAndDisconnectionsTest.java
@@ -7,14 +7,23 @@
  */
 package com.powsybl.iidm.modification;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.computation.ComputationManager;
+import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.modification.topology.AbstractModificationTest;
+import com.powsybl.iidm.modification.topology.DefaultNamingStrategy;
+import com.powsybl.iidm.modification.topology.NamingStrategy;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.BusbarSectionPositionAdder;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
@@ -403,5 +412,62 @@ class ConnectionAndDisconnectionsTest extends AbstractModificationTest {
         modification.apply(network, reportNode);
         writeXmlTest(network, "/network-unplanned-disconnection-not-disconnected.xiidm");
         testReportNode(reportNode, "/reportNode/connectable-not-connected.txt");
+    }
+
+
+    /**
+     * This network modification fails on tie-lines since they are not a connectable
+     */
+    @Test
+    void testExceptions() {
+        Network network = createNetwork();
+
+        // Add tie line
+        DanglingLine nhv1xnode1 = network.getVoltageLevel("VL2").newDanglingLine()
+            .setId("NHV1_XNODE1")
+            .setP0(0.0)
+            .setQ0(0.0)
+            .setR(1.5)
+            .setX(20.0)
+            .setG(1E-6)
+            .setB(386E-6 / 2)
+            .setBus("bus2A")
+            .setPairingKey("XNODE1")
+            .add();
+        DanglingLine xnode1nhv2 = network.getVoltageLevel("VL3").newDanglingLine()
+            .setId("XNODE1_NHV2")
+            .setP0(0.0)
+            .setQ0(0.0)
+            .setR(1.5)
+            .setX(13.0)
+            .setG(2E-6)
+            .setB(386E-6 / 2)
+            .setBus("bus3A")
+            .setPairingKey("XNODE1")
+            .add();
+        network.newTieLine()
+            .setId("NHV1_NHV2_1")
+            .setDanglingLine1(nhv1xnode1.getId())
+            .setDanglingLine2(xnode1nhv2.getId())
+            .add();
+
+        // Disconnection
+        UnplannedDisconnection disconnection = new UnplannedDisconnectionBuilder()
+            .withConnectableId("NHV1_NHV2_1")
+            .withFictitiousSwitchesOperable(false)
+            .build();
+        NamingStrategy namingStrategy = new DefaultNamingStrategy();
+        ComputationManager computationManager = LocalComputationManager.getDefault();
+        PowsyblException disconnectionException = assertThrows(PowsyblException.class, () -> disconnection.apply(network, namingStrategy, true, computationManager, ReportNode.NO_OP));
+        assertEquals("Connectable 'NHV1_NHV2_1' not found", disconnectionException.getMessage());
+
+        // Connection
+        ConnectableConnection connection = new ConnectableConnectionBuilder()
+            .withConnectableId("NHV1_NHV2_1")
+            .withFictitiousSwitchesOperable(false)
+            .withOnlyBreakersOperable(true)
+            .build();
+        PowsyblException connectionException = assertThrows(PowsyblException.class, () -> connection.apply(network, namingStrategy, true, computationManager, ReportNode.NO_OP));
+        assertEquals("Connectable 'NHV1_NHV2_1' not found", connectionException.getMessage());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
If you use for example a ConnectableConnection on a non-existing connectable or on a TieLine (which is not a Connectable), the application of the NetworkModification will crash due to a null pointer exception

**What is the new behavior (if this is a feature change)?**
You will now get a PowsyblException if you apply with `throwException==true` or the Network Modification will not be applied and the error will be logged


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

