### PR TITLE
TerminalsConnectionAction: fix javadoc

### DIFF
--- a/action-api/src/main/java/com/powsybl/action/TerminalsConnectionAction.java
+++ b/action-api/src/main/java/com/powsybl/action/TerminalsConnectionAction.java
@@ -27,9 +27,10 @@ public class TerminalsConnectionAction extends AbstractAction {
 
     /**
      * @param id the id of the action.
-     * @param elementId the id of the element which terminals are operated.
-     *                  The element can be any connectable, including a tie line by referring the terminal of
-     *                  an underlying dangling line.
+     * @param elementId the id of the connectable which terminals are operated.
+     *                  As a tie line (respectively an hvdc line) is not a connectable, opening or closing a tie line
+     *                  (respectively an hvdc line) on both sides is done through two {@link TerminalsConnectionAction},
+     *                  each one referring to one of the underlying dangling lines (respectively converter stations).
      * @param side the side of the element to operate in the action.
      * @param open the status for the terminal to operate. {@code true} means terminal opening.
      */
@@ -42,9 +43,10 @@ public class TerminalsConnectionAction extends AbstractAction {
 
     /**
      * @param id the id of the action.
-     * @param elementId the id of the element which terminals are operated.
-     *                  The element can be any connectable, including a tie line by referring the terminal of
-     *                  an underlying dangling line.
+     * @param elementId the id of the connectable which terminals are operated.
+     *                  As a tie line (respectively an hvdc line) is not a connectable, opening or closing a tie line
+     *                  (respectively an hvdc line) on both sides is done through two {@link TerminalsConnectionAction},
+     *                  each one referring to one of the underlying dangling lines (respectively converter stations).
      * @param open the status for all the terminals of the element to operate. {@code true} means all terminals opening.
      */
     public TerminalsConnectionAction(String id, String elementId, boolean open) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Javadoc fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Reading the javadoc, you can think that it is possible to use a `TerminalsConnectionAction` to connect or disconnect a tie line or an HVDC line.


**What is the new behavior (if this is a feature change)?**
The javadoc explicitly states that a `TerminalsConnectionAction` can NOT be use to connect or disconnect a tie line or an HVDC line, since they are not `Connectable`s.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
