### PR TITLE
Fix area boundary auto-removal with merged and detached Networks

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AreaImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AreaImpl.java
@@ -48,9 +48,19 @@ public class AreaImpl extends AbstractIdentifiable<Area> implements Area {
         }
     }
 
+    /**
+     * Must be called whenever the Area is moved to a different root Network when merging and detaching.
+     * @param fromNetwork previous root network
+     * @param toNetwork new root network
+     */
+    void moveListener(NetworkImpl fromNetwork, NetworkImpl toNetwork) {
+        fromNetwork.removeListener(this.areaListener);
+        toNetwork.addListener(this.areaListener);
+    }
+
     private final NetworkListener areaListener;
 
-    public AreaImpl(Ref<NetworkImpl> ref, Ref<SubnetworkImpl> subnetworkRef, String id, String name, boolean fictitious, String areaType,
+    AreaImpl(Ref<NetworkImpl> ref, Ref<SubnetworkImpl> subnetworkRef, String id, String name, boolean fictitious, String areaType,
                     double acInterchangeTarget) {
         super(id, name, fictitious);
         this.networkRef = Objects.requireNonNull(ref);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -1018,6 +1018,11 @@ public class NetworkImpl extends AbstractNetwork implements VariantManagerHolder
 
         checkMergeability(otherNetwork);
 
+        otherNetwork.getAreaStream().forEach(a -> {
+            AreaImpl area = (AreaImpl) a;
+            area.moveListener(otherNetwork, this);
+        });
+
         // try to find dangling lines couples
         List<DanglingLinePair> lines = new ArrayList<>();
         Map<String, List<DanglingLine>> dl1byPairingKey = new HashMap<>();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubnetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SubnetworkImpl.java
@@ -805,7 +805,7 @@ public class SubnetworkImpl extends AbstractNetwork {
         transferExtensions(this, detachedNetwork);
         transferProperties(this, detachedNetwork);
 
-        // Memorize the network identifiables/voltageAngleLimits before moving references (to use them latter)
+        // Memorize the network identifiables/voltageAngleLimits before moving references (to use them later)
         Collection<Identifiable<?>> identifiables = getIdentifiables();
         Iterable<VoltageAngleLimit> vals = getVoltageAngleLimits();
 
@@ -830,6 +830,11 @@ public class SubnetworkImpl extends AbstractNetwork {
             previousRootNetwork.getVoltageAngleLimitsIndex().remove(val.getId());
             detachedNetwork.getVoltageAngleLimitsIndex().put(val.getId(), val);
         }
+
+        detachedNetwork.getAreaStream().forEach(a -> {
+            AreaImpl area = (AreaImpl) a;
+            area.moveListener(previousRootNetwork, detachedNetwork);
+        });
 
         // We don't control that regulating terminals and phase/ratio regulation terminals are in the same subnetwork
         // as their network elements (generators, PSTs, ...). It is unlikely that those terminals and their elements


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

**What is the current behavior?**
<!-- You can also link to an open issue here -->
In #2955 listeners were implemented to automatically delete area boundaries when the undelying equipment is removed from the network (e.g. DanglingLine removal). This was done using "cleanup" listeners. However when performing network merge or detach, the listeners are lost / not transfered to the new root network of the Areas.


**What is the new behavior (if this is a feature change)?**
The "cleanup" listeners are properly moved to the new root Network when merging and detaching.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
This is very similar to #3076, although here it is not about iIDM extensions.
I originally wanted to add notification mechanism for merging and detaching, but obviously this wouldn't work because manipulating listeners within listeners isn't the right approach (ConcurrentModificationException).
I made few specific code dedicated to Area only. When iIDM will be improved to deal with equipment removal & cleanup in a generic way, this would be revisited.
