### PR TITLE
Datasource: add mainExtension, existsStrict and use it in exists() methods of importers [WIP]

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -190,6 +190,11 @@ public class CgmesImport implements Importer {
         }
 
         @Override
+        public boolean existsStrict(String suffix, String ext) throws IOException {
+            return ds.existsStrict(suffix, ext) && filter.test(DataSourceUtil.getFileName(getBaseName(), suffix, ext));
+        }
+
+        @Override
         public boolean exists(String fileName) throws IOException {
             return ds.exists(fileName) && filter.test(fileName);
         }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/BusbarSectionConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/BusbarSectionConversionTest.java
@@ -25,7 +25,7 @@ class BusbarSectionConversionTest extends AbstractSerDeTest {
     @Test
     void isolatedBusbarSectionWithoutTopologicalNodeInBusBreakerModelTest() {
         Network network = Network.read(
-                new ResourceDataSource("bbs-busbreaker",
+                new ResourceDataSource("",
                 new ResourceSet("/", "bbs-busbreaker_EQ.xml", "bbs-busbreaker_TP_withoutTN.xml")));
         // The network can be imported without any issue
         assertNotNull(network);
@@ -39,7 +39,7 @@ class BusbarSectionConversionTest extends AbstractSerDeTest {
     @Test
     void isolatedBusbarSectionWithoutLinkToTopologicalNodeInBusBreakerModelTest() {
         Network network = Network.read(
-                new ResourceDataSource("bbs-busbreaker",
+                new ResourceDataSource("",
                         new ResourceSet("/", "bbs-busbreaker_EQ.xml", "bbs-busbreaker_TP_withoutLinkToTN.xml")));
         // The network can be imported without any issue
         assertNotNull(network);
@@ -55,7 +55,7 @@ class BusbarSectionConversionTest extends AbstractSerDeTest {
     @Test
     void isolatedBusbarSectionWithTopologicalNodeInBusBreakerModelTest() {
         Network network = Network.read(
-                new ResourceDataSource("bbs-busbreaker",
+                new ResourceDataSource("",
                 new ResourceSet("/", "bbs-busbreaker_EQ.xml", "bbs-busbreaker_TP.xml")));
         // The network can be imported without any issue
         assertNotNull(network);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
@@ -141,7 +141,7 @@ public class ConversionTester {
                 exportCgmes(gm.name(), impl, network);
             }
             if (testExportImportCgmes) {
-                testExportImportCgmes(network, ds, fs, i, iparams, config);
+                testExportImportCgmes(gm.name(), network, ds, fs, i, iparams, config);
             }
             if (validateBusBalances) {
                 validateBusBalances(network);
@@ -186,7 +186,7 @@ public class ConversionTester {
                 .orElse("unknown");
     }
 
-    private void testExportImportCgmes(Network network, ReadOnlyDataSource originalDs, FileSystem fs, CgmesImport i, Properties iparams,
+    private void testExportImportCgmes(String namee, Network network, ReadOnlyDataSource originalDs, FileSystem fs, CgmesImport i, Properties iparams,
                                        ComparisonConfig config) throws IOException {
 
         // We copy everything from the original data source to the temporary destination with a normalized name
@@ -196,7 +196,7 @@ public class ConversionTester {
         // Create a temporary directory to store the exported files
         Path path = fs.getPath("temp-export-cgmes");
         Files.createDirectories(path);
-        String baseName = originalDs.getBaseName();
+        String baseName = namee;
         DataSource ds = new ZipFileDataSource(path, baseName);
 
         // Copy the original files to the temporary destination, ensuring a normalized name

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/GroundConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/GroundConversionTest.java
@@ -55,7 +55,7 @@ class GroundConversionTest extends AbstractSerDeTest {
         Properties importParams = new Properties();
         importParams.put(CgmesImport.POST_PROCESSORS, "RemoveGrounds");
         Network network = Network.read(
-                new ResourceDataSource("groundTest.xml", new ResourceSet("/", "groundTest.xml")),
+                new ResourceDataSource("groundTest", new ResourceSet("/", "groundTest.xml")),
                 importParams);
 
         assertEquals(0, network.getGroundCount());

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
@@ -1217,7 +1217,7 @@ class EquipmentExportTest extends AbstractSerDeTest {
         Path exportedEq = exportToCgmesEQ(expected, transformersWithHighestVoltageAtEnd1);
 
         // From reference data source we use only boundaries
-        Path repackaged = tmpDir.resolve("repackaged.zip");
+        Path repackaged = tmpDir.resolve("test.zip");
         Repackager r = new Repackager(dataSource)
                 .with("test_EQ.xml", exportedEq);
         if (importTP) {

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/StateVariablesExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/StateVariablesExportTest.java
@@ -614,7 +614,7 @@ class StateVariablesExportTest extends AbstractSerDeTest {
         }
 
         // Zip with new SV (and eventually a new TP)
-        Path repackaged = tmpDir.resolve("repackaged.zip");
+        Path repackaged = tmpDir.resolve("test.zip");
         Repackager r = new Repackager(dataSource)
                 .with("test_SV.xml", exportedSv)
                 .with("test_EQ_BD.xml", Repackager::eqBd)

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/SteadyStateHypothesisExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/SteadyStateHypothesisExportTest.java
@@ -141,7 +141,7 @@ class SteadyStateHypothesisExportTest extends AbstractSerDeTest {
         }
 
         // Zip with new SSH
-        Path repackaged = tmpDir.resolve("repackaged.zip");
+        Path repackaged = tmpDir.resolve("test.zip");
         Repackager r = new Repackager(dataSource)
                 .with("test_EQ.xml", Repackager::eq)
                 .with("test_TP.xml", Repackager::tp)

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/TopologyExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/TopologyExportTest.java
@@ -78,7 +78,7 @@ class TopologyExportTest extends AbstractSerDeTest {
         }
 
         // Zip with new TP
-        Path repackaged = tmpDir.resolve("repackaged.zip");
+        Path repackaged = tmpDir.resolve("test.zip");
         Repackager r = new Repackager(dataSource)
                 .with("test_EQ.xml", Repackager::eq)
                 .with("test_TP.xml", exportedTp)

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -33,6 +33,14 @@ public class CgmesOnDataSource {
     }
 
     public boolean exists() {
+        // The user has requested a basename but we need unrestricted access to all files, abort
+        try {
+            if (!dataSource().getBaseName().isEmpty() && !(dataSource().existsStrict(null, "xml") || dataSource().existsStrict("_EQ", "xml") || dataSource().existsStrict("_SV", "xml"))) {
+                return false;
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         // check that RDF and CIM16 are defined as namespaces in the data source
         Set<String> foundNamespaces = namespaces();
         if (!foundNamespaces.contains(RDF_NAMESPACE)) {

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/GridModelReferenceResources.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/GridModelReferenceResources.java
@@ -33,7 +33,7 @@ public class GridModelReferenceResources extends AbstractGridModelReference {
 
     @Override
     public ReadOnlyDataSource dataSource() {
-        ReadOnlyDataSource ds = new ResourceDataSource(baseNameFromResourceNames(), resourceSets);
+        ReadOnlyDataSource ds = new ResourceDataSource("", resourceSets);
         if (LOG.isInfoEnabled()) {
             try {
                 LOG.info("List of names in data source for {} = {}", name(), Arrays.toString(ds.listNames(".*").toArray()));

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class CgmesOnDataSourceTest {
 
     private static void doTestExists(String filename, String cimVersion, boolean expectedExists) {
-        ReadOnlyDataSource dataSource = new ResourceDataSource("incomplete",
+        ReadOnlyDataSource dataSource = new ResourceDataSource("",
                 new ResourceSet("/", filename));
         CgmesOnDataSource cgmesOnDataSource = new CgmesOnDataSource(dataSource);
         boolean exists = "14".equals(cimVersion) ? cgmesOnDataSource.existsCim14() : cgmesOnDataSource.exists();

--- a/commons/src/main/java/com/powsybl/commons/datasource/Bzip2FileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/Bzip2FileDataSource.java
@@ -18,6 +18,10 @@ import java.nio.file.Path;
  */
 public class Bzip2FileDataSource extends FileDataSource {
 
+    public Bzip2FileDataSource(Path directory, String baseName, String mainExtension, DataSourceObserver observer) {
+        super(directory, baseName, mainExtension, observer);
+    }
+
     public Bzip2FileDataSource(Path directory, String baseName, DataSourceObserver observer) {
         super(directory, baseName, observer);
     }

--- a/commons/src/main/java/com/powsybl/commons/datasource/FileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/FileDataSource.java
@@ -29,15 +29,22 @@ public class FileDataSource implements DataSource {
 
     private final String baseName;
 
+    private final String mainExtension;
+
     private final DataSourceObserver observer;
 
     public FileDataSource(Path directory, String baseName) {
-        this(directory, baseName, null);
+        this(directory, baseName, "", null);
     }
 
     public FileDataSource(Path directory, String baseName, DataSourceObserver observer) {
+        this(directory, baseName, "", observer);
+    }
+
+    public FileDataSource(Path directory, String baseName, String mainExtension, DataSourceObserver observer) {
         this.directory = Objects.requireNonNull(directory);
         this.baseName = Objects.requireNonNull(baseName);
+        this.mainExtension = Objects.requireNonNull(mainExtension);
         this.observer = observer;
     }
 
@@ -115,4 +122,10 @@ public class FileDataSource implements DataSource {
                     .collect(Collectors.toSet());
         }
     }
+
+    @Override
+    public boolean existsStrict(String suffix, String ext) throws IOException {
+        return (mainExtension.isEmpty() || mainExtension.equals(ext)) && exists(suffix, ext);
+    }
+
 }

--- a/commons/src/main/java/com/powsybl/commons/datasource/GenericReadOnlyDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/GenericReadOnlyDataSource.java
@@ -60,6 +60,16 @@ public class GenericReadOnlyDataSource implements ReadOnlyDataSource {
     }
 
     @Override
+    public boolean existsStrict(String suffix, String ext) throws IOException {
+        for (ReadOnlyDataSource dataSource : dataSources) {
+            if (dataSource.existsStrict(suffix, ext)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean exists(String fileName) throws IOException {
         for (ReadOnlyDataSource dataSource : dataSources) {
             if (dataSource.exists(fileName)) {

--- a/commons/src/main/java/com/powsybl/commons/datasource/GzFileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/GzFileDataSource.java
@@ -19,6 +19,10 @@ import java.util.zip.GZIPOutputStream;
  */
 public class GzFileDataSource extends FileDataSource {
 
+    public GzFileDataSource(Path directory, String baseName, String mainExtension, DataSourceObserver observer) {
+        super(directory, baseName, mainExtension, observer);
+    }
+
     public GzFileDataSource(Path directory, String baseName, DataSourceObserver observer) {
         super(directory, baseName, observer);
     }

--- a/commons/src/main/java/com/powsybl/commons/datasource/MultipleReadOnlyDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/MultipleReadOnlyDataSource.java
@@ -52,6 +52,17 @@ public class MultipleReadOnlyDataSource implements ReadOnlyDataSource {
     }
 
     @Override
+    public boolean existsStrict(String suffix, String ext) throws IOException {
+        return dataSources.stream().anyMatch(dataSource -> {
+            try {
+                return dataSource.existsStrict(suffix, ext);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
+    @Override
     public boolean exists(String fileName) throws IOException {
         return dataSources.stream().anyMatch(dataSource -> {
             try {

--- a/commons/src/main/java/com/powsybl/commons/datasource/ReadOnlyDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/ReadOnlyDataSource.java
@@ -22,6 +22,8 @@ public interface ReadOnlyDataSource {
 
     boolean exists(String fileName) throws IOException;
 
+    boolean existsStrict(String suffix, String ext) throws IOException;
+
     InputStream newInputStream(String suffix, String ext) throws IOException;
 
     InputStream newInputStream(String fileName) throws IOException;

--- a/commons/src/main/java/com/powsybl/commons/datasource/ReadOnlyMemDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/ReadOnlyMemDataSource.java
@@ -29,12 +29,19 @@ public class ReadOnlyMemDataSource implements ReadOnlyDataSource {
 
     private final String baseName;
 
+    private final String mainExtension;
+
     public ReadOnlyMemDataSource() {
-        this("");
+        this("", "");
     }
 
     public ReadOnlyMemDataSource(String baseName) {
+        this(baseName, "");
+    }
+
+    public ReadOnlyMemDataSource(String baseName, String mainExtension) {
         this.baseName = Objects.requireNonNull(baseName);
+        this.mainExtension = Objects.requireNonNull(mainExtension);
     }
 
     public byte[] getData(String suffix, String ext) {
@@ -65,6 +72,11 @@ public class ReadOnlyMemDataSource implements ReadOnlyDataSource {
     @Override
     public boolean exists(String suffix, String ext) throws IOException {
         return exists(DataSourceUtil.getFileName(baseName, suffix, ext));
+    }
+
+    @Override
+    public boolean existsStrict(String suffix, String ext) throws IOException {
+        return (mainExtension.isEmpty() || mainExtension.equals(ext)) && exists(suffix, ext);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/datasource/ResourceDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/ResourceDataSource.java
@@ -22,6 +22,8 @@ public class ResourceDataSource implements ReadOnlyDataSource {
 
     private final String baseName;
 
+    private final String mainExtension;
+
     private final List<ResourceSet> resourceSets;
 
     public ResourceDataSource(String baseName, ResourceSet... resourceSets) {
@@ -29,7 +31,12 @@ public class ResourceDataSource implements ReadOnlyDataSource {
     }
 
     public ResourceDataSource(String baseName, List<ResourceSet> resourceSets) {
+        this(baseName, "", resourceSets);
+    }
+
+    public ResourceDataSource(String baseName, String mainExtension, List<ResourceSet> resourceSets) {
         this.baseName = Objects.requireNonNull(baseName);
+        this.mainExtension = Objects.requireNonNull(mainExtension);
         this.resourceSets = Objects.requireNonNull(resourceSets);
     }
 
@@ -41,6 +48,11 @@ public class ResourceDataSource implements ReadOnlyDataSource {
     @Override
     public boolean exists(String suffix, String ext) {
         return exists(DataSourceUtil.getFileName(baseName, suffix, ext));
+    }
+
+    @Override
+    public boolean existsStrict(String suffix, String ext) {
+        return (mainExtension.isEmpty() || mainExtension.equals(ext)) && exists(suffix, ext);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/datasource/XZFileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/XZFileDataSource.java
@@ -18,6 +18,10 @@ import java.nio.file.Path;
  */
 public class XZFileDataSource extends FileDataSource {
 
+    public XZFileDataSource(Path directory, String baseName, String mainExtension, DataSourceObserver observer) {
+        super(directory, baseName, mainExtension, observer);
+    }
+
     public XZFileDataSource(Path directory, String baseName, DataSourceObserver observer) {
         super(directory, baseName, observer);
     }

--- a/commons/src/main/java/com/powsybl/commons/datasource/ZipFileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/ZipFileDataSource.java
@@ -38,13 +38,20 @@ public class ZipFileDataSource implements DataSource {
 
     private final String baseName;
 
+    private final String mainExtension;
+
     private final DataSourceObserver observer;
 
-    public ZipFileDataSource(Path directory, String zipFileName, String baseName, DataSourceObserver observer) {
+    public ZipFileDataSource(Path directory, String zipFileName, String baseName, String mainExtension, DataSourceObserver observer) {
         this.directory = Objects.requireNonNull(directory);
         this.zipFileName = Objects.requireNonNull(zipFileName);
         this.baseName = Objects.requireNonNull(baseName);
+        this.mainExtension = Objects.requireNonNull(mainExtension);
         this.observer = observer;
+    }
+
+    public ZipFileDataSource(Path directory, String zipFileName, String baseName, DataSourceObserver observer) {
+        this(directory, zipFileName, baseName, "", observer);
     }
 
     public ZipFileDataSource(Path directory, String zipFileName, String baseName) {
@@ -75,6 +82,11 @@ public class ZipFileDataSource implements DataSource {
     @Override
     public boolean exists(String suffix, String ext) throws IOException {
         return exists(DataSourceUtil.getFileName(baseName, suffix, ext));
+    }
+
+    @Override
+    public boolean existsStrict(String suffix, String ext) throws IOException {
+        return (mainExtension.isEmpty() || mainExtension.equals(ext)) && exists(suffix, ext);
     }
 
     private static boolean entryExists(Path zipFilePath, String fileName) {

--- a/commons/src/main/java/com/powsybl/commons/datasource/ZstdFileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/ZstdFileDataSource.java
@@ -18,6 +18,10 @@ import java.nio.file.Path;
  */
 public class ZstdFileDataSource extends FileDataSource {
 
+    public ZstdFileDataSource(Path directory, String baseName, String mainExtension, DataSourceObserver observer) {
+        super(directory, baseName, mainExtension, observer);
+    }
+
     public ZstdFileDataSource(Path directory, String baseName, DataSourceObserver observer) {
         super(directory, baseName, observer);
     }

--- a/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
+++ b/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
@@ -80,7 +80,7 @@ public class IeeeCdfImporter implements Importer {
     @Override
     public boolean exists(ReadOnlyDataSource dataSource) {
         try {
-            if (dataSource.exists(null, EXT)) {
+            if (dataSource.existsStrict(null, EXT)) {
                 try (BufferedReader reader = new BufferedReader(new InputStreamReader(dataSource.newInputStream(null, EXT)))) {
                     String titleLine = reader.readLine();
                     if (titleLine != null) {

--- a/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/TestImporter.java
+++ b/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/TestImporter.java
@@ -34,7 +34,7 @@ public class TestImporter implements Importer {
     @Override
     public boolean exists(ReadOnlyDataSource dataSource) {
         try {
-            return dataSource == null || dataSource.exists(null, "tst");
+            return dataSource == null || dataSource.existsStrict(null, "tst");
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTreeDataImporter.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTreeDataImporter.java
@@ -97,7 +97,7 @@ public abstract class AbstractTreeDataImporter implements Importer {
 
     private String findExtension(ReadOnlyDataSource dataSource) throws IOException {
         for (String ext : getExtensions()) {
-            if (dataSource.exists(null, ext)) {
+            if (dataSource.existsStrict(null, ext)) {
                 return ext;
             }
         }

--- a/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
+++ b/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
@@ -516,7 +516,7 @@ public class MatpowerImporter implements Importer {
     @Override
     public boolean exists(ReadOnlyDataSource dataSource) {
         try {
-            return dataSource.exists(null, MatpowerConstants.EXT);
+            return dataSource.existsStrict(null, MatpowerConstants.EXT);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/PowerFactoryImporter.java
+++ b/powerfactory/powerfactory-converter/src/main/java/com/powsybl/powerfactory/converter/PowerFactoryImporter.java
@@ -64,7 +64,7 @@ public class PowerFactoryImporter implements Importer {
     private Optional<PowerFactoryDataLoader<StudyCase>> findProjectLoader(ReadOnlyDataSource dataSource) {
         for (PowerFactoryDataLoader<StudyCase> studyCaseLoader : PowerFactoryDataLoader.find(StudyCase.class)) {
             try {
-                if (dataSource.exists(null, studyCaseLoader.getExtension())) {
+                if (dataSource.existsStrict(null, studyCaseLoader.getExtension())) {
                     return Optional.of(studyCaseLoader);
                 }
             } catch (IOException e) {

--- a/psse/psse-converter/src/main/java/com/powsybl/psse/converter/PsseImporter.java
+++ b/psse/psse-converter/src/main/java/com/powsybl/psse/converter/PsseImporter.java
@@ -83,7 +83,7 @@ public class PsseImporter implements Importer {
 
     private String findExtension(ReadOnlyDataSource dataSource) throws IOException {
         for (String ext : EXTENSIONS) {
-            if (dataSource.exists(null, ext)) {
+            if (dataSource.existsStrict(null, ext)) {
                 return ext;
             }
         }

--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
@@ -951,7 +951,7 @@ public class UcteImporter implements Importer {
 
     private String findExtension(ReadOnlyDataSource dataSource, boolean throwException) throws IOException {
         for (String ext : EXTENSIONS) {
-            if (dataSource.exists(null, ext)) {
+            if (dataSource.existsStrict(null, ext)) {
                 return ext;
             }
         }


### PR DESCRIPTION
This allows to import the correct network when a path is provided, the importers will respect the full path and not declare that they can import from the datasource TODO explain more

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
