### PR TITLE
Add historical versions of voltageRegulation xsd for compatibility purposes

### DIFF
--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/VoltageRegulationSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/VoltageRegulationSerDe.java
@@ -32,28 +32,43 @@ import java.util.Objects;
 public class VoltageRegulationSerDe extends AbstractVersionableNetworkExtensionSerDe<Battery, VoltageRegulation> {
 
     public VoltageRegulationSerDe() {
-        super("voltageRegulation", VoltageRegulation.class, "vr",
+        super(VoltageRegulation.NAME, VoltageRegulation.class, "vr",
                 ImmutableMap.<IidmVersion, ImmutableSortedSet<String>>builder()
                         .put(IidmVersion.V_1_0, ImmutableSortedSet.of("1.0", "1.0-legacy"))
                         .put(IidmVersion.V_1_1, ImmutableSortedSet.of("1.1"))
-                        .put(IidmVersion.V_1_2, ImmutableSortedSet.of("1.1"))
-                        .put(IidmVersion.V_1_3, ImmutableSortedSet.of("1.1"))
-                        .put(IidmVersion.V_1_4, ImmutableSortedSet.of("1.1"))
-                        .put(IidmVersion.V_1_5, ImmutableSortedSet.of("1.1"))
-                        .put(IidmVersion.V_1_6, ImmutableSortedSet.of("1.1"))
-                        .put(IidmVersion.V_1_7, ImmutableSortedSet.of("1.1"))
-                        .put(IidmVersion.V_1_8, ImmutableSortedSet.of("1.1"))
-                        .put(IidmVersion.V_1_9, ImmutableSortedSet.of("1.1"))
-                        .put(IidmVersion.V_1_10, ImmutableSortedSet.of("1.1"))
-                        .put(IidmVersion.V_1_11, ImmutableSortedSet.of("1.1"))
-                        .put(IidmVersion.V_1_12, ImmutableSortedSet.of("1.1"))
+                        .put(IidmVersion.V_1_2, reversedNaturalOrderOf("1.1", "1.2"))
+                        .put(IidmVersion.V_1_3, reversedNaturalOrderOf("1.1", "1.3"))
+                        .put(IidmVersion.V_1_4, reversedNaturalOrderOf("1.1", "1.4"))
+                        .put(IidmVersion.V_1_5, reversedNaturalOrderOf("1.1", "1.5"))
+                        .put(IidmVersion.V_1_6, reversedNaturalOrderOf("1.1", "1.6"))
+                        .put(IidmVersion.V_1_7, reversedNaturalOrderOf("1.1", "1.7"))
+                        .put(IidmVersion.V_1_8, reversedNaturalOrderOf("1.1", "1.8"))
+                        .put(IidmVersion.V_1_9, reversedNaturalOrderOf("1.1", "1.9"))
+                        .put(IidmVersion.V_1_10, reversedNaturalOrderOf("1.1", "1.10"))
+                        .put(IidmVersion.V_1_11, reversedNaturalOrderOf("1.1", "1.11"))
+                        .put(IidmVersion.V_1_12, reversedNaturalOrderOf("1.1", "1.12"))
                         .put(IidmVersion.V_1_13, ImmutableSortedSet.of("1.1"))
                         .build(),
                 ImmutableMap.<String, String>builder()
                         .put("1.0", "http://www.itesla_project.eu/schema/iidm/ext/voltage_regulation/1_0")
                         .put("1.0-legacy", "http://www.itesla_project.eu/schema/iidm/ext/voltageregulation/1_0")
                         .put("1.1", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_1")
+                        .put("1.2", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_2")
+                        .put("1.3", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_3")
+                        .put("1.4", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_4")
+                        .put("1.5", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_5")
+                        .put("1.6", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_6")
+                        .put("1.7", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_7")
+                        .put("1.8", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_8")
+                        .put("1.9", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_9")
+                        .put("1.10", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_10")
+                        .put("1.11", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_11")
+                        .put("1.12", "http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_12")
                         .build());
+    }
+
+    private static ImmutableSortedSet<String> reversedNaturalOrderOf(String... versions) {
+        return ImmutableSortedSet.<String>reverseOrder().add(versions).build();
     }
 
     @Override
@@ -63,9 +78,20 @@ public class VoltageRegulationSerDe extends AbstractVersionableNetworkExtensionS
 
     @Override
     public List<InputStream> getXsdAsStreamList() {
-        return List.of(getClass().getResourceAsStream("/xsd/voltageRegulation_V1_0.xsd"),
-                getClass().getResourceAsStream("/xsd/voltageRegulation_V1_0_legacy.xsd"),
-                getClass().getResourceAsStream("/xsd/voltageRegulation_V1_1.xsd"));
+        return List.of(Objects.requireNonNull(getClass().getResourceAsStream("/xsd/voltageRegulation_V1_0.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/voltageRegulation_V1_0_legacy.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/voltageRegulation_V1_1.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/compatibility/voltage_regulation/voltageRegulation_V1_2.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/compatibility/voltage_regulation/voltageRegulation_V1_3.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/compatibility/voltage_regulation/voltageRegulation_V1_4.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/compatibility/voltage_regulation/voltageRegulation_V1_5.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/compatibility/voltage_regulation/voltageRegulation_V1_6.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/compatibility/voltage_regulation/voltageRegulation_V1_7.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/compatibility/voltage_regulation/voltageRegulation_V1_8.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/compatibility/voltage_regulation/voltageRegulation_V1_9.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/compatibility/voltage_regulation/voltageRegulation_V1_10.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/compatibility/voltage_regulation/voltageRegulation_V1_11.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/compatibility/voltage_regulation/voltageRegulation_V1_12.xsd")));
     }
 
     @Override

--- a/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_10.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_10.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_10"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_10"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_10" schemaLocation="../../iidm_V1_10.xsd"/>
+    <xs:element name="voltageRegulation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminalRef" minOccurs="0" type="iidm:TerminalRef"/>
+            </xs:sequence>
+            <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+            <xs:attribute name="targetV" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_11.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_11.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_11"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_11"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_11" schemaLocation="../../iidm_V1_11.xsd"/>
+    <xs:element name="voltageRegulation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminalRef" minOccurs="0" type="iidm:TerminalRef"/>
+            </xs:sequence>
+            <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+            <xs:attribute name="targetV" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_12.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_12.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_12"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_12"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_12" schemaLocation="../../iidm_V1_12.xsd"/>
+    <xs:element name="voltageRegulation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminalRef" minOccurs="0" type="iidm:TerminalRef"/>
+            </xs:sequence>
+            <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+            <xs:attribute name="targetV" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_2.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_2.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_2"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_2" schemaLocation="../../iidm_V1_2.xsd"/>
+    <xs:element name="voltageRegulation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminalRef" minOccurs="0" type="iidm:TerminalRef"/>
+            </xs:sequence>
+            <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+            <xs:attribute name="targetV" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_3.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_3.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_3"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_3"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_3" schemaLocation="../../iidm_V1_3.xsd"/>
+    <xs:element name="voltageRegulation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminalRef" minOccurs="0" type="iidm:TerminalRef"/>
+            </xs:sequence>
+            <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+            <xs:attribute name="targetV" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_4.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_4.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_4"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_4"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_4" schemaLocation="../../iidm_V1_4.xsd"/>
+    <xs:element name="voltageRegulation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminalRef" minOccurs="0" type="iidm:TerminalRef"/>
+            </xs:sequence>
+            <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+            <xs:attribute name="targetV" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_5.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_5.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_5"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_5"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_5" schemaLocation="../../iidm_V1_5.xsd"/>
+    <xs:element name="voltageRegulation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminalRef" minOccurs="0" type="iidm:TerminalRef"/>
+            </xs:sequence>
+            <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+            <xs:attribute name="targetV" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_6.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_6.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_6"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_6" schemaLocation="../../iidm_V1_6.xsd"/>
+    <xs:element name="voltageRegulation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminalRef" minOccurs="0" type="iidm:TerminalRef"/>
+            </xs:sequence>
+            <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+            <xs:attribute name="targetV" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_7.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_7.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_7"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_7" schemaLocation="../../iidm_V1_7.xsd"/>
+    <xs:element name="voltageRegulation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminalRef" minOccurs="0" type="iidm:TerminalRef"/>
+            </xs:sequence>
+            <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+            <xs:attribute name="targetV" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_8.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_8.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_8"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_8" schemaLocation="../../iidm_V1_8.xsd"/>
+    <xs:element name="voltageRegulation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminalRef" minOccurs="0" type="iidm:TerminalRef"/>
+            </xs:sequence>
+            <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+            <xs:attribute name="targetV" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_9.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/compatibility/voltage_regulation/voltageRegulation_V1_9.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:iidm="http://www.powsybl.org/schema/iidm/1_9"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_9"
+           elementFormDefault="qualified">
+    <xs:import namespace="http://www.powsybl.org/schema/iidm/1_9" schemaLocation="../../iidm_V1_9.xsd"/>
+    <xs:element name="voltageRegulation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="terminalRef" minOccurs="0" type="iidm:TerminalRef"/>
+            </xs:sequence>
+            <xs:attribute name="voltageRegulatorOn" use="required" type="xs:boolean"/>
+            <xs:attribute name="targetV" type="xs:double"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/test/VoltageRegulationSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/test/VoltageRegulationSerDeTest.java
@@ -14,7 +14,10 @@ import com.powsybl.iidm.network.extensions.VoltageRegulation;
 import com.powsybl.iidm.network.extensions.VoltageRegulationAdder;
 import com.powsybl.iidm.network.test.BatteryNetworkFactory;
 import com.powsybl.iidm.serde.AbstractIidmSerDeTest;
+import com.powsybl.iidm.serde.ExportOptions;
 import com.powsybl.iidm.serde.IidmSerDeConstants;
+import com.powsybl.iidm.serde.IidmVersion;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -26,28 +29,37 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  * @author Coline Piloquet {@literal <coline.piloquet@rte-france.fr>}
  */
 class VoltageRegulationSerDeTest extends AbstractIidmSerDeTest {
-    @Test
-    void test() throws IOException {
-        Network network = BatteryNetworkFactory.create();
+
+    private static Network network;
+
+    @BeforeAll
+    static void init() {
+        network = BatteryNetworkFactory.create();
         Generator gen = network.getGenerator("GEN");
 
         Battery bat = network.getBattery("BAT");
         assertNotNull(bat);
         bat.newExtension(VoltageRegulationAdder.class)
-            .withVoltageRegulatorOn(true)
-            .withTargetV(100.0)
-            .add();
+                .withVoltageRegulatorOn(true)
+                .withTargetV(100.0)
+                .add();
 
         Battery bat2 = network.getBattery("BAT2");
         assertNotNull(bat2);
         bat2.newExtension(VoltageRegulationAdder.class)
-            .withRegulatingTerminal(gen.getTerminal())
-            .withVoltageRegulatorOn(true)
-            .withTargetV(100)
-            .add();
+                .withRegulatingTerminal(gen.getTerminal())
+                .withVoltageRegulatorOn(true)
+                .withTargetV(100)
+                .add();
+    }
 
+    @Test
+    void test() throws IOException {
         Network network2 = allFormatsRoundTripTest(network, "voltageRegulationRoundTripRef.xml", IidmSerDeConstants.CURRENT_IIDM_VERSION);
+        assertExtension(network2);
+    }
 
+    private static void assertExtension(Network network2) {
         VoltageRegulation voltageRegulationXml = network2.getBattery("BAT").getExtension(VoltageRegulation.class);
         assertNotNull(voltageRegulationXml);
         assertEquals(100.0, voltageRegulationXml.getTargetV(), 0);
@@ -57,5 +69,18 @@ class VoltageRegulationSerDeTest extends AbstractIidmSerDeTest {
         VoltageRegulation voltageRegulationXml2 = network2.getBattery("BAT2").getExtension(VoltageRegulation.class);
         assertNotNull(voltageRegulationXml);
         assertSame(network2.getGenerator("GEN").getTerminal(), voltageRegulationXml2.getRegulatingTerminal());
+    }
+
+    @Test
+    void testOlderVersion() throws IOException {
+        // Round trip with default extension version (v1_1)
+        Network network2 = allFormatsRoundTripTest(network, "voltageRegulationRoundTripRef.xml", IidmVersion.V_1_12);
+        assertExtension(network2);
+
+        // Import then export with version v1_12
+        ExportOptions exportOptions = new ExportOptions();
+        exportOptions.addExtensionVersion(VoltageRegulation.NAME, "1.12");
+        Network network3 = allFormatsRoundTripTest(network, "voltageRegulationCompatibilityVersion.xml", IidmVersion.V_1_12, exportOptions);
+        assertExtension(network3);
     }
 }

--- a/iidm/iidm-serde/src/test/resources/V1_12/voltageRegulationCompatibilityVersion.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_12/voltageRegulationCompatibilityVersion.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_12" xmlns:vr="http://www.powsybl.org/schema/iidm/ext/voltage_regulation/1_12" id="fictitious" caseDate="2017-06-25T17:43:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="R" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.0" q="-225.0">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="R" geographicalTags="B">
+        <iidm:voltageLevel id="VLBAT" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NBAT"/>
+            </iidm:busBreakerTopology>
+            <iidm:battery id="BAT" targetP="9999.99" targetQ="9999.99" minP="-9999.99" maxP="9999.99" bus="NBAT" connectableBus="NBAT" p="-605.0" q="-225.0">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:battery>
+            <iidm:battery id="BAT2" targetP="100.0" targetQ="200.0" minP="-200.0" maxP="200.0" bus="NBAT" connectableBus="NBAT" p="-605.0" q="-225.0">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>
+                    <iidm:point p="70.0" minQ="-54.55" maxQ="46.25"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:battery>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NBAT" connectableBus="NBAT"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NBAT" connectableBus2="NBAT" voltageLevelId2="VLBAT"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NBAT" connectableBus2="NBAT" voltageLevelId2="VLBAT"/>
+    <iidm:extension id="BAT2">
+        <vr:voltageRegulation voltageRegulatorOn="true" targetV="100.0">
+            <vr:terminalRef id="GEN"/>
+        </vr:voltageRegulation>
+    </iidm:extension>
+    <iidm:extension id="BAT">
+        <vr:voltageRegulation voltageRegulatorOn="true" targetV="100.0"/>
+    </iidm:extension>
+</iidm:network>


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
"Historical" versions of the `VoltageRegulation` extension are **not** supported.


**What is the new behavior (if this is a feature change)?**
"Historical" versions of the `VoltageRegulation` extension are supported.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

The `VoltageRegulation` extension was historically a private extension which was added to `powsybl-core`.
When it was private, the extension version was increased with each IIDM versions (from 1.0 to 1.12) but versions from 1.1 to 1.12 were identical. When released in `powsybl-core` these duplicates were not created.
But since there is no clean mechanism to match historical versions to the powsybl-core versions, reading serialized network with an historical version is not possible.
This PR introduces these historical versions for compatibility.

The default version when serializing has not changed and is still 1.1 for IIDM >= 1.2.