### PR TITLE
`ActivePowerControl` extension: Rename optional fields min/maxPOverride -> min/maxTargetP

### DIFF
--- a/docs/grid_model/extensions.md
+++ b/docs/grid_model/extensions.md
@@ -31,7 +31,7 @@ generator.newExtension(ActivePowerControlAdder.class)
     .withParticipationFactor(1.5)
     .add();
 ```
-
+If defined, min targetP and max targetP must be in the [pMin, pMax] interval of the Generator or Battery.
 The participation status, the participation factor, the max targetP and the min targetP are multi-variants: they can vary from one variant to another.
 
 This extension is provided by the `com.powsybl:powsybl-iidm-extensions` module.

--- a/docs/grid_model/extensions.md
+++ b/docs/grid_model/extensions.md
@@ -20,8 +20,8 @@ This extension is used to configure the participation factor of the generator, t
 | participate          | boolean | -                      | yes      | -             | The participation status                                                              |
 | droop                | double  | None (repartition key) | no       | -             | The participation factor equals maxP / droop                                          |
 | participation factor | double  | None (repartition key) | no       | -             | Defines the participation factor explicitly                                           |
-| maxP override        | double  | MW                     | no       | -             | If defined, this limit is used for slack distribution instead of the generator's maxP |
-| minP override        | double  | MW                     | no       | -             | if defined, this limit is used for slack distribution instead of the generator's minP |             
+| max targetP          | double  | MW                     | no       | -             | If defined, this limit is used for slack distribution instead of the generator's maxP |
+| min targetP          | double  | MW                     | no       | -             | if defined, this limit is used for slack distribution instead of the generator's minP |             
 
 Here is how to add an active power control extension to a generator:
 ```java
@@ -32,7 +32,7 @@ generator.newExtension(ActivePowerControlAdder.class)
     .add();
 ```
 
-The participation status, the participation factor, the maxP override and the minP override are multi-variants: they can vary from one variant to another.
+The participation status, the participation factor, the max targetP and the min targetP are multi-variants: they can vary from one variant to another.
 
 This extension is provided by the `com.powsybl:powsybl-iidm-extensions` module.
 

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ActivePowerControl.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ActivePowerControl.java
@@ -62,7 +62,8 @@ public interface ActivePowerControl<I extends Injection<I>> extends Extension<I>
     OptionalDouble getMinTargetP();
 
     /**
-     * Sets the overridden minimal active power.
+     * Sets the minimum value for targetP. The value must be in the [pmin,pmax] interval of the extended
+     * generator or battery.
      * @param minTargetP  The overridden value of minP. A Nan value removes the override.
      */
     void setMinTargetP(double minTargetP);
@@ -73,7 +74,8 @@ public interface ActivePowerControl<I extends Injection<I>> extends Extension<I>
     OptionalDouble getMaxTargetP();
 
     /**
-     * Sets the overridden maximal active power.
+     * Sets the maximum value for targetP. The value must be in the [pmin,pmax] interval of the extended
+     * generator or battery.
      * @param maxTargetP The overridden value of maxP. A Nan value removes the override.
      */
     void setMaxTargetP(double maxTargetP);

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ActivePowerControl.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ActivePowerControl.java
@@ -59,22 +59,22 @@ public interface ActivePowerControl<I extends Injection<I>> extends Extension<I>
     /**
      * @return if present, provides the overridden value of minP to be used for active power control operations.
      */
-    OptionalDouble getMinPOverride();
+    OptionalDouble getMinTargetP();
 
     /**
      * Sets the overridden minimal active power.
-     * @param pMinOverride  The overridden value of minP. A Nan value removes the override.
+     * @param minTargetP  The overridden value of minP. A Nan value removes the override.
      */
-    void setMinPOverride(double pMinOverride);
+    void setMinTargetP(double minTargetP);
 
     /**
      * @return if present, provides the overridden value of maxP to be used for active power control operations.
      */
-    OptionalDouble getMaxPOverride();
+    OptionalDouble getMaxTargetP();
 
     /**
      * Sets the overridden maximal active power.
-     * @param pMaxOverride The overridden value of maxP. A Nan value removes the override.
+     * @param maxTargetP The overridden value of maxP. A Nan value removes the override.
      */
-    void setMaxPOverride(double pMaxOverride);
+    void setMaxTargetP(double maxTargetP);
 }

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ActivePowerControlAdder.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/ActivePowerControlAdder.java
@@ -24,7 +24,7 @@ public interface ActivePowerControlAdder<I extends Injection<I>>
 
     ActivePowerControlAdder<I> withParticipationFactor(double participationFactor);
 
-    ActivePowerControlAdder<I> withMinPOverride(double minPOverride);
+    ActivePowerControlAdder<I> withMinTargetP(double minTargetP);
 
-    ActivePowerControlAdder<I> withMaxPOverride(double maxPOverride);
+    ActivePowerControlAdder<I> withMaxTargetP(double maxTargetP);
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ActivePowerControlAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ActivePowerControlAdderImpl.java
@@ -20,8 +20,8 @@ public class ActivePowerControlAdderImpl<I extends Injection<I>>
 
     private double droop = Double.NaN;
     private double participationFactor = Double.NaN;
-    private double minPOverride = Double.NaN;
-    private double maxPOverride = Double.NaN;
+    private double minTargetP = Double.NaN;
+    private double maxTargetP = Double.NaN;
 
     protected ActivePowerControlAdderImpl(I extendable) {
         super(extendable);
@@ -29,7 +29,7 @@ public class ActivePowerControlAdderImpl<I extends Injection<I>>
 
     @Override
     protected ActivePowerControlImpl<I> createExtension(I extendable) {
-        return new ActivePowerControlImpl<>(extendable, participate, droop, participationFactor, minPOverride, maxPOverride);
+        return new ActivePowerControlImpl<>(extendable, participate, droop, participationFactor, minTargetP, maxTargetP);
     }
 
     @Override
@@ -51,14 +51,14 @@ public class ActivePowerControlAdderImpl<I extends Injection<I>>
     }
 
     @Override
-    public ActivePowerControlAdder<I> withMinPOverride(double minPOverride) {
-        this.minPOverride = minPOverride;
+    public ActivePowerControlAdder<I> withMinTargetP(double minTargetP) {
+        this.minTargetP = minTargetP;
         return this;
     }
 
     @Override
-    public ActivePowerControlAdder<I> withMaxPOverride(double maxPOverride) {
-        this.maxPOverride = maxPOverride;
+    public ActivePowerControlAdder<I> withMaxTargetP(double maxTargetP) {
+        this.maxTargetP = maxTargetP;
         return this;
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ActivePowerControlImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ActivePowerControlImpl.java
@@ -89,10 +89,8 @@ public class ActivePowerControlImpl<T extends Injection<T>> extends AbstractMult
     private double withinPMinMax(double value, T injection) {
         PLimits pLimits = getPLimits(injection);
 
-        // The test always returns false if value is undefined (Double.Nan) as it should,
-        // as side effect of Nan arithmetic operators Nan handling, as they are used below.
-        if (value < pLimits.minP || value > pLimits.maxP) {
-            LOGGER.warn("targetP limit is now outside of pMin,pMax for component %s. Returning closest value in [pmin,pMax].",
+        if (!Double.isNaN(value) && (value < pLimits.minP || value > pLimits.maxP)) {
+            LOGGER.warn("targetP limit is now outside of pMin,pMax for component {}. Returning closest value in [pmin,pMax].",
                         injection.getId());
             return value < pLimits.minP ? pLimits.minP : pLimits.maxP;
         }
@@ -113,10 +111,9 @@ public class ActivePowerControlImpl<T extends Injection<T>> extends AbstractMult
     }
 
     private void checkLimitOrder(double minTargetP, double maxTargetP) {
-        if (!Double.isNaN(minTargetP) && !Double.isNaN(maxTargetP)) {
-            if (minTargetP > maxTargetP) {
-                throw new PowsyblException("invalid targetP limits [" + minTargetP + ", " + maxTargetP + "]");
-            }
+        if (!Double.isNaN(minTargetP) && !Double.isNaN(maxTargetP)
+                && minTargetP > maxTargetP) {
+            throw new PowsyblException("invalid targetP limits [" + minTargetP + ", " + maxTargetP + "]");
         }
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ActivePowerControlImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ActivePowerControlImpl.java
@@ -92,9 +92,8 @@ public class ActivePowerControlImpl<T extends Injection<T>> extends AbstractMult
         // The test always returns false if value is undefined (Double.Nan) as it should,
         // as side effect of Nan arithmetic operators Nan handling, as they are used below.
         if (value < pLimits.minP || value > pLimits.maxP) {
-            LOGGER.warn(String.
-                    format("targetP limit is now outside of pMin,pMax for component %s. Returning closest value in [pmin,pMax].",
-                            injection.getId()));
+            LOGGER.warn("targetP limit is now outside of pMin,pMax for component %s. Returning closest value in [pmin,pMax].",
+                        injection.getId());
             return value < pLimits.minP ? pLimits.minP : pLimits.maxP;
         }
         return value;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ActivePowerControlImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/ActivePowerControlImpl.java
@@ -92,7 +92,9 @@ public class ActivePowerControlImpl<T extends Injection<T>> extends AbstractMult
         // The test always returns false if value is undefined (Double.Nan) as it should,
         // as side effect of Nan arithmetic operators Nan handling, as they are used below.
         if (value < pLimits.minP || value > pLimits.maxP) {
-            LOGGER.warn("targetP limit is now outside of pMin,pMax for component " + injection.getId() + ". Returning closest value in [pmin,pMax].");
+            LOGGER.warn(String.
+                    format("targetP limit is now outside of pMin,pMax for component %s. Returning closest value in [pmin,pMax].",
+                            injection.getId()));
             return value < pLimits.minP ? pLimits.minP : pLimits.maxP;
         }
         return value;

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/ActivePowerControlSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/ActivePowerControlSerDe.java
@@ -67,8 +67,8 @@ public class ActivePowerControlSerDe<T extends Injection<T>> extends AbstractVer
         }
         if ("1.2".compareTo(extVersionStr) <= 0) {
             // not using writeOptionalDouble and trusting implementation convention: : writeDoubleAttribute does not write NaN values in human-readable formats JSON/XML
-            context.getWriter().writeDoubleAttribute("maxPOverride", activePowerControl.getMaxPOverride().orElse(Double.NaN));
-            context.getWriter().writeDoubleAttribute("minPOverride", activePowerControl.getMinPOverride().orElse(Double.NaN));
+            context.getWriter().writeDoubleAttribute("maxTargetP", activePowerControl.getMaxTargetP().orElse(Double.NaN));
+            context.getWriter().writeDoubleAttribute("minTargetP", activePowerControl.getMinTargetP().orElse(Double.NaN));
         }
     }
 
@@ -89,8 +89,8 @@ public class ActivePowerControlSerDe<T extends Injection<T>> extends AbstractVer
         boolean participate = context.getReader().readBooleanAttribute("participate");
         double droop = context.getReader().readDoubleAttribute("droop");
         double participationFactor = Double.NaN;
-        double minPOverride = Double.NaN;
-        double maxPOverride = Double.NaN;
+        double minTargetP = Double.NaN;
+        double maxTargetP = Double.NaN;
         NetworkDeserializerContext networkContext = (NetworkDeserializerContext) context;
         String extVersionStr = networkContext.getExtensionVersion(this).orElseThrow(IllegalStateException::new);
         if ("1.1".compareTo(extVersionStr) <= 0) {
@@ -98,16 +98,16 @@ public class ActivePowerControlSerDe<T extends Injection<T>> extends AbstractVer
         }
         if ("1.2".compareTo(extVersionStr) <= 0) {
             // not using readOptionalDouble and trusting implementation convention: readDoubleAttribute returns Nan if attribute is absent in human-readable formats (JSON / XML)
-            maxPOverride = context.getReader().readDoubleAttribute("maxPOverride");
-            minPOverride = context.getReader().readDoubleAttribute("minPOverride");
+            maxTargetP = context.getReader().readDoubleAttribute("maxTargetP");
+            minTargetP = context.getReader().readDoubleAttribute("minTargetP");
         }
         context.getReader().readEndNode();
         ActivePowerControlAdder<T> activePowerControlAdder = identifiable.newExtension(ActivePowerControlAdder.class);
         return activePowerControlAdder.withParticipate(participate)
                 .withDroop(droop)
                 .withParticipationFactor(participationFactor)
-                .withMinPOverride(minPOverride)
-                .withMaxPOverride(maxPOverride)
+                .withMinTargetP(minTargetP)
+                .withMaxTargetP(maxTargetP)
                 .add();
     }
 }

--- a/iidm/iidm-serde/src/main/resources/xsd/activePowerControl_V1_2.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/activePowerControl_V1_2.xsd
@@ -17,8 +17,8 @@
             <xs:attribute name="participate" use="required" type="xs:boolean"/>
             <xs:attribute name="droop" use="optional" type="xs:double"/>
             <xs:attribute name="participationFactor" use="optional" type="xs:double"/>
-            <xs:attribute name="minPOverride" use="optional" type="xs:double"/>
-            <xs:attribute name="maxPOverride" use="optional" type="xs:double"/>
+            <xs:attribute name="minTargetP" use="optional" type="xs:double"/>
+            <xs:attribute name="maxTargetP" use="optional" type="xs:double"/>
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/ActivePowerControlXmlTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/ActivePowerControlXmlTest.java
@@ -47,24 +47,24 @@ class ActivePowerControlXmlTest extends AbstractIidmSerDeTest {
     }
 
     @Test
-    void testPLimitOverride() throws IOException {
-        network.getGenerator("GEN").getExtension(ActivePowerControl.class).setMaxPOverride(100.);
-        network.getBattery("BAT").getExtension(ActivePowerControl.class).setMinPOverride(10.);
+    void testtargetPLimits() throws IOException {
+        network.getGenerator("GEN").getExtension(ActivePowerControl.class).setMaxTargetP(800.);
+        network.getBattery("BAT").getExtension(ActivePowerControl.class).setMinTargetP(10.);
         Network network2 = allFormatsRoundTripTest(network, "/activePowerControlWithLimitRoundTripRef.xml", CURRENT_IIDM_VERSION);
 
         Generator gen2 = network2.getGenerator("GEN");
         assertNotNull(gen2);
         ActivePowerControl<Generator> activePowerControl1 = gen2.getExtension(ActivePowerControl.class);
         assertNotNull(activePowerControl1);
-        assertEquals(OptionalDouble.of(100), activePowerControl1.getMaxPOverride());
-        assertTrue(activePowerControl1.getMinPOverride().isEmpty());
+        assertEquals(OptionalDouble.of(800), activePowerControl1.getMaxTargetP());
+        assertTrue(activePowerControl1.getMinTargetP().isEmpty());
 
         Battery bat2 = network2.getBattery("BAT");
         assertNotNull(bat2);
         ActivePowerControl<Battery> activePowerControl2 = bat2.getExtension(ActivePowerControl.class);
         assertNotNull(activePowerControl2);
-        assertTrue(activePowerControl2.getMaxPOverride().isEmpty());
-        assertEquals(OptionalDouble.of(10), activePowerControl2.getMinPOverride());
+        assertTrue(activePowerControl2.getMaxTargetP().isEmpty());
+        assertEquals(OptionalDouble.of(10), activePowerControl2.getMinTargetP());
     }
 
     @Test
@@ -75,8 +75,8 @@ class ActivePowerControlXmlTest extends AbstractIidmSerDeTest {
         assertNotNull(bat2);
         ActivePowerControl<Battery> activePowerControl2 = bat2.getExtension(ActivePowerControl.class);
         assertNotNull(activePowerControl2);
-        assertTrue(activePowerControl2.getMaxPOverride().isEmpty());
-        assertTrue(activePowerControl2.getMinPOverride().isEmpty());
+        assertTrue(activePowerControl2.getMaxTargetP().isEmpty());
+        assertTrue(activePowerControl2.getMinTargetP().isEmpty());
     }
 
     @Test

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/ActivePowerControlXmlTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/ActivePowerControlXmlTest.java
@@ -33,6 +33,7 @@ class ActivePowerControlXmlTest extends AbstractIidmSerDeTest {
 
     private Network network;
 
+    @Override
     @BeforeEach
     public void setUp() throws IOException {
         super.setUp();

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/ActivePowerControlXmlTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/ActivePowerControlXmlTest.java
@@ -47,7 +47,7 @@ class ActivePowerControlXmlTest extends AbstractIidmSerDeTest {
     }
 
     @Test
-    void testtargetPLimits() throws IOException {
+    void testTargetPLimits() throws IOException {
         network.getGenerator("GEN").getExtension(ActivePowerControl.class).setMaxTargetP(800.);
         network.getBattery("BAT").getExtension(ActivePowerControl.class).setMinTargetP(10.);
         Network network2 = allFormatsRoundTripTest(network, "/activePowerControlWithLimitRoundTripRef.xml", CURRENT_IIDM_VERSION);

--- a/iidm/iidm-serde/src/test/resources/V1_13/activePowerControlWithLimitRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_13/activePowerControlWithLimitRoundTripRef.xml
@@ -30,9 +30,9 @@
     <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NBAT" connectableBus2="NBAT" voltageLevelId2="VLBAT"/>
     <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NBAT" connectableBus2="NBAT" voltageLevelId2="VLBAT"/>
     <iidm:extension id="GEN">
-        <apc:activePowerControl participate="false" droop="3.0" participationFactor="1.0" maxPOverride="100.0"/>
+        <apc:activePowerControl participate="false" droop="3.0" participationFactor="1.0" maxTargetP="800.0"/>
     </iidm:extension>
     <iidm:extension id="BAT">
-        <apc:activePowerControl participate="true" droop="4.0" participationFactor="1.2" minPOverride="10.0"/>
+        <apc:activePowerControl participate="true" droop="4.0" participationFactor="1.2" minTargetP="10.0"/>
     </iidm:extension>
 </iidm:network>

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractActivePowerControlTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractActivePowerControlTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.OptionalDouble;
 
 import static com.powsybl.iidm.network.VariantManagerConstants.INITIAL_VARIANT_ID;
 import static org.junit.jupiter.api.Assertions.*;
@@ -91,15 +92,21 @@ public abstract class AbstractActivePowerControlTest {
         checkValues1(activePowerControl);
 
         // test limitControl
-        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMaxTargetP(bat.getMaxP() + 1));
-        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMaxTargetP(bat.getMinP() - 1));
-        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMinTargetP(bat.getMaxP() + 1));
-        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMinTargetP(bat.getMinP() - 1));
+        assertThrows(PowsyblException.class, () -> activePowerControl.setMaxTargetP(bat.getMaxP() + 1));
+        assertThrows(PowsyblException.class, () -> activePowerControl.setMaxTargetP(bat.getMinP() - 1));
+        assertThrows(PowsyblException.class, () -> activePowerControl.setMinTargetP(bat.getMaxP() + 1));
+        assertThrows(PowsyblException.class, () -> activePowerControl.setMinTargetP(bat.getMinP() - 1));
 
         activePowerControl.setMaxTargetP(200);
         activePowerControl.setMinTargetP(100);
-        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMinTargetP(201));
-        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMaxTargetP(99));
+        assertThrows(PowsyblException.class, () -> activePowerControl.setMinTargetP(201));
+        assertThrows(PowsyblException.class, () -> activePowerControl.setMaxTargetP(99));
+
+        // try to fool the extension
+        bat.setMaxP(190);
+        bat.setMinP(110);
+        assertEquals(OptionalDouble.of(190), activePowerControl.getMaxTargetP());
+        assertEquals(OptionalDouble.of(110), activePowerControl.getMinTargetP());
 
         // Test removing current variant
         variantManager.removeVariant(variant3);

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractActivePowerControlTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractActivePowerControlTest.java
@@ -92,10 +92,12 @@ public abstract class AbstractActivePowerControlTest {
         checkValues1(activePowerControl);
 
         // test limitControl
-        assertThrows(PowsyblException.class, () -> activePowerControl.setMaxTargetP(bat.getMaxP() + 1));
-        assertThrows(PowsyblException.class, () -> activePowerControl.setMaxTargetP(bat.getMinP() - 1));
-        assertThrows(PowsyblException.class, () -> activePowerControl.setMinTargetP(bat.getMaxP() + 1));
-        assertThrows(PowsyblException.class, () -> activePowerControl.setMinTargetP(bat.getMinP() - 1));
+        double minP = bat.getMinP();
+        double maxP = bat.getMaxP();
+        assertThrows(PowsyblException.class, () -> activePowerControl.setMaxTargetP(maxP + 1));
+        assertThrows(PowsyblException.class, () -> activePowerControl.setMaxTargetP(minP - 1));
+        assertThrows(PowsyblException.class, () -> activePowerControl.setMinTargetP(maxP + 1));
+        assertThrows(PowsyblException.class, () -> activePowerControl.setMinTargetP(minP - 1));
 
         activePowerControl.setMaxTargetP(200);
         activePowerControl.setMinTargetP(100);

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractActivePowerControlTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractActivePowerControlTest.java
@@ -90,6 +90,17 @@ public abstract class AbstractActivePowerControlTest {
         variantManager.setWorkingVariant(variant3);
         checkValues1(activePowerControl);
 
+        // test limitControl
+        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMaxTargetP(bat.getMaxP() + 1));
+        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMaxTargetP(bat.getMinP() - 1));
+        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMinTargetP(bat.getMaxP() + 1));
+        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMinTargetP(bat.getMinP() - 1));
+
+        activePowerControl.setMaxTargetP(200);
+        activePowerControl.setMinTargetP(100);
+        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMinTargetP(201));
+        assertThrows(IllegalArgumentException.class, () -> activePowerControl.setMaxTargetP(99));
+
         // Test removing current variant
         variantManager.removeVariant(variant3);
         try {
@@ -113,8 +124,8 @@ public abstract class AbstractActivePowerControlTest {
                 .withDroop(4.0)
                 .withParticipate(true)
                 .withParticipationFactor(1.2)
-                .withMinPOverride(10)
-                .withMaxPOverride(100)
+                .withMinTargetP(10)
+                .withMaxTargetP(100)
                 .add();
         ActivePowerControl<Battery> activePowerControl = bat.getExtension(ActivePowerControl.class);
         assertNotNull(activePowerControl);
@@ -130,12 +141,12 @@ public abstract class AbstractActivePowerControlTest {
         activePowerControl.setDroop(6.0);
         activePowerControl.setParticipate(false);
         activePowerControl.setParticipationFactor(3.0);
-        activePowerControl.setMaxPOverride(110.);
-        activePowerControl.setMinPOverride(Double.NaN);
+        activePowerControl.setMaxTargetP(110.);
+        activePowerControl.setMinTargetP(Double.NaN);
         checkValues4(activePowerControl);
 
-        activePowerControl.setMinPOverride(11.);
-        activePowerControl.setMaxPOverride(Double.NaN);
+        activePowerControl.setMinTargetP(11.);
+        activePowerControl.setMaxTargetP(Double.NaN);
         checkValues5(activePowerControl);
 
         variantManager.setWorkingVariant(INITIAL_VARIANT_ID);
@@ -164,39 +175,40 @@ public abstract class AbstractActivePowerControlTest {
         assertTrue(activePowerControl.isParticipate());
         assertEquals(4.0, activePowerControl.getDroop(), 0.0);
         assertEquals(1.2, activePowerControl.getParticipationFactor(), 0.0);
-        assertTrue(activePowerControl.getMaxPOverride().isEmpty());
-        assertTrue(activePowerControl.getMinPOverride().isEmpty());
+        assertTrue(activePowerControl.getMaxTargetP().isEmpty());
+        assertTrue(activePowerControl.getMinTargetP().isEmpty());
     }
 
     private static void checkValues2(ActivePowerControl<Battery> activePowerControl) {
         assertFalse(activePowerControl.isParticipate());
         assertEquals(6.0, activePowerControl.getDroop(), 0.0);
         assertEquals(3.0, activePowerControl.getParticipationFactor(), 0.0);
-        assertTrue(activePowerControl.getMaxPOverride().isEmpty());
-        assertTrue(activePowerControl.getMinPOverride().isEmpty());
+        assertTrue(activePowerControl.getMaxTargetP().isEmpty());
+        assertTrue(activePowerControl.getMinTargetP().isEmpty());
     }
 
     private static void checkValues3(ActivePowerControl<Battery> activePowerControl) {
         assertTrue(activePowerControl.isParticipate());
         assertEquals(4.0, activePowerControl.getDroop(), 0.0);
         assertEquals(1.2, activePowerControl.getParticipationFactor(), 0.0);
-        assertEquals(10, activePowerControl.getMinPOverride().getAsDouble());
-        assertEquals(100, activePowerControl.getMaxPOverride().getAsDouble());
+        assertEquals(10, activePowerControl.getMinTargetP().getAsDouble());
+        assertEquals(100, activePowerControl.getMaxTargetP().getAsDouble());
     }
 
     private static void checkValues4(ActivePowerControl<Battery> activePowerControl) {
         assertFalse(activePowerControl.isParticipate());
         assertEquals(6.0, activePowerControl.getDroop(), 0.0);
         assertEquals(3.0, activePowerControl.getParticipationFactor(), 0.0);
-        assertTrue(activePowerControl.getMinPOverride().isEmpty());
-        assertEquals(110, activePowerControl.getMaxPOverride().getAsDouble());
+        assertTrue(activePowerControl.getMinTargetP().isEmpty());
+        assertEquals(110, activePowerControl.getMaxTargetP().getAsDouble());
     }
 
     private static void checkValues5(ActivePowerControl<Battery> activePowerControl) {
         assertFalse(activePowerControl.isParticipate());
         assertEquals(6.0, activePowerControl.getDroop(), 0.0);
         assertEquals(3.0, activePowerControl.getParticipationFactor(), 0.0);
-        assertTrue(activePowerControl.getMaxPOverride().isEmpty());
-        assertEquals(11, activePowerControl.getMinPOverride().getAsDouble());
+        assertTrue(activePowerControl.getMaxTargetP().isEmpty());
+        assertEquals(11, activePowerControl.getMinTargetP().getAsDouble());
     }
+
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Quality / bug fix:
- Better naming of fields.
- Additional checks to avoid inconsistent behaviors.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
- `ActivePowerControl` extension has 2 fields `minPOverride` and `maxPOverride`;
- There are no checks on their values.

**What is the new behavior (if this is a feature change)?**
- `ActivePowerControlExtension`'s fields were renamed:
  -  `minPOverride` -> `minTargetP`;
  - `maxPOverride` -> `maxTargetP`
- Additional checks were introduced on these fields:
  - they should be between `minP` and `maxP`;
  - `minTargetP < maxTargetP`.


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

But these changes are on fields only present in a release candidate version (6.4.0-RC2).

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

To migrate from the 6.4.0-RC2 (there is nothing to do for previous versions), you should replace:
 - `ActivePowerControl.getMinPOverride()` by `ActivePowerControl.getMinTargetP()`;
 - `ActivePowerControl.getMaxPOverride()` by `ActivePowerControl.getMaxTargetP()`;
 - `ActivePowerControl.setMinPOverride(double)` by `ActivePowerControl.setMinTargetP(double)`;
 - `ActivePowerControl.setMaxPOverride(double)` by `ActivePowerControl.setMaxTargetP(double)`;
 - `ActivePowerControlAdder.withMinPOverride(double)` by `ActivePowerControlAdder. withMinTargetP(double)`;
 - `ActivePowerControlAdder.withMaxPOverride(double)` by `ActivePowerControlAdder. withMaxTargetP(double)`;

Serialized IIDM networks with "activePowerControl" v1.2 extension (only possible from the 6.4.0-RC2) can no more be deserialized (unless you edit them to replace "minPOverride" by "minTargetP" and "maxPOverride" by "maxTargetP").

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
