### PR TITLE
Disambiguate files on import

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/datasource/Bzip2FileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/Bzip2FileDataSource.java
@@ -18,12 +18,20 @@ import java.nio.file.Path;
  */
 public class Bzip2FileDataSource extends FileDataSource {
 
+    public Bzip2FileDataSource(Path directory, String baseName, String baseExtension, DataSourceObserver observer) {
+        super(directory, baseName, baseExtension, observer);
+    }
+
+    public Bzip2FileDataSource(Path directory, String baseName, String baseExtension) {
+        super(directory, baseName, baseExtension, null);
+    }
+
     public Bzip2FileDataSource(Path directory, String baseName, DataSourceObserver observer) {
-        super(directory, baseName, observer);
+        super(directory, baseName, "", observer);
     }
 
     public Bzip2FileDataSource(Path directory, String baseName) {
-        super(directory, baseName);
+        super(directory, baseName, "", null);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/datasource/DataSourceUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/DataSourceUtil.java
@@ -39,6 +39,16 @@ public interface DataSourceUtil {
         return pos == -1 ? fileName : fileName.substring(0, pos);
     }
 
+    static String getBaseExtension(String fileName) {
+        Objects.requireNonNull(fileName);
+        int firstpos = fileName.indexOf('.'); // find first dot in case of double extension (.xml.gz)
+        int secondpos = fileName.indexOf('.', firstpos + 1); // find second dot in case of double extension (.xml.gz)
+        if (secondpos == -1) {
+            secondpos = fileName.length();
+        }
+        return firstpos == -1 ? "" : fileName.substring(firstpos + 1, secondpos);
+    }
+
     static DataSource createDataSource(Path directory, String basename, CompressionFormat compressionExtension, DataSourceObserver observer) {
         Objects.requireNonNull(directory);
         Objects.requireNonNull(basename);
@@ -68,17 +78,26 @@ public interface DataSourceUtil {
         Objects.requireNonNull(fileNameOrBaseName);
 
         if (fileNameOrBaseName.endsWith(".zst")) {
-            return new ZstdFileDataSource(directory, getBaseName(fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 4)), observer);
+            String fileNameWithoutCompressionExtension = fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 4);
+            return new ZstdFileDataSource(directory, getBaseName(fileNameWithoutCompressionExtension), getBaseExtension(fileNameWithoutCompressionExtension), observer);
         } else if (fileNameOrBaseName.endsWith(".zip")) {
+            //TODO may be useful to allow to have mainExtension for zips.
+            //It is Not as important as others because zips are supposed to contain only related files.
+            //And we need to rework the constructors into static methods to disambiguate
+            //betweenzipfilename + basename or basename + baseextension
+            //This would allow something like network.xiidm.zip vs network.zip
             return new ZipFileDataSource(directory, fileNameOrBaseName, getBaseName(fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 4)), observer);
         } else if (fileNameOrBaseName.endsWith(".xz")) {
-            return new XZFileDataSource(directory, getBaseName(fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 3)), observer);
+            String fileNameWithoutCompressionExtension = fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 3);
+            return new XZFileDataSource(directory, getBaseName(fileNameWithoutCompressionExtension), getBaseExtension(fileNameWithoutCompressionExtension), observer);
         } else if (fileNameOrBaseName.endsWith(".gz")) {
-            return new GzFileDataSource(directory, getBaseName(fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 3)), observer);
+            String fileNameWithoutCompressionExtension = fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 3);
+            return new GzFileDataSource(directory, getBaseName(fileNameWithoutCompressionExtension), getBaseExtension(fileNameWithoutCompressionExtension), observer);
         } else if (fileNameOrBaseName.endsWith(".bz2")) {
-            return new Bzip2FileDataSource(directory, getBaseName(fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 4)), observer);
+            String fileNameWithoutCompressionExtension = fileNameOrBaseName.substring(0, fileNameOrBaseName.length() - 4);
+            return new Bzip2FileDataSource(directory, getBaseName(fileNameWithoutCompressionExtension), getBaseExtension(fileNameWithoutCompressionExtension), observer);
         } else {
-            return new FileDataSource(directory, getBaseName(fileNameOrBaseName), observer);
+            return new FileDataSource(directory, getBaseName(fileNameOrBaseName), getBaseExtension(fileNameOrBaseName), observer);
         }
     }
 }

--- a/commons/src/main/java/com/powsybl/commons/datasource/FileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/FileDataSource.java
@@ -29,21 +29,37 @@ public class FileDataSource implements DataSource {
 
     private final String baseName;
 
+    private final String baseExtension;
+
     private final DataSourceObserver observer;
 
     public FileDataSource(Path directory, String baseName) {
-        this(directory, baseName, null);
+        this(directory, baseName, "", null);
     }
 
     public FileDataSource(Path directory, String baseName, DataSourceObserver observer) {
+        this(directory, baseName, "", observer);
+    }
+
+    public FileDataSource(Path directory, String baseName, String baseExtension) {
+        this(directory, baseName, baseExtension, null);
+    }
+
+    public FileDataSource(Path directory, String baseName, String baseExtension, DataSourceObserver observer) {
         this.directory = Objects.requireNonNull(directory);
         this.baseName = Objects.requireNonNull(baseName);
+        this.baseExtension = Objects.requireNonNull(baseExtension);
         this.observer = observer;
     }
 
     @Override
     public String getBaseName() {
         return baseName;
+    }
+
+    @Override
+    public String getBaseExtension() {
+        return baseExtension;
     }
 
     protected String getCompressionExt() {

--- a/commons/src/main/java/com/powsybl/commons/datasource/GzFileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/GzFileDataSource.java
@@ -19,12 +19,20 @@ import java.util.zip.GZIPOutputStream;
  */
 public class GzFileDataSource extends FileDataSource {
 
+    public GzFileDataSource(Path directory, String baseName, String baseExtension, DataSourceObserver observer) {
+        super(directory, baseName, baseExtension, observer);
+    }
+
+    public GzFileDataSource(Path directory, String baseName, String baseExtension) {
+        super(directory, baseName, baseExtension, null);
+    }
+
     public GzFileDataSource(Path directory, String baseName, DataSourceObserver observer) {
-        super(directory, baseName, observer);
+        super(directory, baseName, "", observer);
     }
 
     public GzFileDataSource(Path directory, String baseName) {
-        super(directory, baseName);
+        super(directory, baseName, "", null);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/datasource/ReadOnlyDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/ReadOnlyDataSource.java
@@ -18,6 +18,10 @@ public interface ReadOnlyDataSource {
 
     String getBaseName();
 
+    default String getBaseExtension() {
+        return "";
+    }
+
     boolean exists(String suffix, String ext) throws IOException;
 
     boolean exists(String fileName) throws IOException;

--- a/commons/src/main/java/com/powsybl/commons/datasource/XZFileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/XZFileDataSource.java
@@ -18,12 +18,20 @@ import java.nio.file.Path;
  */
 public class XZFileDataSource extends FileDataSource {
 
+    public XZFileDataSource(Path directory, String baseName, String baseExtension, DataSourceObserver observer) {
+        super(directory, baseName, baseExtension, observer);
+    }
+
+    public XZFileDataSource(Path directory, String baseName, String baseExtension) {
+        super(directory, baseName, baseExtension, null);
+    }
+
     public XZFileDataSource(Path directory, String baseName, DataSourceObserver observer) {
-        super(directory, baseName, observer);
+        super(directory, baseName, "", observer);
     }
 
     public XZFileDataSource(Path directory, String baseName) {
-        super(directory, baseName);
+        super(directory, baseName, "", null);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/datasource/ZstdFileDataSource.java
+++ b/commons/src/main/java/com/powsybl/commons/datasource/ZstdFileDataSource.java
@@ -18,12 +18,20 @@ import java.nio.file.Path;
  */
 public class ZstdFileDataSource extends FileDataSource {
 
+    public ZstdFileDataSource(Path directory, String baseName, String baseExtension, DataSourceObserver observer) {
+        super(directory, baseName, baseExtension, observer);
+    }
+
+    public ZstdFileDataSource(Path directory, String baseName, String baseExtension) {
+        super(directory, baseName, baseExtension, null);
+    }
+
     public ZstdFileDataSource(Path directory, String baseName, DataSourceObserver observer) {
-        super(directory, baseName, observer);
+        super(directory, baseName, "", observer);
     }
 
     public ZstdFileDataSource(Path directory, String baseName) {
-        super(directory, baseName);
+        super(directory, baseName, "", null);
     }
 
     @Override

--- a/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
+++ b/ieee-cdf/ieee-cdf-converter/src/main/java/com/powsybl/ieeecdf/converter/IeeeCdfImporter.java
@@ -79,6 +79,12 @@ public class IeeeCdfImporter implements Importer {
 
     @Override
     public boolean exists(ReadOnlyDataSource dataSource) {
+        // if given a main file with an extension and it's not compatible, don't import
+        // to avoid importing a file when the user specified another
+        if (!EXT.equals(dataSource.getBaseExtension()) && !dataSource.getBaseExtension().isEmpty()) {
+            return false;
+        }
+
         try {
             if (dataSource.exists(null, EXT)) {
                 try (BufferedReader reader = new BufferedReader(new InputStreamReader(dataSource.newInputStream(null, EXT)))) {

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTreeDataImporter.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTreeDataImporter.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -96,6 +97,15 @@ public abstract class AbstractTreeDataImporter implements Importer {
     }
 
     private String findExtension(ReadOnlyDataSource dataSource) throws IOException {
+        // if given a main file compatible with our extensions, try that as the mainfile.
+        if (Arrays.asList(getExtensions()).contains(dataSource.getBaseExtension())) {
+            return dataSource.getBaseExtension();
+        // if given a main file with an extension and it's not compatible, don't import
+        // to avoid importing a file when the user specified another
+        } else if (!dataSource.getBaseExtension().isEmpty()) {
+            return null;
+        }
+
         for (String ext : getExtensions()) {
             if (dataSource.exists(null, ext)) {
                 return ext;

--- a/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
+++ b/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerImporter.java
@@ -515,6 +515,12 @@ public class MatpowerImporter implements Importer {
 
     @Override
     public boolean exists(ReadOnlyDataSource dataSource) {
+        // if given a main file with an extension and it's not compatible, don't import
+        // to avoid importing a file when the user specified another
+        if (!EXT.equals(dataSource.getBaseExtension()) && !dataSource.getBaseExtension().isEmpty()) {
+            return false;
+        }
+
         try {
             return dataSource.exists(null, MatpowerConstants.EXT);
         } catch (IOException e) {

--- a/psse/psse-converter/src/main/java/com/powsybl/psse/converter/PsseImporter.java
+++ b/psse/psse-converter/src/main/java/com/powsybl/psse/converter/PsseImporter.java
@@ -82,6 +82,15 @@ public class PsseImporter implements Importer {
     }
 
     private String findExtension(ReadOnlyDataSource dataSource) throws IOException {
+        // if given a main file compatible with our extensions, try that as the mainfile.
+        if (Arrays.asList(EXTENSIONS).contains(dataSource.getBaseExtension())) {
+            return dataSource.getBaseExtension();
+        // if given a main file with an extension and it's not compatible, don't import
+        // to avoid importing a file when the user specified another
+        } else if (!dataSource.getBaseExtension().isEmpty()) {
+            return null;
+        }
+
         for (String ext : EXTENSIONS) {
             if (dataSource.exists(null, ext)) {
                 return ext;

--- a/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
+++ b/ucte/ucte-converter/src/main/java/com/powsybl/ucte/converter/UcteImporter.java
@@ -950,6 +950,15 @@ public class UcteImporter implements Importer {
     }
 
     private String findExtension(ReadOnlyDataSource dataSource, boolean throwException) throws IOException {
+        // if given a main file compatible with our extensions, try that as the mainfile.
+        if (Arrays.asList(EXTENSIONS).contains(dataSource.getBaseExtension())) {
+            return dataSource.getBaseExtension();
+        // if given a main file with an extension and it's not compatible, don't import
+        // to avoid importing a file when the user specified another
+        } else if (!dataSource.getBaseExtension().isEmpty()) {
+            return null;
+        }
+
         for (String ext : EXTENSIONS) {
             if (dataSource.exists(null, ext)) {
                 return ext;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
https://github.com/powsybl/powsybl-core/issues/989
#3082
#2959
others...

**What kind of change does this PR introduce?**
bug fix


**What is the current behavior?**
```shell
$ itools convert-network --input-file foo.xiidm # will wrongly use foo.xml from cgmes if it exists
```

**What is the new behavior (if this is a feature change)?**
always use the file specified by the user in the command line


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
