### PR TITLE
Fix regression on assert command for tool tests

### DIFF
--- a/tools-test/src/main/java/com/powsybl/tools/test/AbstractToolTest.java
+++ b/tools-test/src/main/java/com/powsybl/tools/test/AbstractToolTest.java
@@ -122,7 +122,15 @@ public abstract class AbstractToolTest {
         assertCommand(args, CommandLineTools.EXECUTION_ERROR_STATUS, null, expectedErr, AbstractToolTest::containsTxt);
     }
 
+    /**
+     * @deprecated use {@link AbstractToolTest#assertCommandMatchTextOrRegex} instead
+     */
+    @Deprecated(since = "6.4.0")
     protected void assertCommand(String[] args, int expectedStatus, String expectedOut, String expectedErr) {
+        assertCommandMatchTextOrRegex(args, expectedStatus, expectedOut, expectedErr);
+    }
+
+    protected void assertCommandMatchTextOrRegex(String[] args, int expectedStatus, String expectedOut, String expectedErr) {
         assertCommand(args, expectedStatus, expectedOut, expectedErr, this::matchTextOrRegex);
     }
 

--- a/tools-test/src/main/java/com/powsybl/tools/test/AbstractToolTest.java
+++ b/tools-test/src/main/java/com/powsybl/tools/test/AbstractToolTest.java
@@ -33,6 +33,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -93,6 +94,10 @@ public abstract class AbstractToolTest {
         assertTrue(actual.contains(expected), () -> ASSERT_MATCH_TEXT_BLOCK.formatted(expected, actual));
     }
 
+    public void matchTextOrRegex(String expected, String actual) {
+        assertTrue(actual.equals(expected) || Pattern.compile(expected).matcher(actual).find());
+    }
+
     protected void assertCommandSuccessful(String[] args) {
         assertCommand(args, CommandLineTools.COMMAND_OK_STATUS, null, "", ComparisonUtils::assertTxtEquals);
     }
@@ -115,6 +120,10 @@ public abstract class AbstractToolTest {
 
     protected void assertCommandErrorMatch(String[] args, String expectedErr) {
         assertCommand(args, CommandLineTools.EXECUTION_ERROR_STATUS, null, expectedErr, AbstractToolTest::containsTxt);
+    }
+
+    protected void assertCommand(String[] args, int expectedStatus, String expectedOut, String expectedErr) {
+        assertCommand(args, expectedStatus, expectedOut, expectedErr, this::matchTextOrRegex);
     }
 
     private void assertCommand(String[] args, int expectedStatus, String expectedOut, String expectedErr, BiConsumer<String, String> comparisonFunction) {

--- a/tools-test/src/test/java/com/powsybl/tools/test/CommandLineToolsTest.java
+++ b/tools-test/src/test/java/com/powsybl/tools/test/CommandLineToolsTest.java
@@ -16,9 +16,12 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 
 import java.util.Arrays;
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -262,5 +265,12 @@ class CommandLineToolsTest extends AbstractToolTest {
                         System.lineSeparator() +
                         "footer1" + System.lineSeparator());
 
+    }
+
+    @Test
+    void testComparisonMethods() {
+        matchTextOrRegex("works", "works");
+        matchTextOrRegex("^[a-z0-9-]+$", UUID.randomUUID().toString());
+        assertThrows(AssertionFailedError.class, () -> matchTextOrRegex("^[a-z0-9-]+$", "fail test"));
     }
 }

--- a/tools-test/src/test/java/com/powsybl/tools/test/CommandLineToolsTest.java
+++ b/tools-test/src/test/java/com/powsybl/tools/test/CommandLineToolsTest.java
@@ -182,10 +182,13 @@ class CommandLineToolsTest extends AbstractToolTest {
     @Test
     void testRegexOutput() {
         // Matches a regex
+        assertCommandMatchTextOrRegex(new String[] {"tool3"}, 0, "^[a-z0-9-]+$", "");
+
+        // Matches a regex - deprecated method
         assertCommand(new String[] {"tool3"}, 0, "^[a-z0-9-]+$", "");
 
         // Matches a string
-        assertCommand(new String[] {"tool1", "--option1", "file.txt"}, 0, "result1", "");
+        assertCommandMatchTextOrRegex(new String[] {"tool1", "--option1", "file.txt"}, 0, "result1", "");
     }
 
     @Test

--- a/tools-test/src/test/java/com/powsybl/tools/test/CommandLineToolsTest.java
+++ b/tools-test/src/test/java/com/powsybl/tools/test/CommandLineToolsTest.java
@@ -205,6 +205,9 @@ class CommandLineToolsTest extends AbstractToolTest {
                 System.lineSeparator() +
                 "theme2:" + System.lineSeparator() +
                 "    tool2                                    test tool2" + System.lineSeparator() +
+                System.lineSeparator() +
+                "theme3:" + System.lineSeparator() +
+                "    tool3                                    test tool3" + System.lineSeparator() +
                 System.lineSeparator();
 
         assertCommandError(new String[] {}, CommandLineTools.COMMAND_NOT_FOUND_STATUS, usage);

--- a/tools-test/src/test/resources/com/powsybl/tools/test/tool-output.sh
+++ b/tools-test/src/test/resources/com/powsybl/tools/test/tool-output.sh
@@ -32,12 +32,27 @@ _tool2() {
     esac
 }
 
+_tool3() {
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    local prev=${COMP_WORDS[COMP_CWORD-1]}
+    case "$prev" in
+        --case-file)
+            COMPREPLY=($(compgen -f -- $cur))
+            return 0
+            ;;
+        *)
+            COMPREPLY=($(compgen -W "-I --case-file " -- $cur))
+            return 0
+            ;;
+    esac
+}
+
 _itools() {
     compopt -o filenames
 
     if [[ "${#COMP_WORDS[@]}" == 2 ]]; then
         local cur=${COMP_WORDS[COMP_CWORD]}
-        COMPREPLY=($(compgen -W "tool1 tool2 " -- $cur))
+        COMPREPLY=($(compgen -W "tool1 tool2 tool3 " -- $cur))
     else
         local cmd=${COMP_WORDS[1]}
         case "$cmd" in
@@ -47,6 +62,10 @@ _itools() {
                 ;;
             tool2)
                 _tool2
+                return 0
+                ;;
+            tool3)
+                _tool3
                 return 0
                 ;;
         esac

--- a/tools-test/src/test/resources/com/powsybl/tools/test/tool-output.sh
+++ b/tools-test/src/test/resources/com/powsybl/tools/test/tool-output.sh
@@ -32,27 +32,12 @@ _tool2() {
     esac
 }
 
-_tool3() {
-    local cur=${COMP_WORDS[COMP_CWORD]}
-    local prev=${COMP_WORDS[COMP_CWORD-1]}
-    case "$prev" in
-        --case-file)
-            COMPREPLY=($(compgen -f -- $cur))
-            return 0
-            ;;
-        *)
-            COMPREPLY=($(compgen -W "-I --case-file " -- $cur))
-            return 0
-            ;;
-    esac
-}
-
 _itools() {
     compopt -o filenames
 
     if [[ "${#COMP_WORDS[@]}" == 2 ]]; then
         local cur=${COMP_WORDS[COMP_CWORD]}
-        COMPREPLY=($(compgen -W "tool1 tool2 tool3 " -- $cur))
+        COMPREPLY=($(compgen -W "tool1 tool2 " -- $cur))
     else
         local cmd=${COMP_WORDS[1]}
         case "$cmd" in
@@ -62,10 +47,6 @@ _itools() {
                 ;;
             tool2)
                 _tool2
-                return 0
-                ;;
-            tool3)
-                _tool3
                 return 0
                 ;;
         esac


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
Due to #2777, a regression appeared: it was not anymore possible to use an `assertCommand` with an output and/or error message containing a regex since only strict string comparison were now available

**What is the new behavior (if this is a feature change)?**
- The old `assertCommand` is back (but deprecated), adapted to the modifications from #2777;
- A new `assertCommandMatchTextOrRegex` method was introduced, doing the same thing but with a clearer name.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
