### PR TITLE
Open setters for all properties in PsseTransformerWinding class

### DIFF
--- a/psse/psse-model/src/main/java/com/powsybl/psse/model/pf/PsseTransformerWinding.java
+++ b/psse/psse-model/src/main/java/com/powsybl/psse/model/pf/PsseTransformerWinding.java
@@ -82,20 +82,12 @@ public class PsseTransformerWinding extends PsseVersioned {
         return windv;
     }
 
-    public void setWindv(double windv) {
-        this.windv = windv;
-    }
-
     public double getNomv() {
         return nomv;
     }
 
     public double getAng() {
         return ang;
-    }
-
-    public void setAng(double ang) {
-        this.ang = ang;
     }
 
     public int getCod() {
@@ -145,6 +137,66 @@ public class PsseTransformerWinding extends PsseVersioned {
 
     public double getCnxa() {
         return cnxa;
+    }
+
+    public void setWindv(double windv) {
+        this.windv = windv;
+    }
+
+    public void setNomv(double nomv) {
+        this.nomv = nomv;
+    }
+
+    public void setAng(double ang) {
+        this.ang = ang;
+    }
+
+    public void setCod(int cod) {
+        this.cod = cod;
+    }
+
+    public void setCont(int cont) {
+        this.cont = cont;
+    }
+
+    public void setNode(int node) {
+        this.node = node;
+    }
+
+    public void setRma(double rma) {
+        this.rma = rma;
+    }
+
+    public void setRmi(double rmi) {
+        this.rmi = rmi;
+    }
+
+    public void setVma(double vma) {
+        this.vma = vma;
+    }
+
+    public void setVmi(double vmi) {
+        this.vmi = vmi;
+    }
+
+    public void setNtp(int ntp) {
+        this.ntp = ntp;
+    }
+
+    public void setTab(int tab) {
+        this.tab = tab;
+    }
+
+    public void setCr(double cr) {
+        this.cr = cr;
+    }
+
+    public void setCx(double cx) {
+        this.cx = cx;
+    }
+
+    public void setCnxa(double cnxa) {
+        this.cnxa = cnxa;
     }
 
     public PsseTransformerWinding copy() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
The PsseTransformerWinding have properties only having getters but not setters, which limits modeling capability. This PR creates all setters (if not yet exist).


**What is the current behavior?**
<!-- You can also link to an open issue here -->
See the point above.


**What is the new behavior (if this is a feature change)?**
See the point above.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
