### PR TITLE
CGMES export: report multiple model identifiers

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -137,7 +137,10 @@ public final class CgmesExportUtil {
         }
         writer.writeStartElement(MD_NAMESPACE, "FullModel");
         writer.writeAttribute(RDF_NAMESPACE, CgmesNames.ABOUT, modelDescription.getId());
-        context.getReportNode().newReportNode().withMessageTemplate("CgmesId", modelDescription.getId()).add();
+        context.getReportNode().newReportNode()
+                .withMessageTemplate("CgmesId", "${cgmesid}")
+                .withUntypedValue("cgmesid", modelDescription.getId())
+                .add();
         writer.writeStartElement(MD_NAMESPACE, CgmesNames.SCENARIO_TIME);
         writer.writeCharacters(DATE_TIME_FORMATTER.format(context.getScenarioTime()));
         writer.writeEndElement();

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -18,6 +18,7 @@ import com.powsybl.cgmes.model.CgmesMetadataModel;
 import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.cgmes.model.CgmesSubset;
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.commons.report.TypedValue;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.LoadDetail;
 import org.slf4j.Logger;
@@ -46,6 +47,9 @@ public final class CgmesExportUtil {
 
     private CgmesExportUtil() {
     }
+
+    public static final String REPORT_NODE_KEY_EXPORTED_CGMES_ID = "ExportedCgmesId";
+    public static final String REPORT_VALUE_EXPORTED_CGMES_ID = "cgmesId";
 
     // Avoid trailing zeros and format always using US locale
 
@@ -137,9 +141,10 @@ public final class CgmesExportUtil {
         }
         writer.writeStartElement(MD_NAMESPACE, "FullModel");
         writer.writeAttribute(RDF_NAMESPACE, CgmesNames.ABOUT, modelDescription.getId());
+        // Report the exported CGMES model identifiers
         context.getReportNode().newReportNode()
-                .withMessageTemplate("CgmesId", "${cgmesid}")
-                .withUntypedValue("cgmesid", modelDescription.getId())
+                .withMessageTemplate(REPORT_NODE_KEY_EXPORTED_CGMES_ID, String.format("CGMES exported model identifier: ${%s}", REPORT_VALUE_EXPORTED_CGMES_ID))
+                .withTypedValue(REPORT_VALUE_EXPORTED_CGMES_ID, modelDescription.getId(), TypedValue.URN_UUID)
                 .add();
         writer.writeStartElement(MD_NAMESPACE, CgmesNames.SCENARIO_TIME);
         writer.writeCharacters(DATE_TIME_FORMATTER.format(context.getScenarioTime()));

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -50,6 +50,8 @@ public final class CgmesExportUtil {
 
     public static final String REPORT_NODE_KEY_EXPORTED_CGMES_ID = "ExportedCgmesId";
     public static final String REPORT_VALUE_EXPORTED_CGMES_ID = "cgmesId";
+    public static final String REPORT_VALUE_EXPORTED_CGMES_SUBSET = "cgmesSubset";
+    public static final String REPORT_VALUE_EXPORTED_CGMES_NETWORK_ID = "networkId";
 
     // Avoid trailing zeros and format always using US locale
 
@@ -143,8 +145,10 @@ public final class CgmesExportUtil {
         writer.writeAttribute(RDF_NAMESPACE, CgmesNames.ABOUT, modelDescription.getId());
         // Report the exported CGMES model identifiers
         context.getReportNode().newReportNode()
-                .withMessageTemplate(REPORT_NODE_KEY_EXPORTED_CGMES_ID, "CGMES exported model identifier: ${cgmesId}")
+                .withMessageTemplate(REPORT_NODE_KEY_EXPORTED_CGMES_ID, "CGMES exported model identifier: ${cgmesId} for subset ${cgmesSubset} of network ${networkId}")
                 .withTypedValue(REPORT_VALUE_EXPORTED_CGMES_ID, modelDescription.getId(), TypedValue.URN_UUID)
+                .withTypedValue(REPORT_VALUE_EXPORTED_CGMES_SUBSET, subset.getIdentifier(), TypedValue.CGMES_SUBSET)
+                .withTypedValue(REPORT_VALUE_EXPORTED_CGMES_NETWORK_ID, network.getId(), TypedValue.ID)
                 .add();
         writer.writeStartElement(MD_NAMESPACE, CgmesNames.SCENARIO_TIME);
         writer.writeCharacters(DATE_TIME_FORMATTER.format(context.getScenarioTime()));

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -143,7 +143,7 @@ public final class CgmesExportUtil {
         writer.writeAttribute(RDF_NAMESPACE, CgmesNames.ABOUT, modelDescription.getId());
         // Report the exported CGMES model identifiers
         context.getReportNode().newReportNode()
-                .withMessageTemplate(REPORT_NODE_KEY_EXPORTED_CGMES_ID, String.format("CGMES exported model identifier: ${%s}", REPORT_VALUE_EXPORTED_CGMES_ID))
+                .withMessageTemplate(REPORT_NODE_KEY_EXPORTED_CGMES_ID, "CGMES exported model identifier: ${cgmesId}")
                 .withTypedValue(REPORT_VALUE_EXPORTED_CGMES_ID, modelDescription.getId(), TypedValue.URN_UUID)
                 .add();
         writer.writeStartElement(MD_NAMESPACE, CgmesNames.SCENARIO_TIME);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CommonGridModelExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CommonGridModelExportTest.java
@@ -9,6 +9,7 @@ package com.powsybl.cgmes.conversion.test.export;
 
 import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conversion.CgmesExport;
+import com.powsybl.cgmes.conversion.export.CgmesExportUtil;
 import com.powsybl.cgmes.extensions.CgmesMetadataModels;
 import com.powsybl.cgmes.extensions.CgmesMetadataModelsAdder;
 import com.powsybl.cgmes.model.CgmesMetadataModel;
@@ -462,8 +463,8 @@ class CommonGridModelExportTest extends AbstractSerDeTest {
         // Obtain exported model identifiers from reporter
         Set<String> exportedModelIdsFromReporter = new HashSet<>();
         for (ReportNode n : report.getChildren()) {
-            if ("CgmesId".equals(n.getMessageKey())) {
-                exportedModelIdsFromReporter.add(n.getMessage());
+            if (CgmesExportUtil.REPORT_NODE_KEY_EXPORTED_CGMES_ID.equals(n.getMessageKey())) {
+                n.getValue(CgmesExportUtil.REPORT_VALUE_EXPORTED_CGMES_ID).ifPresent(v -> exportedModelIdsFromReporter.add(v.getValue().toString()));
             }
         }
         assertFalse(exportedModelIdsFromReporter.isEmpty());

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CommonGridModelExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CommonGridModelExportTest.java
@@ -12,12 +12,14 @@ import com.powsybl.cgmes.conversion.CgmesExport;
 import com.powsybl.cgmes.extensions.CgmesMetadataModels;
 import com.powsybl.cgmes.extensions.CgmesMetadataModelsAdder;
 import com.powsybl.cgmes.model.CgmesMetadataModel;
+import com.powsybl.cgmes.model.CgmesNamespace;
 import com.powsybl.cgmes.model.CgmesSubset;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.datasource.DataSource;
 import com.powsybl.commons.datasource.FileDataSource;
 import com.powsybl.commons.datasource.MemDataSource;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
+import com.powsybl.commons.report.ReportNode;
 import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Summary from CGM Building Process Implementation Guide:
@@ -420,8 +423,17 @@ class CommonGridModelExportTest extends AbstractSerDeTest {
         exportParams.put(CgmesExport.UPDATE_DEPENDENCIES, true);
         exportParams.put(CgmesExport.MODELING_AUTHORITY_SET, "MAS1");
 
+        // Export using a reporter to gather the exported model identifiers
+        ReportNode report = ReportNode
+                .newRootReportNode()
+                .withMessageTemplate("rootKey", "")
+                .build();
+
         MemDataSource memDataSource = new MemDataSource();
-        cgmNetwork.write("CGMES", exportParams, memDataSource);
+        cgmNetwork.write(new ExportersServiceLoader(), "CGMES", exportParams, memDataSource, report);
+
+        // Check the output
+        Set<String> exportedModelIdsFromFiles = new HashSet<>();
         for (Map.Entry<Country, String> entry : TSO_BY_COUNTRY.entrySet()) {
             Country country = entry.getKey();
             // For this unit test we do not need the TSO from the entry value
@@ -439,11 +451,23 @@ class CommonGridModelExportTest extends AbstractSerDeTest {
             // To know the exported version we should read what has been written in the output files
             int sshVersionInOutput = readVersion(memDataSource, filenameFromCgmesExport).orElseThrow();
             assertEquals(expectedOutputVersion, sshVersionInOutput);
+            exportedModelIdsFromFiles.add(readModelId(memDataSource, filenameFromCgmesExport));
         }
         String filenameFromCgmesExport = cgmNetwork.getNameOrId() + "_SV.xml";
         // We have to read it from inside the SV file ...
         int svVersionInOutput = readVersion(memDataSource, filenameFromCgmesExport).orElseThrow();
         assertEquals(expectedOutputVersion, svVersionInOutput);
+        exportedModelIdsFromFiles.add(readModelId(memDataSource, filenameFromCgmesExport));
+
+        // Obtain exported model identifiers from reporter
+        Set<String> exportedModelIdsFromReporter = new HashSet<>();
+        for (ReportNode n : report.getChildren()) {
+            if ("CgmesId".equals(n.getMessageKey())) {
+                exportedModelIdsFromReporter.add(n.getMessage());
+            }
+        }
+        assertFalse(exportedModelIdsFromReporter.isEmpty());
+        assertEquals(exportedModelIdsFromReporter, exportedModelIdsFromFiles);
     }
 
     @Test
@@ -550,6 +574,32 @@ class CommonGridModelExportTest extends AbstractSerDeTest {
             throw new RuntimeException(e);
         }
         return Optional.empty();
+    }
+
+    private static String readModelId(ReadOnlyDataSource ds, String filename) {
+        try {
+            return readId(ds.newInputStream(filename));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String readId(InputStream is) {
+        try {
+            XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(is);
+            while (reader.hasNext()) {
+                int next = reader.next();
+                if (next == XMLStreamConstants.START_ELEMENT && reader.getLocalName().equals("FullModel")) {
+                    String id = reader.getAttributeValue(CgmesNamespace.RDF_NAMESPACE, "about");
+                    reader.close();
+                    return id;
+                }
+            }
+            reader.close();
+        } catch (XMLStreamException e) {
+            throw new RuntimeException(e);
+        }
+        return null;
     }
 
     private Network bareNetwork2Subnetworks() {

--- a/commons/src/main/java/com/powsybl/commons/report/TypedValue.java
+++ b/commons/src/main/java/com/powsybl/commons/report/TypedValue.java
@@ -33,6 +33,7 @@ public class TypedValue {
     public static final String VOLTAGE_LEVEL = "VOLTAGE_LEVEL";
     public static final String FILENAME = "FILENAME";
     public static final String TIMESTAMP = "TIMESTAMP";
+    public static final String URN_UUID = "URN_UUID";
 
     public static final TypedValue TRACE_SEVERITY = new TypedValue("TRACE", TypedValue.SEVERITY);
     public static final TypedValue DEBUG_SEVERITY = new TypedValue("DEBUG", TypedValue.SEVERITY);

--- a/commons/src/main/java/com/powsybl/commons/report/TypedValue.java
+++ b/commons/src/main/java/com/powsybl/commons/report/TypedValue.java
@@ -34,6 +34,8 @@ public class TypedValue {
     public static final String FILENAME = "FILENAME";
     public static final String TIMESTAMP = "TIMESTAMP";
     public static final String URN_UUID = "URN_UUID";
+    public static final String CGMES_SUBSET = "CGMES_SUBSET";
+    public static final String ID = "ID";
 
     public static final TypedValue TRACE_SEVERITY = new TypedValue("TRACE", TypedValue.SEVERITY);
     public static final TypedValue DEBUG_SEVERITY = new TypedValue("DEBUG", TypedValue.SEVERITY);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The identifier of the exported model was written in the `Report` under the key `CgmesId`.
After the recent refactoring of `Report`, only the first `CgmesId` key present in the report could be retrieved, because the exported model identifiers were written as message templates instead of values.


**What is the new behavior (if this is a feature change)?**
Allow for multiple `CgmesId` values to be present in the `Report` output.
The identifiers of the exported model must be retrieved by looking at the message of each report node, instead to its message template:

```java
// Prepare a root report node
ReportNode report = ReportNode
        .newRootReportNode()
        .withMessageTemplate("rootKey", "")
        .build();

// Do the export using the report
cgmNetwork.write(new ExportersServiceLoader(), "CGMES", exportParams, dataSource, report);

// Retrieve all the exported model data from the report
Set<ExportedModel> exportedModelsFromReporter = new HashSet<>();
for (ReportNode n : report.getChildren()) {
    if (CgmesExportUtil.REPORT_NODE_KEY_EXPORTED_CGMES_ID.equals(n.getMessageKey())) {
        n.getValue(CgmesExportUtil.REPORT_VALUE_EXPORTED_CGMES_ID).ifPresent(v -> {
                String subset = n.getValue(CgmesExportUtil.REPORT_VALUE_EXPORTED_CGMES_SUBSET)
                        .map(TypedValue::getValue).map(Object::toString).orElse(null);
                String networkId = n.getValue(CgmesExportUtil.REPORT_VALUE_EXPORTED_CGMES_NETWORK_ID)
                        .map(TypedValue::getValue).map(Object::toString).orElse(null);
                exportedModelsFromReporter.add(new ExportedModel(v.getValue().toString(), subset, networkId));
            }
        );
    }
}
```
with
```java
private record ExportedModel(String cgmesId, String subset, String networkId) {
}
```

