### PR TITLE
Fix: Update TapChanger neutralPosition after using a stepsReplacer

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChanger.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChanger.java
@@ -29,7 +29,7 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
 
     protected int lowTapPosition;
 
-    protected final Integer relativeNeutralPosition;
+    protected Integer relativeNeutralPosition;
 
     protected List<S> steps;
 
@@ -160,6 +160,7 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
         }
 
         this.steps = steps;
+        this.relativeNeutralPosition = getRelativeNeutralPosition();
         return (C) this;
     }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTapChangerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTapChangerTest.java
@@ -200,6 +200,92 @@ public abstract class AbstractTapChangerTest {
     }
 
     @Test
+    public void testPhaseTapChangerStepsReplacer() {
+        PhaseTapChanger phaseTapChanger = twt.newPhaseTapChanger()
+                .setTapPosition(1)
+                .setLowTapPosition(0)
+                .setRegulating(true)
+                .setTargetDeadband(1.0)
+                .setRegulationMode(PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL)
+                .setRegulationValue(10.0)
+                .setRegulationTerminal(terminal)
+                .beginStep()
+                .setR(1.0)
+                .setX(2.0)
+                .setG(3.0)
+                .setB(4.0)
+                .setAlpha(0.0)
+                .setRho(1.0)
+                .endStep()
+                .beginStep()
+                .setR(1.0)
+                .setX(2.0)
+                .setG(3.0)
+                .setB(4.0)
+                .setAlpha(5.0)
+                .setRho(6.0)
+                .endStep()
+                .add();
+        assertEquals(2, phaseTapChanger.getStepCount());
+        assertEquals(2, phaseTapChanger.getAllSteps().size());
+        assertEquals(0, phaseTapChanger.getLowTapPosition());
+        assertEquals(1, phaseTapChanger.getHighTapPosition());
+        assertEquals(0, phaseTapChanger.getNeutralPosition().orElseThrow());
+
+        //check neutral step attributes
+        PhaseTapChangerStep neutralStep = phaseTapChanger.getNeutralStep().orElseThrow();
+        assertEquals(0, neutralStep.getAlpha());
+        assertEquals(1, neutralStep.getRho());
+        assertEquals(1, neutralStep.getR());
+        assertEquals(2, neutralStep.getX());
+        assertEquals(3, neutralStep.getG());
+        assertEquals(4, neutralStep.getB());
+
+        //replace steps
+        phaseTapChanger.stepsReplacer()
+                .beginStep()
+                .setR(1.0)
+                .setX(2.0)
+                .setG(3.0)
+                .setB(4.0)
+                .setAlpha(5.0)
+                .setRho(6.0)
+                .endStep()
+                .beginStep()
+                .setR(5.0)
+                .setX(6.0)
+                .setG(7.0)
+                .setB(8.0)
+                .setAlpha(6.0)
+                .setRho(7.0)
+                .endStep()
+                .beginStep()
+                .setR(9.0)
+                .setX(10.0)
+                .setG(11.0)
+                .setB(12.0)
+                .setAlpha(0.0)
+                .setRho(1.0)
+                .endStep()
+                .replaceSteps();
+
+        assertEquals(3, phaseTapChanger.getStepCount());
+        assertEquals(3, phaseTapChanger.getAllSteps().size());
+        assertEquals(0, phaseTapChanger.getLowTapPosition());
+        assertEquals(2, phaseTapChanger.getHighTapPosition());
+        assertEquals(2, phaseTapChanger.getNeutralPosition().orElseThrow());
+
+        //check neutral step attributes
+        neutralStep = phaseTapChanger.getNeutralStep().orElseThrow();
+        assertEquals(0, neutralStep.getAlpha());
+        assertEquals(1, neutralStep.getRho());
+        assertEquals(9, neutralStep.getR());
+        assertEquals(10, neutralStep.getX());
+        assertEquals(11, neutralStep.getG());
+        assertEquals(12, neutralStep.getB());
+    }
+
+    @Test
     public void invalidTapPositionPhase() {
         ValidationException e = assertThrows(ValidationException.class, () -> createPhaseTapChangerWith2Steps(3, 0, false,
                 PhaseTapChanger.RegulationMode.FIXED_TAP, 1.0, 1.0, terminal));
@@ -514,6 +600,85 @@ public abstract class AbstractTapChangerTest {
         assertEquals(0.0, step.getX(), 0.0);
         assertEquals(0.0, step.getG(), 0.0);
         assertEquals(0.0, step.getB(), 0.0);
+    }
+
+    @Test
+    public void testRatioTapChangerStepsReplacer() {
+        RatioTapChanger ratioTapChanger = twt.newRatioTapChanger()
+                .setTapPosition(1)
+                .setLowTapPosition(0)
+                .setRegulating(true)
+                .setTargetDeadband(1.0)
+                .setRegulationMode(RatioTapChanger.RegulationMode.REACTIVE_POWER)
+                .setRegulationValue(10.0)
+                .setRegulationTerminal(terminal)
+                .beginStep()
+                .setR(1.0)
+                .setX(2.0)
+                .setG(3.0)
+                .setB(4.0)
+                .setRho(1.0)
+                .endStep()
+                .beginStep()
+                .setR(1.0)
+                .setX(2.0)
+                .setG(3.0)
+                .setB(4.0)
+                .setRho(6.0)
+                .endStep()
+                .add();
+        assertEquals(2, ratioTapChanger.getStepCount());
+        assertEquals(2, ratioTapChanger.getAllSteps().size());
+        assertEquals(0, ratioTapChanger.getLowTapPosition());
+        assertEquals(1, ratioTapChanger.getHighTapPosition());
+        assertEquals(0, ratioTapChanger.getNeutralPosition().orElseThrow());
+
+        //check neutral step attributes
+        RatioTapChangerStep neutralStep = ratioTapChanger.getNeutralStep().orElseThrow();
+        assertEquals(1, neutralStep.getRho());
+        assertEquals(1, neutralStep.getR());
+        assertEquals(2, neutralStep.getX());
+        assertEquals(3, neutralStep.getG());
+        assertEquals(4, neutralStep.getB());
+
+        //replace steps
+        ratioTapChanger.stepsReplacer()
+                .beginStep()
+                .setR(1.0)
+                .setX(2.0)
+                .setG(3.0)
+                .setB(4.0)
+                .setRho(6.0)
+                .endStep()
+                .beginStep()
+                .setR(5.0)
+                .setX(6.0)
+                .setG(7.0)
+                .setB(8.0)
+                .setRho(7.0)
+                .endStep()
+                .beginStep()
+                .setR(9.0)
+                .setX(10.0)
+                .setG(11.0)
+                .setB(12.0)
+                .setRho(1.0)
+                .endStep()
+                .replaceSteps();
+
+        assertEquals(3, ratioTapChanger.getStepCount());
+        assertEquals(3, ratioTapChanger.getAllSteps().size());
+        assertEquals(0, ratioTapChanger.getLowTapPosition());
+        assertEquals(2, ratioTapChanger.getHighTapPosition());
+        assertEquals(2, ratioTapChanger.getNeutralPosition().orElseThrow());
+
+        //check neutral step attributes
+        neutralStep = ratioTapChanger.getNeutralStep().orElseThrow();
+        assertEquals(1, neutralStep.getRho());
+        assertEquals(9, neutralStep.getR());
+        assertEquals(10, neutralStep.getX());
+        assertEquals(11, neutralStep.getG());
+        assertEquals(12, neutralStep.getB());
     }
 
     @Test

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTapChangerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTapChangerTest.java
@@ -234,12 +234,12 @@ public abstract class AbstractTapChangerTest {
 
         //check neutral step attributes
         PhaseTapChangerStep neutralStep = phaseTapChanger.getNeutralStep().orElseThrow();
-        assertEquals(0, neutralStep.getAlpha());
-        assertEquals(1, neutralStep.getRho());
-        assertEquals(1, neutralStep.getR());
-        assertEquals(2, neutralStep.getX());
-        assertEquals(3, neutralStep.getG());
-        assertEquals(4, neutralStep.getB());
+        assertEquals(0, neutralStep.getAlpha(), 0.0);
+        assertEquals(1, neutralStep.getRho(), 0.0);
+        assertEquals(1, neutralStep.getR(), 0.0);
+        assertEquals(2, neutralStep.getX(), 0.0);
+        assertEquals(3, neutralStep.getG(), 0.0);
+        assertEquals(4, neutralStep.getB(), 0.0);
 
         //replace steps
         phaseTapChanger.stepsReplacer()
@@ -277,12 +277,12 @@ public abstract class AbstractTapChangerTest {
 
         //check neutral step attributes
         neutralStep = phaseTapChanger.getNeutralStep().orElseThrow();
-        assertEquals(0, neutralStep.getAlpha());
-        assertEquals(1, neutralStep.getRho());
-        assertEquals(9, neutralStep.getR());
-        assertEquals(10, neutralStep.getX());
-        assertEquals(11, neutralStep.getG());
-        assertEquals(12, neutralStep.getB());
+        assertEquals(0, neutralStep.getAlpha(), 0.0);
+        assertEquals(1, neutralStep.getRho(), 0.0);
+        assertEquals(9, neutralStep.getR(), 0.0);
+        assertEquals(10, neutralStep.getX(), 0.0);
+        assertEquals(11, neutralStep.getG(), 0.0);
+        assertEquals(12, neutralStep.getB(), 0.0);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
When using a stepsReplacer on a TapChanger, the neutralPosition isn't updated


**What is the new behavior (if this is a feature change)?**
When using a stepsReplacer on a TapChanger, the neutralPosition is updated


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
This is not really a breaking change, but a TCK test is added and so, the mainteners of a custom IIDM implementation must make sure that the neutralPosition of the TapChanger is correctly updated when using a stepsReaplacer on the TapChanger or this new test will fail 