### PR TITLE
Make method to compute hvdc line losses public

### DIFF
--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesMetadataModelImpl.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesMetadataModelImpl.java
@@ -138,6 +138,7 @@ public class CgmesMetadataModelImpl implements CgmesMetadataModel {
     @Override
     public CgmesMetadataModelImpl clearDependencies() {
         this.dependentOn.clear();
+        this.supersedes.clear();
         return this;
     }
 

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesMetadataModelImpl.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesMetadataModelImpl.java
@@ -138,7 +138,6 @@ public class CgmesMetadataModelImpl implements CgmesMetadataModel {
     @Override
     public CgmesMetadataModelImpl clearDependencies() {
         this.dependentOn.clear();
-        this.supersedes.clear();
         return this;
     }
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/HvdcUtils.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/HvdcUtils.java
@@ -77,7 +77,7 @@ public final class HvdcUtils {
         }
     }
 
-    private static double getHvdcLineLosses(double rectifierPDc, double nominalV, double r) {
+    public static double getHvdcLineLosses(double rectifierPDc, double nominalV, double r) {
         // This method computes the losses due to the HVDC line.
         // The active power value on rectifier DC side is known as the HVDC active power set point minus the losses related
         // to AC/DC conversion (rectifier conversion), the voltage is approximated to the nominal voltage as attribute of the HVDC line.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

Yes, https://github.com/powsybl/powsybl-open-loadflow/pull/1062

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Method `HvdcUtils::getHvdcLineLosses` has now a public access.

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
