### PR TITLE
CGMES metadata models: allow clear of supersedes

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
@@ -235,7 +235,9 @@ public class CgmesExport implements Exporter {
      */
     private void updateDependenciesCGM(Collection<IgmModelsForCgm> igmModels, CgmesMetadataModel updatedCgmSvModel) {
         // Each updated SSH model supersedes the original one
+        // Clear previous dependencies
         igmModels.forEach(m -> m.updatedSsh.clearDependencies());
+        igmModels.forEach(m -> m.updatedSsh.clearSupersedes());
         igmModels.forEach(m -> m.updatedSsh.addSupersedes(m.originalSsh.getId()));
 
         // Updated SV model depends on updated SSH models and original TP models

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CommonGridModelExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CommonGridModelExportTest.java
@@ -470,6 +470,7 @@ class CommonGridModelExportTest extends AbstractSerDeTest {
             String country = n.getSubstations().iterator().next().getCountry().orElseThrow().toString();
             CgmesMetadataModel sshModel = n.getExtension(CgmesMetadataModels.class).getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS).orElseThrow();
             sshModel.clearDependencies()
+                    .clearSupersedes()
                     .addDependentOn("myDependency")
                     .addSupersedes("mySupersede")
                     .setVersion(exportedVersion)
@@ -578,6 +579,7 @@ class CommonGridModelExportTest extends AbstractSerDeTest {
                 .setVersion(version)
                 .setModelingAuthoritySet("http://elia.be/CGMES/2.4.15")
                 .addDependentOn("BE EQ model ID")
+                .addSupersedes("BE SSH previous ID")
                 .addProfile("http://entsoe.eu/CIM/SteadyStateHypothesis/1/1")
                 .add()
                 .add();
@@ -589,6 +591,7 @@ class CommonGridModelExportTest extends AbstractSerDeTest {
                 .setVersion(version)
                 .setModelingAuthoritySet("http://tennet.nl/CGMES/2.4.15")
                 .addDependentOn("NL EQ model ID")
+                .addSupersedes("NL SSH previous ID")
                 .addProfile("http://entsoe.eu/CIM/SteadyStateHypothesis/1/1")
                 .add()
                 .add();

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesMetadataModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesMetadataModel.java
@@ -166,4 +166,12 @@ public interface CgmesMetadataModel {
      * @return The model with an empty set of values this model depends on.
      */
     CgmesMetadataModelImpl clearDependencies();
+
+    /**
+     * Remove all the model ids this model supersedes.
+     * @return The model with an empty set of values this model supersedes.
+     */
+    default CgmesMetadataModelImpl clearSupersedes() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesMetadataModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesMetadataModel.java
@@ -171,7 +171,5 @@ public interface CgmesMetadataModel {
      * Remove all the model ids this model supersedes.
      * @return The model with an empty set of values this model supersedes.
      */
-    default CgmesMetadataModelImpl clearSupersedes() {
-        throw new UnsupportedOperationException("Not implemented");
-    }
+    CgmesMetadataModelImpl clearSupersedes();
 }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesMetadataModelImpl.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesMetadataModelImpl.java
@@ -141,6 +141,12 @@ public class CgmesMetadataModelImpl implements CgmesMetadataModel {
         return this;
     }
 
+    @Override
+    public CgmesMetadataModelImpl clearSupersedes() {
+        this.supersedes.clear();
+        return this;
+    }
+
     private static void addIfNonEmpty(String id, Collection<String> ids) {
         if (id != null && !id.isEmpty()) {
             ids.add(id);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Supersedes set in CGMES metadata models (SSH) can not be emptied by the user.
This creates a problem when trying to export CGMES data for a network that is read from CGMES inputs that already specify superseding info. 

In CGM quick export, the previous supersede and the one added automatically during export are present in the output.

In manual export, the user may add a supersede to the model, to prepare the export, but the previous supersede can not be removed. The exported files contains two supersede items.

**What is the new behavior (if this is a feature change)?**

The CGMES metada model supersedes set in the network extension can be emptied with the method `CgmesMetadataModel::clearDependencies`.

The quick CGM export clears the existing SSH supersedes before adding the current one.

For the manual export of single files, the user is now being able to clear previous supersedes before adding the requested one:
```java
network.getExtension(CgmesMetadataModels.class)
    .getModelForSubset(CgmesSubset.STEADY_STATE_HYPOTHESIS).orElseThrow()
        .clearSupersedes()
        .addSupersedes("manual-supersede");
network.write("CGMES", exportParams, ...);
```

**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

If you had define a custom `CgmesMetadataModel` implementation, you need to define a new method:
`CgmesMetadataModelImpl clearSupersedes()`.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
