### PR TITLE
Datasources - part 5: fixes

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -128,12 +128,16 @@ public class CgmesImport implements Importer {
     @Override
     public boolean exists(ReadOnlyDataSource ds) {
         CgmesOnDataSource cds = new CgmesOnDataSource(ds);
-        if (cds.exists()) {
-            return true;
+        try {
+            if (cds.exists()) {
+                return true;
+            }
+            // If we are configured to support CIM14,
+            // check if there is this CIM14 data
+            return importCim14 && cds.existsCim14();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
-        // If we are configured to support CIM14,
-        // check if there is this CIM14 data
-        return importCim14 && cds.existsCim14();
     }
 
     @Override

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -38,11 +38,12 @@ public class CgmesOnDataSource {
         if (dataSource.getDataExtension() == null || dataSource.getDataExtension().isEmpty()) {
             return false;
         } else if (EXTENSION.equals(dataSource.getDataExtension())) {
-            try (InputStream is = dataSource.exists(null, EXTENSION) ? dataSource.newInputStream(null, EXTENSION) : null) {
-                if (is == null) {
-                    return true;
+            try {
+                if (dataSource.exists(null, EXTENSION)) {
+                    try (InputStream is = dataSource.newInputStream(null, EXTENSION)) {
+                        return isCim14 ? !existsNamespacesCim14(NamespaceReader.namespaces(is)) : !existsNamespaces(NamespaceReader.namespaces(is));
+                    }
                 }
-                return isCim14 ? !existsNamespacesCim14(NamespaceReader.namespaces(is)) : !existsNamespaces(NamespaceReader.namespaces(is));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -34,24 +34,18 @@ public class CgmesOnDataSource {
         return dataSource;
     }
 
-    private boolean checkIfMainFileNotWithCgmesData(boolean isCim14) {
+    private boolean checkIfMainFileNotWithCgmesData(boolean isCim14) throws IOException {
         if (dataSource.getDataExtension() == null || dataSource.getDataExtension().isEmpty()) {
             return false;
-        } else if (EXTENSION.equals(dataSource.getDataExtension())) {
-            try {
-                if (dataSource.exists(null, EXTENSION)) {
-                    try (InputStream is = dataSource.newInputStream(null, EXTENSION)) {
-                        return isCim14 ? !existsNamespacesCim14(NamespaceReader.namespaces(is)) : !existsNamespaces(NamespaceReader.namespaces(is));
-                    }
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+        } else if (EXTENSION.equals(dataSource.getDataExtension()) && dataSource.exists(null, EXTENSION)) {
+            try (InputStream is = dataSource.newInputStream(null, EXTENSION)) {
+                return isCim14 ? !existsNamespacesCim14(NamespaceReader.namespaces(is)) : !existsNamespaces(NamespaceReader.namespaces(is));
             }
         }
         return true;
     }
 
-    public boolean exists() {
+    public boolean exists() throws IOException {
         // Check that the main file is a CGMES file
         if (checkIfMainFileNotWithCgmesData(false)) {
             return false;
@@ -69,7 +63,7 @@ public class CgmesOnDataSource {
         return namespaces.contains(CIM_16_NAMESPACE) || namespaces.contains(CIM_100_NAMESPACE);
     }
 
-    public boolean existsCim14() {
+    public boolean existsCim14() throws IOException {
         // Check that the main file is a CGMES file
         if (checkIfMainFileNotWithCgmesData(true)) {
             return false;

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -24,7 +24,7 @@ import static com.powsybl.cgmes.model.CgmesNamespace.*;
  * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
  */
 public class CgmesOnDataSource {
-    private static final String EXTENSIONS = "xml";
+    private static final String EXTENSION = "xml";
 
     public CgmesOnDataSource(ReadOnlyDataSource ds) {
         this.dataSource = ds;
@@ -37,10 +37,10 @@ public class CgmesOnDataSource {
     private boolean checkIfMainFileNotWithCgmesData(boolean isCim14) {
         if (dataSource.getDataExtension() == null || dataSource.getDataExtension().isEmpty()) {
             return false;
-        } else if (EXTENSIONS.equals(dataSource.getDataExtension())) {
+        } else if (EXTENSION.equals(dataSource.getDataExtension())) {
             try {
-                if (dataSource.exists(null, EXTENSIONS)) {
-                    try (InputStream is = dataSource.newInputStream(null, EXTENSIONS)) {
+                if (dataSource.exists(null, EXTENSION)) {
+                    try (InputStream is = dataSource.newInputStream(null, EXTENSION)) {
                         return isCim14 ? !existsNamespacesCim14(NamespaceReader.namespaces(is)) : !existsNamespaces(NamespaceReader.namespaces(is));
                     }
                 }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -38,8 +38,12 @@ public class CgmesOnDataSource {
         if (dataSource.getDataExtension() == null || dataSource.getDataExtension().isEmpty()) {
             return false;
         } else if (EXTENSIONS.equals(dataSource.getDataExtension())) {
-            try (InputStream is = dataSource.newInputStream(null, EXTENSIONS)) {
-                return isCim14 ? !existsNamespacesCim14(NamespaceReader.namespaces(is)) : !existsNamespaces(NamespaceReader.namespaces(is));
+            try {
+                if (dataSource.exists(null, EXTENSIONS)) {
+                    try (InputStream is = dataSource.newInputStream(null, EXTENSIONS)) {
+                        return isCim14 ? !existsNamespacesCim14(NamespaceReader.namespaces(is)) : !existsNamespaces(NamespaceReader.namespaces(is));
+                    }
+                }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -38,12 +38,11 @@ public class CgmesOnDataSource {
         if (dataSource.getDataExtension() == null || dataSource.getDataExtension().isEmpty()) {
             return false;
         } else if (EXTENSION.equals(dataSource.getDataExtension())) {
-            try {
-                if (dataSource.exists(null, EXTENSION)) {
-                    try (InputStream is = dataSource.newInputStream(null, EXTENSION)) {
-                        return isCim14 ? !existsNamespacesCim14(NamespaceReader.namespaces(is)) : !existsNamespaces(NamespaceReader.namespaces(is));
-                    }
+            try (InputStream is = dataSource.exists(null, EXTENSION) ? dataSource.newInputStream(null, EXTENSION) : null) {
+                if (is == null) {
+                    return true;
                 }
+                return isCim14 ? !existsNamespacesCim14(NamespaceReader.namespaces(is)) : !existsNamespaces(NamespaceReader.namespaces(is));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
@@ -43,12 +43,12 @@ class CgmesOnDataSourceTest {
                 Arguments.of("cim no rdf cim14", "validCim14InvalidContent_EQ.xml", "14", false),
                 Arguments.of("rdf no cim16", "validRdfInvalidContent_EQ.xml", "16", false),
                 Arguments.of("rdf no cim14", "validRdfInvalidContent_EQ.xml", "14", false),
-                Arguments.of("rdf cim16 not cim14" ,"empty_cim16_EQ.xml", "14", false),
-                Arguments.of("rdf cim14 not cim16" ,"empty_cim14_EQ.xml", "16", false)
+                Arguments.of("rdf cim16 not cim14", "empty_cim16_EQ.xml", "14", false),
+                Arguments.of("rdf cim14 not cim16", "empty_cim14_EQ.xml", "16", false)
         );
     }
 
-    @ParameterizedTest(name="{0}")
+    @ParameterizedTest(name = "{0}")
     @MethodSource("provideArguments")
     void testExists(String testName, String filename, String cimVersion, boolean expectedExists) throws IOException {
         ReadOnlyDataSource dataSource = new ResourceDataSource("incomplete",

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class CgmesOnDataSourceTest {
 
-    private static void doTestExists(String filename, String cimVersion, boolean expectedExists) {
+    private static void doTestExists(String filename, String cimVersion, boolean expectedExists) throws IOException {
         ReadOnlyDataSource dataSource = new ResourceDataSource("incomplete",
                 new ResourceSet("/", filename));
         CgmesOnDataSource cgmesOnDataSource = new CgmesOnDataSource(dataSource);
@@ -34,7 +34,7 @@ class CgmesOnDataSourceTest {
         assertEquals(expectedExists, exists);
     }
 
-    private static void doTestExistsEmpty(String profile, String cimVersion, boolean expectedExists) {
+    private static void doTestExistsEmpty(String profile, String cimVersion, boolean expectedExists) throws IOException {
         String filename = "empty_cim" + cimVersion + "_" + profile + ".xml";
         doTestExists(filename, cimVersion, expectedExists);
     }
@@ -63,47 +63,47 @@ class CgmesOnDataSourceTest {
     }
 
     @Test
-    void testEQcim14() {
+    void testEQcim14() throws IOException {
         doTestExistsEmpty("EQ", "14", true);
     }
 
     @Test
-    void testEQcim16() {
+    void testEQcim16() throws IOException {
         doTestExistsEmpty("EQ", "16", true);
     }
 
     @Test
-    void testSVcim14() {
+    void testSVcim14() throws IOException {
         doTestExistsEmpty("SV", "14", false);
     }
 
     @Test
-    void testCimNoRdfcim16() {
+    void testCimNoRdfcim16() throws IOException {
         doTestExists("validCim16InvalidContent_EQ.xml", "16", false);
     }
 
     @Test
-    void testCimNoRdfcim14() {
+    void testCimNoRdfcim14() throws IOException {
         doTestExists("validCim14InvalidContent_EQ.xml", "14", false);
     }
 
     @Test
-    void testRdfNoCim16() {
+    void testRdfNoCim16() throws IOException {
         doTestExists("validRdfInvalidContent_EQ.xml", "16", false);
     }
 
     @Test
-    void testRdfNoCim14() {
+    void testRdfNoCim14() throws IOException {
         doTestExists("validRdfInvalidContent_EQ.xml", "14", false);
     }
 
     @Test
-    void testRdfCim16NotExistsCim14() {
+    void testRdfCim16NotExistsCim14() throws IOException {
         doTestExists("empty_cim16_EQ.xml", "14", false);
     }
 
     @Test
-    void testRdfCim14NotExistsCim16() {
+    void testRdfCim14NotExistsCim16() throws IOException {
         doTestExists("empty_cim14_EQ.xml", "16", false);
     }
 }

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
@@ -56,6 +56,7 @@ class CgmesOnDataSourceTest {
                     throw new RuntimeException(ex);
                 }
             }
+//            Files.copy(Path.of(Objects.requireNonNull(getClass().getClassLoader().getResource("foo.iidm.zip")).getFile()), testDir.resolve("foo.iidm.zip"));
             ReadOnlyDataSource dataSource = new ZipArchiveDataSource(testDir, "foo.iidm.zip", "test", "xml", null);
             CgmesOnDataSource cgmesOnDataSource = new CgmesOnDataSource(dataSource);
             assertFalse(cgmesOnDataSource.exists());

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
@@ -56,7 +56,6 @@ class CgmesOnDataSourceTest {
                     throw new RuntimeException(ex);
                 }
             }
-//            Files.copy(Path.of(Objects.requireNonNull(getClass().getClassLoader().getResource("foo.iidm.zip")).getFile()), testDir.resolve("foo.iidm.zip"));
             ReadOnlyDataSource dataSource = new ZipArchiveDataSource(testDir, "foo.iidm.zip", "test", "xml", null);
             CgmesOnDataSource cgmesOnDataSource = new CgmesOnDataSource(dataSource);
             assertFalse(cgmesOnDataSource.exists());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
- In `CgmesOnDataSource.checkIfMainFileNotWithCgmesData()`, a stream was open without first checking if the file existed, which could result in an unexpected exception.

**What is the new behavior (if this is a feature change)?**
- In `CgmesOnDataSource.checkIfMainFileNotWithCgmesData()`, we first check if the file exists before trying to open a stream on it.

**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

The following methods of `CgmesOnDataSource` now throw an `IOException`:
 - `public boolean exists()`
 - `public boolean existsCim14()`

If you call them, you should catch or propagate this exception. To keep the same behavior as before, you can catch this exception and propagate it in a new `UncheckedIOException`.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
