### PR TITLE
Distinguish between line and 2 windings transformer in TerminalFinder default rules

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TerminalFinder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/TerminalFinder.java
@@ -86,7 +86,8 @@ public final class TerminalFinder {
         List<Predicate<Terminal>> rules = new ArrayList<>();
         rules.add(t -> t.getConnectable() instanceof BusbarSection);
         rules.add(t -> t.getConnectable() instanceof Injection);
-        rules.add(t -> t.getConnectable() instanceof Branch);
+        rules.add(t -> t.getConnectable() instanceof Line);
+        rules.add(t -> t.getConnectable() instanceof TwoWindingsTransformer);
         rules.add(t -> t.getConnectable() instanceof ThreeWindingsTransformer);
         rules.add(t -> t.getConnectable() instanceof HvdcConverterStation);
         rules.add(Objects::nonNull);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In TerminalFinderTest tck test class : methods testLineTerminal1 and testLineTerminal2
These 2 tests succeed here only because the 2 lines "NHV1_NHV2_1" and "NHV1_NHV2_2" are created and attached to the bus "NHV1" before the 2 windings transformer "NGEN_NHV1".
If the transformer is created before the lines, these 2 tests will fail.
And In the network store implementation, these 2 tests also fail.


**What is the new behavior (if this is a feature change)?**
Regardless of the lines and transformer creation order on the bus, these 2 tests will succeed.
And in the network store implementation, these 2 tests will also succeed.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
