### PR TITLE
Add anchors in the documentation

### DIFF
--- a/docs/grid_exchange_formats/ampl/export.md
+++ b/docs/grid_exchange_formats/ampl/export.md
@@ -1,6 +1,7 @@
 # Export
 <span style="color: red">TODO</span>
 
+(ampl-export-options)=
 ## Options
 
 These properties can be defined in the configuration file in the [import-export-parameters-default-value](../../user/configuration/import-export-parameters-default-value.md#import-export-parameters-default-value) module.

--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -25,6 +25,7 @@ If the dependencies have to be updated automatically (see parameter **iidm.expor
 
 The output filenames will follow the pattern `<baseName>_<profile>.xml`. The basename is determined from the parameters, or the basename of the export data source or the main network name. 
 
+(cgmes-cgm-quick-export)=
 ## CGM (Common Grid Model) quick export
 
 When exporting a CGM, we need an IIDM network (CGM) that contains multiple subnetworks (one for each IGM). 
@@ -72,6 +73,7 @@ exampleBase_SV.xml
 
 where the updated SSH files will supersede the original ones, and the SV will contain the correct dependencies of new SSH and original TPs.
 
+(cgmes-cgm-manual-export)=
 ## CGM (Common Grid Model) manual export
 
 If you want to intervene in how the updated IGM SSH files or the CGM SV are exported, you can make multiple calls to the CGMES export function.
@@ -155,18 +157,21 @@ Remember that, in addition to setting the info for metadata models in the IIDM e
 
 The following sections describe in detail how each supported PowSyBl network model object is converted to CGMES network components.
 
+(cgmes-battery-export)=
 ### Battery
 
 PowSyBl [`Battery`](../../grid_model/network_subnetwork.md#battery) is exported as `SynchronousMachine` with `HydroGeneratingUnit`.
 
 <span style="color: red">TODO details</span>
 
+(cgmes-busbar-section-export)=
 ### BusbarSection
 
 PowSyBl [`BusbarSection`](../../grid_model/network_subnetwork.md#busbar-section) is exported as CGMES `BusbarSection`.
 
 <span style="color: red">TODO details</span>
 
+(cgmes-dangling-line-export)=
 ### DanglingLine
 
 PowSyBl [`DanglingLine`](../../grid_model/network_subnetwork.md#dangling-line) is exported as several CGMES network objects.
@@ -174,6 +179,7 @@ Each dangling line will be exported as one `EquivalentInjection` and one `ACLine
 
 <span style="color: red">TODO details</span>
 
+(cgmes-generator-export)=
 ### Generator
 
 PowSyBl [`Generator`](../../grid_model/network_subnetwork.md#generator) is exported as CGMES `SynchronousMachine`.
@@ -189,24 +195,28 @@ generator has the extension [`RemoteReactivePowerControl`](../../grid_model/exte
 with the `enabled` activated and the generator attribute `voltageRegulatorOn` set to `false`. In all other cases, a
 `RegulatingControl` is exported with `RegulatingControl.mode` set to `RegulatingControlModeKind.voltage`.
 
+(cgmes-hvdc-export)=
 ### HVDC line and HVDC converter stations
 
 A PowSyBl [`HVDCLine`](../../grid_model/network_subnetwork.md#hvdc-line) and its two [`HVDCConverterStations`](../../grid_model/network_subnetwork.md#hvdc-converter-station) are exported as a `DCLineSegment` with two `DCConverterUnits`.
 
 <span style="color: red">TODO details</span>
 
+(cgmes-line-export)=
 ### Line
 
 PowSyBl [`Line`](../../grid_model/network_subnetwork.md#line) is exported as `ACLineSegment`.
 
 <span style="color: red">TODO details</span>
 
+(cgmes-load-export)=
 ### Load
 
 PowSyBl [`Load`](../../grid_model/network_subnetwork.md#load) is exported as `ConformLoad`, `NonConformLoad` or `EnergyConsumer` depending on the extension [`LoadDetail`](../../grid_model/extensions.md#load-detail).
 
 <span style="color: red">TODO details</span>
 
+(cgmes-shunt-compensator-export)=
 ### Shunt compensator
 
 PowSyBl [`ShuntCompensator`](../../grid_model/network_subnetwork.md#shunt-compensator) is exported as `LinearShuntCompensator` or `NonlinearShuntCompensator` depending on their models.
@@ -220,6 +230,7 @@ A shunt compensator with local voltage control (i.e., the regulating terminal is
 and no valid voltage target will not have any exported regulating control. In all other cases, a `RegulatingControl`
 is exported with `RegulatingControl.mode` set to `RegulatingControlModeKind.voltage`.
 
+(cgmes-static-var-compensator-export)=
 ### StaticVarCompensator
 
 PowSyBl [`StaticVarCompensator`](../../grid_model/network_subnetwork.md#static-var-compensator) is exported as `StaticVarCompensator`.
@@ -238,18 +249,21 @@ to `RegulatingControlModeKind.voltage` when the static VAR compensator mode is `
 is `OFF`, the exported regulating control mode will be reactive power only if the voltage target is not valid but the
 reactive power target is. Otherwise, the exported mode will be voltage.
 
+(cgmes-substation-export)=
 ### Substation
 
 PowSyBl [`Substation`](../../grid_model/network_subnetwork.md#substation) is exported as `Substation`.
 
 <span style="color: red">TODO details</span>
 
+(cgmes-switch-export)=
 ### Switch
 
 PowSyBl [`Switch`](../../grid_model/network_subnetwork.md#breakerswitch) is exported as CGMES `Breaker`, `Disconnector` or `LoadBreakSwitch` depending on its `SwitchKind`.
 
 <span style="color: red">TODO details</span>
 
+(cgmes-three-winding-transformer-export)=
 ### ThreeWindingsTransformer
 
 PowSyBl [`ThreeWindingsTransformer`](../../grid_model/network_subnetwork.md#three-winding-transformer) is exported as `PowerTransformer` with three `PowerTransformerEnds`.
@@ -270,12 +284,14 @@ In a `PhaseTapChanger`, the `TapChangerControl` is exported with `RegulatingCont
 `PhaseTapChanger` `regulationMode` is set to `ACTIVE_POWER_CONTROL`, and with `RegulatingControl.mode` set to `RegulatingControlModeKind.currentFlow`
 when `PhaseTapChanger` `regulationMode` is set to `CURRENT_LIMITER`.
 
+(cgmes-two-winding-transformer-export)=
 ### TwoWindingsTransformer
 
 PowSyBl [`TwoWindingsTransformer`](../../grid_model/network_subnetwork.md#two-winding-transformer) is exported as `PowerTransformer` with two `PowerTransformerEnds`.
 
 Tap changer controls for two-winding transformers are exported following the same rules explained in the previous section about three-winding transformers. See [tap changer control](#tap-changer-control).
 
+(cgmes-voltage-level-export)=
 ### Voltage level
 
 PowSyBl [`VoltageLevel`](../../grid_model/network_subnetwork.md#voltage-level) is exported as `VoltageLevel`.
@@ -284,12 +300,14 @@ PowSyBl [`VoltageLevel`](../../grid_model/network_subnetwork.md#voltage-level) i
 
 ## Extensions
 
+(cgmes-control-areas-export)=
 ### Control areas
 
 PowSyBl [`ControlAreas`](import.md#cgmes-control-areas) are exported as several `ControlArea`.
 
 <span style="color: red">TODO details</span>
 
+(cgmes-export-options)=
 ## Options
 
 These properties can be defined in the configuration file in the [import-export-parameters-default-value](../../user/configuration/import-export-parameters-default-value.md#import-export-parameters-default-value) module.

--- a/docs/grid_exchange_formats/iidm/export.md
+++ b/docs/grid_exchange_formats/iidm/export.md
@@ -2,7 +2,7 @@
 
 <span style="color: red">TODO</span>
 
-(iidm-export-options)
+(iidm-export-options)=
 ## Options
 These properties can be defined in the configuration file in the [import-export-parameters-default-value](../../user/configuration/import-export-parameters-default-value.md#import-export-parameters-default-value) module.
 

--- a/docs/grid_exchange_formats/iidm/export.md
+++ b/docs/grid_exchange_formats/iidm/export.md
@@ -2,6 +2,7 @@
 
 <span style="color: red">TODO</span>
 
+(iidm-export-options)
 ## Options
 These properties can be defined in the configuration file in the [import-export-parameters-default-value](../../user/configuration/import-export-parameters-default-value.md#import-export-parameters-default-value) module.
 

--- a/docs/grid_exchange_formats/iidm/import.md
+++ b/docs/grid_exchange_formats/iidm/import.md
@@ -2,6 +2,7 @@
 
 <span style="color: red">TODO</span>
 
+(iidm-import-options)=
 ## Options
 These properties can be defined in the configuration file in the [import-export-parameters-default-value](../../user/configuration/import-export-parameters-default-value.md#import-export-parameters-default-value) module.
 

--- a/docs/grid_exchange_formats/iidm/index.md
+++ b/docs/grid_exchange_formats/iidm/index.md
@@ -18,6 +18,7 @@ Below are two exports from the same network:
 - one XML export (XIIDM exchange format)
 - one JSON export (JIIDM exchange format)
 
+(xiidm)=
 ## XIIDM
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -64,6 +65,7 @@ Below are two exports from the same network:
 </iidm:network>
 ```
 
+(jiidm)=
 ## JIIDM
 ```json
 {

--- a/docs/grid_exchange_formats/psse/import.md
+++ b/docs/grid_exchange_formats/psse/import.md
@@ -7,12 +7,14 @@ The import module reads and converts a PSS®E power flow data file to the PowSyB
 
 First, input data is obtained by reading and parsing the input file, and as a result, a PSS®E model is created in memory. This model can be viewed as a set of Java classes where each data block of the PSS®E model is associated with a specific Java class that describes all their attributes or data items. Then, some inconsistency checks are performed on this model. If the validation succeeds, the PSS®E model is converted to a PowSyBl grid model.
 
+(psse-import-options)=
 ## Options
 Parameters for the import can be defined in the configuration file in the [import-export-parameters-default-value](../../user/configuration/import-export-parameters-default-value.md#import-export-parameters-default-value) module.
 
 **psse.import.ignore-base-voltage**  
 The `psse.import.ignore-base-voltage` property is an optional property that defines if the importer should ignore the base voltage information present in the PSS®E file. The default value is `false`.
 
+(psse-inconsistency-checks)=
 ## Inconsistency checks
 -<span style="color: red">TODO</span>
 
@@ -37,6 +39,7 @@ Every voltage level is assigned to its corresponding substation, with attributes
 The following sections describe in detail how each supported PSS®E data block is converted to PowSyBl network model objects.
 
 
+(psse-bus-data-conversion)=
 ### _Bus Data_
 
 There is a one-to-one correspondence between the records of the PSS®E _Bus Data_ block and the buses of the PowSyBl network model. For each record in the _Bus Data_ block a PowSyBl bus is created and assigned to its corresponding voltage level with the following attributes:
@@ -46,6 +49,7 @@ There is a one-to-one correspondence between the records of the PSS®E _Bus Data
 - **Angle** is copied from the PSS®E bus voltage phase angle, `VA`.
 
 
+(psse-load-data-conversion)=
 ### _Load Data_
 
 Every _Load Data_ record represents one load. Multiple loads are allowed at the same bus by specifying one _Load Data_ record with the same bus and different load identifiers. Each record defines a new load in the PowSyBl grid model associated with its corresponding voltage level and with the following attributes:
@@ -59,6 +63,7 @@ The load is connected to the ConnectableBus if load status (field `STATUS` in th
 PSS®E supports loads with three different characteristics: Constant Power, Constant Current and Constant Admittance. The current version only takes into consideration the Constant Power component, discarding the Constant Current component (fields `IP` and `IQ` in the _Load Data_ record) and the Constant Admittance component (fields `YP` and `YQ` in the _Load Data_ record).
 
 
+(psse-fixed-bus-shunt-data-conversion)=
 ### _Fixed Bus Shunt Data_
 
 Each _Fixed Bus Shunt Data_ record defines a PowSyBl shunt compensator with a linear model and a single section. It is possible to define multiple fixed shunts at the same bus. The PowSyBl shunt compensator is associated with its corresponding voltage level and has the following attributes:
@@ -73,6 +78,7 @@ Each _Fixed Bus Shunt Data_ record defines a PowSyBl shunt compensator with a li
 The shunt compensator is connected to the ConnectableBus if fixed shunt status (field `STATUS` in the _Fixed Bus Shunt Data_ record) is `1` (In-service).
 
 
+(psse-switched-shunt-data-conversion)=
 ### _Switched Shunt Data_
 
 In the PSS®E version 33, only one switched shunt element can be defined on each bus. Version 35 allows multiple switched shunts on the same bus, adding an alphanumeric switched shunt identifier.
@@ -103,6 +109,7 @@ When the adjustment method `ADJM` is `0`, the behaviour of the switched shunt ca
 
 If the adjustment method `ADJM` is `1`, the reactor and capacitor blocks can be specified at any order, and all the switching combinations are considered in PSS®E. Current conversion does not support building a separate section for each switching combination. To map the PSS@E shunt blocks/steps into PowSyBl sections, first the reactor and capacitor blocks are increasingly ordered by susceptance (field `BI` in the _Switched Shunt Data_ record) and then sections are created like in the previous adjustment considering that blocks are switched on following the sorted order.
 
+(psse-generator-data-conversion)=
 ### _Generator Data_
 
 Every _Generator Data_ single line record represents one generator. Multiple generators are allowed at a PSS®E bus by specifying the same bus and a different identifier. Each record defines a new generator in the PowSyBl grid model associated with its corresponding voltage level and with the following attributes:
@@ -120,7 +127,7 @@ Every _Generator Data_ single line record represents one generator. Multiple gen
 
 The generator is connected to the ConnectableBus if generator status (field `STAT` in the _Generator Data_ record) is `1` (In-service).
 
-
+(psse-branch-data-conversion)=
 ### _Non-Transformer Branch Data_
 
 In PSS®E each AC transmission line is represented as a non-transformer branch record and defines a new line in the PowSyBl grid model with the following attributes:
@@ -140,7 +147,7 @@ The line is connected at both ends if the branch status (field `ST` in the _Non-
 
 A set of current permanent limits is defined as `1000.0` * `rateMva` / (`sqrt(3.0)` * `vnom1`) at the end `1` and `1000.0` * `rateMva` / (`sqrt(3.0)` * `vnom2`) at the end `2` where `rateMva` is the first rating of the branch (field `RATEA` in version 33 of the _Non-Transformer Branch Data_ record and field `RATE1` in version 35) and `vnom1` and `vnom2` are the nominal voltages of the associated voltage levels.
 
-
+(psse-transformer-data-conversion)=
 ### _Transformer Data_
 
 The _Transformer Data_ block defines two- and three-winding transformers. Two-winding transformers have four line records, while three-winding transformers have five line records. A `0` value in the field `K` of the _Transformer Data_ record first line is used to indicate that is a two-winding transformer, otherwise is considered a three-winding transformer.
@@ -222,6 +229,7 @@ When a three-winding transformer is modeled, the two-winding transformer steps s
 ![ThreeWindingsTransformerModels](img/three-winding-transformer-model.svg){width="100%" align=center class="only-light"}
 ![ThreeWindingsTransformerModels](img/dark_mode/three-winding-transformer-model.svg){width="100%" align=center class="only-dark"}
 
+(psse-slack-bus-conversion)=
 ### Slack bus
 
 The buses defined as slack terminal are the buses with type code  `3` (field `IDE` in the _Bus Data_ record).

--- a/docs/grid_exchange_formats/ucte/format_specification.md
+++ b/docs/grid_exchange_formats/ucte/format_specification.md
@@ -13,6 +13,7 @@ Each block is introduced by a key line consisting of the two characters `##` and
 
 The grid is described in Bus/Branch topology, and only a few types of equipment are supported (nodal injections, AC line, two-winding transformer). Fictitious nodes are located at the electric middle of each tie line. The defined X-nodes are binding for all users.
 
+(ucte-file-name-convention)=
 ## File name convention
 The UCTE-DEF format use the following file name convention: `<yyyymmdd>_<HHMM>_<TY><w>_<cc><v>.uct` with:
 - `yyyymmdd`: year, month and day

--- a/docs/grid_exchange_formats/ucte/import.md
+++ b/docs/grid_exchange_formats/ucte/import.md
@@ -8,7 +8,7 @@ The UCTE parser provided by PowSyBl does not support the blocks `##TT` and `##E`
 description of the two-winding transformers and the scheduled active power exchange between countries.
 Those blocks are ignored during the parsing step.
 
-
+(ucte-import-options)=
 ## Options
 Parameters for the import can be defined in the configuration file in the
 [import-export-parameters-default-value](../../user/configuration/import-export-parameters-default-value.md#import-export-parameters-default-value) module.
@@ -31,6 +31,7 @@ considered as [area](../../grid_model/network_subnetwork.md#area) DC boundaries.
 
 The default value is an empty list. For more details see further below about [area conversion](#area-conversion).
 
+(ucte-inconsistency-checks)=
 ## Inconsistency checks
 
 Once the UCTE grid model is created in memory, a consistency check is performed on the different elements (nodes, lines, two-winding transformers and regulations).
@@ -102,6 +103,7 @@ Notations:
 ## From UCTE to IIDM
 The UCTE file name is parsed to extract metadata required to initialize the IIDM network, such as its ID, the case date and the forecast distance.
 
+(ucte-node-conversion)=
 ### Node conversion
 There is no equivalent [voltage level](../../grid_model/network_subnetwork.md#voltage-level) or [substation](../../grid_model/network_subnetwork.md#substation) concept in the UCTE-DEF format,
 so we have to create substations and voltage levels from the node description and the topology.
@@ -132,6 +134,7 @@ The power plant type is converted to an [energy source]() value (see the mapping
 The list of the power plant types is more detailed than the list of available [energy source]() types in IIDM,
 so we add the `powerPlantType` property to each generator to keep the initial value.
 
+(ucte-line-conversion)=
 ### Line conversion
 The busbar couplers connecting two real nodes are converted into a [switch](../../grid_model/network_subnetwork.md#breakerswitch). This switch is open or closed depending
 on the status of the coupler. In the UCTE-DEF format, the coupler can have extra information not supported in IIDM we keep
@@ -151,6 +154,7 @@ In IIDM, a dangling line is a line segment connected to a constant load.
 The sum of the active load and generation (rep. reactive) is computed to initialize the `P0` (resp. `Q0`) of the dangling line.
 The element name of the UCTE line is stored in the `elementName` property and the geographical name of the X-node is stored in the `geographicalName` property.
 
+(ucte-two-winding-transformer-conversion)=
 ### Two-winding transformer conversion
 The two-winding transformers connected between two real nodes are converted into a [two-winding transformer](../../grid_model/network_subnetwork.md#two-winding-transformer).
 If the current limits are defined, a permanent limit is created only for the second side.
@@ -164,13 +168,14 @@ except for the reactance that is set to $0.05\space\Omega$.
 
 **TODO**: insert a schema
 
-
+(ucte-phase-regulation-conversion)=
 #### Phase regulation
 If a phase regulation is defined for a transformer, it is converted into a [ratio tap changer](../../grid_model/additional.md#ratio-tap-changer).
 If the voltage setpoint is defined, the ratio tap changer will regulate the voltage to this setpoint.
 The regulating terminal is assigned to the first side of the transformer.
 The &rho; of each step is calculated according to the following formula: $\rho = 1 / (1 + i * \delta U / 100)$.
 
+(ucte-angle-regulation-conversion)=
 #### Angle regulation
 If an angle regulation is defined for a transformer, it is converted into a [phase tap changer](../../grid_model/additional.md#phase-tap-changer), with a `FIXED_TAP` regulation mode.
 &rho; and &alpha; of each step are calculated according to the following formulas:
@@ -198,6 +203,7 @@ $$
 
 **Note:** The sign of $\alpha$ is changed because the phase tap changer is on side 2 in UCTE-DEF, and on side 1 in IIDM.
 
+(ucte-area-conversion)=
 ### Area conversion
 
 When the [`ucte.import.create-areas` option](#ucteimportcreate-areas) is set to `true` (default), the importer will create

--- a/docs/grid_features/import_post_processor.md
+++ b/docs/grid_features/import_post_processor.md
@@ -6,6 +6,7 @@ PowSyBl provides 2 different implementations of post-processors:
 - [Groovy](#groovy-post-processor): to execute a groovy script
 - [LoadFlow](#loadflow-post-processor): to run a power flow simulation
 
+(groovy-post-processor)=
 ## Groovy post-processor
 This post-processor executes a groovy script, loaded from a file. The script can access to the network and the [computation manager]() using the variables `network` and `computationManager`. To use this post-processor, add the `com.powsybl:powsybl-iidm-scripting` dependency to your classpath, and configure both `import` and `groovy-post-processor` modules:
 
@@ -37,6 +38,7 @@ The following example prints meta-information from the network:
 println "Network " + network.getId() + " (" + network.getSourceFormat()+ ") is imported"
 ```
 
+(loadflow-post-processor)=
 ## LoadFlow post-processor
 Mathematically speaking, a [load flow](../simulation/loadflow/index) result is fully defined by the complex voltages at each node. The consequence is that most load flow algorithms converge very fast if they are initialized with voltages. As a result, it happens that load flow results include only voltages and not flows on branches. This post-processors computes the flows given the voltages. The equations (Kirchhoff law) used are the same as the one used in the [load flow validation](../user/itools/loadflow-validation.md#load-flow-results-validation) to compute $P_1^{\text{calc}}$, $Q_1^{\text{calc}}$, $P_2^{\text{calc}}$, $Q_2^{\text{calc}}$ for branches and $P_3^{\text{calc}}$, $Q_3^{\text{calc}}$ in addition for three-winding transformers.
 
@@ -58,6 +60,7 @@ import:
 
 **Note:** This post-processor relies on the [load flow results completion]() module.
 
+(geographical-data-import-post-processor)=
 ## Geographical data import post-processor
 
 One way to add geographical positions on a network is to use the import post-processor named odreGeoDataImporter, that will automatically add the [LinePosition](../grid_model/extensions.md#line-position) and [SubstationPosition](../grid_model/extensions.md#substation-position) extensions to the network model.

--- a/docs/grid_features/loadflow_validation.md
+++ b/docs/grid_features/loadflow_validation.md
@@ -93,7 +93,7 @@ V - targetV & < & -& \epsilon && \& && |Q-maxQ| & \leq & \epsilon \\
 targetV - V & < && \epsilon && \& && |Q-minQ| & \leq & \epsilon \\
 \end{align*}
 
-(loadflow-validation-laods)=
+(loadflow-validation-loads)=
 ## Loads
 To be implemented, with tests similar to generators with voltage regulation.
 

--- a/docs/grid_features/loadflow_validation.md
+++ b/docs/grid_features/loadflow_validation.md
@@ -4,6 +4,7 @@ A load flow result is considered *acceptable* if it describes a feasible steady-
 More practically, generations of practitioners have set quasi-standard ways to describe them that makes it possible to define precise rules.
 They are described below for the different elements of the network.
 
+(loadflow-validation-buses)=
 ## Buses
 
 The first law of Kirchhoff must be satisfied for every bus for active and reactive power:
@@ -13,6 +14,7 @@ $$\begin{equation}
 \left| \sum_{branches} Q + \sum_{injections} Q \right| \leq \epsilon \\
 \end{equation}$$
 
+(loadflow-validation-branches)=
 ## Branches
 Lines and two-winding transformers are converted into classical PI models:
 
@@ -40,9 +42,11 @@ Thanks to Kirchhoff laws (see the [line](../grid_model/network_subnetwork.md#lin
 
 $(P_1^{calc}, Q_1^{calc}, P_2^{calc}, Q_2^{calc}) = f(\text{Voltages}, \text{Characteristics})$
 
+(loadflow-validation-three-winding-transformers)=
 ## Three-winding transformers
 To be implemented, based on a conversion into 3 two-winding transformers.
 
+(loadflow-validation-generators)=
 ## Generators
 
 ### Active power
@@ -89,9 +93,11 @@ V - targetV & < & -& \epsilon && \& && |Q-maxQ| & \leq & \epsilon \\
 targetV - V & < && \epsilon && \& && |Q-minQ| & \leq & \epsilon \\
 \end{align*}
 
+(loadflow-validation-laods)=
 ## Loads
 To be implemented, with tests similar to generators with voltage regulation.
 
+(loadflow-validation-shunts)=
 ## Shunts
 A shunt is expected not to generate or absorb active power:
 
@@ -100,6 +106,7 @@ $\left| P \right| < \epsilon$
 A shunt is expected to generate reactive power according to the number of activated sections and to the susceptance per section $B$:
 $\left| Q + \text{#sections} * B  V^2 \right| < \epsilon$
 
+(loadflow-validation-static-var-compensators)=
 ## Static VAR Compensators
 Static VAR Compensators behave like generators producing zero active power except that their reactive bounds are expressed
 in susceptance, so that they are voltage dependent.
@@ -111,16 +118,20 @@ $targetP = 0$ MW
 - If the regulation mode is `VOLTAGE`, it behaves like a generator with voltage regulation with the following bounds (dependent on the voltage, which is not the case for generators):
   $minQ = - Bmax * V^2$ and $maxQ = - Bmin V^2$
 
+(loadflow-validation-hvdc)=
 ## HVDC lines
 To be done.
 
+(loadflow-validation-vsc)=
 ## VSC
 VSC converter stations behave like generators with the additional constraints that the sum of active power on converter
 stations paired by a cable is equal to the losses on the converter stations plus the losses on the cable.
 
+(loadflow-validation-lcc)=
 ## LCC
 To be done.
 
+(loadflow-validation-transformers-ratio-tap-changer)=
 ## Transformers with a ratio tap changer
 
 Transformers with a ratio tap changer have a tap with a finite discrete number of positions that allows to change their transformer ratio.

--- a/docs/simulation/shortcircuit/parameters.md
+++ b/docs/simulation/shortcircuit/parameters.md
@@ -129,7 +129,7 @@ Here is an example of this JSON file:
 ]
 ````
 
-
+(shortcircuit-fault-parameters)=
 ## FaultParameters
 
 It is possible to override parameters for each fault by creating an instance of `com.powsybl.shortcircuit.FaultParameters`. This object will take the fault to which it applies and all the parameters

--- a/docs/user/itools/index.md
+++ b/docs/user/itools/index.md
@@ -42,6 +42,7 @@ Available commands are:
 `--config-name`  
 Use this option to overload the default base name for the configuration file. It overrides the [powsybl_config_name](#powsybl_config_name) property defined in the `itools.conf` file.
 
+(itools-configuration)=
 ### Configuration
 The `iTools` script reads its configuration from the `<ITOOLS_PREFIX>/etc/itools.conf` [property file](https://en.wikipedia.org/wiki/.properties). The properties defined in this file are used to configure the Java Virtual Machine.
 
@@ -85,6 +86,7 @@ Sometimes, it could be useful for a user to have its own logging configuration t
 </configuration>
 ```
 
+(itools-available-commands)=
 ## Available commands
 The `iTools` script relies on a [plugin mechanism](): the commands are discovered at runtime and depend on the jars present in the `share/java` folder.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
A lot of sections of the documentation have no anchors so they cannot be referenced to in the documentation of other repositories.


**What is the new behavior (if this is a feature change)?**
Add some anchors

