### PR TITLE
CompletableFutureTask, fix spurious error logging when cancelling

### DIFF
--- a/computation/src/main/java/com/powsybl/computation/CompletableFutureTask.java
+++ b/computation/src/main/java/com/powsybl/computation/CompletableFutureTask.java
@@ -45,11 +45,13 @@ public class CompletableFutureTask<R> extends CompletableFuture<R> implements Ru
         future.run();
         try {
             complete(future.get());
+        } catch (ExecutionException exc) {
+            completeExceptionally(exc.getCause());
         } catch (InterruptedException exc) {
             Thread.currentThread().interrupt();
             completeExceptionally(exc);
         } catch (Exception exc) {
-            completeExceptionally(exc.getCause());
+            completeExceptionally(exc);
         }
     }
 

--- a/computation/src/test/java/com/powsybl/computation/CompletableFutureTaskTest.java
+++ b/computation/src/test/java/com/powsybl/computation/CompletableFutureTaskTest.java
@@ -63,8 +63,8 @@ class CompletableFutureTaskTest {
                     waitForDone = new CountDownLatch(1);
                     try {
                         command.run();
-                    } catch (Exception exception) {
-                        MyTestExecutorWithException.this.exception = exception;
+                    } catch (Exception e) {
+                        MyTestExecutorWithException.this.exception = e;
                     } finally {
                         waitForDone.countDown();
                     }

--- a/computation/src/test/java/com/powsybl/computation/CompletableFutureTaskTest.java
+++ b/computation/src/test/java/com/powsybl/computation/CompletableFutureTaskTest.java
@@ -45,10 +45,10 @@ class CompletableFutureTaskTest {
         );
     }
 
-    // Very basic, spawn a new thread
-    // and allow to wait for the end of the command
-    // just keep exception to be able to assert,
-    // you should only it to launch one command
+    // Very basic executor that spawns a new thread
+    // and allows to wait for the end of the command.
+    // It just keeps an exception to be able to assert it.
+    // You should use it to launch only one command
     // because it has just one latch and one exception
     private static class MyTestExecutorWithException implements Executor {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bug fix 


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When calling cancel(true), the CompletableFutureTask was throwing a NullPointerException in its run method because cancel(true) causes future.get() to throw a CancellationException without a cause (null) and completeExceptionally requires a non null Exception

the exception was thrown to the executor and the very end. Executors usually catch and ignore everything (just logs to stdout) so the problem was just ugly logs and a slight performance drop. But also maybe in some cases an exception with a cause was thrown and the bad exception was used to completeexceptionally the completablefuturetask, not sure.

**What is the new behavior (if this is a feature change)?**
no exception, and we are sure that we always completeexceptionally with the correct exception


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
This was a regression from 5bef72fa5ee, the actual code is reverted to the previous version (except changing throwable to exception to please avoid sonar warnings I guess) 
