### PR TITLE
Create directory for resources in TestPlatformConfigProvider

### DIFF
--- a/config-test/src/main/java/com/powsybl/config/test/TestPlatformConfigProvider.java
+++ b/config-test/src/main/java/com/powsybl/config/test/TestPlatformConfigProvider.java
@@ -74,6 +74,7 @@ public class TestPlatformConfigProvider implements PlatformConfigProvider {
                 // The resources have relative paths (no leading slash) with full package path.
                 Path dest = cfgDir.resolve(resource);
                 LOGGER.info("Copying classpath resource: {} -> {}", resource, dest);
+                Files.createDirectories(dest.getParent());
                 Files.copy(TestPlatformConfigProvider.class.getResourceAsStream(resource), dest);
             }
         } catch (IOException e) {

--- a/config-test/src/test/java/com/powsybl/config/test/TestPlatformConfigProviderTest.java
+++ b/config-test/src/test/java/com/powsybl/config/test/TestPlatformConfigProviderTest.java
@@ -30,11 +30,16 @@ class TestPlatformConfigProviderTest {
         assertEquals("/work/" + TestPlatformConfigProvider.CONFIG_DIR,
                 platformConfig.getConfigDir().map(Path::toString).orElse(null));
 
-        Path testPath = platformConfig.getConfigDir().map(p -> p.resolve("other.txt")).orElse(null);
+        checkFileContent(platformConfig, "other.txt", "conf");
+        checkFileContent(platformConfig, "subfolder/subfolder_file.txt", "subfile content");
+        assertEquals("baz", platformConfig.getOptionalModuleConfig("foo").flatMap(c -> c.getOptionalStringProperty("bar")).orElse(""));
+    }
+
+    private void checkFileContent(PlatformConfig platformConfig, String file, String content) throws IOException {
+        Path testPath = platformConfig.getConfigDir().map(p -> p.resolve(file)).orElse(null);
         assertNotNull(testPath);
         String testContent = Files.readAllLines(testPath, StandardCharsets.UTF_8).get(0);
-        assertEquals("conf", testContent);
-        assertEquals("baz", platformConfig.getOptionalModuleConfig("foo").flatMap(c -> c.getOptionalStringProperty("bar")).orElse(""));
+        assertEquals(content, testContent);
     }
 
     @Test

--- a/config-test/src/test/resources/com/powsybl/config/test/filelist.txt
+++ b/config-test/src/test/resources/com/powsybl/config/test/filelist.txt
@@ -1,3 +1,4 @@
 config.yml
 other.txt
 base-voltages.yml
+subfolder/subfolder_file.txt

--- a/config-test/src/test/resources/com/powsybl/config/test/subfolder/subfolder_file.txt
+++ b/config-test/src/test/resources/com/powsybl/config/test/subfolder/subfolder_file.txt
@@ -1,0 +1,1 @@
+subfile content


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
If you have files in subfolders in the TestPlatformConfigProvider, the copy of these resources during `getPlatformConfig() ` will fail since the subfolder does not yet exists.

**What is the new behavior (if this is a feature change)?**
`getPlatformConfig() ` will first create the subfolder and then copy the resources inside of it.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
