### PR TITLE
Fix CGMES importer documentation of parameter cgm-with-subnetworks-defined-by

### DIFF
--- a/docs/grid_exchange_formats/cgmes/import.md
+++ b/docs/grid_exchange_formats/cgmes/import.md
@@ -548,5 +548,6 @@ Optional property used when in operational limits, temporary limits are present 
 **iidm.import.cgmes.cgm-with-subnetworks**  
 Optional property to define if subnetworks must be added to the network when importing a Common Grid Model (CGM). Each subnetwork will model an Individual Grid Model (IGM). By default `true`: subnetworks are added, and the merging is done at IIDM level, with a main IIDM network representing the CGM and containing a set of subnetworks, one for each IGM. If the value is set to `false` all the CGMES data will be flattened in a single network and information about the ownership of each equipment will be lost.
 
-**iidm.import.cgmes.cgm-with-subnetworks-defined**  
+**iidm.import.cgmes.cgm-with-subnetworks-defined-by**  
 If `iidm.import.cgmes.cgm-with-subnetworks` is set to `true`, use this property to specify how the set of input files should be split by IGM: based on their filenames (use the value `FILENAME`) or by its modeling authority, read from the header (use the value `MODELING_AUTHORITY`).
+Its default value is `MODELING_AUTHORITY`.


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
incorrect parameter name `iidm.import.cgmes.cgm-with-subnetworks-defined`


**What is the new behavior (if this is a feature change)?**
correct parameter name `iidm.import.cgmes.cgm-with-subnetworks-defined-by`. Also added precision on default value.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
