### PR TITLE
CgmesImporter, allow importing with wrong dataextension when the mainfile doesn't exist

### DIFF
--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -37,7 +37,7 @@ public class CgmesOnDataSource {
     private boolean checkIfMainFileNotWithCgmesData(boolean isCim14) throws IOException {
         if (dataSource.getDataExtension() == null || dataSource.getDataExtension().isEmpty() || !dataSource.exists(null, dataSource.getDataExtension())) {
             return false;
-        } else if (EXTENSION.equals(dataSource.getDataExtension()) && dataSource.exists(null, EXTENSION)) {
+        } else if (EXTENSION.equals(dataSource.getDataExtension())) {
             try (InputStream is = dataSource.newInputStream(null, EXTENSION)) {
                 return isCim14 ? !existsNamespacesCim14(NamespaceReader.namespaces(is)) : !existsNamespaces(NamespaceReader.namespaces(is));
             }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesOnDataSource.java
@@ -35,7 +35,7 @@ public class CgmesOnDataSource {
     }
 
     private boolean checkIfMainFileNotWithCgmesData(boolean isCim14) throws IOException {
-        if (dataSource.getDataExtension() == null || dataSource.getDataExtension().isEmpty()) {
+        if (dataSource.getDataExtension() == null || dataSource.getDataExtension().isEmpty() || !dataSource.exists(null, dataSource.getDataExtension())) {
             return false;
         } else if (EXTENSION.equals(dataSource.getDataExtension()) && dataSource.exists(null, EXTENSION)) {
             try (InputStream is = dataSource.newInputStream(null, EXTENSION)) {

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 class CgmesOnDataSourceTest {
 
-    private static String XIIDM_XML_NOT_CGMES = "<?xml version='1.0' encoding='UTF-8'?><some></some>";
+    private final static String XIIDM_XML_NOT_CGMES = "<?xml version='1.0' encoding='UTF-8'?><some></some>";
 
     static Stream<Arguments> provideArguments() {
         return Stream.of(

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
@@ -73,7 +73,7 @@ class CgmesOnDataSourceTest {
     }
 
     @ParameterizedTest
-    @MethodSource("provideArgumentsFortestXmlMainFileXiidmZip")
+    @MethodSource("provideArgumentsForTestXmlMainFileXiidmZip")
     void testXmlMainFileXiidmZip(String basename, String dataextension) throws IOException {
         Path testDir;
         try (FileSystem fileSystem = Jimfs.newFileSystem(Configuration.unix())) {

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
@@ -28,6 +28,7 @@ import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Jon Harper {@literal <jon.harper at rte-france.com>}
@@ -71,13 +72,24 @@ class CgmesOnDataSourceTest {
                     byte[] data = "Test String".getBytes();
                     out.write(data, 0, data.length);
                     out.closeEntry();
+                    e = new ZipEntry("foo.xml");
+                    out.putNextEntry(e);
+                    data = getClass().getResourceAsStream("/empty_cim16_EQ.xml").readAllBytes();
+                    out.write(data, 0, data.length);
+                    out.closeEntry();
                 } catch (IOException ex) {
                     throw new RuntimeException(ex);
                 }
             }
             ReadOnlyDataSource dataSource = new ZipArchiveDataSource(testDir, "foo.iidm.zip", "test", "xml", null);
             CgmesOnDataSource cgmesOnDataSource = new CgmesOnDataSource(dataSource);
-            assertFalse(cgmesOnDataSource.exists());
+            assertTrue(cgmesOnDataSource.exists());
+            ReadOnlyDataSource dataSource2 = new ZipArchiveDataSource(testDir, "foo.iidm.zip", "test", "iidm", null);
+            CgmesOnDataSource cgmesOnDataSource2 = new CgmesOnDataSource(dataSource2);
+            assertTrue(cgmesOnDataSource2.exists());
+            ReadOnlyDataSource dataSource3 = new ZipArchiveDataSource(testDir, "foo.iidm.zip", "foo", "bar", null);
+            CgmesOnDataSource cgmesOnDataSource3 = new CgmesOnDataSource(dataSource3);
+            assertFalse(cgmesOnDataSource3.exists());
         }
     }
 }

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 class CgmesOnDataSourceTest {
 
-    private final static String XIIDM_XML_NOT_CGMES = "<?xml version='1.0' encoding='UTF-8'?><some></some>";
+    private static final String XIIDM_XML_NOT_CGMES = "<?xml version='1.0' encoding='UTF-8'?><some></some>";
 
     static Stream<Arguments> provideArguments() {
         return Stream.of(

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesOnDataSourceTest.java
@@ -59,7 +59,7 @@ class CgmesOnDataSourceTest {
         assertEquals(expectedExists, exists);
     }
 
-    static Stream<Arguments> provideArgumentsFortestXmlMainFileXiidmZip() {
+    static Stream<Arguments> provideArgumentsForTestXmlMainFileXiidmZip() {
         return Stream.of(
                 Arguments.of("foo", "xml"),
                 Arguments.of("foo", null),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
can't import a cgmes zip with a dot in the name and not ".xml.zip" as the extension (e.g. microgrid.v2.complete.zip)



**What is the new behavior (if this is a feature change)?**
can import


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
This happens when filenames have the 2 following properties:
- the filename contains a dot:
- the filename does not contain the dataextension For example this filename triggers the bug:  "microgrid.v2.complete.zip" but these work:
   "microgrid_v2_complete.zip" (because empty dataextension)
or "microgrid.v2.complete.xml.zip" (because ".xml" dataextension)

The problem is that the main extension is derived as ".complete" but the cgmes importer only accepts an empty dataextension or ".xml" (it checks the dataextension to avoid importing as cgmes from a datasource that was meant by the user to be used as another format). But for now no other importer works without a main file, so when the mainfile doesn't exist so we shouldn't block the import just like when the dataextension is not specified

NOTE: this happens because we want to allow archive filenames to be very flexible (with or without the dataextension, and for cgmes even with a totally different basename as what is inside).

NOTE: if we ever have another importer that works like the cgmes importer, this means we will not be able to handle the following case: archive/network_EQ.xml
archive/network_TP.xml # cgmes files
archive/network_foo.other
archive/network_bar.other # some new importer format and be able to import from a single directory containing both networks by specifying the dataextension. But this should be a rare case, and moving the data to separate directories or using separate basenames works around the problem.

