### PR TITLE
Allow adding new post processors on an existing ImportConfig

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ImportConfig.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ImportConfig.java
@@ -10,10 +10,7 @@ package com.powsybl.iidm.network;
 import com.google.common.base.Suppliers;
 import com.powsybl.commons.config.PlatformConfig;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Supplier;
 
 /**
@@ -27,7 +24,7 @@ public class ImportConfig {
 
     public static final Supplier<ImportConfig> CACHE = Suppliers.memoize(ImportConfig::load);
 
-    private static final List<String> DEFAULT_POST_PROCESSORS = Collections.emptyList();
+    private static final List<String> DEFAULT_POST_PROCESSORS = new ArrayList<>();
 
     private final List<String> postProcessors;
 
@@ -44,11 +41,11 @@ public class ImportConfig {
     }
 
     public ImportConfig() {
-        this(Collections.emptyList());
+        this(new ArrayList<>());
     }
 
     public ImportConfig(String... postProcessors) {
-        this(Arrays.asList(postProcessors));
+        this(new ArrayList<>(Arrays.asList(postProcessors)));
     }
 
     public ImportConfig(List<String> postProcessors) {
@@ -56,11 +53,15 @@ public class ImportConfig {
     }
 
     /**
-     * The list of enabled {@link ImportPostProcessor}, defined by their name.
-     * @return the list of enabled {@link ImportPostProcessor}, defined by their name.
+     * The immutable list of enabled {@link ImportPostProcessor}, defined by their name.
+     * @return the immutable list of enabled {@link ImportPostProcessor}, defined by their name.
      */
     public List<String> getPostProcessors() {
-        return postProcessors;
+        return Collections.unmodifiableList(postProcessors);
+    }
+
+    public void addPostProcessors(List<String> postProcessors) {
+        this.postProcessors.addAll(Objects.requireNonNull(postProcessors));
     }
 
     @Override

--- a/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/ImportConfigTest.java
+++ b/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/ImportConfigTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.powsybl.commons.config.InMemoryPlatformConfig;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ */
+class ImportConfigTest {
+
+    @Test
+    void test() throws IOException {
+        var importConfig = new ImportConfig();
+        assertTrue(importConfig.getPostProcessors().isEmpty());
+        importConfig = new ImportConfig("p1", "p2");
+        var postProcessors = importConfig.getPostProcessors();
+        assertEquals(List.of("p1", "p2"), postProcessors);
+        // assert the returned list is immutable
+        assertThrows(UnsupportedOperationException.class, () -> postProcessors.add("p3"));
+        importConfig.addPostProcessors(List.of("p3"));
+        assertEquals(List.of("p1", "p2", "p3"), postProcessors);
+        try (var fs = Jimfs.newFileSystem(Configuration.unix())) {
+            InMemoryPlatformConfig platformConfig = new InMemoryPlatformConfig(fs);
+            importConfig = ImportConfig.load(platformConfig);
+            assertTrue(importConfig.getPostProcessors().isEmpty());
+            var module = platformConfig.createModuleConfig("import");
+            module.setStringListProperty("postProcessors", List.of("p4"));
+            importConfig = ImportConfig.load(platformConfig);
+            assertEquals(List.of("p4"), importConfig.getPostProcessors());
+        }
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug and feature 


**What is the current behavior?**
<!-- You can also link to an open issue here -->
ImportConfig post processors depending on the way it is built (through load, or different constructor), are a mutable or immutable List.


**What is the new behavior (if this is a feature change)?**
ImportConfig post processors getter return an immutable List.
A method has been added to add new post processors.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
