### PR TITLE
Fix visibility of default LF parameters loader's constructor

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/AbstractLoadFlowDefaultParametersLoader.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/AbstractLoadFlowDefaultParametersLoader.java
@@ -18,7 +18,7 @@ public abstract class AbstractLoadFlowDefaultParametersLoader implements LoadFlo
     private final String name;
     private final String jsonParametersFile;
 
-    public AbstractLoadFlowDefaultParametersLoader(String name, String jsonParametersFile) {
+    protected AbstractLoadFlowDefaultParametersLoader(String name, String jsonParametersFile) {
         this.name = Objects.requireNonNull(name);
         this.jsonParametersFile = Objects.requireNonNull(jsonParametersFile);
     }

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/AbstractLoadFlowDefaultParametersLoader.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/AbstractLoadFlowDefaultParametersLoader.java
@@ -18,7 +18,7 @@ public abstract class AbstractLoadFlowDefaultParametersLoader implements LoadFlo
     private final String name;
     private final String jsonParametersFile;
 
-    AbstractLoadFlowDefaultParametersLoader(String name, String jsonParametersFile) {
+    public AbstractLoadFlowDefaultParametersLoader(String name, String jsonParametersFile) {
         this.name = Objects.requireNonNull(name);
         this.jsonParametersFile = Objects.requireNonNull(jsonParametersFile);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix : the constructor of `AbstractLoadFlowDefaultParametersLoader` was not visible outside its package, so this abstract class couldn't be used in other projects.
=> Its visibility is set to protected.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
