### PR TITLE
Fix overload management system deserialization issue

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/OverloadManagementSystemAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/OverloadManagementSystemAdder.java
@@ -7,10 +7,17 @@
  */
 package com.powsybl.iidm.network;
 
+import java.util.Collection;
+import java.util.function.Consumer;
+
 /**
  * @author Olivier Perrin {@literal <olivier.perrin at rte-france.com>}
  */
 public interface OverloadManagementSystemAdder extends IdentifiableAdder<OverloadManagementSystem, OverloadManagementSystemAdder> {
+
+    OverloadManagementSystemAdder validateAfterCreation();
+
+    Collection<Consumer<OverloadManagementSystem>> getValidationChecks();
 
     interface TrippingAdder<I extends TrippingAdder<I>> {
         /**
@@ -39,6 +46,8 @@ public interface OverloadManagementSystemAdder extends IdentifiableAdder<Overloa
         OverloadManagementSystem.Tripping.Type getType();
 
         OverloadManagementSystemAdder add();
+
+        Collection<Consumer<OverloadManagementSystem>> getValidationChecks();
     }
 
     interface SwitchTrippingAdder extends TrippingAdder<SwitchTrippingAdder> {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OverloadManagementSystemAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OverloadManagementSystemAdderImpl.java
@@ -94,9 +94,13 @@ class OverloadManagementSystemAdderImpl extends AbstractIdentifiableAdder<Overlo
             return checkElementId(switchId, "switchId");
         }
 
+        protected void validateSwitchId() {
+            validateElementId(switchId, Network::getSwitch, "switch");
+        }
+
         @Override
         public Collection<Consumer<OverloadManagementSystem>> getValidationChecks() {
-            return Collections.emptyList();
+            return List.of(oms -> this.validateSwitchId());
         }
     }
 
@@ -154,9 +158,13 @@ class OverloadManagementSystemAdderImpl extends AbstractIdentifiableAdder<Overlo
                     "threeWindingsTransformerId");
         }
 
+        protected void validateThreeWindingsTransformerId() {
+            validateElementId(threeWindingsTransformerId, Network::getThreeWindingsTransformer, "three windings transformer");
+        }
+
         @Override
         public Collection<Consumer<OverloadManagementSystem>> getValidationChecks() {
-            return Collections.emptyList();
+            return List.of(oms -> validateThreeWindingsTransformerId());
         }
     }
 
@@ -271,6 +279,9 @@ class OverloadManagementSystemAdderImpl extends AbstractIdentifiableAdder<Overlo
     }
 
     private OverloadManagementSystem.Tripping createTripping(SwitchTrippingAdderImpl adder, String overloadManagementSystemId) {
+        if (!validateAfterCreation) {
+            adder.validateSwitchId();
+        }
         return new OverloadManagementSystemImpl.SwitchTrippingImpl(
                 overloadManagementSystemId, adder.key, adder.name,
                 adder.currentLimit, adder.openAction,
@@ -289,6 +300,9 @@ class OverloadManagementSystemAdderImpl extends AbstractIdentifiableAdder<Overlo
 
     private OverloadManagementSystem.Tripping createTripping(ThreeWindingsTransformerTrippingAdderImpl adder,
                                                              String overloadManagementSystemId) {
+        if (!validateAfterCreation) {
+            adder.validateThreeWindingsTransformerId();
+        }
         return new OverloadManagementSystemImpl.ThreeWindingsTransformerTrippingImpl(
                 overloadManagementSystemId,
                 adder.key, adder.name, adder.currentLimit, adder.openAction,

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OverloadManagementSystemAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OverloadManagementSystemAdderImpl.java
@@ -11,12 +11,15 @@ import com.powsybl.iidm.network.*;
 
 import java.util.*;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 
 /**
  * @author Olivier Perrin {@literal <olivier.perrin at rte-france.com>}
  */
 class OverloadManagementSystemAdderImpl extends AbstractIdentifiableAdder<OverloadManagementSystemAdderImpl>
         implements OverloadManagementSystemAdder {
+
+    private boolean validateAfterCreation = false;
 
     abstract class AbstractTrippingAdderImpl<I extends TrippingAdder<I>> implements Validable, TrippingAdder<I> {
         protected String key = null;
@@ -87,6 +90,11 @@ class OverloadManagementSystemAdderImpl extends AbstractIdentifiableAdder<Overlo
         protected String checkSwitchId() {
             return checkElementId(switchId, Network::getSwitch, "switchId", "switch");
         }
+
+        @Override
+        public Collection<Consumer<OverloadManagementSystem>> getValidationChecks() {
+            return Collections.emptyList();
+        }
     }
 
     class BranchTrippingAdderImpl extends AbstractTrippingAdderImpl<BranchTrippingAdder>
@@ -108,6 +116,11 @@ class OverloadManagementSystemAdderImpl extends AbstractIdentifiableAdder<Overlo
 
         protected String checkBranchId() {
             return checkElementId(branchId, Network::getBranch, "branchId", "branch");
+        }
+
+        @Override
+        public Collection<Consumer<OverloadManagementSystem>> getValidationChecks() {
+            return Collections.emptyList();
         }
     }
 
@@ -132,6 +145,11 @@ class OverloadManagementSystemAdderImpl extends AbstractIdentifiableAdder<Overlo
         protected String checkThreeWindingsTransformerId() {
             return checkElementId(threeWindingsTransformerId, Network::getThreeWindingsTransformer,
                     "threeWindingsTransformerId", "three windings transformer");
+        }
+
+        @Override
+        public Collection<Consumer<OverloadManagementSystem>> getValidationChecks() {
+            return Collections.emptyList();
         }
     }
 
@@ -187,6 +205,17 @@ class OverloadManagementSystemAdderImpl extends AbstractIdentifiableAdder<Overlo
     @Override
     public OverloadManagementSystemAdder.ThreeWindingsTransformerTrippingAdder newThreeWindingsTransformerTripping() {
         return new ThreeWindingsTransformerTrippingAdderImpl();
+    }
+
+    @Override
+    public OverloadManagementSystemAdder validateAfterCreation() {
+        validateAfterCreation = true;
+        return this;
+    }
+
+    @Override
+    public Collection<Consumer<OverloadManagementSystem>> getValidationChecks() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OverloadManagementSystemAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OverloadManagementSystemAdderImpl.java
@@ -215,7 +215,14 @@ class OverloadManagementSystemAdderImpl extends AbstractIdentifiableAdder<Overlo
 
     @Override
     public Collection<Consumer<OverloadManagementSystem>> getValidationChecks() {
-        return Collections.emptyList();
+        return List.of(this::validateMonitoredElementId);
+    }
+
+    public void validateMonitoredElementId(OverloadManagementSystem oms) {
+        Identifiable<?> element = getNetwork().getIdentifiable(monitoredElementId);
+        if (element == null) {
+            throw new ValidationException(this, " '" + monitoredElementId + "' not found");
+        }
     }
 
     @Override
@@ -224,6 +231,10 @@ class OverloadManagementSystemAdderImpl extends AbstractIdentifiableAdder<Overlo
 
         OverloadManagementSystemImpl overloadManagementSystem = new OverloadManagementSystemImpl(id, getName(), substation,
                 monitoredElementId, monitoredElementSide, enabled);
+
+        if (!validateAfterCreation) {
+            validateMonitoredElementId(overloadManagementSystem);
+        }
 
         // Add the trippings
         Set<String> knownTrippingKeys = new HashSet<>();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OverloadManagementSystemImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OverloadManagementSystemImpl.java
@@ -212,10 +212,6 @@ class OverloadManagementSystemImpl extends AbstractAutomationSystem<OverloadMana
         if (monitoredElementId == null) {
             throw new ValidationException(this, "monitoredElementId is not set");
         }
-        Identifiable<?> element = getNetwork().getIdentifiable(monitoredElementId);
-        if (element == null) {
-            throw new ValidationException(this, " '" + monitoredElementId + "' not found");
-        }
         return monitoredElementId;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
https://github.com/powsybl/powsybl-core/issues/3166


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR refactors `OverloadManagementSystemSerDe` to not defer creation of the element when deserializing a file.
In order to maintain, only the validation of external network elements is now postponed.

**What is the current behavior?**
<!-- You can also link to an open issue here -->

Currently, when reading a `Network`, `OverloadManagementSystem`s are created at the end, after attempting to deserialize extensions.

**What is the new behavior (if this is a feature change)?**

`OverloadManagementSystem`s are added to the network when read, allowing extensions to be deserialized properly.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

No test was added to highlight the existing failing behaviour, because, in my understanding, testing it requires to create an extension.
An extension could be created in a separate PR to show the issue, but will require some additional functional validation to be mergeable.