### PR TITLE
fix: OverloadManagementSystem did not serialize to binary when a trip…

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/binary/BinReader.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BinReader.java
@@ -76,7 +76,8 @@ public class BinReader implements TreeDataReader {
             }
             byte[] stringBytes = dis.readNBytes(stringNbBytes);
             if (stringBytes.length != stringNbBytes) {
-                throw new PowsyblException("Cannot read the full string, bytes missing: " + (stringNbBytes - stringBytes.length));
+                throw new PowsyblException("Cannot read the full string, bytes missing: " + (stringNbBytes - stringBytes.length)
+                        + " (this may happen when the attribute wasn't written in the first place, causing string length to be an aberrant number)");
             }
             return new String(stringBytes, StandardCharsets.UTF_8);
         } catch (IOException e) {

--- a/commons/src/main/java/com/powsybl/commons/binary/BinReader.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BinReader.java
@@ -76,8 +76,8 @@ public class BinReader implements TreeDataReader {
             }
             byte[] stringBytes = dis.readNBytes(stringNbBytes);
             if (stringBytes.length != stringNbBytes) {
-                throw new PowsyblException("Cannot read the full string, bytes missing: " + (stringNbBytes - stringBytes.length)
-                        + " (this may happen when the attribute wasn't written in the first place, causing string length to be an aberrant number)");
+                // this may happen when the attribute wasn't written in the first place, causing string length to be an aberrant number
+                throw new PowsyblException("Cannot read the full string, bytes missing: " + (stringNbBytes - stringBytes.length));
             }
             return new String(stringBytes, StandardCharsets.UTF_8);
         } catch (IOException e) {

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/OverloadManagementSystemSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/OverloadManagementSystemSerDe.java
@@ -83,6 +83,8 @@ class OverloadManagementSystemSerDe extends AbstractComplexIdentifiableSerDe<Ove
         String nameOrKey = tripping.getNameOrKey();
         if (nameOrKey != null && !nameOrKey.equals(tripping.getKey())) {
             context.getWriter().writeStringAttribute("name", nameOrKey);
+        } else {
+            context.getWriter().writeStringAttribute("name", null);
         }
         context.getWriter().writeDoubleAttribute("currentLimit", tripping.getCurrentLimit());
         context.getWriter().writeBooleanAttribute("openAction", tripping.isOpenAction());

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/OverloadManagementSystemSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/OverloadManagementSystemSerDeTest.java
@@ -216,6 +216,12 @@ class OverloadManagementSystemSerDeTest extends AbstractIidmSerDeTest {
                     .setOpenAction(true)
                     .setSwitchToOperateId("S1_400_LINE_2_BREAKER")
                     .add()
+                .newSwitchTripping()
+                    .setKey("trippingWithNoName")
+                    .setCurrentLimit(800)
+                    .setOpenAction(true)
+                    .setSwitchToOperateId("S1_400_LINE_2_BREAKER")
+                    .add()
                 .add();
 
         // Create an overload management system monitoring "LINE_1" with a tripping on "LINE_2".

--- a/iidm/iidm-serde/src/test/resources/V1_13/overloadManagementSystemRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_13/overloadManagementSystemRoundTripRef.xml
@@ -36,6 +36,7 @@
             <iidm:branchTripping key="tripping1" name="1st tripping name" currentLimit="1200.0" openAction="true" branchId="2WT" side="ONE"/>
             <iidm:threeWindingsTransformerTripping key="tripping2" name="2nd tripping name" currentLimit="1000.0" openAction="false" threeWindingsTransformerId="3WT" side="ONE"/>
             <iidm:switchTripping key="tripping3" name="3rd tripping name" currentLimit="1000.0" openAction="true" switchId="S1_400_LINE_2_BREAKER"/>
+            <iidm:switchTripping key="trippingWithNoName" currentLimit="800.0" openAction="true" switchId="S1_400_LINE_2_BREAKER"/>
         </iidm:overloadManagementSystem>
         <iidm:overloadManagementSystem id="OMS2" name="2nd OMS" enabled="true" monitoredElementId="LINE_1" side="ONE">
             <iidm:branchTripping key="tripping" name="tripping name" currentLimit="1300.0" openAction="true" branchId="LINE_2" side="ONE"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

No

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Bug fix for serialization issue on overload management systems.

**What is the current behavior?**
<!-- You can also link to an open issue here -->

When an `OverloadManagementSystem` with a nameless tripping is serialized to binary and deserialized again, the deserialization crashes when trying to read the `name attribute`.

This is caused by the writer not writing `name`, thus not creating a "placeholder" for this field in the binary format.
This in turn causes the BinReader trying to read the number of bytes for the `name` string, to read aberrant data instead and throw.

**What is the new behavior (if this is a feature change)?**

`name` attribute is written even when it is null.

Also improved error message for future generations :)

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No