### PR TITLE
Return stable ids/nodes in ViolationLocation classes

### DIFF
--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/BusBreakerViolationLocation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/BusBreakerViolationLocation.java
@@ -17,7 +17,7 @@ public class BusBreakerViolationLocation implements ViolationLocation {
     private final List<String> busIds;
 
     public BusBreakerViolationLocation(List<String> busIds) {
-        this.busIds = Objects.requireNonNull(busIds, "'busIds' should not be null.");
+        this.busIds = Objects.requireNonNull(busIds, "busIds should not be null.");
     }
 
     public List<String> getBusIds() {

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/BusBreakerViolationLocation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/BusBreakerViolationLocation.java
@@ -7,6 +7,8 @@
  */
 package com.powsybl.security;
 
+import com.powsybl.iidm.network.Network;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -43,4 +45,20 @@ public class BusBreakerViolationLocation implements ViolationLocation {
             "busIds='" + busIds + '\'' +
             '}';
     }
+
+    @Override
+    public BusView getBusView(Network network) {
+        return () -> busIds.stream()
+                .map(id -> network.getBusBreakerView().getBus(id))
+                .filter(b -> b.getConnectedTerminalCount() > 0)
+                .map(b -> b.getConnectedTerminals().iterator().next().getBusView().getBus())
+                .distinct();
+
+    }
+
+    @Override
+    public BusView getBusBreakerView(Network network) {
+        return () -> busIds.stream().map(id -> network.getBusBreakerView().getBus(id));
+    }
+
 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/BusBreakerViolationLocation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/BusBreakerViolationLocation.java
@@ -16,10 +16,18 @@ import java.util.Objects;
 public class BusBreakerViolationLocation implements ViolationLocation {
     private final List<String> busIds;
 
+    /**
+     * Create a ViolationLocation for a violation detected in a voltage level in bus/breaker topology.
+     * @param busIds The ids of the <b>configured</b> buses (of the bus/breaker view) where the violation was detected.
+     */
     public BusBreakerViolationLocation(List<String> busIds) {
         this.busIds = Objects.requireNonNull(busIds, "busIds should not be null.");
     }
 
+    /**
+     * Get the ids of the <b>configured</b> buses (of the bus/breaker view) where the violation was detected.
+     * @return the configured bus ids
+     */
     public List<String> getBusIds() {
         return busIds;
     }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/BusBreakerViolationLocation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/BusBreakerViolationLocation.java
@@ -7,35 +7,21 @@
  */
 package com.powsybl.security;
 
+import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * @author Étienne Lesot {@literal <etienne.lesot at rte-france.com>}
  */
 public class BusBreakerViolationLocation implements ViolationLocation {
-    private final String voltageLevelId;
-    private final String busId;
+    private final List<String> busIds;
 
-    public BusBreakerViolationLocation(String voltageLevelId, String busId) {
-        Objects.requireNonNull(voltageLevelId, "voltageLevelId");
-        this.voltageLevelId = voltageLevelId;
-        this.busId = busId;
+    public BusBreakerViolationLocation(List<String> busIds) {
+        this.busIds = Objects.requireNonNull(busIds, "'busIds' should not be null.");
     }
 
-    @Override
-    public String getVoltageLevelId() {
-        return voltageLevelId;
-    }
-
-    @Override
-    public Optional<String> getBusId() {
-        return Optional.ofNullable(busId);
-    }
-
-    @Override
-    public String getId() {
-        return busId == null ? voltageLevelId : busId;
+    public List<String> getBusIds() {
+        return busIds;
     }
 
     @Override
@@ -46,8 +32,7 @@ public class BusBreakerViolationLocation implements ViolationLocation {
     @Override
     public String toString() {
         return "BusBreakerViolationLocation{" +
-            "voltageLevelId='" + voltageLevelId + '\'' +
-            ", busId='" + busId + '\'' +
+            "busIds='" + busIds + '\'' +
             '}';
     }
 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationDetection.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationDetection.java
@@ -11,6 +11,7 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.limitmodification.LimitsComputer;
 import com.powsybl.iidm.network.util.LimitViolationUtils;
+import com.powsybl.iidm.network.util.Networks;
 import com.powsybl.iidm.network.util.PermanentLimitCheckResult;
 import com.powsybl.security.detectors.LoadingLimitType;
 import org.slf4j.Logger;
@@ -272,12 +273,8 @@ public final class LimitViolationDetection {
     public static ViolationLocation createViolationLocation(Bus bus) {
         VoltageLevel vl = bus.getVoltageLevel();
         if (vl.getTopologyKind() == TopologyKind.NODE_BREAKER) {
-            List<String> busbarIds = bus.getConnectedTerminalStream()
-                .map(Terminal::getConnectable)
-                .filter(BusbarSection.class::isInstance)
-                .map(Connectable::getId)
-                .toList();
-            return new NodeBreakerViolationLocation(vl.getId(), busbarIds);
+            List<Integer> nodes = Networks.getNodesByBus(vl).get(bus.getId()).stream().toList();
+            return new NodeBreakerViolationLocation(vl.getId(), nodes);
         } else {
             try {
                 List<String> configuredBusIds = vl.getBusBreakerView().getBusStreamFromBusViewBusId(bus.getId())

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationDetection.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationDetection.java
@@ -211,15 +211,14 @@ public final class LimitViolationDetection {
 
     static void checkVoltage(Bus bus, double value, Consumer<LimitViolation> consumer) {
         VoltageLevel vl = bus.getVoltageLevel();
-        ViolationLocation voltageViolationLocation = createViolationLocation(bus);
         if (!Double.isNaN(vl.getLowVoltageLimit()) && value <= vl.getLowVoltageLimit()) {
             consumer.accept(new LimitViolation(vl.getId(), vl.getOptionalName().orElse(null), LimitViolationType.LOW_VOLTAGE,
-                    vl.getLowVoltageLimit(), 1., value, voltageViolationLocation));
+                    vl.getLowVoltageLimit(), 1., value, createViolationLocation(bus)));
         }
 
         if (!Double.isNaN(vl.getHighVoltageLimit()) && value >= vl.getHighVoltageLimit()) {
             consumer.accept(new LimitViolation(vl.getId(), vl.getOptionalName().orElse(null), LimitViolationType.HIGH_VOLTAGE,
-                    vl.getHighVoltageLimit(), 1., value, voltageViolationLocation));
+                    vl.getHighVoltageLimit(), 1., value, createViolationLocation(bus)));
         }
     }
 

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/NodeBreakerViolationLocation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/NodeBreakerViolationLocation.java
@@ -18,8 +18,8 @@ public class NodeBreakerViolationLocation implements ViolationLocation {
     private final List<String> busBarIds;
 
     public NodeBreakerViolationLocation(String voltageLevelId, List<String> busBarIds) {
-        this.voltageLevelId = Objects.requireNonNull(voltageLevelId, "'voltageLevelId' should not be null");
-        this.busBarIds = Objects.requireNonNull(busBarIds, "'busBarIds' should not be null");
+        this.voltageLevelId = Objects.requireNonNull(voltageLevelId, "voltageLevelId should not be null");
+        this.busBarIds = Objects.requireNonNull(busBarIds, "busBarIds should not be null");
     }
 
     public String getVoltageLevelId() {

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/NodeBreakerViolationLocation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/NodeBreakerViolationLocation.java
@@ -18,24 +18,16 @@ public class NodeBreakerViolationLocation implements ViolationLocation {
     private final List<String> busBarIds;
 
     public NodeBreakerViolationLocation(String voltageLevelId, List<String> busBarIds) {
-        Objects.requireNonNull(voltageLevelId, "voltageLevelId");
-        this.voltageLevelId = voltageLevelId;
-        this.busBarIds = busBarIds;
+        this.voltageLevelId = Objects.requireNonNull(voltageLevelId, "'voltageLevelId' should not be null");
+        this.busBarIds = Objects.requireNonNull(busBarIds, "'busBarIds' should not be null");
     }
 
-    @Override
     public String getVoltageLevelId() {
         return voltageLevelId;
     }
 
-    @Override
     public List<String> getBusBarIds() {
         return busBarIds;
-    }
-
-    @Override
-    public String getId() {
-        return busBarIds.isEmpty() ? voltageLevelId : busBarIds.get(0);
     }
 
     @Override

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/NodeBreakerViolationLocation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/NodeBreakerViolationLocation.java
@@ -15,19 +15,24 @@ import java.util.Objects;
  */
 public class NodeBreakerViolationLocation implements ViolationLocation {
     private final String voltageLevelId;
-    private final List<String> busBarIds;
+    private final List<Integer> nodes;
 
-    public NodeBreakerViolationLocation(String voltageLevelId, List<String> busBarIds) {
+    /**
+     * Create a ViolationLocation for a violation detected in a voltage level in node/breaker topology.
+     * @param voltageLevelId the id of the voltage level
+     * @param nodes The list of the nodes where the violation was detected.
+     */
+    public NodeBreakerViolationLocation(String voltageLevelId, List<Integer> nodes) {
         this.voltageLevelId = Objects.requireNonNull(voltageLevelId, "voltageLevelId should not be null");
-        this.busBarIds = Objects.requireNonNull(busBarIds, "busBarIds should not be null");
+        this.nodes = Objects.requireNonNull(nodes, "nodes should not be null");
     }
 
     public String getVoltageLevelId() {
         return voltageLevelId;
     }
 
-    public List<String> getBusBarIds() {
-        return busBarIds;
+    public List<Integer> getNodes() {
+        return nodes;
     }
 
     @Override
@@ -39,7 +44,7 @@ public class NodeBreakerViolationLocation implements ViolationLocation {
     public String toString() {
         return "NodeBreakerVoltageLocation{" +
             "voltageLevelId='" + voltageLevelId + '\'' +
-            ", busBarIds=" + busBarIds +
+            ", nodes=" + nodes +
             '}';
     }
 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/NodeBreakerViolationLocation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/NodeBreakerViolationLocation.java
@@ -7,6 +7,10 @@
  */
 package com.powsybl.security;
 
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.util.Networks;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -33,6 +37,25 @@ public class NodeBreakerViolationLocation implements ViolationLocation {
 
     public List<Integer> getNodes() {
         return nodes;
+    }
+
+    @Override
+    public BusView getBusView(Network network) {
+        return () -> {
+            VoltageLevel vl = network.getVoltageLevel(voltageLevelId);
+            var busView = vl.getBusView();
+            return Networks.getNodesByBus(vl)
+                    .entrySet()
+                    .stream()
+                    .filter(e -> nodes.stream().anyMatch(i -> e.getValue().contains(i)))
+                    .map(e -> busView.getBus(e.getKey()))
+                    .distinct();
+        };
+    }
+
+    @Override
+    public BusView getBusBreakerView(Network network) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/ViolationLocation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/ViolationLocation.java
@@ -7,6 +7,11 @@
  */
 package com.powsybl.security;
 
+import com.powsybl.iidm.network.Bus;
+import com.powsybl.iidm.network.Network;
+
+import java.util.stream.Stream;
+
 /**
  * @author Étienne Lesot {@literal <etienne.lesot at rte-france.com>}
  */
@@ -18,4 +23,12 @@ public interface ViolationLocation {
     }
 
     Type getType();
+
+    BusView getBusView(Network network);
+
+    BusView getBusBreakerView(Network network);
+
+    interface BusView {
+        Stream<Bus> getBusStream();
+    }
 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/ViolationLocation.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/ViolationLocation.java
@@ -7,10 +7,6 @@
  */
 package com.powsybl.security;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
 /**
  * @author Étienne Lesot {@literal <etienne.lesot at rte-france.com>}
  */
@@ -21,18 +17,5 @@ public interface ViolationLocation {
         BUS_BREAKER
     }
 
-    String getId();
-
     Type getType();
-
-    String getVoltageLevelId();
-
-    default Optional<String> getBusId() {
-        return Optional.empty();
-    }
-
-    default List<String> getBusBarIds() {
-        return Collections.emptyList();
-    }
-
 }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/detectors/DefaultLimitViolationDetector.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/detectors/DefaultLimitViolationDetector.java
@@ -78,15 +78,14 @@ public class DefaultLimitViolationDetector extends AbstractContingencyBlindDetec
     @Override
     public void checkVoltage(Bus bus, double value, Consumer<LimitViolation> consumer) {
         VoltageLevel vl = bus.getVoltageLevel();
-        ViolationLocation voltageViolationLocation = createViolationLocation(bus);
         if (!Double.isNaN(vl.getLowVoltageLimit()) && value <= vl.getLowVoltageLimit()) {
             consumer.accept(new LimitViolation(vl.getId(), vl.getOptionalName().orElse(null), LimitViolationType.LOW_VOLTAGE,
-                    vl.getLowVoltageLimit(), limitReductionValue, value, voltageViolationLocation));
+                    vl.getLowVoltageLimit(), limitReductionValue, value, createViolationLocation(bus)));
         }
 
         if (!Double.isNaN(vl.getHighVoltageLimit()) && value >= vl.getHighVoltageLimit()) {
             consumer.accept(new LimitViolation(vl.getId(), vl.getOptionalName().orElse(null), LimitViolationType.HIGH_VOLTAGE,
-                    vl.getHighVoltageLimit(), limitReductionValue, value, voltageViolationLocation));
+                    vl.getHighVoltageLimit(), limitReductionValue, value, createViolationLocation(bus)));
         }
     }
 

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/ViolationLocationDeserializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/ViolationLocationDeserializer.java
@@ -25,7 +25,7 @@ import java.util.List;
  */
 public class ViolationLocationDeserializer extends StdDeserializer<ViolationLocation> {
 
-    private static final String BUS_ID = "busId";
+    private static final String BUS_IDS = "busIds";
     private static final String VOLTAGE_LEVEL_ID = "voltageLevelId";
     private static final String BUS_BAR_IDS = "busbarIds";
 
@@ -36,7 +36,7 @@ public class ViolationLocationDeserializer extends StdDeserializer<ViolationLoca
     @Override
     public ViolationLocation deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
         String voltageLevelId = null;
-        String busId = null;
+        List<String> busIds = new ArrayList<>();
         List<String> busbarIds = new ArrayList<>();
         ViolationLocation.Type type = null;
         while (parser.nextToken() != JsonToken.END_OBJECT) {
@@ -45,8 +45,9 @@ public class ViolationLocationDeserializer extends StdDeserializer<ViolationLoca
                     parser.nextToken();
                     type = JsonUtil.readValue(deserializationContext, parser, ViolationLocation.Type.class);
                     break;
-                case BUS_ID:
-                    busId = parser.nextTextValue();
+                case BUS_IDS:
+                    parser.nextToken();
+                    busIds = JsonUtil.readList(deserializationContext, parser, String.class);
                     break;
 
                 case VOLTAGE_LEVEL_ID:
@@ -64,7 +65,7 @@ public class ViolationLocationDeserializer extends StdDeserializer<ViolationLoca
         if (type == ViolationLocation.Type.NODE_BREAKER) {
             return new NodeBreakerViolationLocation(voltageLevelId, busbarIds);
         } else if (type == ViolationLocation.Type.BUS_BREAKER) {
-            return new BusBreakerViolationLocation(voltageLevelId, busId);
+            return new BusBreakerViolationLocation(busIds);
         } else {
             throw new IllegalStateException("type should be among [NODE_BREAKER, BUS_BREAKER].");
         }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/ViolationLocationDeserializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/ViolationLocationDeserializer.java
@@ -27,7 +27,7 @@ public class ViolationLocationDeserializer extends StdDeserializer<ViolationLoca
 
     private static final String BUS_IDS = "busIds";
     private static final String VOLTAGE_LEVEL_ID = "voltageLevelId";
-    private static final String BUS_BAR_IDS = "busbarIds";
+    private static final String NODES = "nodes";
 
     public ViolationLocationDeserializer() {
         super(ViolationLocation.class);
@@ -37,7 +37,7 @@ public class ViolationLocationDeserializer extends StdDeserializer<ViolationLoca
     public ViolationLocation deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException {
         String voltageLevelId = null;
         List<String> busIds = new ArrayList<>();
-        List<String> busbarIds = new ArrayList<>();
+        List<Integer> nodes = new ArrayList<>();
         ViolationLocation.Type type = null;
         while (parser.nextToken() != JsonToken.END_OBJECT) {
             switch (parser.currentName()) {
@@ -54,16 +54,16 @@ public class ViolationLocationDeserializer extends StdDeserializer<ViolationLoca
                     voltageLevelId = parser.nextTextValue();
                     break;
 
-                case BUS_BAR_IDS:
+                case NODES:
                     parser.nextToken();
-                    busbarIds = JsonUtil.readList(deserializationContext, parser, String.class);
+                    nodes = JsonUtil.readList(deserializationContext, parser, Integer.class);
                     break;
                 default:
                     throw new IllegalStateException("Unexpected field: " + parser.currentName());
             }
         }
         if (type == ViolationLocation.Type.NODE_BREAKER) {
-            return new NodeBreakerViolationLocation(voltageLevelId, busbarIds);
+            return new NodeBreakerViolationLocation(voltageLevelId, nodes);
         } else if (type == ViolationLocation.Type.BUS_BREAKER) {
             return new BusBreakerViolationLocation(busIds);
         } else {

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/ViolationLocationSerializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/ViolationLocationSerializer.java
@@ -33,7 +33,7 @@ public class ViolationLocationSerializer extends StdSerializer<ViolationLocation
         if (ViolationLocation.Type.NODE_BREAKER == violationLocation.getType()) {
             NodeBreakerViolationLocation location = (NodeBreakerViolationLocation) violationLocation;
             jsonGenerator.writeStringField("voltageLevelId", location.getVoltageLevelId());
-            serializerProvider.defaultSerializeField("busbarIds", location.getBusBarIds(), jsonGenerator);
+            serializerProvider.defaultSerializeField("nodes", location.getNodes(), jsonGenerator);
         } else {
             BusBreakerViolationLocation location = (BusBreakerViolationLocation) violationLocation;
             serializerProvider.defaultSerializeField("busIds", location.getBusIds(), jsonGenerator);

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/ViolationLocationSerializer.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/json/ViolationLocationSerializer.java
@@ -11,10 +11,11 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.powsybl.commons.json.JsonUtil;
+import com.powsybl.security.BusBreakerViolationLocation;
+import com.powsybl.security.NodeBreakerViolationLocation;
 import com.powsybl.security.ViolationLocation;
 
 import java.io.IOException;
-import java.util.Optional;
 
 /**
  * @author Etienne Lesot {@literal <etienne.lesot at rte-france.com>}
@@ -29,13 +30,13 @@ public class ViolationLocationSerializer extends StdSerializer<ViolationLocation
     public void serialize(ViolationLocation violationLocation, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         jsonGenerator.writeStartObject();
         JsonUtil.writeOptionalEnumField(jsonGenerator, "type", violationLocation.getType());
-        jsonGenerator.writeStringField("voltageLevelId", violationLocation.getVoltageLevelId());
-        Optional<String> busId = violationLocation.getBusId();
-        if (busId.isPresent()) {
-            jsonGenerator.writeStringField("busId", busId.get());
-        }
-        if (!violationLocation.getBusBarIds().isEmpty()) {
-            serializerProvider.defaultSerializeField("busbarIds", violationLocation.getBusBarIds(), jsonGenerator);
+        if (ViolationLocation.Type.NODE_BREAKER == violationLocation.getType()) {
+            NodeBreakerViolationLocation location = (NodeBreakerViolationLocation) violationLocation;
+            jsonGenerator.writeStringField("voltageLevelId", location.getVoltageLevelId());
+            serializerProvider.defaultSerializeField("busbarIds", location.getBusBarIds(), jsonGenerator);
+        } else {
+            BusBreakerViolationLocation location = (BusBreakerViolationLocation) violationLocation;
+            serializerProvider.defaultSerializeField("busIds", location.getBusIds(), jsonGenerator);
         }
         jsonGenerator.writeEndObject();
     }

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationDetectionTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationDetectionTest.java
@@ -149,11 +149,11 @@ class LimitViolationDetectionTest extends AbstractLimitViolationDetectionTest {
                             assertEquals(2, vli.getBusIds().size());
                             assertTrue(vli.getBusIds().containsAll(List.of("NHV2", "NHV20"))); // Both configured buses are present
                             Set<Bus> buses = vli.getBusBreakerView(network).getBusStream().collect(Collectors.toSet());
-                            assertEquals(buses.size(), 2);
+                            assertEquals(2, buses.size());
                             assertTrue(buses.contains(network.getBusBreakerView().getBus("NHV2")));
                             assertTrue(buses.contains(network.getBusBreakerView().getBus("NHV20")));
                             Set<Bus> mergedBuses = vli.getBusView(network).getBusStream().collect(Collectors.toSet());
-                            assertEquals(mergedBuses.size(), 1);
+                            assertEquals(1, mergedBuses.size());
                         });
             });
     }

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationDetectionTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationDetectionTest.java
@@ -26,8 +26,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -146,6 +148,12 @@ class LimitViolationDetectionTest extends AbstractLimitViolationDetectionTest {
                             assertEquals(ViolationLocation.Type.BUS_BREAKER, vli.getType());
                             assertEquals(2, vli.getBusIds().size());
                             assertTrue(vli.getBusIds().containsAll(List.of("NHV2", "NHV20"))); // Both configured buses are present
+                            Set<Bus> buses = vli.getBusBreakerView(network).getBusStream().collect(Collectors.toSet());
+                            assertEquals(buses.size(), 2);
+                            assertTrue(buses.contains(network.getBusBreakerView().getBus("NHV2")));
+                            assertTrue(buses.contains(network.getBusBreakerView().getBus("NHV20")));
+                            Set<Bus> mergedBuses = vli.getBusView(network).getBusStream().collect(Collectors.toSet());
+                            assertEquals(mergedBuses.size(), 1);
                         });
             });
     }
@@ -176,6 +184,10 @@ class LimitViolationDetectionTest extends AbstractLimitViolationDetectionTest {
                             Assertions.assertThat(vli.getNodes())
                                 .hasSize(5)
                                 .isEqualTo(List.of(0, 1, 2, 3, 4));
+                            assertThrows(UnsupportedOperationException.class, () -> vli.getBusBreakerView(network));
+                            Set<Bus> mergedBuses = vli.getBusView(network).getBusStream().collect(Collectors.toSet());
+                            assertEquals(1, mergedBuses.size());
+                            assertTrue(mergedBuses.contains(network.getBusView().getBus("S1VL1_0")));
                         });
             });
         // Check corresponding busbar sections

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/LimitViolationTest.java
@@ -87,11 +87,11 @@ class LimitViolationTest {
         LimitViolation limitViolation3 = new LimitViolation("testId", null, LimitViolationType.APPARENT_POWER, null, 6300,
                 1000, 1, 1100, ThreeSides.THREE);
         LimitViolation limitViolation4 = new LimitViolation("testId", null, LimitViolationType.LOW_VOLTAGE,
-            1000, 1, 1100, new BusBreakerViolationLocation("vlId", "busId"));
+            1000, 1, 1100, new BusBreakerViolationLocation(List.of("busId1", "busId2")));
         String expected1 = "Subject id: testId, Subject name: null, limitType: HIGH_VOLTAGE, limit: 420.0, limitName: high, acceptableDuration: 2147483647, limitReduction: 1.0, value: 500.0, side: null, voltageLocation: null";
         String expected2 = "Subject id: testId, Subject name: null, limitType: CURRENT, limit: 1000.0, limitName: null, acceptableDuration: 6300, limitReduction: 1.0, value: 1100.0, side: ONE, voltageLocation: null";
         String expected3 = "Subject id: testId, Subject name: null, limitType: APPARENT_POWER, limit: 1000.0, limitName: null, acceptableDuration: 6300, limitReduction: 1.0, value: 1100.0, side: THREE, voltageLocation: null";
-        String expected4 = "Subject id: testId, Subject name: null, limitType: LOW_VOLTAGE, limit: 1000.0, limitName: null, acceptableDuration: 2147483647, limitReduction: 1.0, value: 1100.0, side: null, voltageLocation: BusBreakerViolationLocation{voltageLevelId='vlId', busId='busId'}";
+        String expected4 = "Subject id: testId, Subject name: null, limitType: LOW_VOLTAGE, limit: 1000.0, limitName: null, acceptableDuration: 2147483647, limitReduction: 1.0, value: 1100.0, side: null, voltageLocation: BusBreakerViolationLocation{busIds='[busId1, busId2]'}";
         assertEquals(expected1, limitViolation1.toString());
         assertEquals(expected2, limitViolation2.toString());
         assertEquals(expected3, limitViolation3.toString());

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
@@ -56,7 +56,7 @@ class ExporterTest extends AbstractSerDeTest {
         violation2.addExtension(CurrentExtension.class, new CurrentExtension(95.0));
 
         LimitViolation violation3 = new LimitViolation("GEN", LimitViolationType.HIGH_VOLTAGE, 100, 0.9f, 110, new BusBreakerViolationLocation(List.of("BUSID")));
-        LimitViolation violation4 = new LimitViolation("GEN2", LimitViolationType.LOW_VOLTAGE, 100, 0.7f, 115, new NodeBreakerViolationLocation("VL", Arrays.asList("BBS1", "BBS2")));
+        LimitViolation violation4 = new LimitViolation("GEN2", LimitViolationType.LOW_VOLTAGE, 100, 0.7f, 115, new NodeBreakerViolationLocation("VL", Arrays.asList(0, 1)));
         violation4.addExtension(VoltageExtension.class, new VoltageExtension(400.0));
 
         LimitViolation violation5 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.ACTIVE_POWER, "20'", 1200, 100, 1.0f, 110.0, TwoSides.ONE);

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
@@ -55,7 +55,7 @@ class ExporterTest extends AbstractSerDeTest {
         violation2.addExtension(ActivePowerExtension.class, new ActivePowerExtension(220.0, 230.0));
         violation2.addExtension(CurrentExtension.class, new CurrentExtension(95.0));
 
-        LimitViolation violation3 = new LimitViolation("GEN", LimitViolationType.HIGH_VOLTAGE, 100, 0.9f, 110, new BusBreakerViolationLocation("VL", "BUSID"));
+        LimitViolation violation3 = new LimitViolation("GEN", LimitViolationType.HIGH_VOLTAGE, 100, 0.9f, 110, new BusBreakerViolationLocation(List.of("BUSID")));
         LimitViolation violation4 = new LimitViolation("GEN2", LimitViolationType.LOW_VOLTAGE, 100, 0.7f, 115, new NodeBreakerViolationLocation("VL", Arrays.asList("BBS1", "BBS2")));
         violation4.addExtension(VoltageExtension.class, new VoltageExtension(400.0));
 

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/PostContingencyResultTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/PostContingencyResultTest.java
@@ -62,7 +62,7 @@ class PostContingencyResultTest extends AbstractSerDeTest {
         LimitViolation violation2 = new LimitViolation("subject_id", LimitViolationType.HIGH_VOLTAGE, 420,
             (float) 0.1, 500, new BusBreakerViolationLocation(List.of("bus_id")));
         LimitViolation violation3 = new LimitViolation("subject_id", LimitViolationType.LOW_VOLTAGE, 200,
-            (float) 0.3, 180, new NodeBreakerViolationLocation("vl_id", Collections.singletonList("bbs_id")));
+            (float) 0.3, 180, new NodeBreakerViolationLocation("vl_id", Collections.singletonList(0)));
         LimitViolationsResult result = new LimitViolationsResult(Arrays.asList(violation, violation2, violation3));
         List<ThreeWindingsTransformerResult> threeWindingsTransformerResults = new ArrayList<>();
         threeWindingsTransformerResults.add(new ThreeWindingsTransformerResult("threeWindingsTransformerId",

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/PostContingencyResultTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/PostContingencyResultTest.java
@@ -60,7 +60,7 @@ class PostContingencyResultTest extends AbstractSerDeTest {
         Contingency contingency = new Contingency("contingency");
         LimitViolation violation = new LimitViolation("violation", LimitViolationType.HIGH_VOLTAGE, 420, (float) 0.1, 500);
         LimitViolation violation2 = new LimitViolation("subject_id", LimitViolationType.HIGH_VOLTAGE, 420,
-            (float) 0.1, 500, new BusBreakerViolationLocation("vl_id", "bus_id"));
+            (float) 0.1, 500, new BusBreakerViolationLocation(List.of("bus_id")));
         LimitViolation violation3 = new LimitViolation("subject_id", LimitViolationType.LOW_VOLTAGE, 200,
             (float) 0.3, 180, new NodeBreakerViolationLocation("vl_id", Collections.singletonList("bbs_id")));
         LimitViolationsResult result = new LimitViolationsResult(Arrays.asList(violation, violation2, violation3));

--- a/security-analysis/security-analysis-api/src/test/resources/PostContingencyResultTest.json
+++ b/security-analysis/security-analysis-api/src/test/resources/PostContingencyResultTest.json
@@ -15,8 +15,7 @@
       "subjectId" : "subject_id",
       "violationLocation" : {
         "type" : "BUS_BREAKER",
-        "voltageLevelId" : "vl_id",
-        "busId" : "bus_id"
+        "busIds" : [ "bus_id" ]
       },
       "limitType" : "HIGH_VOLTAGE",
       "limit" : 420.0,

--- a/security-analysis/security-analysis-api/src/test/resources/PostContingencyResultTest.json
+++ b/security-analysis/security-analysis-api/src/test/resources/PostContingencyResultTest.json
@@ -26,7 +26,7 @@
       "violationLocation" : {
         "type" : "NODE_BREAKER",
         "voltageLevelId" : "vl_id",
-        "busbarIds" : [ "bbs_id" ]
+        "nodes" : [ 0 ]
       },
       "limitType" : "LOW_VOLTAGE",
       "limit" : 200.0,

--- a/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisResult.json
+++ b/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisResult.json
@@ -105,8 +105,7 @@
         "subjectId" : "GEN",
         "violationLocation" : {
           "type" : "BUS_BREAKER",
-          "voltageLevelId" : "VL",
-          "busId" : "BUSID"
+          "busIds" : [ "BUSID" ]
         },
         "limitType" : "HIGH_VOLTAGE",
         "limit" : 100.0,

--- a/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisResult.json
+++ b/security-analysis/security-analysis-api/src/test/resources/SecurityAnalysisResult.json
@@ -116,7 +116,7 @@
         "violationLocation" : {
           "type" : "NODE_BREAKER",
           "voltageLevelId" : "VL",
-          "busbarIds" : [ "BBS1", "BBS2" ]
+          "nodes" : [ 0, 1 ]
         },
         "limitType" : "LOW_VOLTAGE",
         "limit" : 100.0,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
#3153 introduces ViolationLocations for voltage violation.
- In the bus/breaker topology case, the bus id in the `BusBreakerViolationLocation` corresponds to a merged bus. This is not stable depending on the network implementation.
- In the node/breaker topology case, the `NodeBreakerViolationLocation` contains a list of busbar section ids. But in some cases there are no busbar section where the violation is detected.

**What is the new behavior (if this is a feature change)?**
- The `busId` of `BusBreakerViolationLocation` was replaced by a list of ids corresponding to the configured buses of the merge bus.
- The `busbarIds` of `NodeBreakerViolationLocation` was replaced by the list of the nodes where the violation was detected (always present).

Some unnecessary attributes / methods were also removed (for quality purpose):
- `getId()` (from `VoltageLocation` interface + both implementations)
- `getVoltageLevelId()` (from `VoltageLocation` + `BusBreakerViolationLocation`)
- `getBusId()` (from `VoltageLocation` interface + both implementations)
- `getBusbarIds()` (from `VoltageLocation` + both implementations)

**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes: There's breaking change compared to `powsybl:6.5.0-RC1`, **but not compared to any production release**.
- [ ] No


**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

Only for migrating from 6.5.0-RC1:
- To retrieve data from a `ViolationLocation`, you now have to check it's type and cast it in the corresponding implementation.
- The `getBusId()` method from `BusBreakerViolationLocation` is replaced by a `getBusIds()` method returning the list of the ids of the **configured** buses instead of the sole id of the **merged** bus (which is not stable).
- The `getBusbarIds()` method from `NodeBreakerViolationLocation` is replaced by a `getNodes()` method returning the list of the nodes where the violation was detected. If needed, it is possible to retrieve the list of all concerned busbar sections using the following code:
```java
NodeBreakerViolationLocation vloc = (NodeBreakerViolationLocation) violationLocation;
VoltageLevel vl = network.getVoltageLevel(vloc.getVoltageLevelId());
List<String> busbarSectionIds = vloc.getNodes().stream()
        .map(node -> vl.getNodeBreakerView().getTerminal(node))
        .filter(Objects::nonNull)
        .map(Terminal::getConnectable)
        .filter(t -> t.getType() == IdentifiableType.BUSBAR_SECTION)
        .map(Identifiable::getId)
        .toList();
```

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

The serialization versions of the short-circuits and security analysis results were increased in #3153.
The current version doesn't increase them since the said PR isn't already in a production release.