### PR TITLE
Fix load flow default parameters loading mechanism

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
@@ -131,25 +131,26 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
 
         platformConfig.getOptionalModuleConfig("load-flow-default-parameters")
                 .ifPresent(config -> {
-                    parameters.setVoltageInitMode(config.getEnumProperty("voltageInitMode", VoltageInitMode.class, DEFAULT_VOLTAGE_INIT_MODE));
-                    parameters.setTransformerVoltageControlOn(config.getBooleanProperty("transformerVoltageControlOn", DEFAULT_TRANSFORMER_VOLTAGE_CONTROL_ON));
-                    parameters.setUseReactiveLimits(!config.getBooleanProperty("noGeneratorReactiveLimits", !DEFAULT_USE_REACTIVE_LIMITS)); // overwritten by reactiveLimits
-                    parameters.setUseReactiveLimits(config.getBooleanProperty("useReactiveLimits", DEFAULT_USE_REACTIVE_LIMITS));
-                    parameters.setPhaseShifterRegulationOn(config.getBooleanProperty("phaseShifterRegulationOn", DEFAULT_PHASE_SHIFTER_REGULATION_ON));
-                    // keep old tag name "specificCompatibility" for compatibility
-                    parameters.setTwtSplitShuntAdmittance(config.getBooleanProperty("twtSplitShuntAdmittance", config.getBooleanProperty("specificCompatibility", DEFAULT_TWT_SPLIT_SHUNT_ADMITTANCE)));
-                    parameters.setShuntCompensatorVoltageControlOn(config.getBooleanProperty("shuntCompensatorVoltageControlOn",
-                            config.getOptionalBooleanProperty("simulShunt").orElse(DEFAULT_SHUNT_COMPENSATOR_VOLTAGE_CONTROL_ON)));
-                    parameters.setReadSlackBus(config.getBooleanProperty("readSlackBus", DEFAULT_READ_SLACK_BUS));
-                    parameters.setWriteSlackBus(config.getBooleanProperty("writeSlackBus", DEFAULT_WRITE_SLACK_BUS));
-                    parameters.setDc(config.getBooleanProperty("dc", DEFAULT_DC));
-                    parameters.setDistributedSlack(config.getBooleanProperty("distributedSlack", DEFAULT_DISTRIBUTED_SLACK));
-                    parameters.setBalanceType(config.getEnumProperty("balanceType", BalanceType.class, DEFAULT_BALANCE_TYPE));
-                    parameters.setDcUseTransformerRatio(config.getBooleanProperty("dcUseTransformerRatio", DEFAULT_DC_USE_TRANSFORMER_RATIO_DEFAULT));
-                    parameters.setCountriesToBalance(config.getEnumSetProperty("countriesToBalance", Country.class, DEFAULT_COUNTRIES_TO_BALANCE));
-                    parameters.setConnectedComponentMode(config.getEnumProperty("connectedComponentMode", ConnectedComponentMode.class, DEFAULT_CONNECTED_COMPONENT_MODE));
-                    parameters.setHvdcAcEmulation(config.getBooleanProperty("hvdcAcEmulation", DEFAULT_HVDC_AC_EMULATION_ON));
-                    parameters.setDcPowerFactor(config.getDoubleProperty("dcPowerFactor", DEFAULT_DC_POWER_FACTOR));
+                    config.getOptionalEnumProperty("voltageInitMode", VoltageInitMode.class).ifPresent(parameters::setVoltageInitMode);
+                    config.getOptionalBooleanProperty("transformerVoltageControlOn").ifPresent(parameters::setTransformerVoltageControlOn);
+                    config.getOptionalBooleanProperty("useReactiveLimits").ifPresentOrElse(parameters::setUseReactiveLimits,
+                            () -> config.getOptionalBooleanProperty("noGeneratorReactiveLimits").ifPresent(value -> parameters.setUseReactiveLimits(!value)));
+                    config.getOptionalBooleanProperty("phaseShifterRegulationOn").ifPresent(parameters::setPhaseShifterRegulationOn);
+                    config.getOptionalBooleanProperty("twtSplitShuntAdmittance").ifPresentOrElse(parameters::setTwtSplitShuntAdmittance,
+                            () -> config.getOptionalBooleanProperty("specificCompatibility").ifPresent(parameters::setTwtSplitShuntAdmittance));
+                    config.getOptionalBooleanProperty("shuntCompensatorVoltageControlOn").ifPresentOrElse(parameters::setShuntCompensatorVoltageControlOn,
+                            () -> config.getOptionalBooleanProperty("simulShunt").ifPresent(parameters::setShuntCompensatorVoltageControlOn));
+                    config.getOptionalBooleanProperty("readSlackBus").ifPresent(parameters::setReadSlackBus);
+                    config.getOptionalBooleanProperty("writeSlackBus").ifPresent(parameters::setWriteSlackBus);
+                    config.getOptionalBooleanProperty("dc").ifPresent(parameters::setDc);
+                    config.getOptionalBooleanProperty("distributedSlack").ifPresent(parameters::setDistributedSlack);
+                    config.getOptionalEnumProperty("balanceType", BalanceType.class).ifPresent(parameters::setBalanceType);
+                    config.getOptionalBooleanProperty("dcUseTranformerRatio").ifPresent(parameters::setDcUseTransformerRatio);
+                    config.getOptionalBooleanProperty("useReactiveLimits").ifPresent(parameters::setUseReactiveLimits);
+                    config.getOptionalEnumSetProperty("contriesToBalance", Country.class).ifPresent(parameters::setCountriesToBalance);
+                    config.getOptionalEnumProperty("connectedComponentMode", ConnectedComponentMode.class).ifPresent(parameters::setConnectedComponentMode);
+                    config.getOptionalBooleanProperty("hvdcAcEmulation").ifPresent(parameters::setHvdcAcEmulation);
+                    config.getOptionalDoubleProperty("dcPowerFactor").ifPresent(parameters::setDcPowerFactor);
                 });
     }
 

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
@@ -129,6 +129,10 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
         Objects.requireNonNull(parameters);
         Objects.requireNonNull(platformConfig);
 
+        // Only the parameters present in platformConfig will be updated and no default value will be set for the absent parameters
+        // (unlike what is done for the other parameters classes).
+        // This is needed for the LoadFlowDefaultParametersLoader mechanism to work (else the default values defined
+        // by the loader will be overwritten by the hardcoded ones).
         platformConfig.getOptionalModuleConfig("load-flow-default-parameters")
                 .ifPresent(config -> {
                     config.getOptionalEnumProperty("voltageInitMode", VoltageInitMode.class).ifPresent(parameters::setVoltageInitMode);

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
@@ -146,7 +146,6 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
                     config.getOptionalBooleanProperty("distributedSlack").ifPresent(parameters::setDistributedSlack);
                     config.getOptionalEnumProperty("balanceType", BalanceType.class).ifPresent(parameters::setBalanceType);
                     config.getOptionalBooleanProperty("dcUseTranformerRatio").ifPresent(parameters::setDcUseTransformerRatio);
-                    config.getOptionalBooleanProperty("useReactiveLimits").ifPresent(parameters::setUseReactiveLimits);
                     config.getOptionalEnumSetProperty("contriesToBalance", Country.class).ifPresent(parameters::setCountriesToBalance);
                     config.getOptionalEnumProperty("connectedComponentMode", ConnectedComponentMode.class).ifPresent(parameters::setConnectedComponentMode);
                     config.getOptionalBooleanProperty("hvdcAcEmulation").ifPresent(parameters::setHvdcAcEmulation);

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowDefaultParametersLoaderTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowDefaultParametersLoaderTest.java
@@ -11,7 +11,6 @@ import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.commons.config.MapModuleConfig;
-import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.extensions.Extension;
 import com.powsybl.loadflow.json.JsonLoadFlowParametersTest;
 import org.junit.jupiter.api.Test;

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowParametersTest.java
@@ -129,7 +129,7 @@ class LoadFlowParametersTest {
         LoadFlowParameters parameters = new LoadFlowParameters();
         LoadFlowParameters.load(parameters, platformConfig);
         checkValues(parameters, voltageInitMode, transformerVoltageControlOn,
-                    noGeneratorReactiveLimits, phaseShifterRegulationOn, twtSplitShuntAdmittance, simulShunt, readSlackBus, writeSlackBus,
+                    !noGeneratorReactiveLimits, phaseShifterRegulationOn, twtSplitShuntAdmittance, simulShunt, readSlackBus, writeSlackBus,
                     dc, distributedSlack, balanceType, dcUseTransformerRatio, countriesToBalance, computedConnectedComponent, hvdcAcEmulation);
     }
 

--- a/loadflow/loadflow-api/src/test/resources/LoadFlowParametersUpdate.json
+++ b/loadflow/loadflow-api/src/test/resources/LoadFlowParametersUpdate.json
@@ -1,4 +1,7 @@
 {
+  "version": "1.9",
+  "voltageInitMode" : "DC_VALUES",
+  "useReactiveLimits" : false,
   "extensions": {
     "dummy-extension": {
       "parameterDouble": 5,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug 


**What is the current behavior?**
When loading loadflow parameters from a PlatformConfig, every field of the LoadFlowParameters is either set to the value written in the config or to its default value (if the configuration module `load-flow-default-parameters` is used). 
It is a problem for the `LoadFlowDefaultParametersLoader` mechanism that is meant to change values before the PlatformConfig load.

As a additional related problem, the old `noGeneratorReactiveLimits` parameter (now replaced by `useReactiveLimits`) is ignored: its value is overwritten by the default value of `useReactiveLimits`.

**What is the new behavior (if this is a feature change)?**
Now the loading only changes fields that are specified in the configuration file, and does not modify the absent ones.

The backward compatibility of the `noGeneratorReactiveLimits` parameter is also fixed.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
