### PR TITLE
Refactor voltage level topology implementation

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
@@ -72,7 +72,7 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
         for (TerminalExt terminal : terminals) {
             terminal.removeAsRegulationPoint();
             VoltageLevelExt vl = terminal.getVoltageLevel();
-            vl.detach(terminal);
+            vl.getTopologyModel().detach(terminal);
         }
 
         network.getListeners().notifyAfterRemoval(id);
@@ -181,10 +181,10 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
     private void attachTerminal(TerminalExt oldTerminal, TopologyPoint oldTopologyPoint, VoltageLevelExt voltageLevel, TerminalExt terminalExt) {
         // first, attach new terminal to connectable and to voltage level of destination, to ensure that the new terminal is valid
         terminalExt.setConnectable(this);
-        voltageLevel.attach(terminalExt, false);
+        voltageLevel.getTopologyModel().attach(terminalExt, false);
 
         // then we can detach the old terminal, as we now know that the new terminal is valid
-        oldTerminal.getVoltageLevel().detach(oldTerminal);
+        oldTerminal.getVoltageLevel().getTopologyModel().detach(oldTerminal);
 
         // replace the old terminal by the new terminal in the connectable
         int iSide = terminals.indexOf(oldTerminal);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTerminal.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTerminal.java
@@ -182,7 +182,7 @@ abstract class AbstractTerminal implements TerminalExt {
         String variantId = getVariantManagerHolder().getVariantManager().getVariantId(variantIndex);
         boolean connectedBefore = isConnected();
         connectable.notifyUpdate("beginConnect", variantId, connectedBefore, null);
-        boolean connected = voltageLevel.connect(this, isTypeSwitchToOperate);
+        boolean connected = voltageLevel.getTopologyModel().connect(this, isTypeSwitchToOperate);
         boolean connectedAfter = isConnected();
         connectable.notifyUpdate("endConnect", variantId, null, connectedAfter);
         return connected;
@@ -209,7 +209,7 @@ abstract class AbstractTerminal implements TerminalExt {
         String variantId = getVariantManagerHolder().getVariantManager().getVariantId(variantIndex);
         boolean disconnectedBefore = !isConnected();
         connectable.notifyUpdate("beginDisconnect", variantId, disconnectedBefore, null);
-        boolean disconnected = voltageLevel.disconnect(this, isSwitchOpenable);
+        boolean disconnected = voltageLevel.getTopologyModel().disconnect(this, isSwitchOpenable);
         boolean disconnectedAfter = !isConnected();
         connectable.notifyUpdate("endDisconnect", variantId, null, disconnectedAfter);
         return disconnected;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTopologyModel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTopologyModel.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network.impl;
+
+import com.powsybl.commons.config.PlatformConfig;
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.util.ShortIdDictionary;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.Writer;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.stream.Stream;
+
+/**
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ */
+abstract class AbstractTopologyModel implements TopologyModel {
+
+    public static final int DEFAULT_NODE_INDEX_LIMIT = 1000;
+
+    public static final int NODE_INDEX_LIMIT = loadNodeIndexLimit(PlatformConfig.defaultConfig());
+
+    protected final VoltageLevelExt voltageLevel;
+
+    protected AbstractTopologyModel(VoltageLevelExt voltageLevel) {
+        this.voltageLevel = Objects.requireNonNull(voltageLevel);
+    }
+
+    protected static int loadNodeIndexLimit(PlatformConfig platformConfig) {
+        return platformConfig
+                .getOptionalModuleConfig("iidm")
+                .map(moduleConfig -> moduleConfig.getIntProperty("node-index-limit", DEFAULT_NODE_INDEX_LIMIT))
+                .orElse(DEFAULT_NODE_INDEX_LIMIT);
+    }
+
+    protected NetworkImpl getNetwork() {
+        return voltageLevel.getNetwork();
+    }
+
+    protected static void addNextTerminals(TerminalExt otherTerminal, List<TerminalExt> nextTerminals) {
+        Objects.requireNonNull(otherTerminal);
+        Objects.requireNonNull(nextTerminals);
+        Connectable<?> otherConnectable = otherTerminal.getConnectable();
+        if (otherConnectable instanceof Branch<?> branch) {
+            if (branch.getTerminal1() == otherTerminal) {
+                nextTerminals.add((TerminalExt) branch.getTerminal2());
+            } else if (branch.getTerminal2() == otherTerminal) {
+                nextTerminals.add((TerminalExt) branch.getTerminal1());
+            } else {
+                throw new IllegalStateException();
+            }
+        } else if (otherConnectable instanceof ThreeWindingsTransformer ttc) {
+            if (ttc.getLeg1().getTerminal() == otherTerminal) {
+                nextTerminals.add((TerminalExt) ttc.getLeg2().getTerminal());
+                nextTerminals.add((TerminalExt) ttc.getLeg3().getTerminal());
+            } else if (ttc.getLeg2().getTerminal() == otherTerminal) {
+                nextTerminals.add((TerminalExt) ttc.getLeg1().getTerminal());
+                nextTerminals.add((TerminalExt) ttc.getLeg3().getTerminal());
+            } else if (ttc.getLeg3().getTerminal() == otherTerminal) {
+                nextTerminals.add((TerminalExt) ttc.getLeg1().getTerminal());
+                nextTerminals.add((TerminalExt) ttc.getLeg2().getTerminal());
+            } else {
+                throw new IllegalStateException();
+            }
+        }
+    }
+
+    public void invalidateCache() {
+        invalidateCache(false);
+    }
+
+    public abstract Iterable<Terminal> getTerminals();
+
+    public abstract Stream<Terminal> getTerminalStream();
+
+    public abstract VoltageLevelExt.NodeBreakerViewExt getNodeBreakerView();
+
+    public abstract VoltageLevelExt.BusBreakerViewExt getBusBreakerView();
+
+    public abstract VoltageLevelExt.BusViewExt getBusView();
+
+    public abstract Iterable<Switch> getSwitches();
+
+    public abstract int getSwitchCount();
+
+    public abstract TopologyKind getTopologyKind();
+
+    public abstract void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex);
+
+    public abstract void reduceVariantArraySize(int number);
+
+    public abstract void deleteVariantArrayElement(int index);
+
+    public abstract void allocateVariantArrayElement(int[] indexes, int sourceIndex);
+
+    protected abstract void removeTopology();
+
+    public abstract void printTopology();
+
+    public abstract void printTopology(PrintStream out, ShortIdDictionary dict);
+
+    public abstract void exportTopology(Path file) throws IOException;
+
+    public abstract void exportTopology(Writer writer);
+
+    public abstract void exportTopology(Writer writer, Random random);
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTopologyModel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTopologyModel.java
@@ -7,6 +7,8 @@
  */
 package com.powsybl.iidm.network.impl;
 
+import com.google.common.collect.FluentIterable;
+import com.google.common.primitives.Ints;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.util.ShortIdDictionary;
@@ -81,6 +83,38 @@ abstract class AbstractTopologyModel implements TopologyModel {
     public abstract Iterable<Terminal> getTerminals();
 
     public abstract Stream<Terminal> getTerminalStream();
+
+    public <T extends Connectable> Iterable<T> getConnectables(Class<T> clazz) {
+        Iterable<Terminal> terminals = getTerminals();
+        return FluentIterable.from(terminals)
+                .transform(Terminal::getConnectable)
+                .filter(clazz)
+                .toSet();
+    }
+
+    public <T extends Connectable> Stream<T> getConnectableStream(Class<T> clazz) {
+        return getTerminalStream()
+                .map(Terminal::getConnectable)
+                .filter(clazz::isInstance)
+                .map(clazz::cast)
+                .distinct();
+    }
+
+    public <T extends Connectable> int getConnectableCount(Class<T> clazz) {
+        return Ints.checkedCast(getConnectableStream(clazz).count());
+    }
+
+    public Iterable<Connectable> getConnectables() {
+        return FluentIterable.from(getTerminals())
+                .transform(Terminal::getConnectable)
+                .toSet();
+    }
+
+    public Stream<Connectable> getConnectableStream() {
+        return getTerminalStream()
+                .map(Terminal::getConnectable)
+                .distinct();
+    }
 
     public abstract VoltageLevelExt.NodeBreakerViewExt getNodeBreakerView();
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BatteryAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BatteryAdderImpl.java
@@ -92,7 +92,7 @@ public class BatteryAdderImpl extends AbstractInjectionAdder<BatteryAdderImpl> i
         BatteryImpl battery = new BatteryImpl(getNetworkRef(), id, getName(), isFictitious(), targetP, targetQ, minP, maxP);
 
         battery.addTerminal(terminal);
-        voltageLevel.attach(terminal, false);
+        voltageLevel.getTopologyModel().attach(terminal, false);
         network.getIndex().checkAndAdd(battery);
         network.getListeners().notifyCreation(battery);
         return battery;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusAdderImpl.java
@@ -15,9 +15,9 @@ import com.powsybl.iidm.network.BusAdder;
  */
 class BusAdderImpl extends AbstractIdentifiableAdder<BusAdderImpl> implements BusAdder {
 
-    private final BusBreakerVoltageLevel voltageLevel;
+    private final VoltageLevelExt voltageLevel;
 
-    BusAdderImpl(BusBreakerVoltageLevel voltageLevel) {
+    BusAdderImpl(VoltageLevelExt voltageLevel) {
         this.voltageLevel = voltageLevel;
     }
 
@@ -35,7 +35,7 @@ class BusAdderImpl extends AbstractIdentifiableAdder<BusAdderImpl> implements Bu
     public ConfiguredBus add() {
         String id = checkAndGetUniqueId();
         ConfiguredBusImpl bus = new ConfiguredBusImpl(id, getName(), isFictitious(), voltageLevel);
-        voltageLevel.addBus(bus);
+        ((BusBreakerTopologyModel) voltageLevel.getTopologyModel()).addBus(bus);
         getNetwork().getListeners().notifyCreation(bus);
         return bus;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerTopologyModel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerTopologyModel.java
@@ -361,6 +361,7 @@ class BusBreakerTopologyModel extends AbstractTopologyModel {
         });
     }
 
+    @Override
     public void invalidateCache(boolean exceptBusBreakerView) {
         calculatedBusTopology.invalidateCache();
         getNetwork().getBusView().invalidateCache();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerTopologyModel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusBreakerTopologyModel.java
@@ -13,7 +13,6 @@ import com.google.common.collect.Iterables;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.util.Colors;
 import com.powsybl.iidm.network.*;
-import com.powsybl.commons.ref.Ref;
 import com.powsybl.iidm.network.util.Identifiables;
 import com.powsybl.iidm.network.util.Networks;
 import com.powsybl.iidm.network.util.ShortIdDictionary;
@@ -44,11 +43,11 @@ import java.util.stream.Stream;
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
-class BusBreakerVoltageLevel extends AbstractVoltageLevel {
+class BusBreakerTopologyModel extends AbstractTopologyModel {
 
     private static final boolean DRAW_SWITCH_ID = true;
 
-    private final class SwitchAdderImpl extends AbstractIdentifiableAdder<SwitchAdderImpl> implements BusBreakerView.SwitchAdder {
+    private final class SwitchAdderImpl extends AbstractIdentifiableAdder<SwitchAdderImpl> implements VoltageLevel.BusBreakerView.SwitchAdder {
 
         private String busId1;
 
@@ -61,7 +60,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
 
         @Override
         protected NetworkImpl getNetwork() {
-            return BusBreakerVoltageLevel.this.getNetwork();
+            return BusBreakerTopologyModel.this.getNetwork();
         }
 
         @Override
@@ -70,19 +69,19 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
-        public BusBreakerView.SwitchAdder setBus1(String bus1) {
+        public VoltageLevel.BusBreakerView.SwitchAdder setBus1(String bus1) {
             this.busId1 = bus1;
             return this;
         }
 
         @Override
-        public BusBreakerView.SwitchAdder setBus2(String bus2) {
+        public VoltageLevel.BusBreakerView.SwitchAdder setBus2(String bus2) {
             this.busId2 = bus2;
             return this;
         }
 
         @Override
-        public BusBreakerView.SwitchAdder setOpen(boolean open) {
+        public VoltageLevel.BusBreakerView.SwitchAdder setOpen(boolean open) {
             this.open = open;
             return this;
         }
@@ -100,7 +99,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
                 throw new ValidationException(this, "same bus at both ends");
             }
 
-            SwitchImpl aSwitch = new SwitchImpl(BusBreakerVoltageLevel.this, id, getName(), isFictitious(), SwitchKind.BREAKER, open, true);
+            SwitchImpl aSwitch = new SwitchImpl(voltageLevel, id, getName(), isFictitious(), SwitchKind.BREAKER, open, true);
             addSwitch(aSwitch, busId1, busId2);
             getNetwork().getListeners().notifyCreation(aSwitch);
             return aSwitch;
@@ -122,7 +121,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         if (throwException && v == null) {
             throw new PowsyblException("Bus " + busId
                     + " not found in voltage level "
-                    + BusBreakerVoltageLevel.this.id);
+                    + voltageLevel.getId());
         }
         return v;
     }
@@ -145,7 +144,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         if (throwException && e == null) {
             throw new PowsyblException("Switch " + switchId
                     + " not found in voltage level"
-                    + BusBreakerVoltageLevel.this.id);
+                    + voltageLevel.getId());
         }
         return e;
     }
@@ -215,9 +214,9 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
 
         private MergedBus createMergedBus(int busNum, Set<ConfiguredBus> busSet) {
             String suffix = "_" + busNum;
-            String mergedBusId = Identifiables.getUniqueId(BusBreakerVoltageLevel.this.id + suffix, getNetwork().getIndex()::contains);
-            String mergedBusName = BusBreakerVoltageLevel.this.name != null ? BusBreakerVoltageLevel.this.name + suffix : null;
-            return new MergedBus(mergedBusId, mergedBusName, BusBreakerVoltageLevel.this.fictitious, busSet);
+            String mergedBusId = Identifiables.getUniqueId(voltageLevel.getId() + suffix, getNetwork().getIndex()::contains);
+            String mergedBusName = voltageLevel.getOptionalName().map(name -> name + suffix).orElse(null);
+            return new MergedBus(mergedBusId, mergedBusName, voltageLevel.isFictitious(), busSet);
         }
 
         private void updateCache() {
@@ -278,7 +277,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
             if (throwException && bus == null) {
                 throw new PowsyblException("Bus " + mergedBusId
                         + " not found in voltage level "
-                        + BusBreakerVoltageLevel.this.id);
+                        + voltageLevel.getId());
             }
             return bus;
         }
@@ -309,11 +308,10 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
 
     protected final VariantArray<VariantImpl> variants;
 
-    BusBreakerVoltageLevel(String id, String name, boolean fictitious, SubstationImpl substation, Ref<NetworkImpl> ref,
-                           Ref<SubnetworkImpl> subnetworkRef, double nominalV, double lowVoltageLimit, double highVoltageLimit) {
-        super(id, name, fictitious, substation, ref, subnetworkRef, nominalV, lowVoltageLimit, highVoltageLimit);
+    BusBreakerTopologyModel(VoltageLevelExt voltageLevel) {
+        super(voltageLevel);
         // the ref object of the variant array is the same as the current object
-        variants = new VariantArray<>(ref, VariantImpl::new);
+        variants = new VariantArray<>(voltageLevel.getNetworkRef(), VariantImpl::new);
         // invalidate topology and connected components
         graph.addListener(new UndirectedGraphListener<>() {
             @Override
@@ -363,7 +361,6 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         });
     }
 
-    @Override
     public void invalidateCache(boolean exceptBusBreakerView) {
         calculatedBusTopology.invalidateCache();
         getNetwork().getBusView().invalidateCache();
@@ -388,14 +385,14 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         return new PowsyblException("Not supported in a bus breaker topology");
     }
 
-    private final NodeBreakerViewExt nodeBreakerView = new NodeBreakerViewExt() {
+    private final VoltageLevelExt.NodeBreakerViewExt nodeBreakerView = new VoltageLevelExt.NodeBreakerViewExt() {
         @Override
         public double getFictitiousP0(int node) {
             throw createNotSupportedBusBreakerTopologyException();
         }
 
         @Override
-        public NodeBreakerView setFictitiousP0(int node, double p0) {
+        public VoltageLevel.NodeBreakerView setFictitiousP0(int node, double p0) {
             throw createNotSupportedBusBreakerTopologyException();
         }
 
@@ -405,7 +402,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
-        public NodeBreakerView setFictitiousQ0(int node, double q0) {
+        public VoltageLevel.NodeBreakerView setFictitiousQ0(int node, double q0) {
             throw createNotSupportedBusBreakerTopologyException();
         }
 
@@ -576,11 +573,11 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     };
 
     @Override
-    public NodeBreakerViewExt getNodeBreakerView() {
+    public VoltageLevelExt.NodeBreakerViewExt getNodeBreakerView() {
         return nodeBreakerView;
     }
 
-    private final BusBreakerViewExt busBreakerView = new BusBreakerViewExt() {
+    private final VoltageLevelExt.BusBreakerViewExt busBreakerView = new VoltageLevelExt.BusBreakerViewExt() {
 
         @Override
         public Iterable<Bus> getBuses() {
@@ -599,22 +596,22 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
 
         @Override
         public ConfiguredBus getBus(String id) {
-            return BusBreakerVoltageLevel.this.getBus(id, false);
+            return BusBreakerTopologyModel.this.getBus(id, false);
         }
 
         @Override
         public BusAdder newBus() {
-            return new BusAdderImpl(BusBreakerVoltageLevel.this);
+            return new BusAdderImpl(voltageLevel);
         }
 
         @Override
         public void removeBus(String busId) {
-            BusBreakerVoltageLevel.this.removeBus(busId);
+            BusBreakerTopologyModel.this.removeBus(busId);
         }
 
         @Override
         public void removeAllBuses() {
-            BusBreakerVoltageLevel.this.removeAllBuses();
+            BusBreakerTopologyModel.this.removeAllBuses();
         }
 
         @Override
@@ -634,12 +631,12 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
 
         @Override
         public void removeSwitch(String switchId) {
-            BusBreakerVoltageLevel.this.removeSwitch(switchId);
+            BusBreakerTopologyModel.this.removeSwitch(switchId);
         }
 
         @Override
         public void removeAllSwitches() {
-            BusBreakerVoltageLevel.this.removeAllSwitches();
+            BusBreakerTopologyModel.this.removeAllSwitches();
         }
 
         @Override
@@ -671,11 +668,11 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
 
         @Override
         public SwitchImpl getSwitch(String switchId) {
-            return BusBreakerVoltageLevel.this.getSwitch(switchId, false);
+            return BusBreakerTopologyModel.this.getSwitch(switchId, false);
         }
 
         @Override
-        public BusBreakerView.SwitchAdder newSwitch() {
+        public VoltageLevel.BusBreakerView.SwitchAdder newSwitch() {
             return new SwitchAdderImpl();
         }
 
@@ -690,11 +687,11 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     };
 
     @Override
-    public BusBreakerViewExt getBusBreakerView() {
+    public VoltageLevelExt.BusBreakerViewExt getBusBreakerView() {
         return busBreakerView;
     }
 
-    private final BusViewExt busView = new BusViewExt() {
+    private final VoltageLevelExt.BusViewExt busView = new VoltageLevelExt.BusViewExt() {
 
         @Override
         public Iterable<Bus> getBuses() {
@@ -719,7 +716,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     };
 
     @Override
-    public BusViewExt getBusView() {
+    public VoltageLevelExt.BusViewExt getBusView() {
         return busView;
     }
 
@@ -748,7 +745,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     private void removeBus(String busId) {
         ConfiguredBus bus = getBus(busId, true);
         if (bus.getTerminalCount() > 0) {
-            throw new ValidationException(this, "Cannot remove bus "
+            throw new ValidationException(voltageLevel, "Cannot remove bus "
                     + bus.getId() + " because of connectable equipments");
         }
         // TODO improve check efficency
@@ -777,11 +774,11 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
 
     private void removeAllBuses() {
         if (graph.getEdgeCount() > 0) {
-            throw new ValidationException(this, "Cannot remove all buses because there is still some switches");
+            throw new ValidationException(voltageLevel, "Cannot remove all buses because there is still some switches");
         }
         for (ConfiguredBus bus : graph.getVerticesObj()) {
             if (bus.getTerminalCount() > 0) {
-                throw new ValidationException(this, "Cannot remove bus "
+                throw new ValidationException(voltageLevel, "Cannot remove bus "
                         + bus.getId() + " because of connected equipments");
             }
         }
@@ -811,7 +808,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         Integer e = switches.get(switchId);
         if (e == null) {
             throw new PowsyblException("Switch '" + switchId
-                    + "' not found in voltage level '" + id + "'");
+                    + "' not found in voltage level '" + voltageLevel.getId() + "'");
         }
         NetworkImpl network = getNetwork();
         SwitchImpl aSwitch = graph.getEdgeObject(e);
@@ -845,7 +842,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     private void checkTerminal(TerminalExt terminal) {
         if (!(terminal instanceof BusTerminal)) {
             throw new ValidationException(terminal.getConnectable(),
-                    "voltage level " + BusBreakerVoltageLevel.this.id + " has a bus/breaker topology"
+                    "voltage level " + voltageLevel.getId() + " has a bus/breaker topology"
                             + ", a bus connection should be specified instead of a node connection");
         }
 
@@ -863,7 +860,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
             return;
         }
         // create the link terminal -> voltage level
-        terminal.setVoltageLevel(this);
+        terminal.setVoltageLevel(voltageLevel);
 
         // create the link bus -> terminal
         String connectableBusId = ((BusTerminal) terminal).getConnectableBusId();
@@ -899,8 +896,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         terminal.setVoltageLevel(null);
     }
 
-    @Override
-    public boolean connect(TerminalExt terminal) {
+    boolean connect(TerminalExt terminal) {
         if (!(terminal instanceof BusTerminal)) {
             throw new IllegalStateException("Given TerminalExt not supported: " + terminal.getClass().getName());
         }
@@ -923,8 +919,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
         return connect(terminal);
     }
 
-    @Override
-    public boolean disconnect(TerminalExt terminal) {
+    boolean disconnect(TerminalExt terminal) {
         if (!(terminal instanceof BusTerminal)) {
             throw new IllegalStateException("Given TerminalExt not supported: " + terminal.getClass().getName());
         }
@@ -1021,25 +1016,21 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
 
     @Override
     public void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex) {
-        super.extendVariantArraySize(initVariantArraySize, number, sourceIndex);
         variants.push(number, () -> variants.copy(sourceIndex));
     }
 
     @Override
     public void reduceVariantArraySize(int number) {
-        super.reduceVariantArraySize(number);
         variants.pop(number);
     }
 
     @Override
     public void deleteVariantArrayElement(int index) {
-        super.deleteVariantArrayElement(index);
         variants.delete(index);
     }
 
     @Override
     public void allocateVariantArrayElement(int[] indexes, final int sourceIndex) {
-        super.allocateVariantArrayElement(indexes, sourceIndex);
         variants.allocate(indexes, () -> variants.copy(sourceIndex));
     }
 
@@ -1057,7 +1048,7 @@ class BusBreakerVoltageLevel extends AbstractVoltageLevel {
     @Override
     public void printTopology(PrintStream out, ShortIdDictionary dict) {
         out.println("-------------------------------------------------------------");
-        out.println("Topology of " + BusBreakerVoltageLevel.this.id);
+        out.println("Topology of " + voltageLevel.getId());
 
         Function<ConfiguredBus, String> vertexToString = bus -> {
             StringBuilder builder = new StringBuilder();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTerminal.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTerminal.java
@@ -26,10 +26,14 @@ import java.util.Set;
  */
 class BusTerminal extends AbstractTerminal {
 
+    private BusBreakerTopologyModel getTopologyModel() {
+        return (BusBreakerTopologyModel) voltageLevel.getTopologyModel();
+    }
+
     private final NodeBreakerView nodeBreakerView = new NodeBreakerView() {
         @Override
         public int getNode() {
-            throw BusBreakerVoltageLevel.createNotSupportedBusBreakerTopologyException();
+            throw BusBreakerTopologyModel.createNotSupportedBusBreakerTopologyException();
         }
 
         @Override
@@ -56,7 +60,7 @@ class BusTerminal extends AbstractTerminal {
             if (removed) {
                 throw new PowsyblException(CANNOT_ACCESS_BUS_REMOVED_EQUIPMENT + connectable.id);
             }
-            return ((BusBreakerVoltageLevel) voltageLevel).getBus(getConnectableBusId(), true);
+            return getTopologyModel().getBus(getConnectableBusId(), true);
         }
 
         @Override
@@ -65,15 +69,15 @@ class BusTerminal extends AbstractTerminal {
                 throw new PowsyblException(UNMODIFIABLE_REMOVED_EQUIPMENT + connectable.id);
             }
             Objects.requireNonNull(busId);
-            BusBreakerVoltageLevel vl = (BusBreakerVoltageLevel) voltageLevel;
+            BusBreakerTopologyModel topologyModel = getTopologyModel();
 
             // Assert that the new bus exists
-            vl.getBus(busId, true);
+            topologyModel.getBus(busId, true);
 
-            vl.detach(BusTerminal.this);
+            topologyModel.detach(BusTerminal.this);
             int variantIndex = getVariantManagerHolder().getVariantIndex();
             String oldValue = BusTerminal.this.connectableBusId.set(variantIndex, busId);
-            vl.attach(BusTerminal.this, false);
+            topologyModel.attach(BusTerminal.this, false);
             String variantId = getVariantManagerHolder().getVariantManager().getVariantId(variantIndex);
             getConnectable().notifyUpdate("connectableBusId", variantId, oldValue, busId);
         }
@@ -108,8 +112,8 @@ class BusTerminal extends AbstractTerminal {
             if (removed) {
                 throw new PowsyblException(CANNOT_ACCESS_BUS_REMOVED_EQUIPMENT + connectable.id);
             }
-            ConfiguredBus bus = ((BusBreakerVoltageLevel) voltageLevel).getBus(getConnectableBusId(), true);
-            return ((BusBreakerVoltageLevel) voltageLevel).calculatedBusTopology.getMergedBus(bus);
+            ConfiguredBus bus = getTopologyModel().getBus(getConnectableBusId(), true);
+            return getTopologyModel().calculatedBusTopology.getMergedBus(bus);
         }
 
     };
@@ -172,7 +176,7 @@ class BusTerminal extends AbstractTerminal {
         if (removed) {
             throw new PowsyblException(String.format("Associated equipment %s is removed", connectable.id));
         }
-        return ((BusBreakerVoltageLevel) voltageLevel).traverse(this, traverser, visitedTerminals, traversalType);
+        return getTopologyModel().traverse(this, traverser, visitedTerminals, traversalType);
     }
 
     @Override
@@ -185,7 +189,7 @@ class BusTerminal extends AbstractTerminal {
         if (removed) {
             throw new PowsyblException(String.format("Associated equipment %s is removed", connectable.id));
         }
-        ((BusBreakerVoltageLevel) voltageLevel).traverse(this, traverser, traversalType);
+        getTopologyModel().traverse(this, traverser, traversalType);
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusbarSectionAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusbarSectionAdderImpl.java
@@ -50,7 +50,7 @@ class BusbarSectionAdderImpl extends AbstractIdentifiableAdder<BusbarSectionAdde
         TerminalExt terminal = new NodeTerminal(voltageLevel.getNetworkRef(), null, node);
         BusbarSectionImpl section = new BusbarSectionImpl(voltageLevel.getNetworkRef(), id, getName(), isFictitious());
         section.addTerminal(terminal);
-        voltageLevel.attach(terminal, false);
+        voltageLevel.getTopologyModel().attach(terminal, false);
         getNetwork().getIndex().checkAndAdd(section);
         getNetwork().getListeners().notifyCreation(section);
         return section;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/CalculatedBusImpl.java
@@ -29,7 +29,7 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
 
     private NodeTerminal terminalRef;
 
-    CalculatedBusImpl(String id, String name, boolean fictitious, NodeBreakerVoltageLevel voltageLevel, TIntArrayList nodes, List<NodeTerminal> terminals, Function<Terminal, Bus> getBusFromTerminal) {
+    CalculatedBusImpl(String id, String name, boolean fictitious, VoltageLevelExt voltageLevel, TIntArrayList nodes, List<NodeTerminal> terminals, Function<Terminal, Bus> getBusFromTerminal) {
         super(id, name, fictitious, voltageLevel);
         this.terminals = Objects.requireNonNull(terminals);
         this.getBusFromTerminal = Objects.requireNonNull(getBusFromTerminal);
@@ -47,7 +47,7 @@ class CalculatedBusImpl extends AbstractBus implements CalculatedBus {
      * @param terminals The terminals belong to this bus
      * @return The first terminal of the {@code terminals} list, or a terminal which belongs to an equivalent "electrical" bus.
      */
-    private static NodeTerminal findTerminal(NodeBreakerVoltageLevel voltageLevel, TIntArrayList nodes, List<NodeTerminal> terminals) {
+    private static NodeTerminal findTerminal(VoltageLevelExt voltageLevel, TIntArrayList nodes, List<NodeTerminal> terminals) {
         if (!terminals.isEmpty()) {
             return terminals.get(0);
         }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ConnectDisconnectUtil.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ConnectDisconnectUtil.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.powsybl.iidm.network.TopologyKind.BUS_BREAKER;
+import static com.powsybl.iidm.network.TopologyKind.NODE_BREAKER;
 
 /**
  * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
@@ -63,8 +64,9 @@ public final class ConnectDisconnectUtil {
             }
 
             // If it's a node-breaker terminal, the switches to connect are added to a set
-            if (terminal.getVoltageLevel() instanceof NodeBreakerVoltageLevel nodeBreakerVoltageLevel) {
-                isNowConnected = nodeBreakerVoltageLevel.getConnectingSwitches(terminal, isTypeSwitchToOperate, switchForDisconnection);
+            if (terminal.getVoltageLevel().getTopologyKind() == NODE_BREAKER) {
+                NodeBreakerTopologyModel topologyModel = (NodeBreakerTopologyModel) ((VoltageLevelImpl) terminal.getVoltageLevel()).getTopologyModel();
+                isNowConnected = topologyModel.getConnectingSwitches(terminal, isTypeSwitchToOperate, switchForDisconnection);
             }
             // If it's a bus-breaker terminal, there is nothing to do
 
@@ -127,10 +129,12 @@ public final class ConnectDisconnectUtil {
             isAlreadyDisconnected = false;
 
             // If it's a node-breaker terminal, the switches to disconnect are added to a set
-            if (terminal.getVoltageLevel() instanceof NodeBreakerVoltageLevel nodeBreakerVoltageLevel
-                && !nodeBreakerVoltageLevel.getDisconnectingSwitches(terminal, isSwitchOpenable, switchForDisconnection)) {
-                // Exit if the terminal cannot be disconnected
-                return false;
+            if (terminal.getVoltageLevel().getTopologyKind() == NODE_BREAKER) {
+                NodeBreakerTopologyModel topologyModel = (NodeBreakerTopologyModel) ((VoltageLevelImpl) terminal.getVoltageLevel()).getTopologyModel();
+                if (!topologyModel.getDisconnectingSwitches(terminal, isSwitchOpenable, switchForDisconnection)) {
+                    // Exit if the terminal cannot be disconnected
+                    return false;
+                }
             }
             // If it's a bus-breaker terminal, there is nothing to do
         }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DanglingLineAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DanglingLineAdderImpl.java
@@ -114,7 +114,7 @@ class DanglingLineAdderImpl extends AbstractInjectionAdder<DanglingLineAdderImpl
 
         DanglingLineImpl danglingLine = new DanglingLineImpl(network.getRef(), id, getName(), isFictitious(), p0, q0, r, x, g, b, pairingKey, generation);
         danglingLine.addTerminal(terminal);
-        voltageLevel.attach(terminal, false);
+        voltageLevel.getTopologyModel().attach(terminal, false);
         network.getIndex().checkAndAdd(danglingLine);
         network.getListeners().notifyCreation(danglingLine);
         return danglingLine;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/GeneratorAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/GeneratorAdderImpl.java
@@ -131,7 +131,7 @@ class GeneratorAdderImpl extends AbstractInjectionAdder<GeneratorAdderImpl> impl
                                     targetP, targetQ, targetV,
                                     ratedS, isCondenser);
         generator.addTerminal(terminal);
-        voltageLevel.attach(terminal, false);
+        voltageLevel.getTopologyModel().attach(terminal, false);
         network.getIndex().checkAndAdd(generator);
         network.getListeners().notifyCreation(generator);
         return generator;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/GroundAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/GroundAdderImpl.java
@@ -30,7 +30,7 @@ class GroundAdderImpl extends AbstractInjectionAdder<GroundAdderImpl> implements
         TerminalExt terminal = checkAndGetTerminal();
         GroundImpl ground = new GroundImpl(getNetworkRef(), id, getName());
         ground.addTerminal(terminal);
-        voltageLevel.attach(terminal, false);
+        voltageLevel.getTopologyModel().attach(terminal, false);
         network.getIndex().checkAndAdd(ground);
         network.getListeners().notifyCreation(ground);
         return ground;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LccConverterStationAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LccConverterStationAdderImpl.java
@@ -43,7 +43,7 @@ class LccConverterStationAdderImpl extends AbstractHvdcConverterStationAdder<Lcc
         LccConverterStationImpl converterStation
                 = new LccConverterStationImpl(getNetworkRef(), id, name, isFictitious(), getLossFactor(), powerFactor);
         converterStation.addTerminal(terminal);
-        getVoltageLevel().attach(terminal, false);
+        getVoltageLevel().getTopologyModel().attach(terminal, false);
         getNetwork().getIndex().checkAndAdd(converterStation);
         getNetwork().getListeners().notifyCreation(converterStation);
         return converterStation;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LineAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LineAdderImpl.java
@@ -111,11 +111,11 @@ class LineAdderImpl extends AbstractBranchAdder<LineAdderImpl> implements LineAd
         line.addTerminal(terminal2);
 
         // check that the line is attachable on both side
-        voltageLevel1.attach(terminal1, true);
-        voltageLevel2.attach(terminal2, true);
+        voltageLevel1.getTopologyModel().attach(terminal1, true);
+        voltageLevel2.getTopologyModel().attach(terminal2, true);
 
-        voltageLevel1.attach(terminal1, false);
-        voltageLevel2.attach(terminal2, false);
+        voltageLevel1.getTopologyModel().attach(terminal1, false);
+        voltageLevel2.getTopologyModel().attach(terminal2, false);
         network.getIndex().checkAndAdd(line);
         getNetwork().getListeners().notifyCreation(line);
         return line;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LoadAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LoadAdderImpl.java
@@ -77,7 +77,7 @@ class LoadAdderImpl extends AbstractInjectionAdder<LoadAdderImpl> implements Loa
             model.setLoad(load);
         }
         load.addTerminal(terminal);
-        voltageLevel.attach(terminal, false);
+        voltageLevel.getTopologyModel().attach(terminal, false);
         network.getIndex().checkAndAdd(load);
         network.getListeners().notifyCreation(load);
         return load;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -336,20 +336,17 @@ public class NetworkImpl extends AbstractNetwork implements VariantManagerHolder
 
     @Override
     public Iterable<VoltageLevel> getVoltageLevels() {
-        return Iterables.concat(index.getAll(BusBreakerVoltageLevel.class),
-                index.getAll(NodeBreakerVoltageLevel.class));
+        return Collections.unmodifiableCollection(index.getAll(VoltageLevelImpl.class));
     }
 
     @Override
     public Stream<VoltageLevel> getVoltageLevelStream() {
-        return Stream.concat(index.getAll(BusBreakerVoltageLevel.class).stream(),
-                index.getAll(NodeBreakerVoltageLevel.class).stream());
+        return index.getAll(VoltageLevelImpl.class).stream().map(Function.identity());
     }
 
     @Override
     public int getVoltageLevelCount() {
-        return index.getAll(BusBreakerVoltageLevel.class).size()
-                + index.getAll(NodeBreakerVoltageLevel.class).size();
+        return index.getAll(VoltageLevelImpl.class).size();
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerTopologyModel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerTopologyModel.java
@@ -14,6 +14,7 @@ import com.google.common.collect.Iterables;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.util.Colors;
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.VoltageLevel.NodeBreakerView.InternalConnectionAdder;
 import com.powsybl.iidm.network.VoltageLevel.NodeBreakerView.SwitchAdder;
 import com.powsybl.iidm.network.util.Identifiables;
 import com.powsybl.iidm.network.util.ShortIdDictionary;
@@ -84,7 +85,7 @@ class NodeBreakerTopologyModel extends AbstractTopologyModel {
 
     private final VariantArray<VariantImpl> variants;
 
-    private final class SwitchAdderImpl extends AbstractIdentifiableAdder<SwitchAdderImpl> implements VoltageLevel.NodeBreakerView.SwitchAdder {
+    private final class SwitchAdderImpl extends AbstractIdentifiableAdder<SwitchAdderImpl> implements SwitchAdder {
 
         private Integer node1;
 
@@ -176,7 +177,7 @@ class NodeBreakerTopologyModel extends AbstractTopologyModel {
 
     }
 
-    private final class InternalConnectionAdderImpl implements VoltageLevel.NodeBreakerView.InternalConnectionAdder {
+    private final class InternalConnectionAdderImpl implements InternalConnectionAdder {
 
         private Integer node1;
 
@@ -186,13 +187,13 @@ class NodeBreakerTopologyModel extends AbstractTopologyModel {
         }
 
         @Override
-        public VoltageLevel.NodeBreakerView.InternalConnectionAdder setNode1(int node1) {
+        public InternalConnectionAdder setNode1(int node1) {
             this.node1 = node1;
             return this;
         }
 
         @Override
-        public VoltageLevel.NodeBreakerView.InternalConnectionAdder setNode2(int node2) {
+        public InternalConnectionAdder setNode2(int node2) {
             this.node2 = node2;
             return this;
         }
@@ -577,6 +578,7 @@ class NodeBreakerTopologyModel extends AbstractTopologyModel {
         });
     }
 
+    @Override
     public void invalidateCache(boolean exceptBusBreakerView) {
         if (!exceptBusBreakerView) {
             variants.get().calculatedBusBreakerTopology.invalidateCache();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerTopologyModel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerTopologyModel.java
@@ -15,7 +15,6 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.util.Colors;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.VoltageLevel.NodeBreakerView.SwitchAdder;
-import com.powsybl.commons.ref.Ref;
 import com.powsybl.iidm.network.util.Identifiables;
 import com.powsybl.iidm.network.util.ShortIdDictionary;
 import com.powsybl.iidm.network.util.SwitchPredicates;
@@ -50,9 +49,9 @@ import java.util.stream.Stream;
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
-class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
+class NodeBreakerTopologyModel extends AbstractTopologyModel {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NodeBreakerVoltageLevel.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NodeBreakerTopologyModel.class);
 
     private static final String WRONG_TERMINAL_TYPE_EXCEPTION_MESSAGE = "Given TerminalExt not supported: ";
 
@@ -85,7 +84,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
     private final VariantArray<VariantImpl> variants;
 
-    private final class SwitchAdderImpl extends AbstractIdentifiableAdder<SwitchAdderImpl> implements NodeBreakerView.SwitchAdder {
+    private final class SwitchAdderImpl extends AbstractIdentifiableAdder<SwitchAdderImpl> implements VoltageLevel.NodeBreakerView.SwitchAdder {
 
         private Integer node1;
 
@@ -107,7 +106,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
         @Override
         protected NetworkImpl getNetwork() {
-            return NodeBreakerVoltageLevel.this.getNetwork();
+            return NodeBreakerTopologyModel.this.getNetwork();
         }
 
         @Override
@@ -116,19 +115,19 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
-        public NodeBreakerView.SwitchAdder setNode1(int node1) {
+        public SwitchAdder setNode1(int node1) {
             this.node1 = node1;
             return this;
         }
 
         @Override
-        public NodeBreakerView.SwitchAdder setNode2(int node2) {
+        public SwitchAdder setNode2(int node2) {
             this.node2 = node2;
             return this;
         }
 
         @Override
-        public NodeBreakerView.SwitchAdder setKind(SwitchKind kind) {
+        public SwitchAdder setKind(SwitchKind kind) {
             if (kind == null) {
                 throw new NullPointerException("kind is null");
             }
@@ -142,13 +141,13 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
-        public NodeBreakerView.SwitchAdder setOpen(boolean open) {
+        public SwitchAdder setOpen(boolean open) {
             this.open = open;
             return this;
         }
 
         @Override
-        public NodeBreakerView.SwitchAdder setRetained(boolean retained) {
+        public SwitchAdder setRetained(boolean retained) {
             this.retained = retained;
             return this;
         }
@@ -168,7 +167,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             if (kind == null) {
                 throw new ValidationException(this, "kind is not set");
             }
-            SwitchImpl aSwitch = new SwitchImpl(NodeBreakerVoltageLevel.this, id, getName(), isFictitious(), kind, open, retained);
+            SwitchImpl aSwitch = new SwitchImpl(voltageLevel, id, getName(), isFictitious(), kind, open, retained);
             graph.addVertexIfNotPresent(node1);
             graph.addVertexIfNotPresent(node2);
             graph.addEdge(node1, node2, aSwitch);
@@ -177,7 +176,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
     }
 
-    private final class InternalConnectionAdderImpl implements NodeBreakerView.InternalConnectionAdder {
+    private final class InternalConnectionAdderImpl implements VoltageLevel.NodeBreakerView.InternalConnectionAdder {
 
         private Integer node1;
 
@@ -187,13 +186,13 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
-        public NodeBreakerView.InternalConnectionAdder setNode1(int node1) {
+        public VoltageLevel.NodeBreakerView.InternalConnectionAdder setNode1(int node1) {
             this.node1 = node1;
             return this;
         }
 
         @Override
-        public NodeBreakerView.InternalConnectionAdder setNode2(int node2) {
+        public VoltageLevel.NodeBreakerView.InternalConnectionAdder setNode2(int node2) {
             this.node2 = node2;
             return this;
         }
@@ -201,10 +200,10 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         @Override
         public void add() {
             if (node1 == null) {
-                throw new ValidationException(NodeBreakerVoltageLevel.this, "first connection node is not set");
+                throw new ValidationException(voltageLevel, "first connection node is not set");
             }
             if (node2 == null) {
-                throw new ValidationException(NodeBreakerVoltageLevel.this, "second connection node is not set");
+                throw new ValidationException(voltageLevel, "second connection node is not set");
             }
             graph.addVertexIfNotPresent(node1);
             graph.addVertexIfNotPresent(node2);
@@ -274,7 +273,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                 }, encountered);
 
                 // check that the component is a bus
-                String busId = Identifiables.getUniqueId(NAMING_STRATEGY.getId(NodeBreakerVoltageLevel.this, nodes), getNetwork().getIndex()::contains);
+                String busId = Identifiables.getUniqueId(NAMING_STRATEGY.getId(voltageLevel, nodes), getNetwork().getIndex()::contains);
                 CopyOnWriteArrayList<NodeTerminal> terminals = new CopyOnWriteArrayList<>();
                 for (int i = 0; i < nodes.size(); i++) {
                     int n2 = nodes.getQuick(i);
@@ -291,9 +290,9 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
         private void addBus(TIntArrayList nodes, Map<String, CalculatedBus> id2bus, CalculatedBus[] node2bus,
                             String busId, CopyOnWriteArrayList<NodeTerminal> terminals) {
-            String busName = NAMING_STRATEGY.getName(NodeBreakerVoltageLevel.this, nodes);
+            String busName = NAMING_STRATEGY.getName(voltageLevel, nodes);
             Function<Terminal, Bus> getBusFromTerminal = getBusChecker() == CALCULATED_BUS_CHECKER ? t -> t.getBusView().getBus() : t -> t.getBusBreakerView().getBus();
-            CalculatedBusImpl bus = new CalculatedBusImpl(busId, busName, NodeBreakerVoltageLevel.this.fictitious, NodeBreakerVoltageLevel.this, nodes, terminals, getBusFromTerminal);
+            CalculatedBusImpl bus = new CalculatedBusImpl(busId, busName, voltageLevel.isFictitious(), voltageLevel, nodes, terminals, getBusFromTerminal);
             id2bus.put(busId, bus);
             for (int i = 0; i < nodes.size(); i++) {
                 node2bus[nodes.getQuick(i)] = bus;
@@ -304,7 +303,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             if (busCache != null) {
                 return;
             }
-            LOGGER.trace("Update bus topology of voltage level {}", NodeBreakerVoltageLevel.this.id);
+            LOGGER.trace("Update bus topology of voltage level {}", voltageLevel.getId());
             Map<String, CalculatedBus> id2bus = new LinkedHashMap<>();
             CalculatedBus[] node2bus = new CalculatedBus[graph.getVertexCapacity()];
             boolean[] encountered = new boolean[graph.getVertexCapacity()];
@@ -497,28 +496,27 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
     private interface BusNamingStrategy {
 
-        String getId(NodeBreakerVoltageLevel voltageLevel, TIntArrayList nodes);
+        String getId(VoltageLevel voltageLevel, TIntArrayList nodes);
 
-        String getName(NodeBreakerVoltageLevel voltageLevel, TIntArrayList nodes);
+        String getName(VoltageLevel voltageLevel, TIntArrayList nodes);
     }
 
     private static final class LowestNodeNumberBusNamingStrategy implements BusNamingStrategy {
 
         @Override
-        public String getId(NodeBreakerVoltageLevel voltageLevel, TIntArrayList nodes) {
+        public String getId(VoltageLevel voltageLevel, TIntArrayList nodes) {
             return voltageLevel.getId() + "_" + nodes.min();
         }
 
         @Override
-        public String getName(NodeBreakerVoltageLevel voltageLevel, TIntArrayList nodes) {
-            return voltageLevel.name != null ? voltageLevel.name + "_" + nodes.min() : null;
+        public String getName(VoltageLevel voltageLevel, TIntArrayList nodes) {
+            return voltageLevel.getOptionalName().map(name -> name + "_" + nodes.min()).orElse(null);
         }
     }
 
-    NodeBreakerVoltageLevel(String id, String name, boolean fictitious, SubstationImpl substation, Ref<NetworkImpl> ref,
-                            Ref<SubnetworkImpl> subnetworkRef, double nominalV, double lowVoltageLimit, double highVoltageLimit) {
-        super(id, name, fictitious, substation, ref, subnetworkRef, nominalV, lowVoltageLimit, highVoltageLimit);
-        variants = new VariantArray<>(ref, VariantImpl::new);
+    NodeBreakerTopologyModel(VoltageLevelExt voltageLevel) {
+        super(voltageLevel);
+        variants = new VariantArray<>(voltageLevel.getNetworkRef(), VariantImpl::new);
         graph.addListener(new DefaultUndirectedGraphListener<>() {
 
             private static final String INTERNAL_CONNECTION = "internalConnection";
@@ -531,7 +529,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                     switches.put(aSwitch.getId(), e);
                     network.getListeners().notifyCreation(aSwitch);
                 } else {
-                    network.getListeners().notifyElementAdded(NodeBreakerVoltageLevel.this, INTERNAL_CONNECTION, null);
+                    network.getListeners().notifyElementAdded(voltageLevel, INTERNAL_CONNECTION, null);
                 }
                 invalidateCache();
             }
@@ -553,7 +551,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                     switches.remove(switchId);
                     network.getListeners().notifyAfterRemoval(switchId);
                 } else {
-                    network.getListeners().notifyElementRemoved(NodeBreakerVoltageLevel.this, INTERNAL_CONNECTION, null);
+                    network.getListeners().notifyElementRemoved(voltageLevel, INTERNAL_CONNECTION, null);
                 }
             }
 
@@ -570,7 +568,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
                     if (ss != null) {
                         network.getIndex().remove(ss);
                     } else {
-                        network.getListeners().notifyElementRemoved(NodeBreakerVoltageLevel.this, INTERNAL_CONNECTION, null);
+                        network.getListeners().notifyElementRemoved(voltageLevel, INTERNAL_CONNECTION, null);
                     }
                 });
                 switches.clear();
@@ -579,7 +577,6 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         });
     }
 
-    @Override
     public void invalidateCache(boolean exceptBusBreakerView) {
         if (!exceptBusBreakerView) {
             variants.get().calculatedBusBreakerTopology.invalidateCache();
@@ -627,7 +624,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         return variants.get().calculatedBusTopology;
     }
 
-    private final NodeBreakerViewExt nodeBreakerView = new NodeBreakerViewExt() {
+    private final VoltageLevelExt.NodeBreakerViewExt nodeBreakerView = new VoltageLevelExt.NodeBreakerViewExt() {
 
         private final TIntObjectMap<TDoubleArrayList> fictitiousP0ByNode = TCollections.synchronizedMap(new TIntObjectHashMap<>());
         private final TIntObjectMap<TDoubleArrayList> fictitiousQ0ByNode = TCollections.synchronizedMap(new TIntObjectHashMap<>());
@@ -642,9 +639,9 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
-        public NodeBreakerView setFictitiousP0(int node, double p0) {
+        public VoltageLevel.NodeBreakerView setFictitiousP0(int node, double p0) {
             if (Double.isNaN(p0)) {
-                throw new ValidationException(NodeBreakerVoltageLevel.this, "undefined value cannot be set as fictitious p0");
+                throw new ValidationException(voltageLevel, "undefined value cannot be set as fictitious p0");
             }
             TDoubleArrayList p0ByVariant = fictitiousP0ByNode.get(node);
             if (p0ByVariant == null) {
@@ -660,7 +657,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             int variantIndex = getNetwork().getVariantIndex();
             double oldValue = p0ByVariant.set(getNetwork().getVariantIndex(), p0);
             String variantId = getNetwork().getVariantManager().getVariantId(variantIndex);
-            getNetwork().getListeners().notifyUpdate(NodeBreakerVoltageLevel.this, "fictitiousP0", variantId, oldValue, p0);
+            getNetwork().getListeners().notifyUpdate(voltageLevel, "fictitiousP0", variantId, oldValue, p0);
             TIntSet toRemove = clearFictitiousInjections(fictitiousP0ByNode);
             synchronized (fictitiousP0ByNode) {
                 toRemove.forEach(n -> {
@@ -681,9 +678,9 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
-        public NodeBreakerView setFictitiousQ0(int node, double q0) {
+        public VoltageLevel.NodeBreakerView setFictitiousQ0(int node, double q0) {
             if (Double.isNaN(q0)) {
-                throw new ValidationException(NodeBreakerVoltageLevel.this, "undefined value cannot be set as fictitious q0");
+                throw new ValidationException(voltageLevel, "undefined value cannot be set as fictitious q0");
             }
             TDoubleArrayList q0ByVariant = fictitiousQ0ByNode.get(node);
             if (q0ByVariant == null) {
@@ -699,7 +696,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             int variantIndex = getNetwork().getVariantIndex();
             double oldValue = q0ByVariant.set(getNetwork().getVariantIndex(), q0);
             String variantId = getNetwork().getVariantManager().getVariantId(variantIndex);
-            getNetwork().getListeners().notifyUpdate(NodeBreakerVoltageLevel.this, "fictitiousQ0", variantId, oldValue, q0);
+            getNetwork().getListeners().notifyUpdate(voltageLevel, "fictitiousQ0", variantId, oldValue, q0);
             TIntSet toRemove = clearFictitiousInjections(fictitiousQ0ByNode);
             synchronized (fictitiousQ0ByNode) {
                 toRemove.forEach(n -> {
@@ -877,7 +874,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             Integer e = switches.get(switchId);
             if (e == null) {
                 throw new PowsyblException("Switch '" + switchId
-                        + "' not found in voltage level '" + id + "'");
+                        + "' not found in voltage level '" + voltageLevel.getId() + "'");
             }
             graph.removeEdge(e);
             graph.removeIsolatedVertices();
@@ -885,28 +882,28 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
         @Override
         public BusbarSectionAdder newBusbarSection() {
-            return new BusbarSectionAdderImpl(NodeBreakerVoltageLevel.this);
+            return new BusbarSectionAdderImpl(voltageLevel);
         }
 
         @Override
         public Iterable<BusbarSection> getBusbarSections() {
-            return getConnectables(BusbarSection.class);
+            return voltageLevel.getConnectables(BusbarSection.class);
         }
 
         @Override
         public Stream<BusbarSection> getBusbarSectionStream() {
-            return getConnectableStream(BusbarSection.class);
+            return voltageLevel.getConnectableStream(BusbarSection.class);
         }
 
         @Override
         public int getBusbarSectionCount() {
-            return getConnectableCount(BusbarSection.class);
+            return voltageLevel.getConnectableCount(BusbarSection.class);
         }
 
         @Override
         public BusbarSection getBusbarSection(String id) {
             BusbarSection bbs = getNetwork().getIndex().get(id, BusbarSection.class);
-            if (bbs != null && bbs.getTerminal().getVoltageLevel() != NodeBreakerVoltageLevel.this) {
+            if (bbs != null && bbs.getTerminal().getVoltageLevel() != voltageLevel) {
                 return null;
             }
             return bbs;
@@ -942,11 +939,11 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     }
 
     @Override
-    public NodeBreakerViewExt getNodeBreakerView() {
+    public VoltageLevelExt.NodeBreakerViewExt getNodeBreakerView() {
         return nodeBreakerView;
     }
 
-    private final BusViewExt busView = new BusViewExt() {
+    private final VoltageLevelExt.BusViewExt busView = new VoltageLevelExt.BusViewExt() {
 
         @Override
         public Iterable<Bus> getBuses() {
@@ -972,11 +969,11 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     };
 
     @Override
-    public BusViewExt getBusView() {
+    public VoltageLevelExt.BusViewExt getBusView() {
         return busView;
     }
 
-    private final BusBreakerViewExt busBreakerView = new BusBreakerViewExt() {
+    private final VoltageLevelExt.BusBreakerViewExt busBreakerView = new VoltageLevelExt.BusBreakerViewExt() {
 
         @Override
         public Iterable<Bus> getBuses() {
@@ -1074,7 +1071,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         }
 
         @Override
-        public BusBreakerView.SwitchAdder newSwitch() {
+        public SwitchAdder newSwitch() {
             throw createNotSupportedNodeBreakerTopologyException();
         }
 
@@ -1085,7 +1082,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     };
 
     @Override
-    public BusBreakerViewExt getBusBreakerView() {
+    public VoltageLevelExt.BusBreakerViewExt getBusBreakerView() {
         return busBreakerView;
     }
 
@@ -1107,7 +1104,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     private void checkTerminal(TerminalExt terminal) {
         if (!(terminal instanceof NodeTerminal)) {
             throw new ValidationException(terminal.getConnectable(),
-                    "voltage level " + NodeBreakerVoltageLevel.this.id + " has a node/breaker topology"
+                    "voltage level " + voltageLevel.getId() + " has a node/breaker topology"
                             + ", a node connection should be specified instead of a bus connection");
         }
         int node = ((NodeTerminal) terminal).getNode();
@@ -1116,7 +1113,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
             throw new ValidationException(terminal.getConnectable(),
                     "an equipment (" + graph.getVertexObject(node).getConnectable().getId()
                             + ") is already connected to node " + node + " of voltage level "
-                            + NodeBreakerVoltageLevel.this.id);
+                            + voltageLevel.getId());
         }
     }
 
@@ -1129,12 +1126,12 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         int node = ((NodeTerminal) terminal).getNode();
 
         // create the link terminal <-> voltage level
-        terminal.setVoltageLevel(NodeBreakerVoltageLevel.this);
+        terminal.setVoltageLevel(voltageLevel);
 
         // create the link terminal <-> graph vertex
         graph.setVertexObject(node, (NodeTerminal) terminal);
 
-        getNetwork().getVariantManager().forEachVariant(this::invalidateCache);
+        getNetwork().getVariantManager().forEachVariant(NodeBreakerTopologyModel.this::invalidateCache);
     }
 
     @Override
@@ -1147,7 +1144,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
         graph.setVertexObject(node, null);
 
-        getNetwork().getVariantManager().forEachVariant(this::invalidateCache);
+        getNetwork().getVariantManager().forEachVariant(NodeBreakerTopologyModel.this::invalidateCache);
 
         // remove the link terminal -> voltage level
         terminal.setVoltageLevel(null);
@@ -1181,8 +1178,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
      * @param terminal Terminal to connect
      * @return <code>true</code> if the terminal has been connected, <code>false</code> if it hasn't or if it was already connected
      */
-    @Override
-    public boolean connect(TerminalExt terminal) {
+    boolean connect(TerminalExt terminal) {
         // Only keep the closed non-fictional breakers in the nominal case
         return connect(terminal, SwitchPredicates.IS_NONFICTIONAL_BREAKER);
     }
@@ -1224,7 +1220,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         // find all paths starting from the current terminal to a busbar section that does not contain an open switch
         // that is not of the type of switch the user wants to operate
         // Paths are already sorted by the number of open switches and by the size of the paths
-        List<TIntArrayList> paths = graph.findAllPaths(node, NodeBreakerVoltageLevel::isBusbarSection, sw -> checkNonClosableSwitch(sw, isSwitchOperable),
+        List<TIntArrayList> paths = graph.findAllPaths(node, NodeBreakerTopologyModel::isBusbarSection, sw -> checkNonClosableSwitch(sw, isSwitchOperable),
             Comparator.comparing((TIntArrayList o) -> o.grep(idx -> SwitchPredicates.IS_OPEN.test(graph.getEdgeObject(idx))).size())
                 .thenComparing(TIntArrayList::size));
         if (!paths.isEmpty()) {
@@ -1245,8 +1241,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
         return false;
     }
 
-    @Override
-    public boolean disconnect(TerminalExt terminal) {
+    boolean disconnect(TerminalExt terminal) {
         // Only keep the closed non-fictional breakers in the nominal case
         return disconnect(terminal, SwitchPredicates.IS_CLOSED_BREAKER);
     }
@@ -1280,7 +1275,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
         int node = ((NodeTerminal) terminal).getNode();
         // find all paths starting from the current terminal to a busbar section that does not contain an open switch
-        List<TIntArrayList> paths = graph.findAllPaths(node, NodeBreakerVoltageLevel::isBusbarSection, SwitchPredicates.IS_OPEN);
+        List<TIntArrayList> paths = graph.findAllPaths(node, NodeBreakerTopologyModel::isBusbarSection, SwitchPredicates.IS_OPEN);
         if (paths.isEmpty()) {
             return false;
         }
@@ -1385,25 +1380,21 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
 
     @Override
     public void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex) {
-        super.extendVariantArraySize(initVariantArraySize, number, sourceIndex);
         variants.push(number, VariantImpl::new);
     }
 
     @Override
     public void reduceVariantArraySize(int number) {
-        super.reduceVariantArraySize(number);
         variants.pop(number);
     }
 
     @Override
     public void deleteVariantArrayElement(int index) {
-        super.deleteVariantArrayElement(index);
         variants.delete(index);
     }
 
     @Override
     public void allocateVariantArrayElement(int[] indexes, final int sourceIndex) {
-        super.allocateVariantArrayElement(indexes, sourceIndex);
         variants.allocate(indexes, VariantImpl::new);
     }
 
@@ -1424,7 +1415,7 @@ class NodeBreakerVoltageLevel extends AbstractVoltageLevel {
     @Override
     public void printTopology(PrintStream out, ShortIdDictionary dict) {
         out.println("-------------------------------------------------------------");
-        out.println("Topology of " + NodeBreakerVoltageLevel.this.id);
+        out.println("Topology of " + voltageLevel.getId());
         graph.print(out, terminal -> terminal != null ? terminal.getConnectable().toString() : null, null);
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerTopologyModel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerTopologyModel.java
@@ -887,17 +887,17 @@ class NodeBreakerTopologyModel extends AbstractTopologyModel {
 
         @Override
         public Iterable<BusbarSection> getBusbarSections() {
-            return voltageLevel.getConnectables(BusbarSection.class);
+            return getConnectables(BusbarSection.class);
         }
 
         @Override
         public Stream<BusbarSection> getBusbarSectionStream() {
-            return voltageLevel.getConnectableStream(BusbarSection.class);
+            return getConnectableStream(BusbarSection.class);
         }
 
         @Override
         public int getBusbarSectionCount() {
-            return voltageLevel.getConnectableCount(BusbarSection.class);
+            return getConnectableCount(BusbarSection.class);
         }
 
         @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeTerminal.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeTerminal.java
@@ -57,6 +57,10 @@ class NodeTerminal extends AbstractTerminal {
         }
     };
 
+    private NodeBreakerTopologyModel getTopologyModel() {
+        return (NodeBreakerTopologyModel) voltageLevel.getTopologyModel();
+    }
+
     private final BusBreakerViewExt busBreakerView = new BusBreakerViewExt() {
 
         @Override
@@ -64,7 +68,7 @@ class NodeTerminal extends AbstractTerminal {
             if (removed) {
                 throw new PowsyblException(CANNOT_ACCESS_BUS_REMOVED_EQUIPMENT + connectable.id);
             }
-            return ((NodeBreakerVoltageLevel) voltageLevel).getCalculatedBusBreakerTopology().getBus(node);
+            return getTopologyModel().getCalculatedBusBreakerTopology().getBus(node);
         }
 
         @Override
@@ -72,12 +76,12 @@ class NodeTerminal extends AbstractTerminal {
             if (removed) {
                 throw new PowsyblException(CANNOT_ACCESS_BUS_REMOVED_EQUIPMENT + connectable.id);
             }
-            return ((NodeBreakerVoltageLevel) voltageLevel).getCalculatedBusBreakerTopology().getConnectableBus(node);
+            return getTopologyModel().getCalculatedBusBreakerTopology().getConnectableBus(node);
         }
 
         @Override
         public void setConnectableBus(String busId) {
-            throw NodeBreakerVoltageLevel.createNotSupportedNodeBreakerTopologyException();
+            throw NodeBreakerTopologyModel.createNotSupportedNodeBreakerTopologyException();
         }
 
         @Override
@@ -102,7 +106,7 @@ class NodeTerminal extends AbstractTerminal {
             if (removed) {
                 throw new PowsyblException(CANNOT_ACCESS_BUS_REMOVED_EQUIPMENT + connectable.id);
             }
-            return ((NodeBreakerVoltageLevel) voltageLevel).getCalculatedBusTopology().getBus(node);
+            return getTopologyModel().getCalculatedBusTopology().getBus(node);
         }
 
         @Override
@@ -110,7 +114,7 @@ class NodeTerminal extends AbstractTerminal {
             if (removed) {
                 throw new PowsyblException(CANNOT_ACCESS_BUS_REMOVED_EQUIPMENT + connectable.id);
             }
-            return ((NodeBreakerVoltageLevel) voltageLevel).getCalculatedBusTopology().getConnectableBus(node);
+            return getTopologyModel().getCalculatedBusTopology().getConnectableBus(node);
         }
 
     };
@@ -231,7 +235,7 @@ class NodeTerminal extends AbstractTerminal {
         if (removed) {
             throw new PowsyblException("Cannot access connectivity status of removed equipment " + connectable.id);
         }
-        return ((NodeBreakerVoltageLevel) voltageLevel).isConnected(this);
+        return getTopologyModel().isConnected(this);
     }
 
     @Override
@@ -239,7 +243,7 @@ class NodeTerminal extends AbstractTerminal {
         if (removed) {
             throw new PowsyblException(String.format("Associated equipment %s is removed", connectable.id));
         }
-        return ((NodeBreakerVoltageLevel) voltageLevel).traverse(this, traverser, visitedTerminals, traversalType);
+        return getTopologyModel().traverse(this, traverser, visitedTerminals, traversalType);
     }
 
     @Override
@@ -252,7 +256,7 @@ class NodeTerminal extends AbstractTerminal {
         if (removed) {
             throw new PowsyblException(String.format("Associated equipment %s is removed", connectable.id));
         }
-        ((NodeBreakerVoltageLevel) voltageLevel).traverse(this, traverser, traversalType);
+        getTopologyModel().traverse(this, traverser, traversalType);
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ShuntCompensatorAdderImpl.java
@@ -225,7 +225,7 @@ class ShuntCompensatorAdderImpl extends AbstractInjectionAdder<ShuntCompensatorA
                 voltageRegulatorOn, targetV, targetDeadband);
 
         shunt.addTerminal(terminal);
-        voltageLevel.attach(terminal, false);
+        voltageLevel.getTopologyModel().attach(terminal, false);
         network.getIndex().checkAndAdd(shunt);
         network.getListeners().notifyCreation(shunt);
         return shunt;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/StaticVarCompensatorAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/StaticVarCompensatorAdderImpl.java
@@ -91,7 +91,7 @@ class StaticVarCompensatorAdderImpl extends AbstractInjectionAdder<StaticVarComp
                 regulationMode, regulatingTerminal != null ? regulatingTerminal : terminal,
                 getNetworkRef());
         svc.addTerminal(terminal);
-        voltageLevel.attach(terminal, false);
+        voltageLevel.getTopologyModel().attach(terminal, false);
         network.getIndex().checkAndAdd(svc);
         network.getListeners().notifyCreation(svc);
         return svc;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/SwitchImpl.java
@@ -70,7 +70,7 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
         boolean oldValue = this.open.get(index);
         if (oldValue != open) {
             this.open.set(index, open);
-            voltageLevel.invalidateCache(isRetained());
+            voltageLevel.getTopologyModel().invalidateCache(isRetained());
             String variantId = network.getVariantManager().getVariantId(index);
             network.getListeners().notifyUpdate(this, "open", variantId, oldValue, open);
         }
@@ -91,7 +91,7 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
         boolean oldValue = this.retained.get(index);
         if (oldValue != retained) {
             this.retained.set(index, retained);
-            voltageLevel.invalidateCache();
+            voltageLevel.getTopologyModel().invalidateCache();
             String variantId = network.getVariantManager().getVariantId(index);
             network.getListeners().notifyUpdate(this, "retained", variantId, oldValue, retained);
         }
@@ -102,7 +102,7 @@ class SwitchImpl extends AbstractIdentifiable<Switch> implements Switch, MultiVa
         boolean oldValue = this.fictitious;
         if (oldValue != fictitious) {
             this.fictitious = fictitious;
-            voltageLevel.invalidateCache();
+            voltageLevel.getTopologyModel().invalidateCache();
             NetworkImpl network = getNetwork();
             network.getListeners().notifyUpdate(this, "fictitious", oldValue, fictitious);
         }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
@@ -291,14 +291,14 @@ class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder<ThreeW
 
         // check that the 3 windings transformer is attachable on the 3 sides (only
         // verify)
-        voltageLevel1.attach(terminal1, true);
-        voltageLevel2.attach(terminal2, true);
-        voltageLevel3.attach(terminal3, true);
+        voltageLevel1.getTopologyModel().attach(terminal1, true);
+        voltageLevel2.getTopologyModel().attach(terminal2, true);
+        voltageLevel3.getTopologyModel().attach(terminal3, true);
 
         // do attach
-        voltageLevel1.attach(terminal1, false);
-        voltageLevel2.attach(terminal2, false);
-        voltageLevel3.attach(terminal3, false);
+        voltageLevel1.getTopologyModel().attach(terminal1, false);
+        voltageLevel2.getTopologyModel().attach(terminal2, false);
+        voltageLevel3.getTopologyModel().attach(terminal3, false);
 
         getNetwork().getIndex().checkAndAdd(transformer);
         getNetwork().getListeners().notifyCreation(transformer);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TopologyModel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TopologyModel.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network.impl;
+
+import java.util.function.Predicate;
+
+/**
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ */
+interface TopologyModel {
+
+    void invalidateCache(boolean exceptBusBreakerView);
+
+    void invalidateCache();
+
+    void attach(TerminalExt terminal, boolean test);
+
+    void detach(TerminalExt terminal);
+
+    boolean connect(TerminalExt terminal, Predicate<? super SwitchImpl> isTypeSwitchToOperate);
+
+    boolean disconnect(TerminalExt terminal, Predicate<? super SwitchImpl> isSwitchOpenable);
+}

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
@@ -124,11 +124,11 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
         transformer.addTerminal(terminal2);
 
         // check that the two windings transformer is attachable on both side
-        voltageLevel1.attach(terminal1, true);
-        voltageLevel2.attach(terminal2, true);
+        voltageLevel1.getTopologyModel().attach(terminal1, true);
+        voltageLevel2.getTopologyModel().attach(terminal2, true);
 
-        voltageLevel1.attach(terminal1, false);
-        voltageLevel2.attach(terminal2, false);
+        voltageLevel1.getTopologyModel().attach(terminal1, false);
+        voltageLevel2.getTopologyModel().attach(terminal2, false);
         getNetwork().getIndex().checkAndAdd(transformer);
         getNetwork().getListeners().notifyCreation(transformer);
         return transformer;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelAdderImpl.java
@@ -94,12 +94,7 @@ class VoltageLevelAdderImpl extends AbstractIdentifiableAdder<VoltageLevelAdderI
         ValidationUtil.checkVoltageLimits(this, lowVoltageLimit, highVoltageLimit);
         ValidationUtil.checkTopologyKind(this, topologyKind);
 
-        VoltageLevelExt voltageLevel = switch (topologyKind) {
-            case NODE_BREAKER ->
-                new NodeBreakerVoltageLevel(id, getName(), isFictitious(), substation, networkRef, subnetworkRef, nominalV, lowVoltageLimit, highVoltageLimit);
-            case BUS_BREAKER ->
-                new BusBreakerVoltageLevel(id, getName(), isFictitious(), substation, networkRef, subnetworkRef, nominalV, lowVoltageLimit, highVoltageLimit);
-        };
+        VoltageLevelExt voltageLevel = new VoltageLevelImpl(id, getName(), isFictitious(), substation, networkRef, subnetworkRef, nominalV, lowVoltageLimit, highVoltageLimit, topologyKind);
         getNetwork().getIndex().checkAndAdd(voltageLevel);
         Optional.ofNullable(substation).ifPresent(s -> s.addVoltageLevel(voltageLevel));
         getNetwork().getListeners().notifyCreation(voltageLevel);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelExt.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelExt.java
@@ -7,16 +7,15 @@
  */
 package com.powsybl.iidm.network.impl;
 
+import com.powsybl.iidm.network.Validable;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.commons.ref.Ref;
-
-import java.util.function.Predicate;
 
 /**
  *
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
-interface VoltageLevelExt extends VoltageLevel, MultiVariantObject {
+interface VoltageLevelExt extends VoltageLevel, MultiVariantObject, Validable {
 
     interface NodeBreakerViewExt extends NodeBreakerView {
 
@@ -45,29 +44,7 @@ interface VoltageLevelExt extends VoltageLevel, MultiVariantObject {
     @Override
     NetworkExt getParentNetwork();
 
-    /**
-     * Attach an equipment to the topology.
-     */
-    void attach(TerminalExt terminal, boolean test);
-
-    /**
-     * Detach an equipment from the topology.
-     */
-    void detach(TerminalExt terminal);
-
-    boolean connect(TerminalExt terminal);
-
-    boolean connect(TerminalExt terminal, Predicate<? super SwitchImpl> isTypeSwitchToOperate);
-
-    boolean disconnect(TerminalExt terminal);
-
-    boolean disconnect(TerminalExt terminal, Predicate<? super SwitchImpl> isSwitchOpenable);
-
-    default void invalidateCache() {
-        invalidateCache(false);
-    }
-
-    void invalidateCache(boolean exceptBusBreakerView);
+    TopologyModel getTopologyModel();
 
     String getSubnetworkId();
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelImpl.java
@@ -11,10 +11,14 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.iidm.network.*;
 import com.powsybl.commons.ref.Ref;
+import com.powsybl.iidm.network.util.ShortIdDictionary;
 
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.Writer;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -23,11 +27,7 @@ import java.util.stream.Stream;
  *
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
-abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> implements VoltageLevelExt {
-
-    private static final int DEFAULT_NODE_INDEX_LIMIT = 1000;
-
-    public static final int NODE_INDEX_LIMIT = loadNodeIndexLimit(PlatformConfig.defaultConfig());
+class VoltageLevelImpl extends AbstractIdentifiable<VoltageLevel> implements VoltageLevelExt {
 
     private final Ref<NetworkImpl> networkRef;
     private Ref<SubnetworkImpl> subnetworkRef;
@@ -40,13 +40,16 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
 
     private double highVoltageLimit;
 
+    private final AbstractTopologyModel topologyModel;
+
     /** Areas associated to this VoltageLevel, with at most one area for each area type */
     private final Set<Area> areas = new LinkedHashSet<>();
 
     private boolean removed = false;
 
-    AbstractVoltageLevel(String id, String name, boolean fictitious, SubstationImpl substation, Ref<NetworkImpl> networkRef,
-                         Ref<SubnetworkImpl> subnetworkRef, double nominalV, double lowVoltageLimit, double highVoltageLimit) {
+    VoltageLevelImpl(String id, String name, boolean fictitious, SubstationImpl substation, Ref<NetworkImpl> networkRef,
+                     Ref<SubnetworkImpl> subnetworkRef, double nominalV, double lowVoltageLimit, double highVoltageLimit,
+                     TopologyKind topologyKind) {
         super(id, name, fictitious);
         this.substation = substation;
         this.networkRef = networkRef;
@@ -54,13 +57,15 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
         this.nominalV = nominalV;
         this.lowVoltageLimit = lowVoltageLimit;
         this.highVoltageLimit = highVoltageLimit;
+        this.topologyModel = switch (Objects.requireNonNull(topologyKind)) {
+            case NODE_BREAKER -> new NodeBreakerTopologyModel(this);
+            case BUS_BREAKER -> new BusBreakerTopologyModel(this);
+        };
     }
 
-    protected static int loadNodeIndexLimit(PlatformConfig platformConfig) {
-        return platformConfig
-            .getOptionalModuleConfig("iidm")
-            .map(moduleConfig -> moduleConfig.getIntProperty("node-index-limit", DEFAULT_NODE_INDEX_LIMIT))
-            .orElse(DEFAULT_NODE_INDEX_LIMIT);
+    @Override
+    public AbstractTopologyModel getTopologyModel() {
+        return topologyModel;
     }
 
     @Override
@@ -158,6 +163,21 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
     }
 
     @Override
+    public NodeBreakerViewExt getNodeBreakerView() {
+        return topologyModel.getNodeBreakerView();
+    }
+
+    @Override
+    public BusBreakerViewExt getBusBreakerView() {
+        return topologyModel.getBusBreakerView();
+    }
+
+    @Override
+    public BusViewExt getBusView() {
+        return topologyModel.getBusView();
+    }
+
+    @Override
     public NetworkImpl getNetwork() {
         if (removed) {
             throw new PowsyblException("Cannot access network of removed voltage level " + id);
@@ -247,7 +267,7 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
 
     @Override
     public <T extends Connectable> Iterable<T> getConnectables(Class<T> clazz) {
-        Iterable<Terminal> terminals = getTerminals();
+        Iterable<Terminal> terminals = topologyModel.getTerminals();
         return FluentIterable.from(terminals)
                 .transform(Terminal::getConnectable)
                 .filter(clazz)
@@ -256,7 +276,7 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
 
     @Override
     public <T extends Connectable> Stream<T> getConnectableStream(Class<T> clazz) {
-        return getTerminalStream()
+        return topologyModel.getTerminalStream()
                 .map(Terminal::getConnectable)
                 .filter(clazz::isInstance)
                 .map(clazz::cast)
@@ -270,14 +290,14 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
 
     @Override
     public Iterable<Connectable> getConnectables() {
-        return FluentIterable.from(getTerminals())
+        return FluentIterable.from(topologyModel.getTerminals())
                 .transform(Terminal::getConnectable)
                 .toSet();
     }
 
     @Override
     public Stream<Connectable> getConnectableStream() {
-        return getTerminalStream()
+        return topologyModel.getTerminalStream()
                 .map(Terminal::getConnectable)
                 .distinct();
     }
@@ -340,6 +360,16 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
     @Override
     public Stream<Load> getLoadStream() {
         return getConnectableStream(Load.class);
+    }
+
+    @Override
+    public Iterable<Switch> getSwitches() {
+        return topologyModel.getSwitches();
+    }
+
+    @Override
+    public int getSwitchCount() {
+        return topologyModel.getSwitchCount();
     }
 
     @Override
@@ -517,41 +547,39 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
         return "Voltage level";
     }
 
-    protected abstract Iterable<Terminal> getTerminals();
-
-    protected abstract Stream<Terminal> getTerminalStream();
-
     @Override
     public void visitEquipments(TopologyVisitor visitor) {
-        AbstractBus.visitEquipments(getTerminals(), visitor);
+        AbstractBus.visitEquipments(topologyModel.getTerminals(), visitor);
     }
 
-    protected static void addNextTerminals(TerminalExt otherTerminal, List<TerminalExt> nextTerminals) {
-        Objects.requireNonNull(otherTerminal);
-        Objects.requireNonNull(nextTerminals);
-        Connectable otherConnectable = otherTerminal.getConnectable();
-        if (otherConnectable instanceof Branch<?> branch) {
-            if (branch.getTerminal1() == otherTerminal) {
-                nextTerminals.add((TerminalExt) branch.getTerminal2());
-            } else if (branch.getTerminal2() == otherTerminal) {
-                nextTerminals.add((TerminalExt) branch.getTerminal1());
-            } else {
-                throw new IllegalStateException();
-            }
-        } else if (otherConnectable instanceof ThreeWindingsTransformer ttc) {
-            if (ttc.getLeg1().getTerminal() == otherTerminal) {
-                nextTerminals.add((TerminalExt) ttc.getLeg2().getTerminal());
-                nextTerminals.add((TerminalExt) ttc.getLeg3().getTerminal());
-            } else if (ttc.getLeg2().getTerminal() == otherTerminal) {
-                nextTerminals.add((TerminalExt) ttc.getLeg1().getTerminal());
-                nextTerminals.add((TerminalExt) ttc.getLeg3().getTerminal());
-            } else if (ttc.getLeg3().getTerminal() == otherTerminal) {
-                nextTerminals.add((TerminalExt) ttc.getLeg1().getTerminal());
-                nextTerminals.add((TerminalExt) ttc.getLeg2().getTerminal());
-            } else {
-                throw new IllegalStateException();
-            }
-        }
+    @Override
+    public TopologyKind getTopologyKind() {
+        return topologyModel.getTopologyKind();
+    }
+
+    @Override
+    public void printTopology() {
+        topologyModel.printTopology();
+    }
+
+    @Override
+    public void printTopology(PrintStream out, ShortIdDictionary dict) {
+        topologyModel.printTopology(out, dict);
+    }
+
+    @Override
+    public void exportTopology(Path file) throws IOException {
+        topologyModel.exportTopology(file);
+    }
+
+    @Override
+    public void exportTopology(Writer writer, Random random) {
+        topologyModel.exportTopology(writer, random);
+    }
+
+    @Override
+    public void exportTopology(Writer writer) {
+        topologyModel.exportTopology(writer);
     }
 
     @Override
@@ -568,7 +596,7 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
         }
 
         // Remove the topology
-        removeTopology();
+        topologyModel.removeTopology();
 
         // Remove this voltage level from the areas
         getAreas().forEach(area -> area.removeVoltageLevel(this));
@@ -580,5 +608,27 @@ abstract class AbstractVoltageLevel extends AbstractIdentifiable<VoltageLevel> i
         removed = true;
     }
 
-    protected abstract void removeTopology();
+    @Override
+    public void extendVariantArraySize(int initVariantArraySize, int number, int sourceIndex) {
+        super.extendVariantArraySize(initVariantArraySize, number, sourceIndex);
+        topologyModel.extendVariantArraySize(initVariantArraySize, number, sourceIndex);
+    }
+
+    @Override
+    public void reduceVariantArraySize(int number) {
+        super.reduceVariantArraySize(number);
+        topologyModel.reduceVariantArraySize(number);
+    }
+
+    @Override
+    public void deleteVariantArrayElement(int index) {
+        super.deleteVariantArrayElement(index);
+        topologyModel.deleteVariantArrayElement(index);
+    }
+
+    @Override
+    public void allocateVariantArrayElement(int[] indexes, int sourceIndex) {
+        super.allocateVariantArrayElement(indexes, sourceIndex);
+        topologyModel.allocateVariantArrayElement(indexes, sourceIndex);
+    }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelImpl.java
@@ -7,7 +7,6 @@
  */
 package com.powsybl.iidm.network.impl;
 
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import com.powsybl.commons.PowsyblException;
@@ -30,7 +29,7 @@ import java.util.stream.Stream;
 class VoltageLevelImpl extends AbstractIdentifiable<VoltageLevel> implements VoltageLevelExt {
 
     private final Ref<NetworkImpl> networkRef;
-    private Ref<SubnetworkImpl> subnetworkRef;
+    private final Ref<SubnetworkImpl> subnetworkRef;
 
     private final SubstationImpl substation;
 
@@ -267,39 +266,27 @@ class VoltageLevelImpl extends AbstractIdentifiable<VoltageLevel> implements Vol
 
     @Override
     public <T extends Connectable> Iterable<T> getConnectables(Class<T> clazz) {
-        Iterable<Terminal> terminals = topologyModel.getTerminals();
-        return FluentIterable.from(terminals)
-                .transform(Terminal::getConnectable)
-                .filter(clazz)
-                .toSet();
+        return topologyModel.getConnectables(clazz);
     }
 
     @Override
     public <T extends Connectable> Stream<T> getConnectableStream(Class<T> clazz) {
-        return topologyModel.getTerminalStream()
-                .map(Terminal::getConnectable)
-                .filter(clazz::isInstance)
-                .map(clazz::cast)
-                .distinct();
+        return topologyModel.getConnectableStream(clazz);
     }
 
     @Override
     public <T extends Connectable> int getConnectableCount(Class<T> clazz) {
-        return Ints.checkedCast(getConnectableStream(clazz).count());
+        return topologyModel.getConnectableCount(clazz);
     }
 
     @Override
     public Iterable<Connectable> getConnectables() {
-        return FluentIterable.from(topologyModel.getTerminals())
-                .transform(Terminal::getConnectable)
-                .toSet();
+        return topologyModel.getConnectables();
     }
 
     @Override
     public Stream<Connectable> getConnectableStream() {
-        return topologyModel.getTerminalStream()
-                .map(Terminal::getConnectable)
-                .distinct();
+        return topologyModel.getConnectableStream();
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VscConverterStationAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VscConverterStationAdderImpl.java
@@ -73,7 +73,7 @@ class VscConverterStationAdderImpl extends AbstractHvdcConverterStationAdder<Vsc
                 = new VscConverterStationImpl(id, name, isFictitious(), getLossFactor(), getNetworkRef(),
                 voltageRegulatorOn, reactivePowerSetpoint, voltageSetpoint, regulatingTerminal == null ? terminal : regulatingTerminal);
         converterStation.addTerminal(terminal);
-        getVoltageLevel().attach(terminal, false);
+        getVoltageLevel().getTopologyModel().attach(terminal, false);
         network.getIndex().checkAndAdd(converterStation);
         network.getListeners().notifyCreation(converterStation);
         return converterStation;

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerConnectTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/NodeBreakerConnectTest.java
@@ -158,8 +158,8 @@ class NodeBreakerConnectTest {
         assertTrue(network.getSwitch("B2").isOpen());
 
         if (l.getTerminal() instanceof TerminalExt terminal) {
-            NodeBreakerVoltageLevel voltageLevel = (NodeBreakerVoltageLevel) network.getVoltageLevel("VL");
-            voltageLevel.connect(terminal);
+            NodeBreakerTopologyModel topologyModel = (NodeBreakerTopologyModel) ((VoltageLevelImpl) network.getVoltageLevel("VL")).getTopologyModel();
+            topologyModel.connect(terminal);
         }
         assertTrue(network.getSwitch("B2").isOpen());
         assertTrue(l.getTerminal().isConnected());
@@ -183,8 +183,8 @@ class NodeBreakerConnectTest {
         Load l = network.getLoad("L");
         assertTrue(l.getTerminal().isConnected());
         if (l.getTerminal() instanceof TerminalExt terminal) {
-            NodeBreakerVoltageLevel voltageLevel = (NodeBreakerVoltageLevel) network.getVoltageLevel("VL");
-            voltageLevel.disconnect(terminal);
+            NodeBreakerTopologyModel topologyModel = (NodeBreakerTopologyModel) ((VoltageLevelImpl) network.getVoltageLevel("VL")).getTopologyModel();
+            topologyModel.disconnect(terminal);
         }
         assertFalse(l.getTerminal().isConnected());
     }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/TestAbstractTopologyModel.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/TestAbstractTopologyModel.java
@@ -22,12 +22,12 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * @author Lucas Leblow {@literal <lucasleblow@mailbox.org>}
  */
-class TestAbstractVoltageLevel {
+class TestAbstractTopologyModel {
 
     @Test
     void testLoadNodeIndexLimit() throws IOException {
-        assertEquals(1000, AbstractVoltageLevel.NODE_INDEX_LIMIT);
-        assertEquals(1000, AbstractVoltageLevel.loadNodeIndexLimit(PlatformConfig.defaultConfig()));
+        assertEquals(1000, AbstractTopologyModel.NODE_INDEX_LIMIT);
+        assertEquals(1000, AbstractTopologyModel.loadNodeIndexLimit(PlatformConfig.defaultConfig()));
 
         try (FileSystem fileSystem = Jimfs.newFileSystem(Configuration.unix())) {
 
@@ -35,7 +35,7 @@ class TestAbstractVoltageLevel {
             MapModuleConfig moduleConfig = platformConfig.createModuleConfig("iidm");
             moduleConfig.setStringProperty("node-index-limit", "5");
 
-            assertEquals(5, AbstractVoltageLevel.loadNodeIndexLimit(platformConfig));
+            assertEquals(5, AbstractTopologyModel.loadNodeIndexLimit(platformConfig));
         }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Refactoring


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The 2 topology models bus/breaker and node/breaker are implemented by 2 inherited classes from AbstractVoltageLevel.


**What is the new behavior (if this is a feature change)?**
A new TopologyModel concept has been added so that we only have one voltage level implementation class delegating every specific code to a topology model to a dedicated class.
Main advantages:
 - cleaner design promoting composition over weak inheritance.
 - for next devs, easy topology model convertion (switch from bus/breaker to node/breaker or inverse)


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

Noticeable changes:
- Abstract class `AbstractVoltageLevel` was replaced by non-abstract class `VoltageLevelImpl`.
- `BusBreakerVoltageLevel` and `NodeBreakerVoltageLevel` were removed.  Their topology management methods were respectively moved in new classes `BusBreakerTopologyModel` and `NodeBreakerTopologyModel`, implementing a new `ModelTopology` interface.
- In the network index, voltage levels were mapped to either `BusBreakerVoltageLevel.class` or `NodeBreakerVoltageLevel.class`. They are now all mapped to `VoltageLevelImpl.class`.
- The following methods from `VoltageLevelExt` were removed. These operations can be performed on the `TopologyModel`, accessible via `voltageLevel.getTopologyModel()`:
  - `attach(TerminalExt, boolean)`
  - `detach(TerminalExt)`
  - `connect(TerminalExt, Predicate<? super SwitchImpl>)`
  - `disconnect(TerminalExt, Predicate<? super SwitchImpl>)`
  - `invalidateCache()`
  - `invalidateCache(boolean)`

