### PR TITLE
Fix CIM100 CGMES import regression issue on synchronous machine

### DIFF
--- a/cgmes/cgmes-model/src/main/resources/CIM100.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM100.sparql
@@ -63,7 +63,7 @@ WHERE {
         cim:SynchronousMachineKind.motor
         cim:SynchronousMachineKind.generatorOrMotor
         cim:SynchronousMachineKind.motorOrCondenser
-        cim:SynchronousMachineKind.generatorOrMotorOrCondenser
+        cim:SynchronousMachineKind.generatorOrCondenserOrMotor
     }
     OPTIONAL {
         ?SynchronousMachine cim:RotatingMachine.ratedS ?ratedS

--- a/cgmes/cgmes-model/src/main/resources/CIM100.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM100.sparql
@@ -57,7 +57,14 @@ WHERE {
         cim:RotatingMachine.GeneratingUnit ?GeneratingUnit .
     # Some test cases of condensers have a (wrong) association with a generating unit,
     # So we explicitly check for the type of the synchronous machine
-    FILTER (!REGEX(STR(?type), "Kind.condenser"))
+    VALUES ?type {
+        cim:SynchronousMachineKind.generator
+        cim:SynchronousMachineKind.generatorOrCondenser
+        cim:SynchronousMachineKind.motor
+        cim:SynchronousMachineKind.generatorOrMotor
+        cim:SynchronousMachineKind.motorOrCondenser
+        cim:SynchronousMachineKind.generatorOrMotorOrCondenser
+    }
     OPTIONAL {
         ?SynchronousMachine cim:RotatingMachine.ratedS ?ratedS
        }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
Not, but we discovered the issue in slack channel.


**What kind of change does this PR introduce?**
Bug fix - CIM 100 condenser import performance regression.


**What is the current behavior?**
Importing CGMES3 data takes a long time, and most of the time is spent on importing synchronous machines. Activsg70k dataset import takes more than 1 hour.



**What is the new behavior (if this is a feature change)?**
Activsg70k import now takes 1 minute.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
No actions needed.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
