### PR TITLE
Add new matrix methods for DenseMatrix

### DIFF
--- a/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
@@ -61,6 +61,16 @@ public class DenseMatrix extends AbstractMatrix {
         }
     }
 
+    public static final class EmptyDenseMatrix {
+        private static final DenseMatrix INSTANCE = new DenseMatrix(0, 0);
+
+        private EmptyDenseMatrix() { }
+
+        public static DenseMatrix getInstance() {
+            return INSTANCE;
+        }
+    }
+
     private final int rowCount;
 
     private final int columnCount;
@@ -359,6 +369,56 @@ public class DenseMatrix extends AbstractMatrix {
             }
         }
         return new DenseMatrix(transposedRowCount, transposedColumnCount, () -> transposedBuffer);
+    }
+
+    /**
+     * Copy all the values that are in an originalMatrix and paste it in the current DenseMatrix (without allocating new memory spaces)
+     * The dimensions of both matrices must be the same
+     */
+    public void copyValuesFrom(DenseMatrix originalMatrix) {
+        if (originalMatrix.getRowCount() == getRowCount() && originalMatrix.getColumnCount() == getColumnCount()) {
+            for (int columnIndex = 0; columnIndex < originalMatrix.getColumnCount(); columnIndex++) {
+                for (int rowIndex = 0; rowIndex < originalMatrix.getRowCount(); rowIndex++) {
+                    set(rowIndex, columnIndex, originalMatrix.get(rowIndex, columnIndex));
+                }
+            }
+        } else {
+            throw new MatrixException("Incompatible matrix dimensions when copying values. Received (" + originalMatrix.getRowCount() + ", " + originalMatrix.getColumnCount() + ") but expected (" + getRowCount() + ", " + getColumnCount() + ")");
+        }
+    }
+
+    public void resetRow(int row) {
+        if (row >= 0 && row < getRowCount()) {
+            for (int j = 0; j < getColumnCount(); j++) {
+                set(row, j, 0);
+            }
+        } else {
+            throw new IllegalArgumentException("Row value out of bounds. Expected in range [0," + (getRowCount() - 1) + "] but received " + row);
+        }
+    }
+
+    public void resetColumn(int column) {
+        if (column >= 0 && column < getColumnCount()) {
+            for (int i = 0; i < getRowCount(); i++) {
+                set(i, column, 0);
+            }
+        } else {
+            throw new IllegalArgumentException("Column value out of bounds. Expected in range [0," + (getColumnCount() - 1) + "] but received " + column);
+        }
+    }
+
+    public void removeSmallValues(double epsilonValue) {
+        if (epsilonValue >= 0) {
+            for (int i = 0; i < getRowCount(); i++) {
+                for (int j = 0; j < getColumnCount(); j++) {
+                    if (Math.abs(get(i, j)) < epsilonValue) {
+                        set(i, j, 0.);
+                    }
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("Argument epsilonValue should be positive but received " + epsilonValue);
+        }
     }
 
     @Override

--- a/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
+++ b/math/src/main/java/com/powsybl/math/matrix/DenseMatrix.java
@@ -29,6 +29,8 @@ public class DenseMatrix extends AbstractMatrix {
 
     public static final int MAX_ELEMENT_COUNT = Integer.MAX_VALUE / Double.BYTES;
 
+    public static final DenseMatrix EMPTY = new DenseMatrix(0, 0);
+
     /**
      * Dense element implementation.
      * An element in a dense matrix is defined by its row index and column index.
@@ -58,16 +60,6 @@ public class DenseMatrix extends AbstractMatrix {
         @Override
         public void add(double value) {
             DenseMatrix.this.add(i, j, value);
-        }
-    }
-
-    public static final class EmptyDenseMatrix {
-        private static final DenseMatrix INSTANCE = new DenseMatrix(0, 0);
-
-        private EmptyDenseMatrix() { }
-
-        public static DenseMatrix getInstance() {
-            return INSTANCE;
         }
     }
 

--- a/math/src/test/java/com/powsybl/math/matrix/DenseMatrixTest.java
+++ b/math/src/test/java/com/powsybl/math/matrix/DenseMatrixTest.java
@@ -115,4 +115,61 @@ class DenseMatrixTest extends AbstractMatrixTest {
         assertEquals("Too many elements for a dense matrix, maximum allowed is 268435455", e.getMessage());
         assertEquals(268435455, DenseMatrix.MAX_ELEMENT_COUNT);
     }
+
+    @Test
+    void testCopyValuesMatrix() {
+        DenseMatrix a = new DenseMatrix(2, 1);
+        a.set(0, 0, 4);
+        a.set(1, 0, 5);
+        DenseMatrix b = new DenseMatrix(2, 1);
+        b.copyValuesFrom(a);
+        assertEquals(4, b.get(0, 0), EPSILON);
+        assertEquals(5, b.get(1, 0), EPSILON);
+        DenseMatrix c = new DenseMatrix(3, 1);
+        MatrixException e = assertThrows(MatrixException.class, () -> c.copyValuesFrom(a));
+        assertEquals("Incompatible matrix dimensions when copying values. Received (2, 1) but expected (3, 1)", e.getMessage());
+    }
+
+    @Test
+    void testResetRow() {
+        DenseMatrix a = (DenseMatrix) createA(matrixFactory);
+        a.resetRow(0);
+        assertEquals(0d, a.get(0, 0), EPSILON);
+        assertEquals(0d, a.get(1, 0), EPSILON);
+        assertEquals(2d, a.get(2, 0), EPSILON);
+        assertEquals(0d, a.get(0, 1), EPSILON);
+        assertEquals(3d, a.get(1, 1), EPSILON);
+        assertEquals(0d, a.get(2, 1), EPSILON);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> a.resetRow(3));
+        assertEquals("Row value out of bounds. Expected in range [0,2] but received 3", e.getMessage());
+    }
+
+    @Test
+    void testResetColumn() {
+        DenseMatrix a = (DenseMatrix) createA(matrixFactory);
+        a.resetColumn(1);
+        assertEquals(1d, a.get(0, 0), EPSILON);
+        assertEquals(0d, a.get(1, 0), EPSILON);
+        assertEquals(2d, a.get(2, 0), EPSILON);
+        assertEquals(0d, a.get(0, 1), EPSILON);
+        assertEquals(0d, a.get(1, 1), EPSILON);
+        assertEquals(0d, a.get(2, 1), EPSILON);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> a.resetColumn(3));
+        assertEquals("Column value out of bounds. Expected in range [0,1] but received 3", e.getMessage());
+    }
+
+    @Test
+    void testRemoveSmallValues() {
+        DenseMatrix a = (DenseMatrix) createA(matrixFactory);
+        a.removeSmallValues(2d);
+        assertEquals(0d, a.get(0, 0), EPSILON);
+        assertEquals(0d, a.get(1, 0), EPSILON);
+        assertEquals(2d, a.get(2, 0), EPSILON);
+        assertEquals(0d, a.get(0, 1), EPSILON);
+        assertEquals(3d, a.get(1, 1), EPSILON);
+        assertEquals(0d, a.get(2, 1), EPSILON);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> a.removeSmallValues(-1));
+        assertEquals("Argument epsilonValue should be positive but received -1.0", e.getMessage());
+    }
+
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
This PR adresses multiple needs :
- This issue : https://github.com/powsybl/powsybl-core/issues/3194
- This comment PR in OpenLoadFlow which needs emptyMatrix singleton : https://github.com/powsybl/powsybl-open-loadflow/pull/1095#discussion_r1837873885
- The already existing class MatrixUtil in OpenLoadFlow


**What kind of change does this PR introduce?**
This PR introduces 4 new methods in DenseMatrix
- Copying values from another DenseMatrix
- Resetting a specific row of a DenseMatrix
- Resetting a specific column of a DenseMatrix
- Remove small values of a DenseMatrix

It introduces also a new final static object EMPTY for empty matrix.


**What is the current behavior?**
Currently these methods are implemented in OpenLoadFlow but they are concerning DenseMatrix operations so it would be cleaner to have them in powsybl-core


**What is the new behavior (if this is a feature change)?**

These methods have been moved :

- From powsybl.openloadflow.sensi.DcSensitivityAnalysis : 
`private static void matrixCopyValues(DenseMatrix originalMatrix, DenseMatrix copyMatrix)`
=> To powsybl.math.matrix.DenseMatrix :
 `public void copyValuesFrom(DenseMatrix originalMatrix)`

- From powsybl.openloadflow.util.MatrixUtil : 
`public static void resetRow(DenseMatrix m, int row)`
`public static void resetColumn(DenseMatrix m, int column)`
`public static void clean(DenseMatrix m, double epsilonValue)`
=> To powsybl.math.matrix.DenseMatrix :
`public void resetRow(int row)`
`public void resetColumn(int column)`
`public void removeSmallValues(double epsilonValue)`


- From powsybl.openloadflow.sensi.WoodburyEngine (in https://github.com/powsybl/powsybl-open-loadflow/pull/1095/files/f69a2011d21da80c0483d2f68a78295feb541592#diff-cccda1bb06d9d483f786ebdf66343e1d85e9728488bedcf9f9bf732ed4ca610d) : 
`public static class EmptyDenseMatrix`
=> To powsybl.math.matrix.DenseMatrix :
`public static final DenseMatrix EMPTY`


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No (MatrixUtil class in OpenLoadFlow will be kept as deprecated)
