### PR TITLE
Remove use of filter in controlarea query

### DIFF
--- a/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MicroGrid/BaseCase/BC_BE_v2_with_tie_flow/MicroGridTestConfiguration_BC_BE_EQ_V2.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MicroGrid/BaseCase/BC_BE_v2_with_tie_flow/MicroGridTestConfiguration_BC_BE_EQ_V2.xml
@@ -2227,4 +2227,9 @@
 		<entsoe:IdentifiedObject.energyIdentCodeEic>10BE------1</entsoe:IdentifiedObject.energyIdentCodeEic>
 		<cim:ControlArea.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaTypeKind.Interchange"/>
 	</cim:ControlArea>
+	<cim:ControlArea rdf:ID="_BE_FORECAST">
+		<cim:IdentifiedObject.name>BE FORECAST</cim:IdentifiedObject.name>
+		<entsoe:IdentifiedObject.energyIdentCodeEic>10BEFORCAST</entsoe:IdentifiedObject.energyIdentCodeEic>
+		<cim:ControlArea.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#ControlAreaTypeKind.Forecast"/>
+	</cim:ControlArea>
 </rdf:RDF>

--- a/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MicroGrid/BaseCase/BC_BE_v2_with_tie_flow/MicroGridTestConfiguration_BC_BE_SSH_V2.xml
+++ b/cgmes/cgmes-conformity/src/main/resources/conformity-modified/cas-1.1.3-data-4.0.3/MicroGrid/BaseCase/BC_BE_v2_with_tie_flow/MicroGridTestConfiguration_BC_BE_SSH_V2.xml
@@ -12,6 +12,9 @@
   <cim:ControlArea rdf:about="#_BECONTROLAREA">
     <cim:ControlArea.netInterchange>-205.90011555672567</cim:ControlArea.netInterchange>
   </cim:ControlArea>
+  <cim:ControlArea rdf:about="#_BE_FORECAST">
+    <cim:ControlArea.netInterchange>-205.90011555672567</cim:ControlArea.netInterchange>
+  </cim:ControlArea>
   <cim:Terminal rdf:about="#_57ae9251-c022-4c67-a8eb-611ad54c963c">
     <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
   </cim:Terminal>

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/modified/CgmesConformity1ModifiedConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/modified/CgmesConformity1ModifiedConversionTest.java
@@ -321,6 +321,9 @@ class CgmesConformity1ModifiedConversionTest {
         Network network = new CgmesImport().importData(CgmesConformity1ModifiedCatalog.microGridBaseCaseBEWithTieFlow().dataSource(),
             NetworkFactory.findDefault(), importParams);
 
+        // Check that the query discarded the areas that aren't of type Interchange
+        assertEquals(1, network.getAreaCount());
+
         Area area = network.getArea("BECONTROLAREA");
         assertEquals(CgmesNames.CONTROL_AREA_TYPE_KIND_INTERCHANGE, area.getAreaType());
         assertEquals("BE", area.getNameOrId());

--- a/cgmes/cgmes-model/src/main/resources/CIM16.sparql
+++ b/cgmes/cgmes-model/src/main/resources/CIM16.sparql
@@ -1026,7 +1026,7 @@ WHERE {
         cim:IdentifiedObject.name ?name ;
         cim:ControlArea.type ?controlAreaType .
         OPTIONAL { ?ControlArea entsoe:IdentifiedObject.energyIdentCodeEic ?energyIdentCodeEic }
-    FILTER (regex(STR(?controlAreaType), "Interchange", "i"))
+        VALUES ?controlAreaType { cim:ControlAreaTypeKind.Interchange }
 }}
 OPTIONAL { GRAPH ?graphSSH {
     ?ControlArea cim:ControlArea.netInterchange ?netInterchange


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Improve performance


**What is the current behavior?**
<!-- You can also link to an open issue here -->
ControlArea SPARQL query is using a FILTER REGEX clause. This isn't optimal performance-wise.


**What is the new behavior (if this is a feature change)?**
<!-- -->
The query has been slightly changed to use a VALUES clause instead, which gives better performances.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
A similar work has been done in https://github.com/powsybl/powsybl-core/pull/3218 to remove the FILTER clause of NonlinearShuntCompensatorPoints qurery.