### PR TITLE
Store the CGMES id/name of OperationalLimitSet in a unique property

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -1105,4 +1105,5 @@ public class Conversion {
     public static final String PROPERTY_CGMES_GOVERNOR_SCD = CGMES_PREFIX_ALIAS_PROPERTIES + "governorSCD";
     public static final String PROPERTY_CGMES_SYNCHRONOUS_MACHINE_TYPE = CGMES_PREFIX_ALIAS_PROPERTIES + "synchronousMachineType";
     public static final String PROPERTY_CGMES_SYNCHRONOUS_MACHINE_OPERATING_MODE = CGMES_PREFIX_ALIAS_PROPERTIES + "synchronousMachineOperatingMode";
+    public static final String PROPERTY_OPERATIONAL_LIMIT_SET_IDENTIFIERS = CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.OPERATIONAL_LIMIT_SET + "_identifiers";
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
@@ -94,7 +94,7 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
      * @param limitSetId The OperationalLimitSet id to store.
      * @param limitSetName The OperationalLimitSet name to store.
      */
-    private void storeCgmesId(Identifiable<?> identifiable, String limitSetId, String limitSetName) {
+    private void storeOperationalLimitSetIdentifiers(Identifiable<?> identifiable, String limitSetId, String limitSetName) {
         try {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode node;
@@ -121,12 +121,12 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
     private void createLimitsAdder(int terminalNumber, String limitSubClass, String limitSetId, String limitSetName, Branch<?> b) {
         if (terminalNumber == 1) {
             OperationalLimitsGroup limitsGroup = b.getOperationalLimitsGroup1(limitSetId).orElseGet(() -> {
-                storeCgmesId(b, limitSetId, limitSetName);
+                storeOperationalLimitSetIdentifiers(b, limitSetId, limitSetName);
                 return b.newOperationalLimitsGroup1(limitSetId); });
             loadingLimitsAdder1 = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
         } else if (terminalNumber == 2) {
             OperationalLimitsGroup limitsGroup = b.getOperationalLimitsGroup2(limitSetId).orElseGet(() -> {
-                storeCgmesId(b, limitSetId, limitSetName);
+                storeOperationalLimitSetIdentifiers(b, limitSetId, limitSetName);
                 return b.newOperationalLimitsGroup2(limitSetId); });
             loadingLimitsAdder2 = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
         } else {
@@ -143,7 +143,7 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
      */
     private void createLimitsAdder(String limitSubClass, String limitSetId, String limitSetName, DanglingLine dl) {
         OperationalLimitsGroup limitsGroup = dl.getOperationalLimitsGroup(limitSetId).orElseGet(() -> {
-            storeCgmesId(dl, limitSetId, limitSetName);
+            storeOperationalLimitSetIdentifiers(dl, limitSetId, limitSetName);
             return dl.newOperationalLimitsGroup(limitSetId); });
         loadingLimitsAdder = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
     }
@@ -159,17 +159,17 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
     private void createLimitsAdder(int terminalNumber, String limitSubClass, String limitSetId, String limitSetName, ThreeWindingsTransformer twt) {
         if (terminalNumber == 1) {
             OperationalLimitsGroup limitsGroup = twt.getLeg1().getOperationalLimitsGroup(limitSetId).orElseGet(() -> {
-                storeCgmesId(twt, limitSetId, limitSetName);
+                storeOperationalLimitSetIdentifiers(twt, limitSetId, limitSetName);
                 return twt.getLeg1().newOperationalLimitsGroup(limitSetId); });
             loadingLimitsAdder = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
         } else if (terminalNumber == 2) {
             OperationalLimitsGroup limitsGroup = twt.getLeg2().getOperationalLimitsGroup(limitSetId).orElseGet(() -> {
-                storeCgmesId(twt, limitSetId, limitSetName);
+                storeOperationalLimitSetIdentifiers(twt, limitSetId, limitSetName);
                 return twt.getLeg2().newOperationalLimitsGroup(limitSetId); });
             loadingLimitsAdder = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
         } else if (terminalNumber == 3) {
             OperationalLimitsGroup limitsGroup = twt.getLeg3().getOperationalLimitsGroup(limitSetId).orElseGet(() -> {
-                storeCgmesId(twt, limitSetId, limitSetName);
+                storeOperationalLimitSetIdentifiers(twt, limitSetId, limitSetName);
                 return twt.getLeg3().newOperationalLimitsGroup(limitSetId); });
             loadingLimitsAdder = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
         } else {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.powsybl.cgmes.conversion.Context;
-import com.powsybl.cgmes.conversion.Conversion;
 import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
@@ -21,6 +20,8 @@ import com.powsybl.triplestore.api.PropertyBag;
 
 import java.util.Optional;
 import java.util.function.Supplier;
+
+import static com.powsybl.cgmes.conversion.Conversion.PROPERTY_OPERATIONAL_LIMIT_SET_IDENTIFIERS;
 
 /**
  * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
@@ -33,7 +34,6 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
     private static final String OPERATIONAL_LIMIT_SUBCLASS = "OperationalLimitSubclass";
     private static final String OPERATIONAL_LIMIT_SET_ID = "OperationalLimitSet";
     private static final String OPERATIONAL_LIMIT_SET_NAME = "OperationalLimitSetName";
-    private static final String PROPERTY_PREFIX = Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.OPERATIONAL_LIMIT_SET;
     private static final String PERMANENT_LIMIT = "Permanent Limit";
     private static final String TEMPORARY_LIMIT = "Temporary Limit";
 
@@ -98,13 +98,13 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
         try {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode node;
-            if (identifiable.hasProperty(PROPERTY_PREFIX)) {
-                node = mapper.readTree(identifiable.getProperty(PROPERTY_PREFIX));
+            if (identifiable.hasProperty(PROPERTY_OPERATIONAL_LIMIT_SET_IDENTIFIERS)) {
+                node = mapper.readTree(identifiable.getProperty(PROPERTY_OPERATIONAL_LIMIT_SET_IDENTIFIERS));
             } else {
                 node = mapper.createObjectNode();
             }
             ((ObjectNode) node).put(limitSetId, limitSetName);
-            identifiable.setProperty(PROPERTY_PREFIX, mapper.writeValueAsString(node));
+            identifiable.setProperty(PROPERTY_OPERATIONAL_LIMIT_SET_IDENTIFIERS, mapper.writeValueAsString(node));
         } catch (JsonProcessingException e) {
             throw new PowsyblException(e.getMessage(), e);
         }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/OperationalLimitConversion.java
@@ -8,9 +8,14 @@
 
 package com.powsybl.cgmes.conversion.elements;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.powsybl.cgmes.conversion.Context;
 import com.powsybl.cgmes.conversion.Conversion;
 import com.powsybl.cgmes.model.CgmesNames;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.triplestore.api.PropertyBag;
 
@@ -28,7 +33,7 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
     private static final String OPERATIONAL_LIMIT_SUBCLASS = "OperationalLimitSubclass";
     private static final String OPERATIONAL_LIMIT_SET_ID = "OperationalLimitSet";
     private static final String OPERATIONAL_LIMIT_SET_NAME = "OperationalLimitSetName";
-    private static final String PROPERTY_PREFIX = Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.OPERATIONAL_LIMIT_SET + "_";
+    private static final String PROPERTY_PREFIX = Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.OPERATIONAL_LIMIT_SET;
     private static final String PERMANENT_LIMIT = "Permanent Limit";
     private static final String TEMPORARY_LIMIT = "Temporary Limit";
 
@@ -82,6 +87,30 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
     }
 
     /**
+     * Store the CGMES OperationalLimitSet id/name pair in a property of the identifiable.
+     * If the property already exists, meaning it has been created for another limit set of that identifiable,
+     * then append the id/name pair to the property value (which actually represents a serialized json).
+     * @param identifiable The Branch, DanglingLine, ThreeWindingsTransformer where the limit set id/name are stored.
+     * @param limitSetId The OperationalLimitSet id to store.
+     * @param limitSetName The OperationalLimitSet name to store.
+     */
+    private void storeCgmesId(Identifiable<?> identifiable, String limitSetId, String limitSetName) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode node;
+            if (identifiable.hasProperty(PROPERTY_PREFIX)) {
+                node = mapper.readTree(identifiable.getProperty(PROPERTY_PREFIX));
+            } else {
+                node = mapper.createObjectNode();
+            }
+            ((ObjectNode) node).put(limitSetId, limitSetName);
+            identifiable.setProperty(PROPERTY_PREFIX, mapper.writeValueAsString(node));
+        } catch (JsonProcessingException e) {
+            throw new PowsyblException(e.getMessage(), e);
+        }
+    }
+
+    /**
      * Create the LoadingLimitsAdder for the given branch + side and the given limit set + subclass.
      * @param terminalNumber The side of the branch to which the OperationalLimit applies.
      * @param limitSubClass The subclass of the OperationalLimit.
@@ -92,12 +121,12 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
     private void createLimitsAdder(int terminalNumber, String limitSubClass, String limitSetId, String limitSetName, Branch<?> b) {
         if (terminalNumber == 1) {
             OperationalLimitsGroup limitsGroup = b.getOperationalLimitsGroup1(limitSetId).orElseGet(() -> {
-                b.setProperty(PROPERTY_PREFIX + limitSetId, limitSetName);
+                storeCgmesId(b, limitSetId, limitSetName);
                 return b.newOperationalLimitsGroup1(limitSetId); });
             loadingLimitsAdder1 = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
         } else if (terminalNumber == 2) {
             OperationalLimitsGroup limitsGroup = b.getOperationalLimitsGroup2(limitSetId).orElseGet(() -> {
-                b.setProperty(PROPERTY_PREFIX + limitSetId, limitSetName);
+                storeCgmesId(b, limitSetId, limitSetName);
                 return b.newOperationalLimitsGroup2(limitSetId); });
             loadingLimitsAdder2 = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
         } else {
@@ -114,7 +143,7 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
      */
     private void createLimitsAdder(String limitSubClass, String limitSetId, String limitSetName, DanglingLine dl) {
         OperationalLimitsGroup limitsGroup = dl.getOperationalLimitsGroup(limitSetId).orElseGet(() -> {
-            dl.setProperty(PROPERTY_PREFIX + limitSetId, limitSetName);
+            storeCgmesId(dl, limitSetId, limitSetName);
             return dl.newOperationalLimitsGroup(limitSetId); });
         loadingLimitsAdder = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
     }
@@ -130,17 +159,17 @@ public class OperationalLimitConversion extends AbstractIdentifiedObjectConversi
     private void createLimitsAdder(int terminalNumber, String limitSubClass, String limitSetId, String limitSetName, ThreeWindingsTransformer twt) {
         if (terminalNumber == 1) {
             OperationalLimitsGroup limitsGroup = twt.getLeg1().getOperationalLimitsGroup(limitSetId).orElseGet(() -> {
-                twt.setProperty(PROPERTY_PREFIX + limitSetId, limitSetName);
+                storeCgmesId(twt, limitSetId, limitSetName);
                 return twt.getLeg1().newOperationalLimitsGroup(limitSetId); });
             loadingLimitsAdder = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
         } else if (terminalNumber == 2) {
             OperationalLimitsGroup limitsGroup = twt.getLeg2().getOperationalLimitsGroup(limitSetId).orElseGet(() -> {
-                twt.setProperty(PROPERTY_PREFIX + limitSetId, limitSetName);
+                storeCgmesId(twt, limitSetId, limitSetName);
                 return twt.getLeg2().newOperationalLimitsGroup(limitSetId); });
             loadingLimitsAdder = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
         } else if (terminalNumber == 3) {
             OperationalLimitsGroup limitsGroup = twt.getLeg3().getOperationalLimitsGroup(limitSetId).orElseGet(() -> {
-                twt.setProperty(PROPERTY_PREFIX + limitSetId, limitSetName);
+                storeCgmesId(twt, limitSetId, limitSetName);
                 return twt.getLeg3().newOperationalLimitsGroup(limitSetId); });
             loadingLimitsAdder = context.loadingLimitsMapping().getLoadingLimitsAdder(limitsGroup, limitSubClass);
         } else {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -1213,7 +1213,7 @@ public final class EquipmentExport {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode propertyNode = mapper.readTree(identifiable.getProperty(propertyKey));
                 JsonNode limitsGroupNode = propertyNode.get(operationalLimitSetId);
-                operationalLimitSetName = limitsGroupNode.textValue();
+                operationalLimitSetName = limitsGroupNode != null ? limitsGroupNode.textValue() : operationalLimitSetId;
             } catch (JsonProcessingException e) {
                 operationalLimitSetName = operationalLimitSetId;
             }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -1206,12 +1206,11 @@ public final class EquipmentExport {
         // Write the OperationalLimitSet
         String operationalLimitSetId;
         String operationalLimitSetName;
-        String propertyKey = Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.OPERATIONAL_LIMIT_SET;
-        if (identifiable.hasProperty(propertyKey)) {
+        if (identifiable.hasProperty(Conversion.PROPERTY_OPERATIONAL_LIMIT_SET_IDENTIFIERS)) {
             operationalLimitSetId = limitsGroup.getId();
             try {
                 ObjectMapper mapper = new ObjectMapper();
-                JsonNode propertyNode = mapper.readTree(identifiable.getProperty(propertyKey));
+                JsonNode propertyNode = mapper.readTree(identifiable.getProperty(Conversion.PROPERTY_OPERATIONAL_LIMIT_SET_IDENTIFIERS));
                 JsonNode limitsGroupNode = propertyNode.get(operationalLimitSetId);
                 operationalLimitSetName = limitsGroupNode != null ? limitsGroupNode.textValue() : operationalLimitSetId;
             } catch (JsonProcessingException e) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -7,6 +7,9 @@
  */
 package com.powsybl.cgmes.conversion.export;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.cgmes.conversion.CgmesExport;
 import com.powsybl.cgmes.conversion.Conversion;
 import com.powsybl.cgmes.conversion.naming.NamingStrategy;
@@ -1203,10 +1206,17 @@ public final class EquipmentExport {
         // Write the OperationalLimitSet
         String operationalLimitSetId;
         String operationalLimitSetName;
-        String propertyKey = Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.OPERATIONAL_LIMIT_SET + "_" + limitsGroup.getId();
+        String propertyKey = Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.OPERATIONAL_LIMIT_SET;
         if (identifiable.hasProperty(propertyKey)) {
             operationalLimitSetId = limitsGroup.getId();
-            operationalLimitSetName = identifiable.getProperty(propertyKey);
+            try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode propertyNode = mapper.readTree(identifiable.getProperty(propertyKey));
+                JsonNode limitsGroupNode = propertyNode.get(operationalLimitSetId);
+                operationalLimitSetName = limitsGroupNode.textValue();
+            } catch (JsonProcessingException e) {
+                operationalLimitSetName = operationalLimitSetId;
+            }
         } else {
             operationalLimitSetId = context.getNamingStrategy().getCgmesId(ref(terminalId), ref(limitsGroup.getId()), OPERATIONAL_LIMIT_SET);
             operationalLimitSetName = limitsGroup.getId();

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/OperationalLimitsGroupTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/OperationalLimitsGroupTest.java
@@ -10,7 +10,6 @@ package com.powsybl.cgmes.conversion.test;
 
 import com.powsybl.cgmes.conversion.CgmesExport;
 import com.powsybl.cgmes.conversion.Conversion;
-import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
@@ -56,9 +55,8 @@ class OperationalLimitsGroupTest extends AbstractSerDeTest {
         assertFalse(line.getSelectedOperationalLimitsGroup2().isPresent());
 
         // The CGMES id/name have been correctly imported
-        String propertyKey = Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.OPERATIONAL_LIMIT_SET;
         String propertyValue = "{\"OLS_1\":\"SPRING\",\"OLS_2\":\"SPRING\",\"OLS_3\":\"WINTER\"}";
-        assertEquals(propertyValue, line.getProperty(propertyKey));
+        assertEquals(propertyValue, line.getProperty(Conversion.PROPERTY_OPERATIONAL_LIMIT_SET_IDENTIFIERS));
     }
 
     @Test

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/OperationalLimitsGroupTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/OperationalLimitsGroupTest.java
@@ -9,6 +9,8 @@
 package com.powsybl.cgmes.conversion.test;
 
 import com.powsybl.cgmes.conversion.CgmesExport;
+import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ import java.nio.file.Files;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import static com.powsybl.cgmes.conversion.test.ConversionUtil.getFirstMatch;
 import static com.powsybl.cgmes.conversion.test.ConversionUtil.getUniqueMatches;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -51,6 +54,11 @@ class OperationalLimitsGroupTest extends AbstractSerDeTest {
         // When an end has only 1 set, this set gets selected, otherwise none is
         assertTrue(line.getSelectedOperationalLimitsGroup1().isPresent());
         assertFalse(line.getSelectedOperationalLimitsGroup2().isPresent());
+
+        // The CGMES id/name have been correctly imported
+        String propertyKey = Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.OPERATIONAL_LIMIT_SET;
+        String propertyValue = "{\"OLS_1\":\"SPRING\",\"OLS_2\":\"SPRING\",\"OLS_3\":\"WINTER\"}";
+        assertEquals(propertyValue, line.getProperty(propertyKey));
     }
 
     @Test
@@ -62,25 +70,25 @@ class OperationalLimitsGroupTest extends AbstractSerDeTest {
         exportParams.put(CgmesExport.EXPORT_ALL_LIMITS_GROUP, false);
         exportParams.put(CgmesExport.PROFILES, List.of("EQ"));
         network.write("CGMES", exportParams, tmpDir.resolve("ExportSelectedLimitsGroup.xml"));
-        String exportSelectedLimitsGroupXml = Files.readString(tmpDir.resolve("ExportSelectedLimitsGroup_EQ.xml"));
+        String xmlFile = Files.readString(tmpDir.resolve("ExportSelectedLimitsGroup_EQ.xml"));
 
         // There is 1 set on side 1 which is selected, and there are 2 sets on side 2 but none of them is selected
-        assertEquals(1, getUniqueMatches(exportSelectedLimitsGroupXml, OPERATIONAL_LIMIT_SET).size());
-        assertEquals(3, getUniqueMatches(exportSelectedLimitsGroupXml, OPERATIONAL_LIMIT_TYPE).size());
-        assertEquals(0, getUniqueMatches(exportSelectedLimitsGroupXml, ACTIVE_POWER_LIMIT).size());
-        assertEquals(3, getUniqueMatches(exportSelectedLimitsGroupXml, CURRENT_LIMIT).size());
+        assertEquals(1, getUniqueMatches(xmlFile, OPERATIONAL_LIMIT_SET).size());
+        assertEquals(3, getUniqueMatches(xmlFile, OPERATIONAL_LIMIT_TYPE).size());
+        assertEquals(0, getUniqueMatches(xmlFile, ACTIVE_POWER_LIMIT).size());
+        assertEquals(3, getUniqueMatches(xmlFile, CURRENT_LIMIT).size());
 
         // Manually select one of the limits group on side 2 and export again
         Line line = network.getLine("Line");
         line.setSelectedOperationalLimitsGroup2("OLS_2");
         network.write("CGMES", exportParams, tmpDir.resolve("ExportSelectedLimitsGroup.xml"));
-        exportSelectedLimitsGroupXml = Files.readString(tmpDir.resolve("ExportSelectedLimitsGroup_EQ.xml"));
+        xmlFile = Files.readString(tmpDir.resolve("ExportSelectedLimitsGroup_EQ.xml"));
 
         // That makes 1 set selected on each side = 2 in total
-        assertEquals(2, getUniqueMatches(exportSelectedLimitsGroupXml, OPERATIONAL_LIMIT_SET).size());
-        assertEquals(3, getUniqueMatches(exportSelectedLimitsGroupXml, OPERATIONAL_LIMIT_TYPE).size());
-        assertEquals(0, getUniqueMatches(exportSelectedLimitsGroupXml, ACTIVE_POWER_LIMIT).size());
-        assertEquals(6, getUniqueMatches(exportSelectedLimitsGroupXml, CURRENT_LIMIT).size());
+        assertEquals(2, getUniqueMatches(xmlFile, OPERATIONAL_LIMIT_SET).size());
+        assertEquals(3, getUniqueMatches(xmlFile, OPERATIONAL_LIMIT_TYPE).size());
+        assertEquals(0, getUniqueMatches(xmlFile, ACTIVE_POWER_LIMIT).size());
+        assertEquals(6, getUniqueMatches(xmlFile, CURRENT_LIMIT).size());
     }
 
     @Test
@@ -92,13 +100,19 @@ class OperationalLimitsGroupTest extends AbstractSerDeTest {
         exportParams.put(CgmesExport.EXPORT_ALL_LIMITS_GROUP, true);
         exportParams.put(CgmesExport.PROFILES, List.of("EQ"));
         network.write("CGMES", exportParams, tmpDir.resolve("ExportAllLimitsGroup.xml"));
-        String exportAllLimitsGroupXml = Files.readString(tmpDir.resolve("ExportAllLimitsGroup_EQ.xml"));
+        String xmlFile = Files.readString(tmpDir.resolve("ExportAllLimitsGroup_EQ.xml"));
 
         // All 3 OperationalLimitsGroup are exported, even though only 2 are selected
-        assertEquals(3, getUniqueMatches(exportAllLimitsGroupXml, OPERATIONAL_LIMIT_SET).size());
-        assertEquals(3, getUniqueMatches(exportAllLimitsGroupXml, OPERATIONAL_LIMIT_TYPE).size());
-        assertEquals(3, getUniqueMatches(exportAllLimitsGroupXml, ACTIVE_POWER_LIMIT).size());
-        assertEquals(9, getUniqueMatches(exportAllLimitsGroupXml, CURRENT_LIMIT).size());
+        assertEquals(3, getUniqueMatches(xmlFile, OPERATIONAL_LIMIT_SET).size());
+        assertEquals(3, getUniqueMatches(xmlFile, OPERATIONAL_LIMIT_TYPE).size());
+        assertEquals(3, getUniqueMatches(xmlFile, ACTIVE_POWER_LIMIT).size());
+        assertEquals(9, getUniqueMatches(xmlFile, CURRENT_LIMIT).size());
+
+        // The CGMES id/name have been correctly exported
+        String regex = "<cim:OperationalLimitSet rdf:ID=\"_OLS_NUM\">.*?<cim:IdentifiedObject.name>(.*?)</cim:IdentifiedObject.name>";
+        assertEquals("SPRING", getFirstMatch(xmlFile, Pattern.compile(regex.replace("NUM", "1"), Pattern.DOTALL)));
+        assertEquals("SPRING", getFirstMatch(xmlFile, Pattern.compile(regex.replace("NUM", "2"), Pattern.DOTALL)));
+        assertEquals("WINTER", getFirstMatch(xmlFile, Pattern.compile(regex.replace("NUM", "3"), Pattern.DOTALL)));
     }
 
 }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/OperationalLimitsGroupTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/OperationalLimitsGroupTest.java
@@ -55,7 +55,8 @@ class OperationalLimitsGroupTest extends AbstractSerDeTest {
         assertFalse(line.getSelectedOperationalLimitsGroup2().isPresent());
 
         // The CGMES id/name have been correctly imported
-        String propertyValue = "{\"OLS_1\":\"SPRING\",\"OLS_2\":\"SPRING\",\"OLS_3\":\"WINTER\"}";
+        String propertyValue = """
+                {"OLS_1":"SPRING","OLS_2":"SPRING","OLS_3":"WINTER"}""";
         assertEquals(propertyValue, line.getProperty(Conversion.PROPERTY_OPERATIONAL_LIMIT_SET_IDENTIFIERS));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature change.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
At CGMES import, OperationalLimitSet names and ids are stored in a property of the corresponding identifiable as follows:
- Property name: "CGMES.OperationalLimitSet_\<rdfid\>"
- Property value: "\<name\>"

Since rdfid are globally uniques, this results in the model creating overall as many property keys as OperationalLimitSet. This is an issue in pypowsybl where a huge number of property keys severly alters performances.

**What is the new behavior (if this is a feature change)?**
<!-- -->
At CGMES import, OperationalLimitSet names and ids are stored in a property of the corresponding identifiable as follows:
- Property name: "CGMES.OperationalLimitSet"
- Property value: Serialized json of all "\<rdfid\>:\<name\>"

That way there is only one property key for storing limit sets id/name overall.

CGMES export has been adapted accordingly.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
This is a refactoring of: https://github.com/powsybl/powsybl-core/pull/3139
