### PR TITLE
[Shortcircuit] Add some documentation about the voltage attribute of voltage ranges.

### DIFF
--- a/docs/simulation/shortcircuit/parameters.md
+++ b/docs/simulation/shortcircuit/parameters.md
@@ -106,25 +106,31 @@ This property defines the voltage profile that should be used for the calculatio
 **voltage-ranges**
 
 This property specifies a path to a JSON file containing the voltage ranges and associated coefficients to be used when `initial-voltage-profile-mode` is set to `CONFIGURED`.
-The JSON file must contain a list of voltage ranges and coefficients. Then, for each nominal voltage in the network that belongs to the range, the given coefficient is applied to calculate the voltage to be used
-in the calculation. All the coefficients should be between 0.8 and 1.2.
+The JSON file must contain a list of voltage ranges and for each range, coefficients and/or voltages.
+Then, for each nominal voltage in the network that belongs to the range, the coefficient is applied to calculate the voltage to be used
+in the calculation. All the coefficients should be between 0.8 and 1.2. They are optional, and if they are missing for a range, 1 will be used. 
+The voltage attribute of the voltage range defines the nominal voltage of all the voltage levels in the network that are in the range.
+It is also optional, and if it is not defined, then the nominal voltage already in the network will be used.
 Here is an example of this JSON file:
 ````json
 [
     {
       "minimumNominalVoltage": 350.0, 
       "maximumNominalVoltage": 400.0,
-      "voltageRangeCoefficient": 1.1
+      "voltageRangeCoefficient": 1.1,
+      "voltage": 380.0
     },
     {
       "minimumNominalVoltage": 215.0,
       "maximumNominalVoltage": 235.0,
-      "voltageRangeCoefficient": 1.2
+      "voltageRangeCoefficient": 1.2,
+      "voltage": 225.0
     },
     {
       "minimumNominalVoltage": 80.0,
       "maximumNominalVoltage": 150.0,
-      "voltageRangeCoefficient": 1.05
+      "voltageRangeCoefficient": 1.05,
+      "voltage": 105.0
     }
 ]
 ````


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The voltage field of the shortcircuit voltage range parameter is not mentioned in the documentation.


**What is the new behavior (if this is a feature change)?**
Adds the documentation.



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
