### PR TITLE
Fix switch contingency support

### DIFF
--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/Contingency.java
@@ -112,8 +112,8 @@ public class Contingency extends AbstractExtendable<Contingency> {
                 case LOAD -> checkLoadContingency(this, (LoadContingency) element, network);
                 case BUS -> checkBusContingency(this, (BusContingency) element, network);
                 case TIE_LINE -> checkTieLineContingency(this, (TieLineContingency) element, network);
+                case SWITCH -> checkSwitchContingency(this, (SwitchContingency) element, network);
                 case BATTERY -> checkBatteryContingency(this, (BatteryContingency) element, network);
-                default -> throw new IllegalStateException("Unknown contingency element type " + element.getType());
             };
         }
         if (!valid) {
@@ -258,6 +258,15 @@ public class Contingency extends AbstractExtendable<Contingency> {
                     && !(element.getVoltageLevelId().equals(tieLine.getDanglingLine1().getTerminal().getVoltageLevel().getId())
                         || element.getVoltageLevelId().equals(tieLine.getDanglingLine2().getTerminal().getVoltageLevel().getId()))) {
             LOGGER.warn("Tie line '{}' of contingency '{}' not found", element.getId(), contingency.getId());
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean checkSwitchContingency(Contingency contingency, SwitchContingency element, Network network) {
+        Switch switchElement = network.getSwitch(element.getId());
+        if (switchElement == null) {
+            LOGGER.warn("Switch '{}' of contingency '{}' not found", element.getId(), contingency.getId());
             return false;
         }
         return true;

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ContingencyElementDeserializer.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/json/ContingencyElementDeserializer.java
@@ -56,10 +56,10 @@ public class ContingencyElementDeserializer extends StdDeserializer<ContingencyE
                 case TWO_WINDINGS_TRANSFORMER -> new TwoWindingsTransformerContingency(id, voltageLevelId);
                 case THREE_WINDINGS_TRANSFORMER -> new ThreeWindingsTransformerContingency(id);
                 case LOAD -> new LoadContingency(id);
+                case SWITCH -> new SwitchContingency(id);
+                case BATTERY -> new BatteryContingency(id);
                 case BUS -> new BusContingency(id);
                 case TIE_LINE -> new TieLineContingency(id, voltageLevelId);
-                case BATTERY -> new BatteryContingency(id);
-                default -> throw new IllegalStateException("Unexpected ContingencyElementType value: " + type);
             };
         }
 

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/SwitchContingencyTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/SwitchContingencyTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.contingency;
+
+import com.google.common.testing.EqualsTester;
+import com.powsybl.iidm.modification.tripping.SwitchTripping;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Switch;
+import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Etienne Lesot {@literal <etienne.lesot@rte-france.com>}
+ */
+class SwitchContingencyTest {
+    @Test
+    void test() {
+        var switchContingency = new SwitchContingency("switch");
+        assertEquals("switch", switchContingency.getId());
+        assertEquals(ContingencyElementType.SWITCH, switchContingency.getType());
+
+        assertNotNull(switchContingency.toModification());
+        assertInstanceOf(SwitchTripping.class, switchContingency.toModification());
+
+        new EqualsTester()
+            .addEqualityGroup(new SwitchContingency("foo"), new SwitchContingency("foo"))
+            .addEqualityGroup(new SwitchContingency("bar"), new SwitchContingency("bar"))
+            .testEquals();
+    }
+
+    @Test
+    void testContingencyElement() {
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        Switch networkSwitch = network.getSwitch("S1VL1_LD1_BREAKER");
+        assertNotNull(networkSwitch);
+        ContingencyElement element = ContingencyElement.of(networkSwitch);
+        assertNotNull(element);
+        assertInstanceOf(SwitchContingency.class, element);
+        assertEquals("S1VL1_LD1_BREAKER", element.getId());
+        assertEquals(ContingencyElementType.SWITCH, element.getType());
+    }
+
+    @Test
+    void testContingencyElementNotFound() {
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        ContingencyElement element = new SwitchContingency("id");
+        Contingency contingency = new Contingency("contingencyId", "contingencyName", List.of(element));
+        assertFalse(contingency.isValid(network));
+        ContingencyElement element2 = new SwitchContingency("S1VL1_LD1_BREAKER");
+        Contingency contingency2 = new Contingency("contingencyId2", "contingencyName2", List.of(element2));
+        assertTrue(contingency2.isValid(network));
+    }
+}

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/ContingencyJsonTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/json/ContingencyJsonTest.java
@@ -22,8 +22,7 @@ import com.powsybl.contingency.Contingency;
 import com.powsybl.contingency.contingency.list.ContingencyList;
 import com.powsybl.contingency.contingency.list.DefaultContingencyList;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.test.BatteryNetworkFactory;
-import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.network.test.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +35,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 
+import static com.powsybl.contingency.ContingencyElementType.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -52,6 +52,9 @@ class ContingencyJsonTest extends AbstractSerDeTest {
         Files.copy(getClass().getResourceAsStream("/contingencies.json"), fileSystem.getPath("/contingencies.json"));
         Files.copy(getClass().getResourceAsStream("/contingenciesBatteries.json"), fileSystem.getPath("/contingenciesBatteries.json"));
         Files.copy(getClass().getResourceAsStream("/contingenciesWithOptionalName.json"), fileSystem.getPath("/contingenciesWithOptionalName.json"));
+        Files.copy(getClass().getResourceAsStream("/contingenciesWithSeveralElements.json"), fileSystem.getPath("/contingenciesWithSeveralElements.json"));
+        Files.copy(getClass().getResourceAsStream("/contingenciesWith3wt.json"), fileSystem.getPath("/contingenciesWith3wt.json"));
+        Files.copy(getClass().getResourceAsStream("/contingenciesWithDlAndTl.json"), fileSystem.getPath("/contingenciesWithDlAndTl.json"));
     }
 
     private static Contingency create() {
@@ -155,6 +158,68 @@ class ContingencyJsonTest extends AbstractSerDeTest {
         assertEquals(1, contingencies.get(3).getElements().size());
 
         roundTripTest(contingencyList, ContingencyJsonTest::write, ContingencyJsonTest::readContingencyList, "/contingenciesBatteries.json");
+    }
+
+    @Test
+    void readJsonListWithSwitchHvdcSvcShuntBbsTwtContingency() throws IOException {
+        Network network = FourSubstationsNodeBreakerFactory.create();
+
+        ContingencyList contingencyList = ContingencyList.load(fileSystem.getPath("/contingenciesWithSeveralElements.json"));
+        assertEquals("list", contingencyList.getName());
+
+        List<Contingency> contingencies = contingencyList.getContingencies(network);
+        assertEquals(6, contingencies.size());
+        assertEquals("contingency", contingencies.get(0).getId());
+        assertEquals(1, contingencies.get(0).getElements().size());
+        assertEquals(HVDC_LINE, contingencies.get(0).getElements().get(0).getType());
+        assertEquals("contingency2", contingencies.get(1).getId());
+        assertEquals(1, contingencies.get(1).getElements().size());
+        assertEquals(TWO_WINDINGS_TRANSFORMER, contingencies.get(1).getElements().get(0).getType());
+        assertEquals("contingency3", contingencies.get(2).getId());
+        assertEquals(1, contingencies.get(2).getElements().size());
+        assertEquals(SHUNT_COMPENSATOR, contingencies.get(2).getElements().get(0).getType());
+        assertEquals("contingency4", contingencies.get(3).getId());
+        assertEquals(1, contingencies.get(3).getElements().size());
+        assertEquals(STATIC_VAR_COMPENSATOR, contingencies.get(3).getElements().get(0).getType());
+        assertEquals("contingency5", contingencies.get(4).getId());
+        assertEquals(1, contingencies.get(4).getElements().size());
+        assertEquals(BUSBAR_SECTION, contingencies.get(4).getElements().get(0).getType());
+        assertEquals("contingency6", contingencies.get(5).getId());
+        assertEquals(1, contingencies.get(5).getElements().size());
+        assertEquals(SWITCH, contingencies.get(5).getElements().get(0).getType());
+
+        roundTripTest(contingencyList, ContingencyJsonTest::write, ContingencyJsonTest::readContingencyList, "/contingenciesWithSeveralElements.json");
+    }
+
+    @Test
+    void readJsonListWithTwt3Contingency() throws IOException {
+        Network network = ThreeWindingsTransformerNetworkFactory.create();
+        ContingencyList contingencyList = ContingencyList.load(fileSystem.getPath("/contingenciesWith3wt.json"));
+        assertEquals("list", contingencyList.getName());
+
+        List<Contingency> contingencies = contingencyList.getContingencies(network);
+        assertEquals(1, contingencies.size());
+        assertEquals("contingency", contingencies.get(0).getId());
+        assertEquals(1, contingencies.get(0).getElements().size());
+        assertEquals(THREE_WINDINGS_TRANSFORMER, contingencies.get(0).getElements().get(0).getType());
+        roundTripTest(contingencyList, ContingencyJsonTest::write, ContingencyJsonTest::readContingencyList, "/contingenciesWith3wt.json");
+    }
+
+    @Test
+    void readJsonListWithTieLineAndDanglingLineContingency() throws IOException {
+        Network network = EurostagTutorialExample1Factory.createWithTieLine();
+        ContingencyList contingencyList = ContingencyList.load(fileSystem.getPath("/contingenciesWithDlAndTl.json"));
+        assertEquals("list", contingencyList.getName());
+
+        List<Contingency> contingencies = contingencyList.getContingencies(network);
+        assertEquals(2, contingencies.size());
+        assertEquals("contingency", contingencies.get(0).getId());
+        assertEquals(1, contingencies.get(0).getElements().size());
+        assertEquals(DANGLING_LINE, contingencies.get(0).getElements().get(0).getType());
+        assertEquals("contingency2", contingencies.get(1).getId());
+        assertEquals(1, contingencies.get(1).getElements().size());
+        assertEquals(TIE_LINE, contingencies.get(1).getElements().get(0).getType());
+        roundTripTest(contingencyList, ContingencyJsonTest::write, ContingencyJsonTest::readContingencyList, "/contingenciesWithDlAndTl.json");
     }
 
     @Test

--- a/contingency/contingency-api/src/test/resources/contingenciesWith3wt.json
+++ b/contingency/contingency-api/src/test/resources/contingenciesWith3wt.json
@@ -1,0 +1,12 @@
+{
+  "type" : "default",
+  "version" : "1.0",
+  "name" : "list",
+  "contingencies" : [ {
+    "id" : "contingency",
+    "elements" : [ {
+      "id" : "3WT",
+      "type" : "THREE_WINDINGS_TRANSFORMER"
+    } ]
+  } ]
+}

--- a/contingency/contingency-api/src/test/resources/contingenciesWithDlAndTl.json
+++ b/contingency/contingency-api/src/test/resources/contingenciesWithDlAndTl.json
@@ -1,0 +1,18 @@
+{
+  "type" : "default",
+  "version" : "1.0",
+  "name" : "list",
+  "contingencies" : [ {
+    "id" : "contingency",
+    "elements" : [ {
+      "id" : "NHV1_XNODE1",
+      "type" : "DANGLING_LINE"
+    } ]
+  }, {
+    "id" : "contingency2",
+    "elements" : [ {
+      "id" : "NHV1_NHV2_1",
+      "type" : "TIE_LINE"
+    } ]
+  } ]
+}

--- a/contingency/contingency-api/src/test/resources/contingenciesWithSeveralElements.json
+++ b/contingency/contingency-api/src/test/resources/contingenciesWithSeveralElements.json
@@ -1,0 +1,42 @@
+{
+  "type" : "default",
+  "version" : "1.0",
+  "name" : "list",
+  "contingencies" : [ {
+    "id" : "contingency",
+    "elements" : [ {
+      "id" : "HVDC1",
+      "type" : "HVDC_LINE"
+    } ]
+  }, {
+    "id" : "contingency2",
+    "elements" : [ {
+      "id" : "TWT",
+      "type" : "TWO_WINDINGS_TRANSFORMER"
+    } ]
+  }, {
+    "id" : "contingency3",
+    "elements" : [ {
+      "id" : "SHUNT",
+      "type" : "SHUNT_COMPENSATOR"
+    } ]
+  }, {
+    "id" : "contingency4",
+    "elements" : [ {
+      "id" : "SVC",
+      "type" : "STATIC_VAR_COMPENSATOR"
+    } ]
+  }, {
+    "id" : "contingency5",
+    "elements" : [ {
+      "id" : "S1VL1_BBS",
+      "type" : "BUSBAR_SECTION"
+    } ]
+  }, {
+    "id" : "contingency6",
+    "elements" : [ {
+      "id" : "S1VL1_LD1_BREAKER",
+      "type" : "SWITCH"
+    } ]
+  } ]
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
Switch contingency type is not fully supported: no validation + no deserialization



**What is the new behavior (if this is a feature change)?**
Switch contingency type is supported at validation and deserialization.  
\+ add unit tests on other contingency types.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No