### PR TITLE
Use PowerTransformerEnd.endNumber to sort transformer windings

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
@@ -16,6 +16,7 @@ import com.powsybl.cgmes.conversion.elements.AbstractConductingEquipmentConversi
 import com.powsybl.cgmes.extensions.CgmesTapChangers;
 import com.powsybl.cgmes.extensions.CgmesTapChangersAdder;
 import com.powsybl.cgmes.model.CgmesNames;
+import com.powsybl.cgmes.model.WindingType;
 import com.powsybl.iidm.network.*;
 import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
@@ -111,10 +112,8 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
     @Override
     protected void addAliasesAndProperties(Identifiable<?> identifiable) {
         super.addAliasesAndProperties(identifiable);
-        int end = 1;
         for (PropertyBag p : ps) {
-            identifiable.addAlias(p.getId("TransformerEnd"), Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TRANSFORMER_END + end);
-            end++;
+            identifiable.addAlias(p.getId("TransformerEnd"), Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.TRANSFORMER_END + WindingType.endNumber(p));
         }
         List<String> ptcs = context.cgmes().phaseTapChangerListForPowerTransformer(identifiable.getId());
         if (ptcs != null) {

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
@@ -201,14 +201,7 @@ public abstract class AbstractCgmesModel implements CgmesModel {
                     powerTransformerRatioTapChanger.get(id)[end.asInt(endNumber, 1) - 1] = end.getId("RatioTapChanger");
                 }
             });
-        gends.entrySet()
-            .forEach(tends -> {
-                PropertyBags tends1 = new PropertyBags(
-                    tends.getValue().stream()
-                        .sorted(Comparator.comparing(WindingType::endNumber))
-                        .toList());
-                tends.setValue(tends1);
-            });
+        gends.values().forEach(tends -> tends.sort(Comparator.comparing(WindingType::endNumber)));
         return gends;
     }
 

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/AbstractCgmesModel.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * @author Luma Zamarreño {@literal <zamarrenolm at aia.es>}
@@ -206,10 +205,8 @@ public abstract class AbstractCgmesModel implements CgmesModel {
             .forEach(tends -> {
                 PropertyBags tends1 = new PropertyBags(
                     tends.getValue().stream()
-                        .sorted(Comparator
-                            .comparing(WindingType::fromTransformerEnd)
-                            .thenComparing(end -> end.asInt(endNumber, -1)))
-                        .collect(Collectors.toList()));
+                        .sorted(Comparator.comparing(WindingType::endNumber))
+                        .toList());
                 tends.setValue(tends1);
             });
         return gends;

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/WindingType.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/WindingType.java
@@ -17,13 +17,14 @@ public enum WindingType {
 
     PRIMARY, SECONDARY, TERTIARY;
 
-    public static WindingType fromTransformerEnd(PropertyBag end) {
-        // For CIM14 (CIM ENTSOE Profile1) primary is determined by windingType
-        // For CIM16 (CGMES) primary is defined by the corresponding terminal sequence number:
-        // "The Terminal.sequenceNumber distinguishes the terminals much as previously done by
-        // TransformerWinding.windingType:WindingType"
-
+    /**
+     * Retrieve the WindingType for the given transformer winding/end.
+     * @param end A PropertyBag with the transformer winding/end properties.
+     * @return The WindingType (PRIMARY/SECONDARY/TERTIARY) corresponding to the given transformer winding/end.
+     */
+    public static WindingType windingType(PropertyBag end) {
         if (end.containsKey("windingType")) {
+            // For CIM14 (CIM ENTSOE Profile1) primary is determined by TransformerWinding.windingType
             String wtype = end.getLocal("windingType");
             if (wtype.endsWith("WindingType.primary")) {
                 return WindingType.PRIMARY;
@@ -32,10 +33,23 @@ public enum WindingType {
             } else if (wtype.endsWith("WindingType.tertiary")) {
                 return WindingType.TERTIARY;
             }
-        } else if (end.containsKey("terminalSequenceNumber")) {
-            // Terminal.sequenceNumber := 1, 2 ,3 ...
-            return WindingType.values()[end.asInt("terminalSequenceNumber") - 1];
+        } else if (end.containsKey("endNumber")) {
+            // For CIM16 (CGMES 2.4.15) primary is defined by TransformerEnd.endNumber
+            try {
+                return WindingType.values()[end.asInt("endNumber") - 1];
+            } catch (Exception e) {
+                return WindingType.PRIMARY;
+            }
         }
         return WindingType.PRIMARY;
+    }
+
+    /**
+     * Retrieve the endNumber for the given transformer winding/end.
+     * @param end A PropertyBag with the transformer winding/end properties.
+     * @return The endNumber value (1/2/3) corresponding to the given transformer winding/end.
+     */
+    public static int endNumber(PropertyBag end) {
+        return windingType(end).ordinal() + 1;
     }
 }

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/WindingType.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/WindingType.java
@@ -15,7 +15,7 @@ import com.powsybl.triplestore.api.PropertyBag;
  */
 public enum WindingType {
 
-    PRIMARY, SECONDARY, TERTIARY;
+    UNKNOWN, PRIMARY, SECONDARY, TERTIARY;
 
     /**
      * Retrieve the WindingType for the given transformer winding/end.
@@ -25,23 +25,21 @@ public enum WindingType {
     public static WindingType windingType(PropertyBag end) {
         if (end.containsKey("windingType")) {
             // For CIM14 (CIM ENTSOE Profile1) primary is determined by TransformerWinding.windingType
-            String wtype = end.getLocal("windingType");
-            if (wtype.endsWith("WindingType.primary")) {
-                return WindingType.PRIMARY;
-            } else if (wtype.endsWith("WindingType.secondary")) {
-                return WindingType.SECONDARY;
-            } else if (wtype.endsWith("WindingType.tertiary")) {
-                return WindingType.TERTIARY;
-            }
+            return switch (end.getLocal("windingType")) {
+                case "WindingType.primary" -> WindingType.PRIMARY;
+                case "WindingType.secondary" -> WindingType.SECONDARY;
+                case "WindingType.tertiary" -> WindingType.TERTIARY;
+                default -> WindingType.UNKNOWN;
+            };
         } else if (end.containsKey("endNumber")) {
             // For CIM16 (CGMES 2.4.15) primary is defined by TransformerEnd.endNumber
             try {
-                return WindingType.values()[end.asInt("endNumber") - 1];
+                return WindingType.values()[end.asInt("endNumber")];
             } catch (Exception e) {
-                return WindingType.PRIMARY;
+                return WindingType.UNKNOWN;
             }
         }
-        return WindingType.PRIMARY;
+        return WindingType.UNKNOWN;
     }
 
     /**
@@ -50,6 +48,6 @@ public enum WindingType {
      * @return The endNumber value (1/2/3) corresponding to the given transformer winding/end.
      */
     public static int endNumber(PropertyBag end) {
-        return windingType(end).ordinal() + 1;
+        return windingType(end).ordinal();
     }
 }

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/WindingTypeTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/WindingTypeTest.java
@@ -45,9 +45,9 @@ class WindingTypeTest {
         assertEquals(3, WindingType.endNumber(end3));
 
         end4 = new PropertyBag(Collections.singletonList(WINDING_TYPE), true);
-        end4.put(WINDING_TYPE, "WindingType.quaternary");
-        assertEquals(WindingType.PRIMARY, WindingType.windingType(end4));
-        assertEquals(1, WindingType.endNumber(end4));
+        end4.put(WINDING_TYPE, "Unknown");
+        assertEquals(WindingType.UNKNOWN, WindingType.windingType(end4));
+        assertEquals(0, WindingType.endNumber(end4));
     }
 
     @Test
@@ -68,8 +68,8 @@ class WindingTypeTest {
         assertEquals(3, WindingType.endNumber(end3));
 
         end4 = new PropertyBag(Collections.singletonList(END_NUMBER), true);
-        end4.put(END_NUMBER, "4");
-        assertEquals(WindingType.PRIMARY, WindingType.windingType(end4));
-        assertEquals(1, WindingType.endNumber(end4));
+        end4.put(END_NUMBER, "Unknown");
+        assertEquals(WindingType.UNKNOWN, WindingType.windingType(end4));
+        assertEquals(0, WindingType.endNumber(end4));
     }
 }

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/WindingTypeTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/WindingTypeTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.model;
+
+import com.powsybl.triplestore.api.PropertyBag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Romain Courtier {@literal <romain.courtier at rte-france.com>}
+ */
+class WindingTypeTest {
+
+    PropertyBag end1;
+    PropertyBag end2;
+    PropertyBag end3;
+    PropertyBag end4;
+
+    static final String WINDING_TYPE = "windingType";
+    static final String END_NUMBER = "endNumber";
+
+    @Test
+    void cim14WindingTypeTest() {
+        end1 = new PropertyBag(Collections.singletonList(WINDING_TYPE), true);
+        end1.put(WINDING_TYPE, "http://iec.ch/TC57/2009/CIM-schema-cim14#WindingType.primary");
+        assertEquals(WindingType.PRIMARY, WindingType.windingType(end1));
+        assertEquals(1, WindingType.endNumber(end1));
+
+        end2 = new PropertyBag(Collections.singletonList(WINDING_TYPE), true);
+        end2.put(WINDING_TYPE, "http://iec.ch/TC57/2009/CIM-schema-cim14#WindingType.secondary");
+        assertEquals(WindingType.SECONDARY, WindingType.windingType(end2));
+        assertEquals(2, WindingType.endNumber(end2));
+
+        end3 = new PropertyBag(Collections.singletonList(WINDING_TYPE), true);
+        end3.put(WINDING_TYPE, "http://iec.ch/TC57/2009/CIM-schema-cim14#WindingType.tertiary");
+        assertEquals(WindingType.TERTIARY, WindingType.windingType(end3));
+        assertEquals(3, WindingType.endNumber(end3));
+
+        end4 = new PropertyBag(Collections.singletonList(WINDING_TYPE), true);
+        end4.put(WINDING_TYPE, "WindingType.quaternary");
+        assertEquals(WindingType.PRIMARY, WindingType.windingType(end4));
+        assertEquals(1, WindingType.endNumber(end4));
+    }
+
+    @Test
+    void cim16WindingTypeTest() {
+        end1 = new PropertyBag(Collections.singletonList(END_NUMBER), true);
+        end1.put(END_NUMBER, "1");
+        assertEquals(WindingType.PRIMARY, WindingType.windingType(end1));
+        assertEquals(1, WindingType.endNumber(end1));
+
+        end2 = new PropertyBag(Collections.singletonList(END_NUMBER), true);
+        end2.put(END_NUMBER, "2");
+        assertEquals(WindingType.SECONDARY, WindingType.windingType(end2));
+        assertEquals(2, WindingType.endNumber(end2));
+
+        end3 = new PropertyBag(Collections.singletonList(END_NUMBER), true);
+        end3.put(END_NUMBER, "3");
+        assertEquals(WindingType.TERTIARY, WindingType.windingType(end3));
+        assertEquals(3, WindingType.endNumber(end3));
+
+        end4 = new PropertyBag(Collections.singletonList(END_NUMBER), true);
+        end4.put(END_NUMBER, "4");
+        assertEquals(WindingType.PRIMARY, WindingType.windingType(end4));
+        assertEquals(1, WindingType.endNumber(end4));
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Refactoring.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
During CGMES conversion of a CIM16 file (CGMES 2.4.15), `WindingType` class is using Terminal.sequenceNumber to classify and sort the windings as PRIMARY/SECONDARY/TERTIARY. However, sequenceNumber isn't fetched by the SPARQL query and therefore is never used in the `WindingType` class. As a consequence, WindingType.windingType always returns PRIMARY for CIM16 Propertybags.

This is not an issue because another sort is done in the CGMES import using PowerTransformerEnd.endNumber, giving the correct classifications of windings for CIM16 files, but this additional sorting shouldn't be required and should be done directly in `WindingType`.


**What is the new behavior (if this is a feature change)?**
<!-- -->
Since the SPARQL queries fetch the PowerTransformerEnd.endNumber and use it to classify and sort the windings as PRIMARY/SECONDARY/TERTIARY, the use of Terminal.sequenceNumber is droped in favor of PowerTransformerEnd.endNumber.

As a consequence, the additional sorting in CGMES import isn't required anymore.

This also gives the iidm `WindingType` class a clearer purpose which is to support the difference in the modeling of the winding numberings between CIM14 and CIM16.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
This is bad practice to rely on PowerTransformerEnd.Terminal.sequenceNumber. The correct way to classify windings in CIM16 is with the use of PowerTransformerEnd.endNumber.