### PR TITLE
Handle duplicate timeseries index

### DIFF
--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/IrregularTimeSeriesIndex.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/IrregularTimeSeriesIndex.java
@@ -15,10 +15,7 @@ import gnu.trove.list.array.TLongArrayList;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Stream;
 
 /**
@@ -32,6 +29,11 @@ public class IrregularTimeSeriesIndex extends AbstractTimeSeriesIndex {
 
     public IrregularTimeSeriesIndex(long[] times) {
         this.times = Objects.requireNonNull(times);
+        for (int i = 1; i < times.length; i++) {
+            if (times[i] <= times[i - 1]) {
+                throw new IllegalArgumentException("Time list should be sorted and without duplicate values");
+            }
+        }
         if (times.length == 0) {
             throw new IllegalArgumentException("Empty time list");
         }

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/IrregularTimeSeriesIndexTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/IrregularTimeSeriesIndexTest.java
@@ -65,5 +65,9 @@ class IrregularTimeSeriesIndexTest {
     @Test
     void testContructorError() {
         assertThrows(IllegalArgumentException.class, IrregularTimeSeriesIndex::create);
+        long[] duplicates = {0L, 1L, 1L};
+        assertThrows(IllegalArgumentException.class, () -> new IrregularTimeSeriesIndex(duplicates));
+        long[] unordered = {0L, 2L, 1L};
+        assertThrows(IllegalArgumentException.class, () -> new IrregularTimeSeriesIndex(unordered));
     }
 }

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
@@ -139,6 +139,25 @@ class TimeSeriesTest {
     }
 
     @Test
+    void testFractionsOfSecondsRegularTimeSeriesIndexWithDuplicateTime() {
+        String csv = String.join(System.lineSeparator(),
+                "Time;Version;ts1;ts2",
+                "0.000;1;1.0;",
+                "0.001;1;;a",
+                "0.0015;1;;b",
+                "0.002;1;3.0;b",
+                "0.000;2;4.0;c",
+                "0.0002;2;4.5;c",
+                "0.001;2;5.0;",
+                "0.002;2;6.0;d") + System.lineSeparator();
+
+        TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', true, TimeFormat.FRACTIONS_OF_SECOND, true);
+        Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv, timeSeriesCsvConfig);
+
+        assertOnParsedTimeSeries(timeSeriesPerVersion, RegularTimeSeriesIndex.class);
+    }
+
+    @Test
     void testParseCsvBuffered() {
         String csv = String.join(System.lineSeparator(),
             "Time;Version;ts1;ts2",

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
@@ -61,23 +61,25 @@ class TimeSeriesTest {
 
     @Test
     void testRegularTimeSeriesIndex() {
-        String csv = String.join(System.lineSeparator(),
-                "Time;Version;ts1;ts2",
-                "1970-01-01T01:00:00.000+01:00;1;1.0;",
-                "1970-01-01T02:00:00.000+01:00;1;;a",
-                "1970-01-01T03:00:00.000+01:00;1;3.0;b",
-                "1970-01-01T01:00:00.000+01:00;2;4.0;c",
-                "1970-01-01T02:00:00.000+01:00;2;5.0;",
-                "1970-01-01T03:00:00.000+01:00;2;6.0;d") + System.lineSeparator();
+        String csv = """
+                Time;Version;ts1;ts2
+                1970-01-01T01:00:00.000+01:00;1;1.0;
+                1970-01-01T02:00:00.000+01:00;1;;a
+                1970-01-01T03:00:00.000+01:00;1;3.0;b
+                1970-01-01T01:00:00.000+01:00;2;4.0;c
+                1970-01-01T02:00:00.000+01:00;2;5.0;
+                1970-01-01T03:00:00.000+01:00;2;6.0;d
+                """;
 
-        String csvWithQuotes = String.join(System.lineSeparator(),
-                "\"Time\";\"Version\";\"ts1\";\"ts2\"",
-                "\"1970-01-01T01:00:00.000+01:00\";\"1\";\"1.0\";",
-                "\"1970-01-01T02:00:00.000+01:00\";\"1\";;\"a\"",
-                "\"1970-01-01T03:00:00.000+01:00\";\"1\";\"3.0\";\"b\"",
-                "\"1970-01-01T01:00:00.000+01:00\";\"2\";\"4.0\";\"c\"",
-                "\"1970-01-01T02:00:00.000+01:00\";\"2\";\"5.0\";",
-                "\"1970-01-01T03:00:00.000+01:00\";\"2\";\"6.0\";\"d\"") + System.lineSeparator();
+        String csvWithQuotes = """
+                "Time";"Version";"ts1";"ts2"
+                "1970-01-01T01:00:00.000+01:00";"1";"1.0";
+                "1970-01-01T02:00:00.000+01:00";"1";;"a"
+                "1970-01-01T03:00:00.000+01:00";"1";"3.0";"b"
+                "1970-01-01T01:00:00.000+01:00";"2";"4.0";"c"
+                "1970-01-01T02:00:00.000+01:00";"2";"5.0";
+                "1970-01-01T03:00:00.000+01:00";"2";"6.0";"d"
+                """;
 
         Arrays.asList(csv, csvWithQuotes).forEach(data -> {
             Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(data);
@@ -88,14 +90,15 @@ class TimeSeriesTest {
 
     @Test
     void testIrregularTimeSeriesIndex() {
-        String csv = String.join(System.lineSeparator(),
-                "Time;Version;ts1;ts2",
-                "1970-01-01T01:00:00.000+01:00;1;1.0;",
-                "1970-01-01T02:00:00.000+01:00;1;;a",
-                "1970-01-01T04:00:00.000+01:00;1;3.0;b",
-                "1970-01-01T01:00:00.000+01:00;2;4.0;c",
-                "1970-01-01T02:00:00.000+01:00;2;5.0;",
-                "1970-01-01T04:00:00.000+01:00;2;6.0;d") + System.lineSeparator();
+        String csv = """
+                Time;Version;ts1;ts2
+                1970-01-01T01:00:00.000+01:00;1;1.0;
+                1970-01-01T02:00:00.000+01:00;1;;a
+                1970-01-01T04:00:00.000+01:00;1;3.0;b
+                1970-01-01T01:00:00.000+01:00;2;4.0;c
+                1970-01-01T02:00:00.000+01:00;2;5.0;
+                1970-01-01T04:00:00.000+01:00;2;6.0;d
+                """;
 
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv);
 
@@ -104,14 +107,15 @@ class TimeSeriesTest {
 
     @Test
     void testTimeSeriesNameMissing() {
-        String csv = String.join(System.lineSeparator(),
-            "Time;Version;;ts2",
-            "1970-01-01T01:00:00.000+01:00;1;1.0;",
-            "1970-01-01T02:00:00.000+01:00;1;;a",
-            "1970-01-01T04:00:00.000+01:00;1;3.0;b",
-            "1970-01-01T01:00:00.000+01:00;2;4.0;c",
-            "1970-01-01T02:00:00.000+01:00;2;5.0;",
-            "1970-01-01T04:00:00.000+01:00;2;6.0;d") + System.lineSeparator();
+        String csv = """    
+            Time;Version;;ts2
+            1970-01-01T01:00:00.000+01:00;1;1.0;
+            1970-01-01T02:00:00.000+01:00;1;;a
+            1970-01-01T04:00:00.000+01:00;1;3.0;b
+            1970-01-01T01:00:00.000+01:00;2;4.0;c
+            1970-01-01T02:00:00.000+01:00;2;5.0;
+            1970-01-01T04:00:00.000+01:00;2;6.0;d
+            """;
 
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv);
 
@@ -123,14 +127,15 @@ class TimeSeriesTest {
 
     @Test
     void testFractionsOfSecondsRegularTimeSeriesIndex() {
-        String csv = String.join(System.lineSeparator(),
-                "Time;Version;ts1;ts2",
-                "0.000;1;1.0;",
-                "0.001;1;;a",
-                "0.002;1;3.0;b",
-                "0.000;2;4.0;c",
-                "0.001;2;5.0;",
-                "0.002;2;6.0;d") + System.lineSeparator();
+        String csv = """
+                Time;Version;ts1;ts2
+                0.000;1;1.0;
+                0.001;1;;a
+                0.002;1;3.0;b
+                0.000;2;4.0;c
+                0.001;2;5.0;
+                0.002;2;6.0;d
+                """;
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', true, TimeFormat.FRACTIONS_OF_SECOND, true);
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv, timeSeriesCsvConfig);
@@ -140,16 +145,17 @@ class TimeSeriesTest {
 
     @Test
     void testFractionsOfSecondsRegularTimeSeriesIndexWithDuplicateTime() {
-        String csv = String.join(System.lineSeparator(),
-                "Time;Version;ts1;ts2",
-                "0.000;1;1.0;",
-                "0.001;1;;a",
-                "0.0015;1;;b",
-                "0.002;1;3.0;b",
-                "0.000;2;4.0;c",
-                "0.0002;2;4.5;c",
-                "0.001;2;5.0;",
-                "0.002;2;6.0;d") + System.lineSeparator();
+        String csv = """
+                Time;Version;ts1;ts2
+                0.000;1;1.0;
+                0.001;1;;a
+                0.0015;1;;b
+                0.002;1;3.0;b
+                0.000;2;4.0;c
+                0.0002;2;4.5;c
+                0.001;2;5.0;
+                0.002;2;6.0;d
+                """;
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', true, TimeFormat.FRACTIONS_OF_SECOND, true);
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv, timeSeriesCsvConfig);
@@ -159,14 +165,15 @@ class TimeSeriesTest {
 
     @Test
     void testParseCsvBuffered() {
-        String csv = String.join(System.lineSeparator(),
-            "Time;Version;ts1;ts2",
-            "0.000;1;1.0;",
-            "0.001;1;;a",
-            "0.002;1;3.0;b",
-            "0.000;2;4.0;c",
-            "0.001;2;5.0;",
-            "0.002;2;6.0;d") + System.lineSeparator();
+        String csv = """
+                Time;Version;ts1;ts2
+                0.000;1;1.0;
+                0.001;1;;a
+                0.002;1;3.0;b
+                0.000;2;4.0;c
+                0.001;2;5.0;
+                0.002;2;6.0;d
+                """;
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', true, TimeFormat.FRACTIONS_OF_SECOND, true);
         try (BufferedReader reader = new BufferedReader(new StringReader(csv))) {
@@ -179,14 +186,15 @@ class TimeSeriesTest {
 
     @Test
     void testMillisIrregularTimeSeriesIndex() {
-        String csv = String.join(System.lineSeparator(),
-                "Time;Version;ts1;ts2",
-                "0;1;1.0;",
-                "1;1;;a",
-                "4;1;3.0;b",
-                "0;2;4.0;c",
-                "1;2;5.0;",
-                "4;2;6.0;d") + System.lineSeparator();
+        String csv = """
+                Time;Version;ts1;ts2
+                0;1;1.0;
+                1;1;;a
+                4;1;3.0;b
+                0;2;4.0;c
+                1;2;5.0;
+                4;2;6.0;d
+                """;
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', true, TimeFormat.MILLIS);
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv, timeSeriesCsvConfig);
@@ -196,14 +204,15 @@ class TimeSeriesTest {
 
     @Test
     void testNoVersion() {
-        String csv = String.join(System.lineSeparator(),
-            "Time;ts1;ts2",
-            "1970-01-01T01:00:00.000+01:00;1.0;",
-            "1970-01-01T02:00:00.000+01:00;;a",
-            "1970-01-01T03:00:00.000+01:00;3.0;b",
-            "1970-01-01T04:00:00.000+01:00;4.0;c",
-            "1970-01-01T05:00:00.000+01:00;5.0;",
-            "1970-01-01T06:00:00.000+01:00;6.0;d") + System.lineSeparator();
+        String csv = """
+            Time;ts1;ts2
+            1970-01-01T01:00:00.000+01:00;1.0;
+            1970-01-01T02:00:00.000+01:00;;a
+            1970-01-01T03:00:00.000+01:00;3.0;b
+            1970-01-01T04:00:00.000+01:00;4.0;c
+            1970-01-01T05:00:00.000+01:00;5.0;
+            1970-01-01T06:00:00.000+01:00;6.0;d
+            """;
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', false, TimeFormat.DATE_TIME);
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv, timeSeriesCsvConfig);
@@ -225,14 +234,15 @@ class TimeSeriesTest {
 
     @Test
     void testVersionedAtDefaultNumberNotStrictCSV() {
-        String csv = String.join(System.lineSeparator(),
-            "Time;Version;ts1;ts2",
-            "0.000;-1;1.0;",
-            "0.001;-1;;a",
-            "0.002;-1;3.0;b",
-            "0.000;2;4.0;c",
-            "0.001;2;5.0;",
-            "0.002;2;6.0;d") + System.lineSeparator();
+        String csv = """
+            Time;Version;ts1;ts2
+            0.000;-1;1.0;
+            0.001;-1;;a
+            0.002;-1;3.0;b
+            0.000;2;4.0;c
+            0.001;2;5.0;
+            0.002;2;6.0;d
+            """;
 
         // Reporter
         ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestVersionedAtDefaultNumberNotStrictCSV", "Testing reportNode TimeSeriesImport with wrong version number").build();
@@ -252,14 +262,15 @@ class TimeSeriesTest {
 
     @Test
     void testVersionedAtDefaultNumberStrictCSV() {
-        String csv = String.join(System.lineSeparator(),
-            "Time;Version;ts1;ts2",
-            "0.000;-1;1.0;",
-            "0.001;-1;;a",
-            "0.002;-1;3.0;b",
-            "0.000;2;4.0;c",
-            "0.001;2;5.0;",
-            "0.002;2;6.0;d") + System.lineSeparator();
+        String csv = """
+                Time;Version;ts1;ts2
+                0.000;-1;1.0;
+                0.001;-1;;a
+                0.002;-1;3.0;b
+                0.000;2;4.0;c
+                0.001;2;5.0;
+                0.002;2;6.0;d
+                """;
 
         // Reporter
         ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestVersionedAtDefaultNumberNotStrictCSV", "Testing reportNode TimeSeriesImport with wrong version number").build();
@@ -291,56 +302,62 @@ class TimeSeriesTest {
         String emptyCsv = "";
         assertThatCode(() -> TimeSeries.parseCsv(emptyCsv)).hasMessage("CSV header is missing").isInstanceOf(TimeSeriesException.class);
 
-        String badHeaderNoTime = String.join(System.lineSeparator(),
-            "NoTime;ts1;ts2",
-            "1970-01-01T01:00:00.000+01:00;1.0;",
-            "1970-01-01T02:00:00.000+01:00;;a",
-            "1970-01-01T03:00:00.000+01:00;3.0;b",
-            "1970-01-01T04:00:00.000+01:00;4.0;c",
-            "1970-01-01T05:00:00.000+01:00;5.0;",
-            "1970-01-01T06:00:00.000+01:00;6.0;d") + System.lineSeparator();
+        String badHeaderNoTime = """
+            NoTime;ts1;ts2
+            1970-01-01T01:00:00.000+01:00;1.0;
+            1970-01-01T02:00:00.000+01:00;;a
+            1970-01-01T03:00:00.000+01:00;3.0;b
+            1970-01-01T04:00:00.000+01:00;4.0;c
+            1970-01-01T05:00:00.000+01:00;5.0;
+            1970-01-01T06:00:00.000+01:00;6.0;d
+            """;
         assertThatCode(() -> TimeSeries.parseCsv(badHeaderNoTime, timeSeriesCsvConfig)).hasMessage("Bad CSV header, should be \ntime;...").isInstanceOf(TimeSeriesException.class);
 
-        String badHeaderNoVersion = String.join(System.lineSeparator(),
-            "Time;NoVersion;ts1;ts2",
-            "1970-01-01T01:00:00.000+01:00;1;1.0;",
-            "1970-01-01T02:00:00.000+01:00;1;;a",
-            "1970-01-01T03:00:00.000+01:00;1;3.0;b",
-            "1970-01-01T01:00:00.000+01:00;2;4.0;c",
-            "1970-01-01T02:00:00.000+01:00;2;5.0;",
-            "1970-01-01T03:00:00.000+01:00;2;6.0;d") + System.lineSeparator();
+        String badHeaderNoVersion = """
+            Time;NoVersion;ts1;ts2
+            1970-01-01T01:00:00.000+01:00;1;1.0;
+            1970-01-01T02:00:00.000+01:00;1;;a
+            1970-01-01T03:00:00.000+01:00;1;3.0;b
+            1970-01-01T01:00:00.000+01:00;2;4.0;c
+            1970-01-01T02:00:00.000+01:00;2;5.0;
+            1970-01-01T03:00:00.000+01:00;2;6.0;d
+            """;
         assertThatCode(() -> TimeSeries.parseCsv(badHeaderNoVersion)).hasMessage("Bad CSV header, should be \ntime;version;...").isInstanceOf(TimeSeriesException.class);
 
-        String duplicates = String.join(System.lineSeparator(),
-            "Time;Version;ts1;ts1",
-            "1970-01-01T01:00:00.000+01:00;1;1.0;",
-            "1970-01-01T02:00:00.000+01:00;1;;a",
-            "1970-01-01T03:00:00.000+01:00;1;3.0;b",
-            "1970-01-01T01:00:00.000+01:00;2;4.0;c",
-            "1970-01-01T02:00:00.000+01:00;2;5.0;",
-            "1970-01-01T03:00:00.000+01:00;2;6.0;d") + System.lineSeparator();
+        String duplicates = """
+            Time;Version;ts1;ts1
+            1970-01-01T01:00:00.000+01:00;1;1.0;
+            1970-01-01T02:00:00.000+01:00;1;;a
+            1970-01-01T03:00:00.000+01:00;1;3.0;b
+            1970-01-01T01:00:00.000+01:00;2;4.0;c
+            1970-01-01T02:00:00.000+01:00;2;5.0;
+            1970-01-01T03:00:00.000+01:00;2;6.0;d
+            """;
         assertThatCode(() -> TimeSeries.parseCsv(duplicates)).hasMessageContaining("Bad CSV header, there are duplicates in time series names").isInstanceOf(TimeSeriesException.class);
 
-        String noData = String.join(System.lineSeparator(),
-            "Time;Version",
-            "1970-01-01T01:00:00.000+01:00;1",
-            "1970-01-01T02:00:00.000+01:00;1",
-            "1970-01-01T03:00:00.000+01:00;1",
-            "1970-01-01T01:00:00.000+01:00;2",
-            "1970-01-01T02:00:00.000+01:00;2",
-            "1970-01-01T03:00:00.000+01:00;2") + System.lineSeparator();
+        String noData = """
+            Time;Version
+            1970-01-01T01:00:00.000+01:00;1
+            1970-01-01T02:00:00.000+01:00;1
+            1970-01-01T03:00:00.000+01:00;1
+            1970-01-01T01:00:00.000+01:00;2
+            1970-01-01T02:00:00.000+01:00;2
+            1970-01-01T03:00:00.000+01:00;2
+            """;
         assertThatCode(() -> TimeSeries.parseCsv(noData)).hasMessageContaining("Bad CSV header, should be \ntime;version;...").isInstanceOf(TimeSeriesException.class);
 
-        String onlyOneTime = String.join(System.lineSeparator(),
-            "Time;ts1",
-            "1970-01-01T03:00:00.000+01:00;2.0") + System.lineSeparator();
+        String onlyOneTime = """
+            Time;ts1
+            1970-01-01T03:00:00.000+01:00;2.0
+            """;
         assertThatCode(() -> TimeSeries.parseCsv(onlyOneTime, timeSeriesCsvConfig)).hasMessageContaining("At least 2 rows are expected").isInstanceOf(TimeSeriesException.class);
 
-        String unexpectedTokens = String.join(System.lineSeparator(),
-            "Time;ts1;ts2",
-            "1970-01-01T01:00:00.000+01:00;1.0;3.2",
-            "1970-01-01T02:00:00.000+01:00;2.0",
-            "1970-01-01T03:00:00.000+01:00;2.0;1.0") + System.lineSeparator();
+        String unexpectedTokens = """
+            Time;ts1;ts2
+            1970-01-01T01:00:00.000+01:00;1.0;3.2
+            1970-01-01T02:00:00.000+01:00;2.0
+            1970-01-01T03:00:00.000+01:00;2.0;1.0
+            """;
         assertThatCode(() -> TimeSeries.parseCsv(unexpectedTokens, timeSeriesCsvConfig)).hasMessageContaining("Columns of line 1 are inconsistent with header").isInstanceOf(TimeSeriesException.class);
 
         Path path = Path.of("wrongPath.csv");

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
@@ -107,7 +107,7 @@ class TimeSeriesTest {
 
     @Test
     void testTimeSeriesNameMissing() {
-        String csv = """    
+        String csv = """
             Time;Version;;ts2
             1970-01-01T01:00:00.000+01:00;1;1.0;
             1970-01-01T02:00:00.000+01:00;1;;a

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/TimeSeriesTest.java
@@ -69,7 +69,7 @@ class TimeSeriesTest {
                 1970-01-01T01:00:00.000+01:00;2;4.0;c
                 1970-01-01T02:00:00.000+01:00;2;5.0;
                 1970-01-01T03:00:00.000+01:00;2;6.0;d
-                """;
+                """.replaceAll("\n", System.lineSeparator());
 
         String csvWithQuotes = """
                 "Time";"Version";"ts1";"ts2"
@@ -79,7 +79,7 @@ class TimeSeriesTest {
                 "1970-01-01T01:00:00.000+01:00";"2";"4.0";"c"
                 "1970-01-01T02:00:00.000+01:00";"2";"5.0";
                 "1970-01-01T03:00:00.000+01:00";"2";"6.0";"d"
-                """;
+                """.replaceAll("\n", System.lineSeparator());
 
         Arrays.asList(csv, csvWithQuotes).forEach(data -> {
             Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(data);
@@ -98,7 +98,7 @@ class TimeSeriesTest {
                 1970-01-01T01:00:00.000+01:00;2;4.0;c
                 1970-01-01T02:00:00.000+01:00;2;5.0;
                 1970-01-01T04:00:00.000+01:00;2;6.0;d
-                """;
+                """.replaceAll("\n", System.lineSeparator());
 
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv);
 
@@ -115,7 +115,7 @@ class TimeSeriesTest {
             1970-01-01T01:00:00.000+01:00;2;4.0;c
             1970-01-01T02:00:00.000+01:00;2;5.0;
             1970-01-01T04:00:00.000+01:00;2;6.0;d
-            """;
+            """.replaceAll("\n", System.lineSeparator());
 
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv);
 
@@ -135,7 +135,7 @@ class TimeSeriesTest {
                 0.000;2;4.0;c
                 0.001;2;5.0;
                 0.002;2;6.0;d
-                """;
+                """.replaceAll("\n", System.lineSeparator());
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', true, TimeFormat.FRACTIONS_OF_SECOND, true);
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv, timeSeriesCsvConfig);
@@ -155,7 +155,7 @@ class TimeSeriesTest {
                 0.0002;2;4.5;c
                 0.001;2;5.0;
                 0.002;2;6.0;d
-                """;
+                """.replaceAll("\n", System.lineSeparator());
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', true, TimeFormat.FRACTIONS_OF_SECOND, true);
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv, timeSeriesCsvConfig);
@@ -173,7 +173,7 @@ class TimeSeriesTest {
                 0.000;2;4.0;c
                 0.001;2;5.0;
                 0.002;2;6.0;d
-                """;
+                """.replaceAll("\n", System.lineSeparator());
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', true, TimeFormat.FRACTIONS_OF_SECOND, true);
         try (BufferedReader reader = new BufferedReader(new StringReader(csv))) {
@@ -194,7 +194,7 @@ class TimeSeriesTest {
                 0;2;4.0;c
                 1;2;5.0;
                 4;2;6.0;d
-                """;
+                """.replaceAll("\n", System.lineSeparator());
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', true, TimeFormat.MILLIS);
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv, timeSeriesCsvConfig);
@@ -212,7 +212,7 @@ class TimeSeriesTest {
             1970-01-01T04:00:00.000+01:00;4.0;c
             1970-01-01T05:00:00.000+01:00;5.0;
             1970-01-01T06:00:00.000+01:00;6.0;d
-            """;
+            """.replaceAll("\n", System.lineSeparator());
 
         TimeSeriesCsvConfig timeSeriesCsvConfig = new TimeSeriesCsvConfig(';', false, TimeFormat.DATE_TIME);
         Map<Integer, List<TimeSeries>> timeSeriesPerVersion = TimeSeries.parseCsv(csv, timeSeriesCsvConfig);
@@ -242,7 +242,7 @@ class TimeSeriesTest {
             0.000;2;4.0;c
             0.001;2;5.0;
             0.002;2;6.0;d
-            """;
+            """.replaceAll("\n", System.lineSeparator());
 
         // Reporter
         ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestVersionedAtDefaultNumberNotStrictCSV", "Testing reportNode TimeSeriesImport with wrong version number").build();
@@ -270,7 +270,7 @@ class TimeSeriesTest {
                 0.000;2;4.0;c
                 0.001;2;5.0;
                 0.002;2;6.0;d
-                """;
+                """.replaceAll("\n", System.lineSeparator());
 
         // Reporter
         ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("reportTestVersionedAtDefaultNumberNotStrictCSV", "Testing reportNode TimeSeriesImport with wrong version number").build();
@@ -310,7 +310,7 @@ class TimeSeriesTest {
             1970-01-01T04:00:00.000+01:00;4.0;c
             1970-01-01T05:00:00.000+01:00;5.0;
             1970-01-01T06:00:00.000+01:00;6.0;d
-            """;
+            """.replaceAll("\n", System.lineSeparator());
         assertThatCode(() -> TimeSeries.parseCsv(badHeaderNoTime, timeSeriesCsvConfig)).hasMessage("Bad CSV header, should be \ntime;...").isInstanceOf(TimeSeriesException.class);
 
         String badHeaderNoVersion = """
@@ -321,7 +321,7 @@ class TimeSeriesTest {
             1970-01-01T01:00:00.000+01:00;2;4.0;c
             1970-01-01T02:00:00.000+01:00;2;5.0;
             1970-01-01T03:00:00.000+01:00;2;6.0;d
-            """;
+            """.replaceAll("\n", System.lineSeparator());
         assertThatCode(() -> TimeSeries.parseCsv(badHeaderNoVersion)).hasMessage("Bad CSV header, should be \ntime;version;...").isInstanceOf(TimeSeriesException.class);
 
         String duplicates = """
@@ -332,7 +332,7 @@ class TimeSeriesTest {
             1970-01-01T01:00:00.000+01:00;2;4.0;c
             1970-01-01T02:00:00.000+01:00;2;5.0;
             1970-01-01T03:00:00.000+01:00;2;6.0;d
-            """;
+            """.replaceAll("\n", System.lineSeparator());
         assertThatCode(() -> TimeSeries.parseCsv(duplicates)).hasMessageContaining("Bad CSV header, there are duplicates in time series names").isInstanceOf(TimeSeriesException.class);
 
         String noData = """
@@ -343,13 +343,13 @@ class TimeSeriesTest {
             1970-01-01T01:00:00.000+01:00;2
             1970-01-01T02:00:00.000+01:00;2
             1970-01-01T03:00:00.000+01:00;2
-            """;
+            """.replaceAll("\n", System.lineSeparator());
         assertThatCode(() -> TimeSeries.parseCsv(noData)).hasMessageContaining("Bad CSV header, should be \ntime;version;...").isInstanceOf(TimeSeriesException.class);
 
         String onlyOneTime = """
             Time;ts1
             1970-01-01T03:00:00.000+01:00;2.0
-            """;
+            """.replaceAll("\n", System.lineSeparator());
         assertThatCode(() -> TimeSeries.parseCsv(onlyOneTime, timeSeriesCsvConfig)).hasMessageContaining("At least 2 rows are expected").isInstanceOf(TimeSeriesException.class);
 
         String unexpectedTokens = """
@@ -357,7 +357,7 @@ class TimeSeriesTest {
             1970-01-01T01:00:00.000+01:00;1.0;3.2
             1970-01-01T02:00:00.000+01:00;2.0
             1970-01-01T03:00:00.000+01:00;2.0;1.0
-            """;
+            """.replaceAll("\n", System.lineSeparator());
         assertThatCode(() -> TimeSeries.parseCsv(unexpectedTokens, timeSeriesCsvConfig)).hasMessageContaining("Columns of line 1 are inconsistent with header").isInstanceOf(TimeSeriesException.class);
 
         Path path = Path.of("wrongPath.csv");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`TimeSeries` can be created with duplicate time index value.


**What is the new behavior (if this is a feature change)?**
Skipped row when duplicate time index is found during CSV `timeseries` parsing
Throws exception in `IrregularTimeSeriesIndex` if the times array contains duplicate or is unordered

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Linked to a practical case in powsybl-dynawo PR [413](https://github.com/powsybl/powsybl-dynawo/pull/413)