### PR TITLE
Fix missing buses in bus breaker view

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerTopologyModel.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeBreakerTopologyModel.java
@@ -313,10 +313,8 @@ class NodeBreakerTopologyModel extends AbstractTopologyModel {
             Map<String, CalculatedBus> id2bus = new LinkedHashMap<>();
             CalculatedBus[] node2bus = new CalculatedBus[graph.getVertexCapacity()];
             boolean[] encountered = new boolean[graph.getVertexCapacity()];
-            Arrays.fill(encountered, false);
-            for (int e : graph.getEdges()) {
-                traverse(graph.getEdgeVertex1(e), encountered, terminate, id2bus, node2bus);
-                traverse(graph.getEdgeVertex2(e), encountered, terminate, id2bus, node2bus);
+            for (int v : graph.getVertices()) {
+                traverse(v, encountered, terminate, id2bus, node2bus);
             }
             busCache = new BusCache(node2bus, id2bus);
             LOGGER.trace("Found buses {}", id2bus.values());

--- a/iidm/iidm-serde/src/test/resources/V1_13/fictitiousSwitchRef-bbk.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_13/fictitiousSwitchRef-bbk.xml
@@ -13,11 +13,11 @@
             <iidm:busBreakerTopology>
                 <iidm:bus id="N_0" v="236.44736" angle="15.250391"/>
                 <iidm:bus id="N_1" v="236.44736" angle="15.250391"/>
-                <iidm:bus id="N_11"/>
-                <iidm:bus id="N_13"/>
                 <iidm:bus id="N_2"/>
                 <iidm:bus id="N_3"/>
+                <iidm:bus id="N_11"/>
                 <iidm:bus id="N_12"/>
+                <iidm:bus id="N_13"/>
                 <iidm:bus id="N_14"/>
                 <iidm:switch id="BJ" name="BK" kind="BREAKER" retained="true" open="false" bus1="N_1" bus2="N_0"/>
             </iidm:busBreakerTopology>

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNodeBreakerTest.java
@@ -454,11 +454,19 @@ public abstract class AbstractNodeBreakerTest {
         assertFalse(g2.getTerminal().disconnect(SwitchPredicates.IS_NONFICTIONAL_CLOSED_BREAKER));
     }
 
-    private static Bus getBus(Injection i) {
+    private static Bus getBusInBusBreakerView(Injection<?> i) {
+        return i.getTerminal().getBusBreakerView().getBus();
+    }
+
+    private static Bus getBusInBusView(Injection<?> i) {
         return i.getTerminal().getBusView().getBus();
     }
 
-    private static Bus getConnectableBus(Injection i) {
+    private static Bus getConnectableBusInBusBreakerView(Injection<?> i) {
+        return i.getTerminal().getBusBreakerView().getConnectableBus();
+    }
+
+    private static Bus getConnectableBusInBusView(Injection<?> i) {
         return i.getTerminal().getBusView().getConnectableBus();
     }
 
@@ -493,7 +501,7 @@ public abstract class AbstractNodeBreakerTest {
 
         // Check thew load is connected to the correct bus bar.
         BusbarSection bb = vl.getNodeBreakerView().getBusbarSection("voltageLevel1BusbarSection1");
-        assertEquals(getBus(bb), getBus(l2));
+        assertEquals(getBusInBusView(bb), getBusInBusView(l2));
     }
 
     @Test
@@ -502,24 +510,39 @@ public abstract class AbstractNodeBreakerTest {
         assertEquals(2, network.getBusView().getBusStream().count());
 
         // load "L0" is connected to bus "VL_0"
-        assertNotNull(getBus(network.getLoad("L0")));
-        assertEquals("VL_0", getConnectableBus(network.getLoad("L0")).getId());
+        Load l0 = network.getLoad("L0");
+        assertNotNull(getBusInBusBreakerView(l0));
+        assertEquals("VL_0", getConnectableBusInBusBreakerView(l0).getId());
+        assertNotNull(getBusInBusView(l0));
+        assertEquals("VL_0", getConnectableBusInBusView(l0).getId());
 
         // load "L1" is connected to bus "VL_1"
-        assertNotNull(getBus(network.getLoad("L1")));
-        assertEquals("VL_1", getConnectableBus(network.getLoad("L1")).getId());
+        Load l1 = network.getLoad("L1");
+        assertNotNull(getBusInBusBreakerView(l1));
+        assertEquals("VL_1", getConnectableBusInBusBreakerView(l1).getId());
+        assertNotNull(getBusInBusView(l1));
+        assertEquals("VL_1", getConnectableBusInBusView(l1).getId());
 
         // load "L2" is not connected but is connectable to bus "VL_1"
-        assertNull(getBus(network.getLoad("L2")));
-        assertEquals("VL_1", getConnectableBus(network.getLoad("L2")).getId());
+        Load l2 = network.getLoad("L2");
+        assertNotNull(getBusInBusBreakerView(l2));
+        assertEquals("VL_4", getConnectableBusInBusBreakerView(l2).getId());
+        assertNull(getBusInBusView(l2));
+        assertEquals("VL_1", getConnectableBusInBusView(l2).getId());
 
         // load "L3" is not connected and has no connectable bus (the first bus is taken as connectable bus in this case)
-        assertNull(getBus(network.getLoad("L3")));
-        assertEquals("VL_0", getConnectableBus(network.getLoad("L3")).getId());
+        Load l3 = network.getLoad("L3");
+        assertNotNull(getBusInBusBreakerView(l3));
+        assertEquals("VL_5", getConnectableBusInBusBreakerView(l3).getId());
+        assertNull(getBusInBusView(l3));
+        assertEquals("VL_0", getConnectableBusInBusView(l3).getId());
 
         // load "L4" is not connected, has no connectable bus and is in a disconnected voltage level
-        assertNull(getBus(network.getLoad("L4")));
-        assertNull(getConnectableBus(network.getLoad("L4")));
+        Load l4 = network.getLoad("L4");
+        assertNotNull(getBusInBusBreakerView(l4));
+        assertEquals("VL2_0", getConnectableBusInBusBreakerView(l4).getId());
+        assertNull(getBusInBusView(l4));
+        assertNull(getConnectableBusInBusView(l4));
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
Connectables which are not connected to any switch / internal connection in node breaker do not have a calculated bus in bus breaker view, whereas connectables which are connected to a dangling internal connection do have a calculated bus.

**What is the new behavior (if this is a feature change)?**
All connectables of a node breaker voltage level do have a calculated bus in bus breaker view (in particular connectables which are not connected to any switch / internal connection)

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No