### PR TITLE
Save GroundDisconnector CGMES switch kind in a property

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
@@ -111,17 +111,17 @@ public class SwitchConversion extends AbstractConductingEquipmentConversion impl
     }
 
     private SwitchKind kind() {
-        String type = p.getLocal("type").toLowerCase();
+        String type = p.getLocal("type");
         return switch (type) {
-            case "disconnector", "grounddisconnector", "jumper" -> SwitchKind.DISCONNECTOR;
-            case "loadbreakswitch" -> SwitchKind.LOAD_BREAK_SWITCH;
-            default -> SwitchKind.BREAKER;  // breaker, switch, protectedswitch
+            case "Disconnector", "GroundDisconnector", "Jumper" -> SwitchKind.DISCONNECTOR;
+            case "LoadBreakSwitch" -> SwitchKind.LOAD_BREAK_SWITCH;
+            default -> SwitchKind.BREAKER;  // Breaker, Switch, ProtectedSwitch
         };
     }
 
     private boolean kindHasDirectMapToIiidm() {
-        String type = p.getLocal("type").toLowerCase();
-        return type.equals("breaker") || type.equals("disconnector") || type.equals("loadbreakswitch");
+        String type = p.getLocal("type");
+        return type.equals("Breaker") || type.equals("Disconnector") || type.equals("LoadBreakSwitch");
     }
 
     private void addTypeAsProperty(Switch s) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
@@ -112,21 +112,16 @@ public class SwitchConversion extends AbstractConductingEquipmentConversion impl
 
     private SwitchKind kind() {
         String type = p.getLocal("type").toLowerCase();
-        if (type.contains("breaker")) {
-            return SwitchKind.BREAKER;
-        } else if (type.contains("disconnector")) {
-            return SwitchKind.DISCONNECTOR;
-        } else if (type.contains("loadbreak")) {
-            return SwitchKind.LOAD_BREAK_SWITCH;
-        } else if (type.contains("jumper")) {
-            return SwitchKind.DISCONNECTOR;
-        }
-        return SwitchKind.BREAKER;
+        return switch (type) {
+            case "disconnector", "grounddisconnector", "jumper" -> SwitchKind.DISCONNECTOR;
+            case "loadbreakswitch" -> SwitchKind.LOAD_BREAK_SWITCH;
+            default -> SwitchKind.BREAKER;  // breaker, switch, protectedswitch
+        };
     }
 
     private boolean kindHasDirectMapToIiidm() {
         String type = p.getLocal("type").toLowerCase();
-        return type.contains("breaker") || type.contains("disconnector") || type.contains("loadbreak");
+        return type.equals("breaker") || type.equals("disconnector") || type.equals("loadbreakswitch");
     }
 
     private void addTypeAsProperty(Switch s) {

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/SwitchConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/SwitchConversionTest.java
@@ -15,6 +15,10 @@ import com.powsybl.iidm.network.Switch;
 import com.powsybl.iidm.network.SwitchKind;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import static com.powsybl.cgmes.conversion.test.ConversionUtil.getUniqueMatches;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -33,5 +37,15 @@ class SwitchConversionTest extends AbstractSerDeTest {
         assertEquals("opened jumper", aswitch.getNameOrId());
         assertTrue(aswitch.isOpen());
         assertFalse(aswitch.isRetained());
+    }
+
+    @Test
+    void groundDisconnectorTest() throws IOException {
+        Network network = ConversionUtil.readCgmesResources("/", "groundTest.xml");
+        assertEquals("GroundDisconnector", network.getSwitch("CO").getProperty("CGMES.switchType"));
+
+        String eqFile = ConversionUtil.writeCgmesProfile(network, "EQ", tmpDir);
+        Pattern pattern = Pattern.compile("(<cim:GroundDisconnector rdf:ID=\"_CO\">)");
+        assertEquals(1, getUniqueMatches(eqFile, pattern).size());
     }
 }

--- a/docs/grid_exchange_formats/cgmes/import.md
+++ b/docs/grid_exchange_formats/cgmes/import.md
@@ -400,17 +400,16 @@ A PowSyBl [`VoltagePerReactivePowerControl`](../../grid_model/extensions.md#volt
 <span style="color: red">TODO regulation</span>
 
 (cgmes-switch-import)=
-### Switch (Switch, Breaker, Disconnector, LoadBreakSwitch, ProtectedSwitch, GroundDisconnector)
+### Switch (Switch, Breaker, Disconnector, LoadBreakSwitch, ProtectedSwitch, GroundDisconnector, Jumper)
 
-Switches, breakers, disconnectors, load break switches, protected switches and ground disconnectors are
+Switches, breakers, disconnectors, load break switches, protected switches, jumpers and ground disconnectors are
 all imported in the same manner. For convenience purposes, we will now use `Switch` as a say but keep in mind that this section is valid for all these CGMES classes.
 
 If the `Switch` has its ends both inside the same voltage level, it is mapped to a PowSyBl [`Switch`](../../grid_model/network_subnetwork.md#breakerswitch) with attributes as described below:
 - `SwitchKind` is defined depending on the CGMES class
-  - If it is a CGMES `Breaker`, it is `BREAKER`
-  - If it is a CGMES `Disconnector`, it is `DISCONNECTOR`
+  - If it is a CGMES `Breaker`, `Switch` or `ProtectedSwitch`, it is `BREAKER`
+  - If it is a CGMES `Disconnector`, `GroundDisconnector` or `Jumper` it is `DISCONNECTOR`
   - If it is a CGMES `LoadBreakSwitch`, it is `LOAD_BREAK_SWITCH`
-  - Otherwise, it is `BREAKER`
 - `Retained` is copied from CGMES `retained` if defined in node-breaker. Else, it is `false`.
 - `Open` is copied from CGMES SSH `open` if defined. Else, it is copied from CGMES `normalOpen`. If neither are defined, it is `false`.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
A CGMES GroundDisconnector is imported in IIDM as a `Switch` with kind `SwitchKind.DISCONNECTOR`, which is intended. However, the original CGMES switch type is not saved in the `CGMES.switchType` property in IIDM, and as a consequence it is exported back to CGMES as Disconnector instead of GroundDisconnector.


**What is the new behavior (if this is a feature change)?**
<!-- -->
GroundDisconnector CGMES switch type is saved in IIDM during import. Thus, GroundDisconnector can be reexported as such in CGMES.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
