### PR TITLE
Replace CGMES.switchType property by CGMES.originalClass property.

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java
@@ -125,7 +125,7 @@ public class SwitchConversion extends AbstractConductingEquipmentConversion impl
     }
 
     private void addTypeAsProperty(Switch s) {
-        s.setProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "switchType", p.getLocal("type"));
+        s.setProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS, p.getLocal("type"));
     }
 
     private void warnDanglingLineCreated() {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -196,7 +196,7 @@ public final class EquipmentExport {
         for (Switch sw : network.getSwitches()) {
             if (context.isExportedEquipment(sw)) {
                 VoltageLevel vl = sw.getVoltageLevel();
-                String switchType = sw.getProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "switchType"); // may be null
+                String switchType = sw.getProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS); // may be null
                 // To ensure we do not violate rule SwitchTN1 of ENTSO-E QoCDC,
                 // we only export as retained a switch if it will be exported with different TNs at both ends
                 boolean exportAsRetained = sw.isRetained() && hasDifferentTNsAtBothEnds(sw);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
@@ -578,7 +578,7 @@ public final class SteadyStateHypothesisExport {
 
     private static void writeSwitch(Switch sw, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) {
         try {
-            String switchType = sw.getProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "switchType");
+            String switchType = sw.getProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS);
             String className = switchType != null ? switchType : CgmesExportUtil.switchClassname(sw.getKind());
             CgmesExportUtil.writeStartAbout(className, context.getNamingStrategy().getCgmesId(sw), cimNamespace, writer, context);
             writer.writeStartElement(cimNamespace, "Switch.open");

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/SwitchConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/SwitchConversionTest.java
@@ -33,7 +33,7 @@ class SwitchConversionTest extends AbstractSerDeTest {
 
         Switch aswitch = network.getSwitch("Jumper");
         assertEquals(SwitchKind.DISCONNECTOR, aswitch.getKind());
-        assertEquals("Jumper", aswitch.getProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "switchType"));
+        assertEquals("Jumper", aswitch.getProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS));
         assertEquals("opened jumper", aswitch.getNameOrId());
         assertTrue(aswitch.isOpen());
         assertFalse(aswitch.isRetained());
@@ -42,7 +42,7 @@ class SwitchConversionTest extends AbstractSerDeTest {
     @Test
     void groundDisconnectorTest() throws IOException {
         Network network = ConversionUtil.readCgmesResources("/", "groundTest.xml");
-        assertEquals("GroundDisconnector", network.getSwitch("CO").getProperty("CGMES.switchType"));
+        assertEquals("GroundDisconnector", network.getSwitch("CO").getProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS));
 
         String eqFile = ConversionUtil.writeCgmesProfile(network, "EQ", tmpDir);
         Pattern pattern = Pattern.compile("(<cim:GroundDisconnector rdf:ID=\"_CO\">)");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Refactoring.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
At CGMES import, if the Switch kind doesn't have a direct map to IIDM, i.e. if its class is: Switch, ProtectedSwitch, GroundDisconnector, Jumper, then its CGMES original class is stored in a CGMES.switchType property. The purpose is to be able to export back to CGMES the object with the correct class.
Similarly, at CGMES import, the original CGMES class of load or generator is stored in a CGMES.originalClass property.


**What is the new behavior (if this is a feature change)?**
<!-- -->
For consistency purposes, drop the use of CGMES.switchType property in favor of CGMES.originalClass.


*Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section


**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

Any access to the `CGMES.switchType` property should be replaced with `CGMES.originalClass` property. For instance:
```java
String cgmesSwitchType = network.getSwitch("someSwitchUUID").getProperty("CGMES.switchType");
```
should be replaced by:
```java
String cgmesSwitchType = network.getSwitch("someSwitchUUID").getProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS);
```
Similarly, any network saved to a serialized IIDM file should be updated by replacing all occurences of `CGMES.switchType` with `CGMES.originalClass` property, in case the network needs to be exported to CGMES.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
