### PR TITLE
WIP: Add MATPOWER switch import

### DIFF
--- a/matpower/matpower-converter/src/test/java/com/powsybl/matpower/converter/MatpowerImporterTest.java
+++ b/matpower/matpower-converter/src/test/java/com/powsybl/matpower/converter/MatpowerImporterTest.java
@@ -156,6 +156,11 @@ class MatpowerImporterTest extends AbstractSerDeTest {
     }
 
     @Test
+    void testCase5Switch() throws IOException {
+        testCase(MatpowerModelFactory.create5Switch());
+    }
+
+    @Test
     void testNonexistentCase() {
         assertThrows(UncheckedIOException.class, () -> testNetwork(new MatpowerImporter().importData(new DirectoryDataSource(tmpDir, "unknown"), NetworkFactory.findDefault(), null)));
     }

--- a/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MSwitch.java
+++ b/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MSwitch.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.matpower.model;
+
+/**
+ *
+ * @author Caio Luke {@literal <caio.luke at rte-france.com>}
+ */
+public class MSwitch {
+
+    /**
+     * from bus number
+     */
+    private int from;
+
+    /**
+     * to bus number
+     */
+    private int to;
+
+    /**
+     * real power flow at “from” bus end (MW), “from” → “to”
+     */
+    private double psw;
+
+    /**
+     * reactive power flow at “from” bus end (MW), “from” → “to”
+     */
+    private double qsw;
+
+    /**
+     * initial switch state, 1 = closed, 0 = open
+     */
+    private int state;
+
+    /**
+     * MVA thermal rating, set to 0 for unlimited
+     */
+    private double thermalRating;
+
+    /**
+     * initial switch status, 1 = in-service, 0 = out-of-service
+     */
+    private int status;
+
+    public int getFrom() {
+        return from;
+    }
+
+    public void setFrom(int from) {
+        this.from = from;
+    }
+
+    public int getTo() {
+        return to;
+    }
+
+    public void setTo(int to) {
+        this.to = to;
+    }
+
+    public double getPsw() { return psw; }
+
+    public void setPsw(double psw) { this.psw = psw; }
+
+    public double getQsw() { return qsw; }
+
+    public void setQsw(double qsw) { this.qsw = qsw; }
+
+    public int getState() {
+        return state;
+    }
+
+    public void setState(int state) {
+        this.state = state;
+    }
+
+    public double getThermalRating() {
+        return thermalRating;
+    }
+
+    public void setThermalRating(double thermalRating) {
+        this.thermalRating = thermalRating;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+}

--- a/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MatpowerModel.java
+++ b/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MatpowerModel.java
@@ -34,6 +34,8 @@ public class MatpowerModel {
 
     private final List<MDcLine> dcLines = new ArrayList<>();
 
+    private final List<MSwitch> switches = new ArrayList<>();
+
     @JsonCreator
     public MatpowerModel(@JsonProperty("caseName") String caseName) {
         this.caseName = Objects.requireNonNull(caseName);
@@ -132,5 +134,14 @@ public class MatpowerModel {
     public void addDcLine(MDcLine dcLine) {
         Objects.requireNonNull(dcLine);
         dcLines.add(dcLine);
+    }
+
+    public List<MSwitch> getSwitches() {
+        return switches;
+    }
+
+    public void addSwitch(MSwitch mSwitch) {
+        Objects.requireNonNull(mSwitch);
+        switches.add(mSwitch);
     }
 }

--- a/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MatpowerModelFactory.java
+++ b/matpower/matpower-model/src/main/java/com/powsybl/matpower/model/MatpowerModelFactory.java
@@ -74,4 +74,8 @@ public final class MatpowerModelFactory {
     public static MatpowerModel create9Dcline() {
         return readModelJsonFromResources("t_case9_dcline.json");
     }
+
+    public static MatpowerModel create5Switch() {
+        return readModelJsonFromResources("t_case5_switch.json");
+    }
 }

--- a/matpower/matpower-model/src/test/java/com/powsybl/matpower/model/MatpowerReaderWriterTest.java
+++ b/matpower/matpower-model/src/test/java/com/powsybl/matpower/model/MatpowerReaderWriterTest.java
@@ -94,6 +94,11 @@ class MatpowerReaderWriterTest {
     }
 
     @Test
+    void testCase5Switch() throws IOException {
+        testMatpowerFile(MatpowerModelFactory.create5Switch());
+    }
+
+    @Test
     void testInvalidModel() {
         MatpowerModel model = new MatpowerModel("not-valid");
         model.setVersion(MatpowerFormatVersion.V1);
@@ -116,20 +121,20 @@ class MatpowerReaderWriterTest {
     void testRequiredColumns() {
         int generatorV2Columns = MatpowerFormatVersion.V2.getGeneratorColumns();
         assertEquals(MatpowerFormatVersion.V2,
-                     MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, generatorV2Columns, MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS).generatorVersion());
+                     MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, generatorV2Columns, MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS, MATPOWER_SWITCHES_COLUMNS).generatorVersion());
         assertEquals(MatpowerFormatVersion.V1,
-                MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, MatpowerFormatVersion.V1.getGeneratorColumns(), MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS).generatorVersion());
+                MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, MatpowerFormatVersion.V1.getGeneratorColumns(), MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS, MATPOWER_SWITCHES_COLUMNS).generatorVersion());
         assertEquals(MatpowerFormatVersion.V1,
-                MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, 12, MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS).generatorVersion());
+                MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, 12, MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS, MATPOWER_SWITCHES_COLUMNS).generatorVersion());
         assertEquals(MatpowerFormatVersion.V2,
-                MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, 23, MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS).generatorVersion());
-        var e = assertThrows(PowsyblException.class, () -> MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, 5, MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS));
+                MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, 23, MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS, MATPOWER_SWITCHES_COLUMNS).generatorVersion());
+        var e = assertThrows(PowsyblException.class, () -> MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, 5, MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS, MATPOWER_SWITCHES_COLUMNS));
         assertEquals("Unexpected number of columns for generators, expected at least 10 columns, but got 5", e.getMessage());
-        e = assertThrows(PowsyblException.class, () -> MatpowerReader.checkNumberOfColumns(4, generatorV2Columns, MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS));
+        e = assertThrows(PowsyblException.class, () -> MatpowerReader.checkNumberOfColumns(4, generatorV2Columns, MATPOWER_BRANCHES_COLUMNS, MATPOWER_DCLINES_COLUMNS, MATPOWER_SWITCHES_COLUMNS));
         assertEquals("Unexpected number of columns for buses, expected at least 13 columns, but got 4", e.getMessage());
-        e = assertThrows(PowsyblException.class, () -> MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, generatorV2Columns, 7, MATPOWER_DCLINES_COLUMNS));
+        e = assertThrows(PowsyblException.class, () -> MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, generatorV2Columns, 7, MATPOWER_DCLINES_COLUMNS, MATPOWER_SWITCHES_COLUMNS));
         assertEquals("Unexpected number of columns for branches, expected at least 13 columns, but got 7", e.getMessage());
-        e = assertThrows(PowsyblException.class, () -> MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, generatorV2Columns, MATPOWER_BRANCHES_COLUMNS, 13));
+        e = assertThrows(PowsyblException.class, () -> MatpowerReader.checkNumberOfColumns(MATPOWER_BUSES_COLUMNS, generatorV2Columns, MATPOWER_BRANCHES_COLUMNS, 13, MATPOWER_SWITCHES_COLUMNS));
         assertEquals("Unexpected number of columns for DC lines, expected at least 17 columns, but got 13", e.getMessage());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently, we don't import MATPOWER switches


**What is the new behavior (if this is a feature change)?**
We would import MATPOWER switches, which correspond to non impedant lines in Powsybl - as they are defined between buses and not between nodes of a bus.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No