### PR TITLE
Adding a method to loadflow provider for parameters update

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/AbstractNoSpecificParametersLoadFlowProvider.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/AbstractNoSpecificParametersLoadFlowProvider.java
@@ -53,6 +53,11 @@ public abstract class AbstractNoSpecificParametersLoadFlowProvider implements Lo
     }
 
     @Override
+    public void updateSpecificParameters(Extension<LoadFlowParameters> extension, PlatformConfig config) {
+        // nothing to do
+    }
+
+    @Override
     public List<Parameter> getSpecificParameters() {
         return Collections.emptyList();
     }

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
@@ -111,6 +111,11 @@ public interface LoadFlowProvider extends Versionable, PlatformConfigNamedProvid
     void updateSpecificParameters(Extension<LoadFlowParameters> extension, Map<String, String> properties);
 
     /**
+     * Updates implementation-specific parameters from a PlatformConfig
+     */
+    void updateSpecificParameters(Extension<LoadFlowParameters> extension, PlatformConfig config);
+
+    /**
      * Get the parameters of the parameters extension associated with this provider.
      *
      * @return the parameters of the parameters extension associated with this provider.

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowDefaultParametersLoaderTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowDefaultParametersLoaderTest.java
@@ -11,6 +11,7 @@ import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.commons.config.MapModuleConfig;
+import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.extensions.Extension;
 import com.powsybl.loadflow.json.JsonLoadFlowParametersTest;
 import org.junit.jupiter.api.Test;
@@ -19,8 +20,7 @@ import java.nio.file.FileSystem;
 import java.util.List;
 
 import static com.powsybl.loadflow.LoadFlowParameters.load;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Hugo Kulesza {@literal <hugo.kulesza at rte-france.com>}
@@ -64,5 +64,18 @@ class LoadFlowDefaultParametersLoaderTest {
         load(parameters, platformConfig);
         assertFalse(parameters.isUseReactiveLimits());
         assertEquals(LoadFlowParameters.VoltageInitMode.PREVIOUS_VALUES, parameters.getVoltageInitMode());
+    }
+
+    @Test
+    void testProviderParameters() {
+        LoadFlowDefaultParametersLoaderMock loader = new LoadFlowDefaultParametersLoaderMock("test");
+        LoadFlowParameters parameters = new LoadFlowParameters(List.of(loader));
+        load(parameters);
+        parameters.loadExtensions(PlatformConfig.defaultConfig());
+
+        JsonLoadFlowParametersTest.DummyExtension extension = parameters.getExtension(JsonLoadFlowParametersTest.DummyExtension.class);
+        assertNotNull(extension);
+        assertEquals(5, extension.getParameterDouble());
+
     }
 }

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderMock.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderMock.java
@@ -68,11 +68,7 @@ public class LoadFlowProviderMock implements LoadFlowProvider {
     @Override
     public Optional<Extension<LoadFlowParameters>> loadSpecificParameters(PlatformConfig config) {
         DummyExtension extension = new DummyExtension();
-        config.getOptionalModuleConfig("dummy-extension").ifPresent(moduleConfig -> {
-            extension.setParameterDouble(moduleConfig.getDoubleProperty(DOUBLE_PARAMETER_NAME, DummyExtension.PARAMETER_DOUBLE_DEFAULT_VALUE));
-            extension.setParameterBoolean(moduleConfig.getBooleanProperty(BOOLEAN_PARAMETER_NAME, DummyExtension.PARAMETER_BOOLEAN_DEFAULT_VALUE));
-            extension.setParameterString(moduleConfig.getStringProperty(STRING_PARAMETER_NAME, DummyExtension.PARAMETER_STRING_DEFAULT_VALUE));
-        });
+        updateSpecificParameters(extension, config);
         return Optional.of(extension);
     }
 
@@ -98,6 +94,18 @@ public class LoadFlowProviderMock implements LoadFlowProvider {
                 .ifPresent(prop -> ((DummyExtension) extension).setParameterBoolean(Boolean.parseBoolean(prop)));
         Optional.ofNullable(properties.get(STRING_PARAMETER_NAME))
                 .ifPresent(prop -> ((DummyExtension) extension).setParameterString(prop));
+    }
+
+    @Override
+    public void updateSpecificParameters(Extension<LoadFlowParameters> extension, PlatformConfig config) {
+        config.getOptionalModuleConfig("dummy-extension").ifPresent(moduleConfig -> {
+            moduleConfig.getOptionalDoubleProperty(DOUBLE_PARAMETER_NAME)
+                    .ifPresent(prop -> ((DummyExtension) extension).setParameterDouble(prop));
+            moduleConfig.getOptionalBooleanProperty(BOOLEAN_PARAMETER_NAME)
+                    .ifPresent(prop -> ((DummyExtension) extension).setParameterBoolean(prop));
+            moduleConfig.getOptionalStringProperty(STRING_PARAMETER_NAME)
+                    .ifPresent(prop -> ((DummyExtension) extension).setParameterString(prop));
+        });
     }
 
     @Override


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #3217 

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Anyone who created a LoadFlowProvider implementation must add to their implementation a new `void updateSpecificParameters(Extension<LoadFlowParameters> extension, PlatformConfig config)` method, that updates an existing specific parameters extension using the information found in the PlatformConfig provided.