### PR TITLE
Rework condition to better identify boundary subsets

### DIFF
--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesSubset.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/CgmesSubset.java
@@ -48,16 +48,17 @@ public enum CgmesSubset {
         @Override
         public boolean isValidName(String contextName) {
             return super.isValidName(contextName)
-                    || EQUIPMENT.isValidName(contextName) && isBoundary(contextName);
+                    || EQUIPMENT.isValidBaseName(contextName) && isBoundary(contextName);
         }
     },
     TOPOLOGY_BOUNDARY("TP_BD") {
         @Override
         public boolean isValidName(String contextName) {
             return super.isValidName(contextName)
-                    || TOPOLOGY.isValidName(contextName) && isBoundary(contextName);
+                    || TOPOLOGY.isValidBaseName(contextName) && isBoundary(contextName);
         }
-    }, UNKNOWN("unknown") {
+    },
+    UNKNOWN("unknown") {
         @Override
         public boolean isValidName(String contextName) {
             return false;
@@ -82,6 +83,10 @@ public enum CgmesSubset {
     }
 
     public boolean isValidName(String contextName) {
+        return isValidBaseName(contextName);
+    }
+
+    private boolean isValidBaseName(String contextName) {
         return contextName.contains(validName0) || contextName.contains(validName1);
     }
 

--- a/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesSubsetTest.java
+++ b/cgmes/cgmes-model/src/test/java/com/powsybl/cgmes/model/CgmesSubsetTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Romain Courtier {@literal <romain.courtier at rte-france.com>}
+ */
+class CgmesSubsetTest {
+
+    @Test
+    void isValidSubsetName() {
+        // Valid EQ name
+        assertTrue(CgmesSubset.EQUIPMENT.isValidName("20210325T1530Z_1D_BE_EQ_001.xml"));
+        assertTrue(CgmesSubset.EQUIPMENT.isValidName("IGM_EQ.xml"));
+
+        // Valid EQ_BD name
+        assertTrue(CgmesSubset.EQUIPMENT_BOUNDARY.isValidName("20171002T0930Z_ENTSO-E_EQ_BD_2.xml"));
+        assertTrue(CgmesSubset.EQUIPMENT_BOUNDARY.isValidName("BOUNDARY_EQ.xml"));
+
+        // Valid TP name
+        assertTrue(CgmesSubset.TOPOLOGY.isValidName("20210325T1530Z_1D_ASSEMBLED_TP_001.xml"));
+        assertTrue(CgmesSubset.TOPOLOGY.isValidName("IGM_TP.xml"));
+
+        // Valid TP_BD name
+        assertTrue(CgmesSubset.TOPOLOGY_BOUNDARY.isValidName("20171002T0930Z_ENTSO-E_TP_BD_2.xml"));
+        assertTrue(CgmesSubset.TOPOLOGY_BOUNDARY.isValidName("BOUNDARY_TP.xml"));
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #3295 


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes
- [X] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Boundary cgmes subsets were not always clearly identified.


**What is the new behavior (if this is a feature change)?**
Boundary cgmes subsets are now better identified.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
