### PR TITLE
ReportNode: change timestamp feature

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/report/AbstractReportNodeAdderOrBuilder.java
+++ b/commons/src/main/java/com/powsybl/commons/report/AbstractReportNodeAdderOrBuilder.java
@@ -9,6 +9,7 @@ package com.powsybl.commons.report;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
@@ -122,7 +123,7 @@ public abstract class AbstractReportNodeAdderOrBuilder<T extends ReportNodeAdder
     @Override
     public T withTimestamp(String pattern) {
         this.withTimestamp = true;
-        this.timestampPattern = pattern;
+        this.timestampPattern = Objects.requireNonNull(pattern);
         return self();
     }
 

--- a/commons/src/main/java/com/powsybl/commons/report/AbstractReportNodeAdderOrBuilder.java
+++ b/commons/src/main/java/com/powsybl/commons/report/AbstractReportNodeAdderOrBuilder.java
@@ -18,6 +18,7 @@ public abstract class AbstractReportNodeAdderOrBuilder<T extends ReportNodeAdder
     protected final Map<String, TypedValue> values = new LinkedHashMap<>();
     protected String key;
     protected String messageTemplate;
+    protected boolean withTimestamp = false;
 
     @Override
     public T withMessageTemplate(String key, String messageTemplate) {
@@ -108,6 +109,12 @@ public abstract class AbstractReportNodeAdderOrBuilder<T extends ReportNodeAdder
     @Override
     public T withSeverity(String severity) {
         values.put(ReportConstants.SEVERITY_KEY, TypedValue.of(severity, TypedValue.SEVERITY));
+        return self();
+    }
+
+    @Override
+    public T withTimestamp() {
+        this.withTimestamp = true;
         return self();
     }
 

--- a/commons/src/main/java/com/powsybl/commons/report/AbstractReportNodeAdderOrBuilder.java
+++ b/commons/src/main/java/com/powsybl/commons/report/AbstractReportNodeAdderOrBuilder.java
@@ -19,6 +19,7 @@ public abstract class AbstractReportNodeAdderOrBuilder<T extends ReportNodeAdder
     protected String key;
     protected String messageTemplate;
     protected boolean withTimestamp = false;
+    protected String timestampPattern;
 
     @Override
     public T withMessageTemplate(String key, String messageTemplate) {
@@ -115,6 +116,13 @@ public abstract class AbstractReportNodeAdderOrBuilder<T extends ReportNodeAdder
     @Override
     public T withTimestamp() {
         this.withTimestamp = true;
+        return self();
+    }
+
+    @Override
+    public T withTimestamp(String pattern) {
+        this.withTimestamp = true;
+        this.timestampPattern = pattern;
         return self();
     }
 

--- a/commons/src/main/java/com/powsybl/commons/report/ReportConstants.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportConstants.java
@@ -18,8 +18,8 @@ public final class ReportConstants {
     public static final String SEVERITY_KEY = "reportSeverity";
     public static final String TIMESTAMP_KEY = "reportTimestamp";
     public static final String DEFAULT_TIMESTAMP_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
-    public static final Locale DEFAULT_TIMESTAMP_LOCALE = Locale.US;
-    public static final DateTimeFormatter DEFAULT_TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern(DEFAULT_TIMESTAMP_PATTERN, DEFAULT_TIMESTAMP_LOCALE);
+    public static final Locale DEFAULT_LOCALE = Locale.US;
+    public static final DateTimeFormatter DEFAULT_TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern(DEFAULT_TIMESTAMP_PATTERN, DEFAULT_LOCALE);
     public static final ReportNodeVersion CURRENT_VERSION = ReportNodeVersion.V_2_1;
 
     private ReportConstants() {

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeAdderOrBuilder.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeAdderOrBuilder.java
@@ -136,8 +136,15 @@ public interface ReportNodeAdderOrBuilder<T extends ReportNodeAdderOrBuilder<T>>
     T withSeverity(String severity);
 
     /**
-     * Indicate that a timestamp should be added to the {@link ReportNode}.
+     * Indicate that a timestamp should be added to the {@link ReportNode} with default pattern (see {@link ReportConstants#DEFAULT_TIMESTAMP_PATTERN}).
      * @return a reference to this object
      */
     T withTimestamp();
+
+    /**
+     * Indicate that a timestamp should be added to the {@link ReportNode}.
+     * @param timestampPattern the pattern to use
+     * @return a reference to this object
+     */
+    T withTimestamp(String timestampPattern);
 }

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeAdderOrBuilder.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeAdderOrBuilder.java
@@ -7,6 +7,9 @@
  */
 package com.powsybl.commons.report;
 
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
 public interface ReportNodeAdderOrBuilder<T extends ReportNodeAdderOrBuilder<T>> {
 
     /**
@@ -136,14 +139,16 @@ public interface ReportNodeAdderOrBuilder<T extends ReportNodeAdderOrBuilder<T>>
     T withSeverity(String severity);
 
     /**
-     * Indicate that a timestamp should be added to the {@link ReportNode} with default pattern (see {@link ReportConstants#DEFAULT_TIMESTAMP_PATTERN}).
+     * Indicate that a timestamp should be added to the {@link ReportNode} with the default pattern from the
+     * corresponding {@link TreeContext}, which is defined when building the root {@link ReportNode}.
      * @return a reference to this object
      */
     T withTimestamp();
 
     /**
-     * Indicate that a timestamp should be added to the {@link ReportNode}.
-     * @param timestampPattern the pattern to use
+     * Indicate that a timestamp should be added to the {@link ReportNode}, with a pattern overriding the default
+     * pattern from the {@link TreeContext}.
+     * @param timestampPattern the pattern to use for the timestamp (see {@link DateTimeFormatter#ofPattern(String, Locale)}})
      * @return a reference to this object
      */
     T withTimestamp(String timestampPattern);

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeAdderOrBuilder.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeAdderOrBuilder.java
@@ -134,4 +134,10 @@ public interface ReportNodeAdderOrBuilder<T extends ReportNodeAdderOrBuilder<T>>
      * @return a reference to this object
      */
     T withSeverity(String severity);
+
+    /**
+     * Indicate that a timestamp should be added to the {@link ReportNode}.
+     * @return a reference to this object
+     */
+    T withTimestamp();
 }

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeBuilder.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeBuilder.java
@@ -18,33 +18,21 @@ import java.util.Locale;
 public interface ReportNodeBuilder extends ReportNodeAdderOrBuilder<ReportNodeBuilder> {
 
     /**
-     * Sets the pattern and the locale used for formatting timestamps (see {@link DateTimeFormatter#ofPattern(String, Locale)}}), if timestamps are enabled.
-     * If no pattern and locale are given, the default pattern {@link ReportConstants#DEFAULT_TIMESTAMP_PATTERN} and locale
-     * {@link ReportConstants#DEFAULT_TIMESTAMP_LOCALE} are used.
-     *
-     * @param timestampPattern : the pattern to use for the timestamp
-     * @param locale the locale to use for formatting the timestamp
-     * @return a reference to this object
-     */
-    ReportNodeBuilder withTimestampPattern(String timestampPattern, Locale locale);
-
-    /**
-     * Sets the pattern used for timestamps, if timestamps are enabled, with the default Locale {@link ReportConstants#DEFAULT_TIMESTAMP_LOCALE}.
+     * Sets the pattern used for timestamps, when a timestamp is added.
      * If no pattern is given, the default pattern {@link ReportConstants#DEFAULT_TIMESTAMP_PATTERN} is used.
+     * Note that the {@link Locale} used to format the timestamps is the one set by {@link #withLocale(Locale)}, or,
+     * if not set, the default Locale {@link ReportConstants#DEFAULT_LOCALE}.
      *
      * @param timestampPattern : the pattern to use for the timestamp (see {@link DateTimeFormatter#ofPattern(String, Locale)}})
      * @return a reference to this object
      */
-    default ReportNodeBuilder withTimestampPattern(String timestampPattern) {
-        return withTimestampPattern(timestampPattern, ReportConstants.DEFAULT_TIMESTAMP_LOCALE);
-    }
+    ReportNodeBuilder withTimestampPattern(String timestampPattern);
 
     /**
-     * Enable timestamps on build ReportNode and all descendants.
+     * Choose which {@link Locale} to use for formatting all the `ReportNode` messages of the tree.
      * @return a reference to this object
      */
-    ReportNodeBuilder withTimestamps(boolean enabled);
-
+    ReportNodeBuilder withLocale(Locale locale);
 
     /**
      * Build the corresponding {@link ReportNode}.

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeBuilder.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeBuilder.java
@@ -7,7 +7,6 @@
  */
 package com.powsybl.commons.report;
 
-import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
 /**
@@ -26,7 +25,7 @@ public interface ReportNodeBuilder extends ReportNodeAdderOrBuilder<ReportNodeBu
      * @param timestampPattern : the pattern to use for the timestamp (see {@link DateTimeFormatter#ofPattern(String, Locale)}})
      * @return a reference to this object
      */
-    ReportNodeBuilder withTimestampPattern(String timestampPattern);
+    ReportNodeBuilder withDefaultTimestampPattern(String timestampPattern);
 
     /**
      * Choose which {@link Locale} to use for formatting all the `ReportNode` messages of the tree.

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeBuilder.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeBuilder.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.commons.report;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
 /**
@@ -17,7 +18,7 @@ import java.util.Locale;
 public interface ReportNodeBuilder extends ReportNodeAdderOrBuilder<ReportNodeBuilder> {
 
     /**
-     * Sets the pattern used for timestamps, when a timestamp is added.
+     * Sets the pattern used for timestamps, when a timestamp is added with {@link ReportNodeAdder#withTimestamp()}.
      * If no pattern is given, the default pattern {@link ReportConstants#DEFAULT_TIMESTAMP_PATTERN} is used.
      * Note that the {@link Locale} used to format the timestamps is the one set by {@link #withLocale(Locale)}, or,
      * if not set, the default Locale {@link ReportConstants#DEFAULT_LOCALE}.

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeChildAdderImpl.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeChildAdderImpl.java
@@ -24,7 +24,7 @@ public class ReportNodeChildAdderImpl extends AbstractReportNodeAdderOrBuilder<R
 
     @Override
     public ReportNode add() {
-        ReportNodeImpl node = ReportNodeImpl.createChildReportNode(key, messageTemplate, values, withTimestamp, parent);
+        ReportNodeImpl node = ReportNodeImpl.createChildReportNode(key, messageTemplate, values, withTimestamp, timestampPattern, parent);
         parent.addChild(node);
         return node;
     }

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeChildAdderImpl.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeChildAdderImpl.java
@@ -24,7 +24,7 @@ public class ReportNodeChildAdderImpl extends AbstractReportNodeAdderOrBuilder<R
 
     @Override
     public ReportNode add() {
-        ReportNodeImpl node = ReportNodeImpl.createChildReportNode(key, messageTemplate, values, parent);
+        ReportNodeImpl node = ReportNodeImpl.createChildReportNode(key, messageTemplate, values, withTimestamp, parent);
         parent.addChild(node);
         return node;
     }

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeImpl.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeImpl.java
@@ -23,6 +23,7 @@ import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -49,24 +50,28 @@ public final class ReportNodeImpl implements ReportNode {
     private Collection<Map<String, TypedValue>> valuesMapsInheritance;
 
     static ReportNodeImpl createChildReportNode(String messageKey, String messageTemplate, Map<String, TypedValue> values,
-                                                boolean withTimestamp, ReportNodeImpl parent) {
+                                                boolean withTimestamp, String timestampPattern, ReportNodeImpl parent) {
         return createReportNode(messageKey, messageTemplate, values, parent.getValuesMapsInheritance(), parent.getTreeContextRef(),
-                withTimestamp, false);
+                withTimestamp, timestampPattern, false);
     }
 
     static ReportNodeImpl createRootReportNode(String messageKey, String messageTemplate, Map<String, TypedValue> values,
-                                               boolean withTimestamp, TreeContextImpl treeContext) {
+                                               boolean withTimestamp, String timestampPattern, TreeContextImpl treeContext) {
         RefChain<TreeContextImpl> treeContextRef = new RefChain<>(new RefObj<>(treeContext));
-        return createReportNode(messageKey, messageTemplate, values, Collections.emptyList(), treeContextRef, withTimestamp, true);
+        return createReportNode(messageKey, messageTemplate, values, Collections.emptyList(), treeContextRef,
+                withTimestamp, timestampPattern, true);
     }
 
     private static ReportNodeImpl createReportNode(String messageKey, String messageTemplate, Map<String, TypedValue> values,
                                                    Collection<Map<String, TypedValue>> inheritedValuesMaps, RefChain<TreeContextImpl> treeContextRef,
-                                                   boolean withTimestamp, boolean isRoot) {
+                                                   boolean withTimestamp, String timestampPattern, boolean isRoot) {
         TreeContextImpl treeContext = treeContextRef.get();
         treeContext.addDictionaryEntry(Objects.requireNonNull(messageKey), Objects.requireNonNull(messageTemplate));
         if (withTimestamp) {
-            values.put(ReportConstants.TIMESTAMP_KEY, TypedValue.getTimestamp(treeContext.getTimestampFormatter()));
+            DateTimeFormatter formatter = timestampPattern != null
+                    ? DateTimeFormatter.ofPattern(timestampPattern, treeContext.getLocale())
+                    : treeContext.getDefaultTimestampFormatter();
+            values.put(ReportConstants.TIMESTAMP_KEY, TypedValue.getTimestamp(formatter));
         }
         return new ReportNodeImpl(messageKey, values, inheritedValuesMaps, treeContextRef, isRoot);
     }

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeImpl.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeImpl.java
@@ -23,7 +23,6 @@ import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -49,21 +48,24 @@ public final class ReportNodeImpl implements ReportNode {
     private boolean isRoot;
     private Collection<Map<String, TypedValue>> valuesMapsInheritance;
 
-    static ReportNodeImpl createChildReportNode(String messageKey, String messageTemplate, Map<String, TypedValue> values, ReportNodeImpl parent) {
-        return createReportNode(messageKey, messageTemplate, values, parent.getValuesMapsInheritance(), parent.getTreeContextRef(), false);
+    static ReportNodeImpl createChildReportNode(String messageKey, String messageTemplate, Map<String, TypedValue> values,
+                                                boolean withTimestamp, ReportNodeImpl parent) {
+        return createReportNode(messageKey, messageTemplate, values, parent.getValuesMapsInheritance(), parent.getTreeContextRef(),
+                withTimestamp, false);
     }
 
-    static ReportNodeImpl createRootReportNode(String messageKey, String messageTemplate, Map<String, TypedValue> values, boolean timestamps, DateTimeFormatter timestampPattern) {
-        RefChain<TreeContextImpl> treeContext = new RefChain<>(new RefObj<>(new TreeContextImpl(timestamps, timestampPattern)));
-        return createReportNode(messageKey, messageTemplate, values, Collections.emptyList(), treeContext, true);
+    static ReportNodeImpl createRootReportNode(String messageKey, String messageTemplate, Map<String, TypedValue> values,
+                                               boolean withTimestamp, TreeContextImpl treeContext) {
+        RefChain<TreeContextImpl> treeContextRef = new RefChain<>(new RefObj<>(treeContext));
+        return createReportNode(messageKey, messageTemplate, values, Collections.emptyList(), treeContextRef, withTimestamp, true);
     }
 
     private static ReportNodeImpl createReportNode(String messageKey, String messageTemplate, Map<String, TypedValue> values,
                                                    Collection<Map<String, TypedValue>> inheritedValuesMaps, RefChain<TreeContextImpl> treeContextRef,
-                                                   boolean isRoot) {
+                                                   boolean withTimestamp, boolean isRoot) {
         TreeContextImpl treeContext = treeContextRef.get();
         treeContext.addDictionaryEntry(Objects.requireNonNull(messageKey), Objects.requireNonNull(messageTemplate));
-        if (treeContext.isTimestampAdded()) {
+        if (withTimestamp) {
             values.put(ReportConstants.TIMESTAMP_KEY, TypedValue.getTimestamp(treeContext.getTimestampFormatter()));
         }
         return new ReportNodeImpl(messageKey, values, inheritedValuesMaps, treeContextRef, isRoot);

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeNoOp.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeNoOp.java
@@ -229,5 +229,10 @@ public class ReportNodeNoOp implements ReportNode {
         public ReportNodeAdder withSeverity(String severity) {
             return this;
         }
+
+        @Override
+        public ReportNodeAdder withTimestamp() {
+            return this;
+        }
     }
 }

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeNoOp.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeNoOp.java
@@ -234,5 +234,10 @@ public class ReportNodeNoOp implements ReportNode {
         public ReportNodeAdder withTimestamp() {
             return this;
         }
+
+        @Override
+        public ReportNodeAdder withTimestamp(String timestampPattern) {
+            return this;
+        }
     }
 }

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeRootBuilderImpl.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeRootBuilderImpl.java
@@ -33,8 +33,7 @@ public class ReportNodeRootBuilderImpl extends AbstractReportNodeAdderOrBuilder<
 
     @Override
     public ReportNode build() {
-        Locale localeSetOrDefault = this.locale != null ? this.locale : ReportConstants.DEFAULT_LOCALE;
-        TreeContextImpl treeContext = new TreeContextImpl(timestampPattern, localeSetOrDefault);
+        TreeContextImpl treeContext = new TreeContextImpl(timestampPattern, locale);
         return ReportNodeImpl.createRootReportNode(key, messageTemplate, values, withTimestamp, treeContext);
     }
 

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeRootBuilderImpl.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeRootBuilderImpl.java
@@ -16,12 +16,12 @@ import java.util.Locale;
  */
 public class ReportNodeRootBuilderImpl extends AbstractReportNodeAdderOrBuilder<ReportNodeBuilder> implements ReportNodeBuilder {
 
-    private String timestampPattern;
+    private String defaultTimestampPattern;
     private Locale locale;
 
     @Override
-    public ReportNodeBuilder withTimestampPattern(String timestampPattern) {
-        this.timestampPattern = timestampPattern;
+    public ReportNodeBuilder withDefaultTimestampPattern(String timestampPattern) {
+        this.defaultTimestampPattern = timestampPattern;
         return this;
     }
 
@@ -33,8 +33,8 @@ public class ReportNodeRootBuilderImpl extends AbstractReportNodeAdderOrBuilder<
 
     @Override
     public ReportNode build() {
-        TreeContextImpl treeContext = new TreeContextImpl(timestampPattern, locale);
-        return ReportNodeImpl.createRootReportNode(key, messageTemplate, values, withTimestamp, treeContext);
+        TreeContextImpl treeContext = new TreeContextImpl(locale, defaultTimestampPattern);
+        return ReportNodeImpl.createRootReportNode(key, messageTemplate, values, withTimestamp, timestampPattern, treeContext);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeRootBuilderImpl.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeRootBuilderImpl.java
@@ -7,7 +7,6 @@
  */
 package com.powsybl.commons.report;
 
-import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
 /**

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeRootBuilderImpl.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeRootBuilderImpl.java
@@ -18,38 +18,25 @@ import java.util.Locale;
 public class ReportNodeRootBuilderImpl extends AbstractReportNodeAdderOrBuilder<ReportNodeBuilder> implements ReportNodeBuilder {
 
     private String timestampPattern;
-    private Locale timestampLocale;
-    private boolean timestamps;
+    private Locale locale;
 
     @Override
-    public ReportNodeBuilder withTimestampPattern(String timestampPattern, Locale locale) {
+    public ReportNodeBuilder withTimestampPattern(String timestampPattern) {
         this.timestampPattern = timestampPattern;
-        this.timestampLocale = locale;
         return this;
     }
 
     @Override
-    public ReportNodeBuilder withTimestamps(boolean enabled) {
-        this.timestamps = true;
+    public ReportNodeBuilder withLocale(Locale locale) {
+        this.locale = locale;
         return this;
     }
 
     @Override
     public ReportNode build() {
-        return ReportNodeImpl.createRootReportNode(key, messageTemplate, values, timestamps, createDateTimeFormatter(timestampPattern, timestampLocale));
-    }
-
-    private static DateTimeFormatter createDateTimeFormatter(String timestampPattern, Locale timestampLocale) {
-        if (timestampPattern == null && timestampLocale == null) {
-            return ReportConstants.DEFAULT_TIMESTAMP_FORMATTER;
-        }
-        if (timestampPattern == null) {
-            return DateTimeFormatter.ofPattern(ReportConstants.DEFAULT_TIMESTAMP_PATTERN, timestampLocale);
-        }
-        if (timestampLocale == null) {
-            return DateTimeFormatter.ofPattern(timestampPattern, ReportConstants.DEFAULT_TIMESTAMP_LOCALE);
-        }
-        return DateTimeFormatter.ofPattern(timestampPattern, timestampLocale);
+        Locale localeSetOrDefault = this.locale != null ? this.locale : ReportConstants.DEFAULT_LOCALE;
+        TreeContextImpl treeContext = new TreeContextImpl(timestampPattern, localeSetOrDefault);
+        return ReportNodeImpl.createRootReportNode(key, messageTemplate, values, withTimestamp, treeContext);
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/report/TreeContext.java
+++ b/commons/src/main/java/com/powsybl/commons/report/TreeContext.java
@@ -8,6 +8,7 @@
 package com.powsybl.commons.report;
 
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -29,7 +30,12 @@ public interface TreeContext {
     /**
      * Get the {@link DateTimeFormatter} to use for timestamps, if enabled.
      */
-    DateTimeFormatter getTimestampFormatter();
+    DateTimeFormatter getDefaultTimestampFormatter();
+
+    /**
+     * Get the {@link Locale} to use in the tree.
+     */
+    Locale getLocale();
 
     /**
      * Merge given {@link TreeContext} with current one.

--- a/commons/src/main/java/com/powsybl/commons/report/TreeContext.java
+++ b/commons/src/main/java/com/powsybl/commons/report/TreeContext.java
@@ -32,11 +32,6 @@ public interface TreeContext {
     DateTimeFormatter getTimestampFormatter();
 
     /**
-     * Return whether a timestamp is added at each {@link ReportNode} creation.
-     */
-    boolean isTimestampAdded();
-
-    /**
      * Merge given {@link TreeContext} with current one.
      */
     void merge(TreeContext treeContext);

--- a/commons/src/main/java/com/powsybl/commons/report/TreeContextImpl.java
+++ b/commons/src/main/java/com/powsybl/commons/report/TreeContextImpl.java
@@ -19,20 +19,27 @@ import java.util.*;
 public class TreeContextImpl implements TreeContext {
     private static final Logger LOGGER = LoggerFactory.getLogger(TreeContextImpl.class);
     private final SortedMap<String, String> dictionary = new TreeMap<>();
-    private final boolean timestamps;
     private final DateTimeFormatter timestampFormatter;
 
     public TreeContextImpl() {
-        this(false);
+        this(ReportConstants.DEFAULT_TIMESTAMP_PATTERN, ReportConstants.DEFAULT_LOCALE);
     }
 
-    public TreeContextImpl(boolean timestamps) {
-        this(timestamps, ReportConstants.DEFAULT_TIMESTAMP_FORMATTER);
+    public TreeContextImpl(String timestampPattern, Locale locale) {
+        this.timestampFormatter = createDateTimeFormatter(timestampPattern, locale);
     }
 
-    public TreeContextImpl(boolean timestamps, DateTimeFormatter dateTimeFormatter) {
-        this.timestamps = timestamps;
-        this.timestampFormatter = Objects.requireNonNull(dateTimeFormatter);
+    private static DateTimeFormatter createDateTimeFormatter(String timestampPattern, Locale locale) {
+        if (timestampPattern == null && locale == null) {
+            return ReportConstants.DEFAULT_TIMESTAMP_FORMATTER;
+        }
+        if (timestampPattern == null) {
+            return DateTimeFormatter.ofPattern(ReportConstants.DEFAULT_TIMESTAMP_PATTERN, locale);
+        }
+        if (locale == null) {
+            return DateTimeFormatter.ofPattern(timestampPattern, ReportConstants.DEFAULT_LOCALE);
+        }
+        return DateTimeFormatter.ofPattern(timestampPattern, locale);
     }
 
     @Override
@@ -43,11 +50,6 @@ public class TreeContextImpl implements TreeContext {
     @Override
     public DateTimeFormatter getTimestampFormatter() {
         return timestampFormatter;
-    }
-
-    @Override
-    public boolean isTimestampAdded() {
-        return timestamps;
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/report/TreeContextImpl.java
+++ b/commons/src/main/java/com/powsybl/commons/report/TreeContextImpl.java
@@ -19,13 +19,15 @@ import java.util.*;
 public class TreeContextImpl implements TreeContext {
     private static final Logger LOGGER = LoggerFactory.getLogger(TreeContextImpl.class);
     private final SortedMap<String, String> dictionary = new TreeMap<>();
+    private final Locale locale;
     private final DateTimeFormatter timestampFormatter;
 
     public TreeContextImpl() {
-        this(ReportConstants.DEFAULT_TIMESTAMP_PATTERN, ReportConstants.DEFAULT_LOCALE);
+        this(ReportConstants.DEFAULT_LOCALE, ReportConstants.DEFAULT_TIMESTAMP_PATTERN);
     }
 
-    public TreeContextImpl(String timestampPattern, Locale locale) {
+    public TreeContextImpl(Locale locale, String timestampPattern) {
+        this.locale = Objects.requireNonNullElse(locale, ReportConstants.DEFAULT_LOCALE);
         this.timestampFormatter = createDateTimeFormatter(timestampPattern, locale);
     }
 
@@ -48,8 +50,13 @@ public class TreeContextImpl implements TreeContext {
     }
 
     @Override
-    public DateTimeFormatter getTimestampFormatter() {
+    public DateTimeFormatter getDefaultTimestampFormatter() {
         return timestampFormatter;
+    }
+
+    @Override
+    public Locale getLocale() {
+        return locale;
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/report/TreeContextNoOp.java
+++ b/commons/src/main/java/com/powsybl/commons/report/TreeContextNoOp.java
@@ -26,11 +26,6 @@ public class TreeContextNoOp implements TreeContext {
     }
 
     @Override
-    public boolean isTimestampAdded() {
-        return false;
-    }
-
-    @Override
     public void merge(TreeContext treeContext) {
         // no-op
     }

--- a/commons/src/main/java/com/powsybl/commons/report/TreeContextNoOp.java
+++ b/commons/src/main/java/com/powsybl/commons/report/TreeContextNoOp.java
@@ -8,6 +8,7 @@
 package com.powsybl.commons.report;
 
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -21,7 +22,12 @@ public class TreeContextNoOp implements TreeContext {
     }
 
     @Override
-    public DateTimeFormatter getTimestampFormatter() {
+    public DateTimeFormatter getDefaultTimestampFormatter() {
+        return null;
+    }
+
+    @Override
+    public Locale getLocale() {
         return null;
     }
 

--- a/commons/src/test/java/com/powsybl/commons/report/NoOpTest.java
+++ b/commons/src/test/java/com/powsybl/commons/report/NoOpTest.java
@@ -72,6 +72,8 @@ class NoOpTest extends AbstractSerDeTest {
     @Test
     void testTreeContextNoOp() {
         assertEquals(0, TreeContextNoOp.NO_OP.getDictionary().size());
+        assertNull(TreeContextNoOp.NO_OP.getDefaultTimestampFormatter());
+        assertNull(TreeContextNoOp.NO_OP.getLocale());
 
         TreeContextImpl treeContext = new TreeContextImpl();
         treeContext.addDictionaryEntry("key", "value");

--- a/commons/src/test/java/com/powsybl/commons/report/NoOpTest.java
+++ b/commons/src/test/java/com/powsybl/commons/report/NoOpTest.java
@@ -73,7 +73,6 @@ class NoOpTest extends AbstractSerDeTest {
     void testTreeContextNoOp() {
         assertEquals(0, TreeContextNoOp.NO_OP.getDictionary().size());
         assertNull(TreeContextNoOp.NO_OP.getTimestampFormatter());
-        assertFalse(TreeContextNoOp.NO_OP.isTimestampAdded());
 
         TreeContextImpl treeContext = new TreeContextImpl();
         treeContext.addDictionaryEntry("key", "value");

--- a/commons/src/test/java/com/powsybl/commons/report/NoOpTest.java
+++ b/commons/src/test/java/com/powsybl/commons/report/NoOpTest.java
@@ -85,6 +85,7 @@ class NoOpTest extends AbstractSerDeTest {
         ReportNode root = ReportNode.NO_OP;
         ReportNode childNode = root.newReportNode()
                 .withMessageTemplate("key", "message with value = ${double}")
+                .withTimestamp()
                 .add();
         childNode.addTypedValue("double", 2.0, TypedValue.ACTIVE_POWER)
                 .addTypedValue("float", 2.0f, TypedValue.ACTIVE_POWER)

--- a/commons/src/test/java/com/powsybl/commons/report/NoOpTest.java
+++ b/commons/src/test/java/com/powsybl/commons/report/NoOpTest.java
@@ -72,7 +72,6 @@ class NoOpTest extends AbstractSerDeTest {
     @Test
     void testTreeContextNoOp() {
         assertEquals(0, TreeContextNoOp.NO_OP.getDictionary().size());
-        assertNull(TreeContextNoOp.NO_OP.getTimestampFormatter());
 
         TreeContextImpl treeContext = new TreeContextImpl();
         treeContext.addDictionaryEntry("key", "value");
@@ -86,6 +85,7 @@ class NoOpTest extends AbstractSerDeTest {
         ReportNode childNode = root.newReportNode()
                 .withMessageTemplate("key", "message with value = ${double}")
                 .withTimestamp()
+                .withTimestamp("pattern")
                 .add();
         childNode.addTypedValue("double", 2.0, TypedValue.ACTIVE_POWER)
                 .addTypedValue("float", 2.0f, TypedValue.ACTIVE_POWER)

--- a/commons/src/test/java/com/powsybl/commons/report/ReportNodeTest.java
+++ b/commons/src/test/java/com/powsybl/commons/report/ReportNodeTest.java
@@ -261,7 +261,8 @@ class ReportNodeTest extends AbstractSerDeTest {
 
     @Test
     void testTimestamps() {
-        DateTimeFormatter defaultDateTimeFormatter = DateTimeFormatter.ofPattern(ReportConstants.DEFAULT_TIMESTAMP_PATTERN);
+        DateTimeFormatter defaultDateTimeFormatter = DateTimeFormatter.ofPattern(
+                ReportConstants.DEFAULT_TIMESTAMP_PATTERN, ReportConstants.DEFAULT_LOCALE);
 
         ReportNode root1 = ReportNode.newRootReportNode()
                 .withMessageTemplate("rootTemplate", "Root message")
@@ -324,6 +325,14 @@ class ReportNodeTest extends AbstractSerDeTest {
                 .add();
         assertHasTimeStamp(child4, customPatternAndLocaleFormatter2);
 
+        // with Locale set but no timestamp pattern
+        DateTimeFormatter noPatternAndLocaleFormatter = DateTimeFormatter.ofPattern(ReportConstants.DEFAULT_TIMESTAMP_PATTERN, customLocale);
+        ReportNode root4 = ReportNode.newRootReportNode()
+                .withLocale(customLocale)
+                .withMessageTemplate("rootTemplate", "Root message")
+                .withTimestamp()
+                .build();
+        assertHasTimeStamp(root4, noPatternAndLocaleFormatter);
     }
 
     private static void assertHasNoTimeStamp(ReportNode root1) {

--- a/commons/src/test/java/com/powsybl/commons/report/ReportNodeTest.java
+++ b/commons/src/test/java/com/powsybl/commons/report/ReportNodeTest.java
@@ -264,26 +264,26 @@ class ReportNodeTest extends AbstractSerDeTest {
         DateTimeFormatter defaultDateTimeFormatter = DateTimeFormatter.ofPattern(ReportConstants.DEFAULT_TIMESTAMP_PATTERN);
 
         ReportNode root1 = ReportNode.newRootReportNode()
-                .withTimestamps(true)
                 .withMessageTemplate("rootTemplate", "Root message")
                 .build();
-        assertHasTimeStamp(root1, defaultDateTimeFormatter);
+        assertHasNoTimeStamp(root1);
 
         ReportNode child = root1.newReportNode()
                 .withMessageTemplate("child", "Child message")
+                .withTimestamp()
                 .add();
         assertHasTimeStamp(child, defaultDateTimeFormatter);
 
         Path report = tmpDir.resolve("report");
         ReportNodeSerializer.write(root1, report);
         ReportNode rootRead = ReportNodeDeserializer.read(report);
-        assertHasTimeStamp(rootRead, defaultDateTimeFormatter);
+        assertHasNoTimeStamp(rootRead);
         assertHasTimeStamp(rootRead.getChildren().get(0), defaultDateTimeFormatter);
 
         String customPattern = "dd MMMM yyyy HH:mm:ss XXX";
-        DateTimeFormatter customPatternFormatter = DateTimeFormatter.ofPattern(customPattern, ReportConstants.DEFAULT_TIMESTAMP_LOCALE);
+        DateTimeFormatter customPatternFormatter = DateTimeFormatter.ofPattern(customPattern, ReportConstants.DEFAULT_LOCALE);
         ReportNode root2 = ReportNode.newRootReportNode()
-                .withTimestamps(true)
+                .withTimestamp()
                 .withTimestampPattern(customPattern)
                 .withMessageTemplate("rootTemplate", "Root message")
                 .build();
@@ -292,12 +292,17 @@ class ReportNodeTest extends AbstractSerDeTest {
         Locale customLocale = Locale.ITALIAN;
         DateTimeFormatter customPatternAndLocaleFormatter = DateTimeFormatter.ofPattern(customPattern, customLocale);
         ReportNode root3 = ReportNode.newRootReportNode()
-                .withTimestamps(true)
-                .withTimestampPattern(customPattern, customLocale)
+                .withTimestamp()
+                .withTimestampPattern(customPattern)
+                .withLocale(customLocale)
                 .withMessageTemplate("rootTemplate", "Root message")
                 .build();
         assertHasTimeStamp(root3, customPatternAndLocaleFormatter);
 
+    }
+
+    private static void assertHasNoTimeStamp(ReportNode root1) {
+        assertTrue(root1.getValue(ReportConstants.TIMESTAMP_KEY).isEmpty());
     }
 
     private static void assertHasTimeStamp(ReportNode root, DateTimeFormatter dateTimeFormatter) {

--- a/commons/src/test/java/com/powsybl/commons/report/ReportNodeTest.java
+++ b/commons/src/test/java/com/powsybl/commons/report/ReportNodeTest.java
@@ -283,8 +283,7 @@ class ReportNodeTest extends AbstractSerDeTest {
         String customPattern = "dd MMMM yyyy HH:mm:ss XXX";
         DateTimeFormatter customPatternFormatter = DateTimeFormatter.ofPattern(customPattern, ReportConstants.DEFAULT_LOCALE);
         ReportNode root2 = ReportNode.newRootReportNode()
-                .withTimestamp()
-                .withTimestampPattern(customPattern)
+                .withTimestamp(customPattern)
                 .withMessageTemplate("rootTemplate", "Root message")
                 .build();
         assertHasTimeStamp(root2, customPatternFormatter);
@@ -292,8 +291,7 @@ class ReportNodeTest extends AbstractSerDeTest {
         Locale customLocale = Locale.ITALIAN;
         DateTimeFormatter customPatternAndLocaleFormatter = DateTimeFormatter.ofPattern(customPattern, customLocale);
         ReportNode root3 = ReportNode.newRootReportNode()
-                .withTimestamp()
-                .withTimestampPattern(customPattern)
+                .withTimestamp(customPattern)
                 .withLocale(customLocale)
                 .withMessageTemplate("rootTemplate", "Root message")
                 .build();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Remove unused feature

**What is the current behavior?**
timestamp may be added automatically on all report nodes if specified at root node construction.

**What is the new behavior (if this is a feature change)?**
timestamp may be added on any report node manually.

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
Timestamps can not be automatically added on a whole `ReportNode` tree.
If timestamp is needed on a specific `ReportNode`, the user has to add it explicitly with a call to `withTimestamp()` or `withTimestamp(pattern)`, and to refer to it in the message template if it should be displayed to the end user.

The `TimestampPattern` and the `Locale` used are specified at the construction of the root `ReportNode`, but separately. Hence, you need to replace the use of `withTimestampPattern(String pattern, Locale locale)` with `withDefaultTimestampPattern(String pattern).withLocale(Locale locale)`.
Finally, you should replace the use of `withTimestampPattern(String pattern)` with `withDefaultTimestampPattern(String pattern)`.