### PR TITLE
Add copy to ReportNode API

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/report/ReportNode.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNode.java
@@ -124,6 +124,13 @@ public interface ReportNode {
     void include(ReportNode reportRoot);
 
     /**
+     * Copy the given <code>ReportNode</code> and inserts the resulting <code>ReportNode</code> as a child of current <code>ReportNode</code>.
+     *
+     * @param reportNode the <code>ReportNode</code> to copy into the children of current <code>ReportNode</code>
+     */
+    void copy(ReportNode reportNode);
+
+    /**
      * Serialize the current report node
      * @param generator the jsonGenerator to use for serialization
      */

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNodeNoOp.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNodeNoOp.java
@@ -35,6 +35,11 @@ public class ReportNodeNoOp implements ReportNode {
     }
 
     @Override
+    public void copy(ReportNode reportNode) {
+        // No-op
+    }
+
+    @Override
     public String getMessageKey() {
         return null;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
A `ReportNode` can only insert a root `ReportNode`

**What is the new behavior (if this is a feature change)?**
A `ReportNode` can insert any `ReportNode` by calling `reportNode.copy(otherReportNode)`

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
The implementation of copy is done with serialization / deserialization. This gives a very simple version of copying, which besides does not need to check for an infinite loop. The drawback is that the inherited values of the report node to copy are lost. 