### PR TITLE
Change GroovyScriptExtension.load to use a map of context objects instead of a ComputationManager to be more generic

### DIFF
--- a/iidm/iidm-scripting/src/main/groovy/com/powsybl/iidm/network/scripting/NetworkLoadSaveGroovyScriptExtension.groovy
+++ b/iidm/iidm-scripting/src/main/groovy/com/powsybl/iidm/network/scripting/NetworkLoadSaveGroovyScriptExtension.groovy
@@ -8,7 +8,6 @@
 package com.powsybl.iidm.network.scripting
 
 import com.google.auto.service.AutoService
-import com.powsybl.computation.ComputationManager
 import com.powsybl.computation.local.LocalComputationManager
 import com.powsybl.iidm.network.ExportersLoader
 import com.powsybl.iidm.network.ExportersServiceLoader
@@ -48,7 +47,7 @@ class NetworkLoadSaveGroovyScriptExtension implements GroovyScriptExtension {
     }
 
     @Override
-    void load(Binding binding, ComputationManager computationManager) {
+    void load(Binding binding, Map<Class<?>, Object> contextObjects) {
         binding.loadNetwork = { String file, Properties parameters = null ->
             Network.read(fileSystem.getPath(file), LocalComputationManager.getDefault(),
                     importConfig, parameters, importersLoader)

--- a/loadflow/loadflow-scripting/src/main/groovy/com/powsybl/loadflow/scripting/LoadFlowGroovyScriptExtension.groovy
+++ b/loadflow/loadflow-scripting/src/main/groovy/com/powsybl/loadflow/scripting/LoadFlowGroovyScriptExtension.groovy
@@ -23,8 +23,7 @@ class LoadFlowGroovyScriptExtension implements GroovyScriptExtension {
     private final LoadFlowParameters parameters
 
     LoadFlowGroovyScriptExtension(LoadFlowParameters parameters) {
-        assert parameters
-        this.parameters = parameters
+        this.parameters = Objects.requireNonNull(parameters)
     }
 
     LoadFlowGroovyScriptExtension() {
@@ -32,12 +31,16 @@ class LoadFlowGroovyScriptExtension implements GroovyScriptExtension {
     }
 
     @Override
-    void load(Binding binding, ComputationManager computationManager) {
-        binding.loadFlow = { Network network, LoadFlowParameters parameters = this.parameters ->
-            LoadFlow.run(network, network.getVariantManager().getWorkingVariantId(), computationManager, parameters)
-        }
-        binding.loadflow = { Network network, LoadFlowParameters parameters = this.parameters ->
-            LoadFlow.run(network, network.getVariantManager().getWorkingVariantId(), computationManager, parameters)
+    void load(Binding binding, Map<Class<?>, Object> contextObjects) {
+        if (contextObjects.keySet().contains(ComputationManager.class)) {
+            ComputationManager computationManager = contextObjects.get(ComputationManager.class) as ComputationManager
+
+            binding.loadFlow = { Network network, LoadFlowParameters parameters = this.parameters ->
+                LoadFlow.run(network, network.getVariantManager().getWorkingVariantId(), computationManager, parameters)
+            }
+            binding.loadflow = { Network network, LoadFlowParameters parameters = this.parameters ->
+                LoadFlow.run(network, network.getVariantManager().getWorkingVariantId(), computationManager, parameters)
+            }
         }
     }
 

--- a/loadflow/loadflow-scripting/src/test/java/com/powsybl/loadflow/scripting/LoadFlowExtensionGroovyScriptTest.java
+++ b/loadflow/loadflow-scripting/src/test/java/com/powsybl/loadflow/scripting/LoadFlowExtensionGroovyScriptTest.java
@@ -7,7 +7,6 @@
  */
 package com.powsybl.loadflow.scripting;
 
-import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VariantManager;
 import com.powsybl.iidm.network.VariantManagerConstants;
@@ -21,6 +20,7 @@ import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -28,7 +28,6 @@ import java.util.List;
 class LoadFlowExtensionGroovyScriptTest extends AbstractGroovyScriptTest {
 
     private Network fooNetwork;
-    private ComputationManager computationManager;
 
     @BeforeEach
     void setUp() {
@@ -57,12 +56,13 @@ class LoadFlowExtensionGroovyScriptTest extends AbstractGroovyScriptTest {
     protected List<GroovyScriptExtension> getExtensions() {
         GroovyScriptExtension ext = new GroovyScriptExtension() {
             @Override
-            public void load(Binding binding, ComputationManager computationManager) {
+            public void load(Binding binding, Map<Class<?>, Object> contextObjects) {
                 binding.setVariable("n", fooNetwork);
             }
 
             @Override
             public void unload() {
+                // Nothing to do here
             }
         };
 

--- a/scripting-test/src/main/java/com/powsybl/scripting/test/AbstractGroovyScriptTest.java
+++ b/scripting-test/src/main/java/com/powsybl/scripting/test/AbstractGroovyScriptTest.java
@@ -19,7 +19,9 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -35,7 +37,8 @@ public abstract class AbstractGroovyScriptTest {
     protected abstract List<GroovyScriptExtension> getExtensions();
 
     public void doTest() {
-        ComputationManager computationManager = Mockito.mock(ComputationManager.class);
+        Map<Class<?>, Object> contextObjects = new HashMap<>();
+        contextObjects.put(ComputationManager.class, Mockito.mock(ComputationManager.class));
         Binding binding = new Binding();
         StringWriter out = null;
         try {
@@ -47,7 +50,7 @@ public abstract class AbstractGroovyScriptTest {
                 // Add a check on thread interruption in every loop (for, while) in the script
                 conf.addCompilationCustomizers(new ASTTransformationCustomizer(ThreadInterrupt.class));
 
-                getExtensions().forEach(it -> it.load(binding, computationManager));
+                getExtensions().forEach(it -> it.load(binding, contextObjects));
                 GroovyShell shell = new GroovyShell(binding, conf);
                 shell.evaluate(getCode());
                 out = (StringWriter) binding.getProperty("out");

--- a/scripting/src/main/groovy/com/powsybl/scripting/groovy/GroovyScripts.groovy
+++ b/scripting/src/main/groovy/com/powsybl/scripting/groovy/GroovyScripts.groovy
@@ -7,6 +7,7 @@
  */
 package com.powsybl.scripting.groovy
 
+import com.powsybl.computation.ComputationManager
 import com.powsybl.computation.DefaultComputationManagerConfig
 import groovy.transform.ThreadInterrupt
 import org.codehaus.groovy.control.CompilerConfiguration
@@ -47,6 +48,10 @@ class GroovyScripts {
     }
 
     static void run(Reader codeReader, Binding binding, Iterable<GroovyScriptExtension> extensions, PrintStream out) {
+        run(codeReader, binding, extensions, out, new HashMap<>())
+    }
+
+    static void run(Reader codeReader, Binding binding, Iterable<GroovyScriptExtension> extensions, PrintStream out, Map<Class<?>, Objects> contextObjects) {
         assert codeReader
         assert extensions != null
 
@@ -58,6 +63,7 @@ class GroovyScripts {
         // Computation manager
         DefaultComputationManagerConfig config = DefaultComputationManagerConfig.load()
         binding.computationManager = config.createShortTimeExecutionComputationManager()
+        contextObjects.put(ComputationManager.class, binding.computationManager)
 
         if (out != null) {
             binding.out = out
@@ -65,7 +71,7 @@ class GroovyScripts {
 
         try {
             // load extensions
-            extensions.forEach { it.load(binding, binding.computationManager) }
+            extensions.forEach { it.load(binding, contextObjects) }
 
             GroovyShell shell = new GroovyShell(binding, conf)
 

--- a/scripting/src/main/java/com/powsybl/scripting/groovy/GroovyScriptExtension.java
+++ b/scripting/src/main/java/com/powsybl/scripting/groovy/GroovyScriptExtension.java
@@ -7,15 +7,16 @@
  */
 package com.powsybl.scripting.groovy;
 
-import com.powsybl.computation.ComputationManager;
 import groovy.lang.Binding;
+
+import java.util.Map;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface GroovyScriptExtension {
 
-    void load(Binding binding, ComputationManager computationManager);
+    void load(Binding binding, Map<Class<?>, Object> contextObjects);
 
     void unload();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
`GroovyScriptExtension.load` expect only a ComputationManager, it is not possible to give other objects that would be used in the binding of groovy scripts.
The issue was raised with a Class implemented in powsybl-metrix could not be used in a script through powsybl-afs since the binding could not be made using the GroovyScriptExtension system.

**What is the new behavior (if this is a feature change)?**
`GroovyScriptExtension.load` now expect a `Map<Class<?>, Object>` instead so that each extension implementing GroovyScriptExtension can find their specific object inside.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Classes implementing GroovyScriptExtension have to change their method `void load(Binding binding, ComputationManager computationManager)` to `void load(Binding binding, Map<Class<?>, Object> contextObjects)`
If the `computationManager` was used inside, it now has to be found in the map.
See for example how the LoadFlowGroovyScriptExtension changes from:
```groovy
   @Override
    void load(Binding binding, ComputationManager computationManager) {
        binding.loadFlow = { Network network, LoadFlowParameters parameters = this.parameters ->
            LoadFlow.run(network, network.getVariantManager().getWorkingVariantId(), computationManager, parameters)
        }
        binding.loadflow = { Network network, LoadFlowParameters parameters = this.parameters ->
            LoadFlow.run(network, network.getVariantManager().getWorkingVariantId(), computationManager, parameters)
        }
    }
```
to:
```groovy
    @Override
    void load(Binding binding, Map<Class<?>, Object> contextObjects) {
        if (contextObjects.keySet().contains(ComputationManager.class)) {
            ComputationManager computationManager = contextObjects.get(ComputationManager.class) as ComputationManager

            binding.loadFlow = { Network network, LoadFlowParameters parameters = this.parameters ->
                LoadFlow.run(network, network.getVariantManager().getWorkingVariantId(), computationManager, parameters)
            }
            binding.loadflow = { Network network, LoadFlowParameters parameters = this.parameters ->
                LoadFlow.run(network, network.getVariantManager().getWorkingVariantId(), computationManager, parameters)
            }
        }
    }
```

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
