### PR TITLE
AmplNetworkWriter: only call getExtension for the ones that have a writer

### DIFF
--- a/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplExtensionWriters.java
+++ b/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplExtensionWriters.java
@@ -7,25 +7,34 @@
  */
 package com.powsybl.ampl.converter;
 
+import java.util.List;
 import java.util.Objects;
-import java.util.ServiceLoader;
+
+import com.powsybl.commons.util.ServiceLoaderCache;
 
 /**
 *
 * @author Ferrari Giovanni {@literal <giovanni.ferrari@techrain.eu>}
 */
 public final class AmplExtensionWriters {
-    private AmplExtensionWriters() {
 
+    private static final ServiceLoaderCache<AmplExtensionWriter> WRITERS_LOADER = new ServiceLoaderCache<>(AmplExtensionWriter.class);
+
+    private AmplExtensionWriters() {
     }
 
     public static AmplExtensionWriter getWriter(String name) {
         Objects.requireNonNull(name);
-        for (AmplExtensionWriter w : ServiceLoader.load(AmplExtensionWriter.class, AmplExtensionWriters.class.getClassLoader())) {
+        for (AmplExtensionWriter w : WRITERS_LOADER.getServices()) {
             if (w.getName().equals(name)) {
                 return w;
             }
         }
         return null;
     }
+
+    public static List<String> getWriterNames() {
+        return WRITERS_LOADER.getServices().stream().map(AmplExtensionWriter::getName).toList();
+    }
+
 }

--- a/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplNetworkWriter.java
+++ b/ampl-converter/src/main/java/com/powsybl/ampl/converter/AmplNetworkWriter.java
@@ -247,10 +247,13 @@ public class AmplNetworkWriter {
     }
 
     private <E> void addExtensions(int extendedNum, Extendable<E> extendable) {
-        for (Extension<E> ext : extendable.getExtensions()) {
-            List<AmplExtension> extList = extensionMap.computeIfAbsent(ext.getName(), k -> new ArrayList<>());
-            extList.add(new AmplExtension(extendedNum, extendable, ext));
-            extensionMap.put(ext.getName(), extList);
+        for (String amplExtName : AmplExtensionWriters.getWriterNames()) {
+            Extension<E> ext = extendable.getExtensionByName(amplExtName);
+            if (ext != null) {
+                List<AmplExtension> extList = extensionMap.computeIfAbsent(ext.getName(), k -> new ArrayList<>());
+                extList.add(new AmplExtension(extendedNum, extendable, ext));
+                extensionMap.put(ext.getName(), extList);
+            }
         }
     }
 
@@ -263,9 +266,7 @@ public class AmplNetworkWriter {
 
         for (Entry<String, List<AmplExtension>> entry : extensionMap.entrySet()) {
             AmplExtensionWriter extWriter = AmplExtensionWriters.getWriter(entry.getKey());
-            if (extWriter != null) {
-                extWriter.write(entry.getValue(), network, variantIndex, mapper, dataSource, append, config);
-            }
+            extWriter.write(entry.getValue(), network, variantIndex, mapper, dataSource, append, config);
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature/bugfix

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
when exporting a network in ampl format, we call getExtensions and then we filter to do nothing based on the absence/presence of extension specific writes.


**What is the new behavior (if this is a feature change)?**
when exporting a network in ampl format, we only call getExtension for data that we will actually serialize


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
This is very useful for iidm implementations like network-store which don't have everything loaded in memory and do network requests to load the data