### PR TITLE
Add a check on minQ <= maxQ

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ReactiveCapabilityCurveAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ReactiveCapabilityCurveAdder.java
@@ -27,4 +27,6 @@ public interface ReactiveCapabilityCurveAdder {
     PointAdder beginPoint();
 
     ReactiveCapabilityCurve add();
+
+    ReactiveCapabilityCurveAdder setShouldCheckMinMaxValues(boolean shouldCheckMinMaxValues);
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ReactiveCapabilityCurveAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ReactiveCapabilityCurveAdder.java
@@ -28,5 +28,15 @@ public interface ReactiveCapabilityCurveAdder {
 
     ReactiveCapabilityCurve add();
 
+    /**
+     * Sets whether the validation for checking minQ and maxQ values should be performed when adding a reactive
+     * capability curve.
+     *
+     * <p>This method is used only for retroactive compatibility of IIDM files for custom IIDM implementations.
+     * It should not be called manually.</p>
+     *
+     * @param shouldCheckMinMaxValues a boolean indicating whether to check for minQ and maxQ values
+     * @return the current instance of the {@code ReactiveCapabilityCurveAdder} for method chaining
+     */
     ReactiveCapabilityCurveAdder setShouldCheckMinMaxValues(boolean shouldCheckMinMaxValues);
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveAdderImpl.java
@@ -31,6 +31,8 @@ class ReactiveCapabilityCurveAdderImpl<O extends ReactiveLimitsOwner & Validable
 
     private final TreeMap<Double, ReactiveCapabilityCurve.Point> points = new TreeMap<>();
 
+    private boolean shouldCheckMinMaxValues = true;
+
     private final class PointAdderImpl implements PointAdder {
 
         private double p = Double.NaN;
@@ -79,12 +81,14 @@ class ReactiveCapabilityCurveAdderImpl<O extends ReactiveLimitsOwner & Validable
                     NetworkReports.parentHasDuplicatePointForActivePower(owner.getNetwork().getReportNodeContext().getReportNode(), owner.getMessageHeader(), p);
                 }
             }
-            // TODO: to be activated in IIDM v1.1
-            // if (maxQ < minQ) {
-            //     throw new ValidationException(owner,
-            //             "maximum reactive power is expected to be greater than or equal to minimum reactive power");
-            // }
-            points.put(p, new PointImpl(p, minQ, maxQ));
+
+            // Check the min/max Q values
+            if (shouldCheckMinMaxValues && maxQ < minQ) {
+                throw new ValidationException(owner,
+                    "maximum reactive power is expected to be greater than or equal to minimum reactive power");
+            }
+
+            points.put(p, new PointImpl(p, minQ, maxQ, shouldCheckMinMaxValues));
             return ReactiveCapabilityCurveAdderImpl.this;
         }
 
@@ -109,4 +113,9 @@ class ReactiveCapabilityCurveAdderImpl<O extends ReactiveLimitsOwner & Validable
         return curve;
     }
 
+    @Override
+    public ReactiveCapabilityCurveAdder setShouldCheckMinMaxValues(boolean shouldCheckMinMaxValues) {
+        this.shouldCheckMinMaxValues = shouldCheckMinMaxValues;
+        return this;
+    }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImpl.java
@@ -46,8 +46,12 @@ class ReactiveCapabilityCurveImpl implements ReactiveCapabilityCurve {
         private double maxQ;
 
         PointImpl(double p, double minQ, double maxQ) {
-            if (minQ > maxQ) {
-                throw new IllegalStateException("minQ should be inferior or equal to maxQ");
+            this(p, minQ, maxQ, true);
+        }
+
+        PointImpl(double p, double minQ, double maxQ, boolean shouldCheckMinMaxValues) {
+            if (shouldCheckMinMaxValues && minQ > maxQ) {
+                throw new IllegalStateException("maximum reactive power is expected to be greater than or equal to minimum reactive power");
             }
             this.p = p;
             this.minQ = minQ;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImpl.java
@@ -46,6 +46,9 @@ class ReactiveCapabilityCurveImpl implements ReactiveCapabilityCurve {
         private double maxQ;
 
         PointImpl(double p, double minQ, double maxQ) {
+            if (minQ > maxQ) {
+                throw new IllegalStateException("minQ should be inferior or equal to maxQ");
+            }
             this.p = p;
             this.minQ = minQ;
             this.maxQ = maxQ;

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImplTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImplTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 /**
  *
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -90,5 +92,10 @@ class ReactiveCapabilityCurveImplTest {
         // "-0.0 == 0.0" (JLS), but "Double.compareTo(-0.0, 0.0) = -1"
         // This test asserts that -0.0 is considered as equal to 0.0 by the reactive capability curve.
         assertEquals(200.0, curve.getMinQ(-0.0), 0.0);
+    }
+
+    @Test
+    void testMinQStrictlySuperiorToMaxQ() {
+        assertThrows(IllegalStateException.class, () -> createCurve(new PointImpl(100, 200, 100), new PointImpl(200, 100, 400)));
     }
 }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImplTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImplTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.TreeMap;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -96,6 +97,7 @@ class ReactiveCapabilityCurveImplTest {
 
     @Test
     void testMinQStrictlySuperiorToMaxQ() {
-        assertThrows(IllegalStateException.class, () -> createCurve(new PointImpl(100, 200, 100), new PointImpl(200, 100, 400)));
+        assertThrows(IllegalStateException.class, () -> new PointImpl(100, 200, 100));
+        assertDoesNotThrow(() -> new PointImpl(100, 200, 100, false));
     }
 }

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ReactiveLimitsSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ReactiveLimitsSerDe.java
@@ -12,6 +12,7 @@ import com.powsybl.iidm.network.MinMaxReactiveLimits;
 import com.powsybl.iidm.network.ReactiveCapabilityCurve;
 import com.powsybl.iidm.network.ReactiveCapabilityCurveAdder;
 import com.powsybl.iidm.network.ReactiveLimitsHolder;
+import com.powsybl.iidm.serde.util.IidmSerDeUtil;
 
 /**
  * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
@@ -59,6 +60,10 @@ public class ReactiveLimitsSerDe {
 
     public void readReactiveCapabilityCurve(ReactiveLimitsHolder holder, NetworkDeserializerContext context) {
         ReactiveCapabilityCurveAdder curveAdder = holder.newReactiveCapabilityCurve();
+
+        // Add the check on min/max Q values for IIDM v1.14 and later
+        IidmSerDeUtil.runUntilMaximumVersion(IidmVersion.V_1_13, context, () -> curveAdder.setShouldCheckMinMaxValues(false));
+
         context.getReader().readChildNodes(elementName -> {
             if (elementName.equals(POINT_ROOT_ELEMENT_NAME)) {
                 double p = context.getReader().readDoubleAttribute("p");

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
@@ -7,12 +7,17 @@
  */
 package com.powsybl.iidm.serde;
 
+import com.powsybl.iidm.network.ValidationException;
 import com.powsybl.iidm.network.test.ReactiveLimitsTestNetworkFactory;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
@@ -25,5 +30,25 @@ class ReactiveLimitsSerDeTest extends AbstractIidmSerDeTest {
         allFormatsRoundTripAllPreviousVersionedXmlTest("reactiveLimitsRoundTripRef.xml");
 
         allFormatsRoundTripTest(ReactiveLimitsTestNetworkFactory.create(), "reactiveLimitsRoundTripRef.xml", CURRENT_IIDM_VERSION);
+    }
+
+    @Test
+    void maxQInferiorToMinQExceptionTest() {
+        // Test for the last version with no check in minQ/maxQ (IIDM v1.13)
+        try (InputStream is = getVersionedNetworkAsStream("reactiveLimitsMinMaxException.xml", IidmVersion.V_1_13)) {
+            assertDoesNotThrow(() -> NetworkSerDe.read(is));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Test for the following versions with check in minQ/maxQ (starting at IIDM v1.14)
+        testForAllVersionsSince(IidmVersion.V_1_14, version -> {
+            try (InputStream is = getVersionedNetworkAsStream("reactiveLimitsMinMaxException.xml", version)) {
+                ValidationException e = assertThrows(ValidationException.class, () -> NetworkSerDe.read(is));
+                assertTrue(e.getMessage().contains("maximum reactive power is expected to be greater than or equal to minimum reactive power"));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 }

--- a/iidm/iidm-serde/src/test/resources/V1_13/reactiveLimitsMinMaxException.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_13/reactiveLimitsMinMaxException.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_13" id="ReactiveLimits" sourceFormat="???" caseDate="2016-01-01T10:00:00.000+02:00" forecastDistance="0" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S" country="FR" tso="RTE">
+        <iidm:voltageLevel id="VL" nominalV="380.0"  topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="G1" energySource="OTHER" maxP="10.0" minP="0.0" targetV="380.0" voltageRegulatorOn="true" targetP="10.0" bus="B" connectableBus="B">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="5.0" minQ="10.0" maxQ="1.0"/>
+                    <iidm:point p="10.0" minQ="-10.0" maxQ="1.0"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="G2" energySource="OTHER" maxP="10.0" minP="0.0" targetV="380.0" voltageRegulatorOn="true" targetP="10.0" bus="B" connectableBus="B">
+                <iidm:minMaxReactiveLimits minQ="1.0" maxQ="10.0" />
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+</iidm:network>

--- a/iidm/iidm-serde/src/test/resources/V1_14/reactiveLimitsMinMaxException.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/reactiveLimitsMinMaxException.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_14" id="ReactiveLimits" sourceFormat="???" caseDate="2016-01-01T10:00:00.000+02:00" forecastDistance="0" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S" country="FR" tso="RTE">
+        <iidm:voltageLevel id="VL" nominalV="380.0"  topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="G1" energySource="OTHER" maxP="10.0" minP="0.0" targetV="380.0" voltageRegulatorOn="true" targetP="10.0" bus="B" connectableBus="B">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="5.0" minQ="10.0" maxQ="1.0"/>
+                    <iidm:point p="10.0" minQ="-10.0" maxQ="1.0"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="G2" energySource="OTHER" maxP="10.0" minP="0.0" targetV="380.0" voltageRegulatorOn="true" targetP="10.0" bus="B" connectableBus="B">
+                <iidm:minMaxReactiveLimits minQ="1.0" maxQ="10.0" />
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+</iidm:network>

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractReactiveCapabilityCurveTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractReactiveCapabilityCurveTest.java
@@ -10,16 +10,18 @@ package com.powsybl.iidm.network.tck;
 import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ReactiveCapabilityCurve;
+import com.powsybl.iidm.network.ReactiveCapabilityCurveAdder;
 import com.powsybl.iidm.network.ValidationException;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
 import static com.powsybl.iidm.network.ReactiveLimitsKind.CURVE;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractReactiveCapabilityCurveTest {
 
@@ -123,16 +125,14 @@ public abstract class AbstractReactiveCapabilityCurveTest {
         assertTrue(e.getMessage().contains("min Q is not set"));
     }
 
-    @Disabled(value = "To be reactivated in IIDM v1.1")
     @Test
     public void invalidMinQGreaterThanMaxQ() {
-        ValidationException e = assertThrows(ValidationException.class, () -> generator.newReactiveCapabilityCurve()
-                    .beginPoint()
-                        .setP(1.0)
-                        .setMaxQ(5.0)
-                        .setMinQ(50.0)
-                    .endPoint()
-                .add());
+        ReactiveCapabilityCurveAdder.PointAdder pointAdder = generator.newReactiveCapabilityCurve()
+            .beginPoint()
+            .setP(1.0)
+            .setMaxQ(5.0)
+            .setMinQ(50.0);
+        ValidationException e = assertThrows(ValidationException.class, pointAdder::endPoint);
         assertTrue(e.getMessage().contains("maximum reactive power is expected to be greater than or equal to minimum reactive power"));
     }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractReactiveCapabilityCurveTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractReactiveCapabilityCurveTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static com.powsybl.iidm.network.ReactiveLimitsKind.CURVE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -134,6 +135,21 @@ public abstract class AbstractReactiveCapabilityCurveTest {
             .setMinQ(50.0);
         ValidationException e = assertThrows(ValidationException.class, pointAdder::endPoint);
         assertTrue(e.getMessage().contains("maximum reactive power is expected to be greater than or equal to minimum reactive power"));
+    }
+
+    @Test
+    public void setShouldCheckMinMaxValuesTest() {
+        ReactiveCapabilityCurveAdder curveAdder = generator.newReactiveCapabilityCurve();
+        ReactiveCapabilityCurveAdder.PointAdder pointAdder = curveAdder
+            .beginPoint()
+            .setP(1.0)
+            .setMaxQ(5.0)
+            .setMinQ(50.0);
+        assertThrows(ValidationException.class, pointAdder::endPoint);
+
+        // Deactivate the check on min/max values
+        curveAdder.setShouldCheckMinMaxValues(false);
+        assertDoesNotThrow(pointAdder::endPoint);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
Quality

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes
- [x] No

**What is the current behavior?**
There is no check to ensure minQ <= maxQ in a ReactiveCapabilityCurve Point.


**What is the new behavior (if this is a feature change)?**
In `PointImpl`, a constructor is added to allow de/activating a new check is added to ensure `minQ <= maxQ`. An exception is thrown when the check is activated and `minQ > maxQ`.
The existing constructor will now call the new one with the check activated.

The same check has been added to the `PointAdderImpl`, in `ReactiveCapabilityCurveAdderImpl`.
A condition has been added to deactivate the check for IIDM versions preceding the version 1.14.

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
If you need to create a `PointImpl` with `minQ > maxQ`, you need to change `PointImpl(p, minQ, maxQ)` to `PointImpl(p, minQ, maxQ, false)`

Custom IIDM implementations' maintainers should implement `ReactiveCapabilityCurveAdder.setShouldCheckMinMaxValues(boolean shouldCheckMinMaxValues)`.



**Other information**:
- Is it really a change in IIDM since no new attribute is added? Maybe it is since an IIDM file with a minQ > maxQ will not be processed the same way as before...
- Should we throw an exception or should we "fix" one of the values (take the smallest value both for minQ and maxQ to be conservative?) with a warning to make the model more robust?