### PR TITLE
CGMES export: Add a parameter to export as bus branch

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
@@ -706,7 +706,7 @@ public class CgmesExport implements Exporter {
     private static final Parameter TOPOLOGY_KIND_PARAMETER = new Parameter(
             TOPOLOGY_KIND,
             ParameterType.STRING,
-            "The topology kind of the export",
+            "Force the topology kind for the export (disable automatic detection)",
             null,
             List.of(CgmesTopologyKind.NODE_BREAKER.name(), CgmesTopologyKind.BUS_BRANCH.name()));
     private static final Parameter CGM_EXPORT_PARAMETER = new Parameter(

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
@@ -514,7 +514,7 @@ public class CgmesExport implements Exporter {
      * @param params The optional parameters to read and store.
      * @return An ExportParameters record.
      */
-    public ExportParameters readExportParameters(Properties params) {
+    private ExportParameters readExportParameters(Properties params) {
         return new ExportParameters(
                 Parameter.readBoolean(getFormat(), params, EXPORT_BOUNDARY_POWER_FLOWS_PARAMETER, defaultValueConfig),
                 Parameter.readBoolean(getFormat(), params, EXPORT_POWER_FLOWS_FOR_SWITCHES_PARAMETER, defaultValueConfig),

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
@@ -300,9 +300,11 @@ public class CgmesExportContext {
     public boolean isExportedEquipment(Identifiable<?> c) {
         boolean ignored = false;
         if (c instanceof Load load) {
-            ignored = load.isFictitious();
+            ignored = load.isFictitious()
+                    || isCim16BusBranchExport() && CgmesNames.STATION_SUPPLY.equals(CgmesExportUtil.loadClassName(load));
         } else if (c instanceof Switch sw) {
             ignored = sw.isFictitious() && "true".equals(sw.getProperty(Conversion.PROPERTY_IS_CREATED_FOR_DISCONNECTED_TERMINAL))
+                    || isCim16BusBranchExport() && sw.getProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS, "").equals("GroundDisconnector")
                     || isBusBranchExport() && !sw.isRetained();
         }
         return !ignored;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
@@ -32,6 +32,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.powsybl.cgmes.conversion.export.CgmesExportUtil.obtainSynchronousMachineKind;
+import static com.powsybl.cgmes.conversion.export.EquipmentExport.hasDifferentTNsAtBothEnds;
 import static com.powsybl.cgmes.conversion.naming.CgmesObjectReference.*;
 import static com.powsybl.cgmes.conversion.naming.CgmesObjectReference.Part.*;
 import static com.powsybl.cgmes.conversion.naming.CgmesObjectReference.ref;
@@ -377,7 +378,8 @@ public class CgmesExportContext {
         } else if (c instanceof Switch sw) {
             ignored = sw.isFictitious() && "true".equals(sw.getProperty(Conversion.PROPERTY_IS_CREATED_FOR_DISCONNECTED_TERMINAL))
                     || isCim16BusBranchExport() && sw.getProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS, "").equals("GroundDisconnector")
-                    || isBusBranchExport() && !sw.isRetained();
+                    || isBusBranchExport() && !sw.isRetained()
+                    || isBusBranchExport() && !hasDifferentTNsAtBothEnds(sw);
         }
         return !ignored;
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
@@ -141,7 +141,7 @@ public class CgmesExportContext {
             setCimVersion(cimCharacteristics.getCimVersion());
             topologyKind = cimCharacteristics.getTopologyKind();
         } else {
-            topologyKind = networkTopologyKind(network);
+            topologyKind = detectNetworkTopologyKind(network);
         }
         scenarioTime = network.getCaseDate();
         addIidmMappings(network);
@@ -158,7 +158,7 @@ public class CgmesExportContext {
         return referenceDataProvider;
     }
 
-    private CgmesTopologyKind networkTopologyKind(Network network) {
+    private CgmesTopologyKind detectNetworkTopologyKind(Network network) {
         long nodeBreakerVoltageLevelsCount = network.getVoltageLevelStream()
                 .filter(vl -> vl.getTopologyKind() == TopologyKind.NODE_BREAKER)
                 .count();

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -174,7 +174,7 @@ public final class CgmesExportUtil {
             writer.writeCharacters(profile);
             writer.writeEndElement();
         }
-        if (subset == CgmesSubset.EQUIPMENT && context.getTopologyKind().equals(CgmesTopologyKind.NODE_BREAKER) && context.getCimVersion() < 100) {
+        if (subset == CgmesSubset.EQUIPMENT && context.getTopologyKind() == CgmesTopologyKind.NODE_BREAKER && context.getCimVersion() < 100) {
             // From CGMES 3 EquipmentOperation is not required to write operational limits, connectivity nodes
             writer.writeStartElement(MD_NAMESPACE, CgmesNames.PROFILE);
             writer.writeCharacters(context.getCim().getProfileUri("EQ_OP"));

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -201,7 +201,7 @@ public final class EquipmentExport {
         }
     }
 
-    private static boolean hasDifferentTNsAtBothEnds(Switch sw) {
+    public static boolean hasDifferentTNsAtBothEnds(Switch sw) {
         // The exported Topological Nodes come from IIDM bus/breaker view buses
         Bus bus1 = sw.getVoltageLevel().getBusBreakerView().getBus1(sw.getId());
         Bus bus2 = sw.getVoltageLevel().getBusBreakerView().getBus2(sw.getId());

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -108,7 +108,7 @@ public final class EquipmentExport {
 
     private static void writeConnectivityNodes(Network network, Map <String, String> mapNodeKey2NodeId, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
         // ConnectivityNodes are:
-        // - always exported from nodes and buses in case of a node-breaker or CIM 100 export
+        // - always exported, preferably from nodes if present or buses otherwise in case of a node-breaker export
         // - exported from buses in case of a CIM 100 bus-branch export
         // - never exported in case of a CIM 16 bus-branch export
         if (!context.isCim16BusBranchExport()) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
@@ -605,12 +605,14 @@ public final class StateVariablesExport {
     }
 
     private static void writeStatus(Network network, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) {
-        // create SvStatus, iterate on Connectables, check Terminal status, add to SvStatus
-        network.getConnectableStream().forEach(c -> {
-            if (context.isExportedEquipment(c)) {
-                writeConnectableStatus(c, cimNamespace, writer, context);
-            }
-        });
+        if (!context.isCim16BusBranchExport()) {
+            // create SvStatus, iterate on Connectables, check Terminal status, add to SvStatus
+            network.getConnectableStream().forEach(c -> {
+                if (context.isExportedEquipment(c)) {
+                    writeConnectableStatus(c, cimNamespace, writer, context);
+                }
+            });
+        }
 
         // RK: For dangling lines (boundaries), the AC Line Segment is considered in service if and only if it is connected on the network side.
         // If it is disconnected on the boundary side, it might not appear on the SV file.

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/elements/ControlAreaEq.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/elements/ControlAreaEq.java
@@ -29,7 +29,9 @@ public final class ControlAreaEq {
         writer.writeEndElement();
         writer.writeEmptyElement(cimNamespace, "ControlArea.type");
         writer.writeAttribute(RDF_NAMESPACE, CgmesNames.RESOURCE, cimNamespace + CONTROL_AREA_TYPE);
-        CgmesExportUtil.writeReference("ControlArea.EnergyArea", energyAreaId, cimNamespace, writer, context);
+        if (!context.isCim16BusBranchExport()) {
+            CgmesExportUtil.writeReference("ControlArea.EnergyArea", energyAreaId, cimNamespace, writer, context);
+        }
         writer.writeEndElement();
     }
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionUtil.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionUtil.java
@@ -130,4 +130,11 @@ public final class ConversionUtil {
         Pattern pattern = Pattern.compile(regex, Pattern.DOTALL);
         return getFirstMatch(xmlFile, pattern);
     }
+
+    public static long getElementCount(String xmlFile, String className) {
+        String regex = "(<cim:" + className + " (rdf:ID=\"_|rdf:about=\"#_).*?\")>";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(xmlFile);
+        return matcher.results().count();
+    }
 }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportContextTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportContextTest.java
@@ -62,7 +62,7 @@ class CgmesExportContextTest {
         CgmesExportContext context = new CgmesExportContext();
         assertEquals(16, context.getCimVersion());
         assertEquals(CgmesNamespace.CIM_16_NAMESPACE, context.getCim().getNamespace());
-        assertEquals(CgmesTopologyKind.BUS_BRANCH, context.getTopologyKind());
+        assertEquals(CgmesTopologyKind.NODE_BREAKER, context.getTopologyKind());
         assertTrue(Duration.between(ZonedDateTime.now(), context.getScenarioTime()).toMinutes() < 1);
         assertTrue(context.exportBoundaryPowerFlows());
         assertEquals("1D", context.getBusinessProcess());

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
@@ -9,7 +9,6 @@ package com.powsybl.cgmes.conversion.test.export;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import com.powsybl.cgmes.conformity.Cgmes3Catalog;
 import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conformity.CgmesConformity1ModifiedCatalog;
 import com.powsybl.cgmes.conversion.CgmesExport;
@@ -327,22 +326,24 @@ class CgmesExportTest {
         // Before exporting, we have to define to which point
         // in the external boundary definition we want to associate this dangling line
         // For this test we chose the Conformity MicroGrid BaseCase
-        ResourceSet boundaries = Cgmes3Catalog.microGridBaseCaseBoundaries();
+        ResourceSet boundaries = CgmesConformity1Catalog.microGridBaseCaseBoundaries();
         String boundaryCN = "b675a570-cb6e-11e1-bcee-406c8f32ef58";
         expected.setProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.CONNECTIVITY_NODE_BOUNDARY, boundaryCN);
         // We inform the identifier of the boundaries we depend on
         Properties exportParameters = new Properties();
         exportParameters.put(CgmesExport.BOUNDARY_EQ_ID, "urn:uuid:536f9bf1-3f8f-a546-87e3-7af2272f29b7");
-        exportParameters.put(CgmesExport.CIM_VERSION, "100");
+        exportParameters.put(CgmesExport.TOPOLOGY_KIND, "NODE_BREAKER");
 
         try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
             Path tmpDir = Files.createDirectory(fs.getPath("/cgmes"));
             network.write("CGMES", exportParameters, tmpDir.resolve("tmp"));
 
             // To be able to import from the exported CGMES data we must add the external boundary definitions
-            // Because we work with node/breaker we only need the boundary EQ instance file
-            try (InputStream is = boundaries.newInputStream("20171002T0930Z_ENTSO-E_EQ_BD_2.xml")) {
+            try (InputStream is = boundaries.newInputStream("MicroGridTestConfiguration_EQ_BD.xml")) {
                 Files.copy(is, tmpDir.resolve("tmp_EQ_BD.xml"), StandardCopyOption.REPLACE_EXISTING);
+            }
+            try (InputStream is = boundaries.newInputStream("MicroGridTestConfiguration_TP_BD.xml")) {
+                Files.copy(is, tmpDir.resolve("tmp_TP_BD.xml"), StandardCopyOption.REPLACE_EXISTING);
             }
 
             Network networkFromCgmes = Network.read(new GenericReadOnlyDataSource(tmpDir, "tmp"), importParams);
@@ -367,7 +368,7 @@ class CgmesExportTest {
         try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
             Path tmpDir = Files.createDirectory(fs.getPath("/cgmes"));
             Properties exportParameters = new Properties();
-            exportParameters.put(CgmesExport.CIM_VERSION, "100");
+            exportParameters.put(CgmesExport.TOPOLOGY_KIND, "NODE_BREAKER");
             network.write("CGMES", exportParameters, tmpDir.resolve("tmp"));
 
             Network networkFromCgmes = Network.read(new GenericReadOnlyDataSource(tmpDir, "tmp"), importParams);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesTopologyKindTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesTopologyKindTest.java
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.test.export;
+
+import com.powsybl.cgmes.conversion.CgmesExport;
+import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.cgmes.conversion.test.ConversionUtil;
+import com.powsybl.cgmes.extensions.CgmesTopologyKind;
+import com.powsybl.cgmes.model.CgmesNames;
+import com.powsybl.cgmes.model.CgmesNamespace;
+import com.powsybl.commons.test.AbstractSerDeTest;
+import com.powsybl.iidm.network.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static com.powsybl.cgmes.conversion.test.ConversionUtil.getElement;
+import static com.powsybl.cgmes.conversion.test.ConversionUtil.getElementCount;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Romain Courtier {@literal <romain.courtier at rte-france.com>}
+ */
+class CgmesTopologyKindTest extends AbstractSerDeTest {
+
+    @ParameterizedTest
+    @EnumSource(value = CgmesTopologyKind.class, names = {"NODE_BREAKER", "BUS_BRANCH"})
+    void cgmesTopologyKindTest(CgmesTopologyKind topologyKind) throws IOException {
+        Network network = mixedTopologyNetwork();
+
+        // Assert the CIM 16 and CIM 100 exports with given topology kind are valid
+        assertValidExport(network, topologyKind, false);
+        assertValidExport(network, topologyKind, true);
+    }
+
+    private void assertValidExport(Network network, CgmesTopologyKind topologyKind, boolean cim100Export) throws IOException {
+        // Build the export parameters
+        Properties exportParams = new Properties();
+        exportParams.put(CgmesExport.TOPOLOGY_KIND, topologyKind.name());
+        if (cim100Export) {
+            exportParams.put(CgmesExport.CIM_VERSION, "100");
+        }
+
+        // Export to CGMES
+        String eqFile = ConversionUtil.writeCgmesProfile(network, "EQ", tmpDir, exportParams);
+        String sshFile = ConversionUtil.writeCgmesProfile(network, "SSH", tmpDir, exportParams);
+        String svFile = ConversionUtil.writeCgmesProfile(network, "SV", tmpDir, exportParams);
+
+        // Assert the exports are valid
+        assertValidProfileInHeader(eqFile, topologyKind, cim100Export);
+        assertValidCim16EquipmentOperationElements(eqFile, sshFile, svFile, topologyKind, cim100Export);
+        assertValidNodeBreakerElements(eqFile, topologyKind, cim100Export);
+        assertValidTerminalCount(eqFile, topologyKind, cim100Export);
+    }
+
+    private void assertValidProfileInHeader(String eqFile, CgmesTopologyKind topologyKind, boolean cim100Export) {
+        if (topologyKind == CgmesTopologyKind.NODE_BREAKER && !cim100Export) {
+            assertTrue(eqFile.contains(CgmesNamespace.CIM_16_EQ_OPERATION_PROFILE));
+        } else {
+            assertFalse(eqFile.contains(CgmesNamespace.CIM_100_EQ_OPERATION_PROFILE));
+        }
+    }
+
+    private void assertValidCim16EquipmentOperationElements(String eqFile, String sshFile, String svFile, CgmesTopologyKind topologyKind, boolean cim100Export) {
+        if (topologyKind == CgmesTopologyKind.NODE_BREAKER || cim100Export) {
+            assertEquals(1, getElementCount(eqFile, "CurrentLimit"));
+            assertEquals(1, getElementCount(eqFile, "ActivePowerLimit"));
+            assertEquals(2, getElementCount(eqFile, "ApparentPowerLimit"));
+            assertEquals(1, getElementCount(eqFile, "StationSupply"));
+            assertEquals(1, getElementCount(eqFile, "GroundDisconnector"));
+            assertEquals(1, getElementCount(eqFile, "LoadArea"));
+            assertEquals(1, getElementCount(eqFile, "SubLoadArea"));
+            assertTrue(getElement(eqFile, "ConformLoadGroup", "ConformLoad_LG").contains("cim:LoadGroup.SubLoadArea"));
+            assertTrue(getElement(eqFile, "NonConformLoadGroup", "NonConformLoad_LG").contains("cim:LoadGroup.SubLoadArea"));
+            assertTrue(getElement(eqFile, "ControlArea", "Interchange").contains("cim:ControlArea.EnergyArea"));
+            assertEquals(1, getElementCount(sshFile, "StationSupply"));
+            assertEquals(1, getElementCount(sshFile, "GroundDisconnector"));
+            assertEquals(7, getElementCount(svFile, "SvStatus"));
+        } else {
+            assertEquals(1, getElementCount(eqFile, "CurrentLimit")); // CurrentLimit are NOT part of CIM16 EQ_OP
+            assertEquals(0, getElementCount(eqFile, "ActivePowerLimit"));
+            assertEquals(0, getElementCount(eqFile, "ApparentPowerLimit"));
+            assertEquals(0, getElementCount(eqFile, "StationSupply"));
+            assertEquals(0, getElementCount(eqFile, "GroundDisconnector"));
+            assertEquals(0, getElementCount(eqFile, "LoadArea"));
+            assertEquals(0, getElementCount(eqFile, "SubLoadArea"));
+            assertFalse(getElement(eqFile, "ConformLoadGroup", "ConformLoad_LG").contains("cim:LoadGroup.SubLoadArea"));
+            assertFalse(getElement(eqFile, "NonConformLoadGroup", "NonConformLoad_LG").contains("cim:LoadGroup.SubLoadArea"));
+            assertFalse(getElement(eqFile, "ControlArea", "Interchange").contains("cim:ControlArea.EnergyArea"));
+            assertEquals(0, getElementCount(sshFile, "StationSupply"));
+            assertEquals(0, getElementCount(sshFile, "GroundDisconnector"));
+            assertEquals(0, getElementCount(svFile, "SvStatus"));
+        }
+    }
+
+    private void assertValidNodeBreakerElements(String eqFile, CgmesTopologyKind topologyKind, boolean cim100Export) {
+        if (topologyKind == CgmesTopologyKind.NODE_BREAKER) {
+            assertEquals(4, getElementCount(eqFile, "ConnectivityNode"));
+            assertEquals(1, getElementCount(eqFile, "Disconnector"));
+        } else {
+            // In case of a CIM100 bus-branch export, the buses from the BusBreakerView aren't exported as ConnectivityNode
+            int connectivityNodesCount = cim100Export ? 3 : 0;
+            assertEquals(connectivityNodesCount, getElementCount(eqFile, "ConnectivityNode"));
+            assertEquals(0, getElementCount(eqFile, "Disconnector")); // because it is non-retained
+        }
+    }
+
+    private void assertValidTerminalCount(String eqFile, CgmesTopologyKind topologyKind, boolean cim100Export) {
+        // BusbarSection (2), Generator (1), ACLineSegment (2), ConformLoad (1), NonConformLoad (1) terminals are always exported
+        int terminalCount = 7;
+        if (topologyKind == CgmesTopologyKind.NODE_BREAKER || cim100Export) {
+            // StationSupply (1), GroundDisconnector (2) terminals are exported if not a CIM16 bus-branch export
+            terminalCount += 3;
+        }
+        if (topologyKind == CgmesTopologyKind.NODE_BREAKER) {
+            // non-retained Disconnector (2) terminals are exported if not a bus-branch export
+            terminalCount += 2;
+        }
+
+        assertEquals(terminalCount, getElementCount(eqFile, "Terminal"));
+    }
+
+    private Network mixedTopologyNetwork() {
+        Network network = NetworkFactory.findDefault().createNetwork("network", "test");
+
+        //  VL_1: Bus-Breaker                      VL_2: Node-Breaker
+        //
+        //                  ________LN________
+        //                  |                |    BBS_2A        BBS_2B
+        // ______(BUS)______|__            _(1)____(0)____DIS____(3)________GRDIS__
+        //     |       |                            |             |           |
+        //     |       |                           (2)           (4)         (5)
+        //    GEN     AUX                          LD_C         LD_NC
+
+        // Create Substation 1 with a Generator and a station supply Load
+        Substation substation1 = network.newSubstation()
+                .setId("ST_1")
+                .add();
+        VoltageLevel voltageLevel1 = substation1.newVoltageLevel()
+                .setId("VL_1")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        voltageLevel1.getBusBreakerView().newBus()
+                .setId("BUS")
+                .add();
+        voltageLevel1.newGenerator()
+                .setId("GEN")
+                .setBus("BUS")
+                .setTargetP(1.0)
+                .setTargetQ(1.0)
+                .setMinP(0.0)
+                .setMaxP(2.0)
+                .setVoltageRegulatorOn(false)
+                .add();
+        voltageLevel1.newLoad()
+                .setId("AUX")
+                .setBus("BUS")
+                .setP0(0.0)
+                .setQ0(0.0)
+                .setLoadType(LoadType.AUXILIARY)
+                .add()
+                .setProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS, CgmesNames.STATION_SUPPLY);
+
+        // Create Substation 2 with a BusbarSection, a Load and a GroundDisconnector
+        Substation substation2 = network.newSubstation()
+                .setId("ST_2")
+                .add();
+        VoltageLevel voltageLevel2 = substation2.newVoltageLevel()
+                .setId("VL_2")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        voltageLevel2.getNodeBreakerView().newBusbarSection()
+                .setId("BBS_2A")
+                .setNode(0)
+                .add();
+        voltageLevel2.getNodeBreakerView().newBusbarSection()
+                .setId("BBS_2B")
+                .setNode(3)
+                .add();
+        voltageLevel2.getNodeBreakerView().newSwitch()
+                .setNode1(0)
+                .setNode2(3)
+                .setId("DIS")
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setOpen(false)
+                .setRetained(false)
+                .add();
+        voltageLevel2.newLoad()
+                .setId("LD_C")
+                .setNode(2)
+                .setP0(1.0)
+                .setQ0(0.0)
+                .add()
+                .setProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS, CgmesNames.CONFORM_LOAD);
+        voltageLevel2.newLoad()
+                .setId("LD_NC")
+                .setNode(4)
+                .setP0(0.0)
+                .setQ0(1.0)
+                .add()
+                .setProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS, CgmesNames.NONCONFORM_LOAD);
+        voltageLevel2.getNodeBreakerView().newSwitch()
+                .setId("GRDIS")
+                .setNode1(3)
+                .setNode2(5)
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setOpen(false)
+                .setRetained(true)
+                .add()
+                .setProperty(Conversion.PROPERTY_CGMES_ORIGINAL_CLASS, "GroundDisconnector");
+
+        // Create a Line between substations 1 and 2
+        Line line = network.newLine()
+                .setId("LN")
+                .setR(0.1)
+                .setX(1.0)
+                .setG1(0.0)
+                .setG2(0.0)
+                .setB1(0.0)
+                .setB2(0.0)
+                .setVoltageLevel1("VL_1")
+                .setVoltageLevel2("VL_2")
+                .setBus1("BUS")
+                .setNode2(1)
+                .add();
+
+        // Create ControlArea
+        network.newArea()
+                .setId("Interchange")
+                .setAreaType("ControlAreaTypeKind.Interchange")
+                .add();
+
+        // Create connectivity
+        voltageLevel2.getNodeBreakerView().newInternalConnection().setNode1(0).setNode2(1).add();
+        voltageLevel2.getNodeBreakerView().newInternalConnection().setNode1(0).setNode2(2).add();
+        voltageLevel2.getNodeBreakerView().newInternalConnection().setNode1(3).setNode2(4).add();
+
+        // Add limits
+        line.newCurrentLimits1().setPermanentLimit(100).add();
+        line.newApparentPowerLimits1().setPermanentLimit(100).add();
+        line.newActivePowerLimits2().setPermanentLimit(100).add();
+        line.newApparentPowerLimits2().setPermanentLimit(100).add();
+
+        return network;
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesTopologyKindTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesTopologyKindTest.java
@@ -57,7 +57,7 @@ class CgmesTopologyKindTest extends AbstractSerDeTest {
         // Assert the exports are valid
         assertValidProfileInHeader(eqFile, topologyKind, cim100Export);
         assertValidCim16EquipmentOperationElements(eqFile, sshFile, svFile, topologyKind, cim100Export);
-        assertValidNodeBreakerElements(eqFile, topologyKind, cim100Export);
+        assertValidConnectivityElements(eqFile, topologyKind, cim100Export);
         assertValidTerminalCount(eqFile, topologyKind, cim100Export);
     }
 
@@ -65,6 +65,7 @@ class CgmesTopologyKindTest extends AbstractSerDeTest {
         if (topologyKind == CgmesTopologyKind.NODE_BREAKER && !cim100Export) {
             assertTrue(eqFile.contains(CgmesNamespace.CIM_16_EQ_OPERATION_PROFILE));
         } else {
+            assertFalse(eqFile.contains(CgmesNamespace.CIM_16_EQ_OPERATION_PROFILE));
             assertFalse(eqFile.contains(CgmesNamespace.CIM_100_EQ_OPERATION_PROFILE));
         }
     }
@@ -101,7 +102,7 @@ class CgmesTopologyKindTest extends AbstractSerDeTest {
         }
     }
 
-    private void assertValidNodeBreakerElements(String eqFile, CgmesTopologyKind topologyKind, boolean cim100Export) {
+    private void assertValidConnectivityElements(String eqFile, CgmesTopologyKind topologyKind, boolean cim100Export) {
         if (topologyKind == CgmesTopologyKind.NODE_BREAKER) {
             assertEquals(4, getElementCount(eqFile, "ConnectivityNode"));
             assertEquals(1, getElementCount(eqFile, "Disconnector"));

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesTopologyKindTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesTopologyKindTest.java
@@ -173,7 +173,7 @@ class CgmesTopologyKindTest extends AbstractSerDeTest {
                 .add();
         voltageLevel1.newGenerator()
                 .setId("GEN")
-                .setBus("BUS")
+                .setBus("GEN-BUS")
                 .setTargetP(1.0)
                 .setTargetQ(1.0)
                 .setMinP(0.0)
@@ -182,7 +182,7 @@ class CgmesTopologyKindTest extends AbstractSerDeTest {
                 .add();
         voltageLevel1.newLoad()
                 .setId("AUX")
-                .setBus("BUS")
+                .setBus("GEN-BUS")
                 .setP0(0.0)
                 .setQ0(0.0)
                 .setLoadType(LoadType.AUXILIARY)

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportToCimVersionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportToCimVersionTest.java
@@ -9,9 +9,7 @@ package com.powsybl.cgmes.conversion.test.export;
 
 import com.powsybl.cgmes.conversion.CgmesExport;
 import com.powsybl.cgmes.conversion.CgmesImport;
-import com.powsybl.cgmes.conversion.CgmesModelExtension;
 import com.powsybl.cgmes.extensions.CimCharacteristics;
-import com.powsybl.cgmes.model.CgmesModel;
 import com.powsybl.cgmes.model.test.Cim14SmallCasesCatalog;
 import com.powsybl.commons.datasource.*;
 import com.powsybl.commons.test.AbstractSerDeTest;
@@ -60,29 +58,6 @@ class ExportToCimVersionTest extends AbstractSerDeTest {
         Network network = ieee14Cim14();
         assertEquals(14, network.getExtension(CimCharacteristics.class).getCimVersion());
         testExportToCim(network, "IEEE14", 100);
-    }
-
-    @Test
-    void testExportIEEE14ToCim100CheckIsNodeBreaker() {
-        // Testing export to CGMES 3 is interpreted as a node/breaker CGMES model
-        // Input was a bus/branch model
-
-        Network network = ieee14Cim14();
-        CgmesModel cgmesModel14 = network.getExtension(CgmesModelExtension.class).getCgmesModel();
-        assertFalse(cgmesModel14.isNodeBreaker());
-
-        String cimZipFilename = "ieee14_CIM100";
-        Properties params = new Properties();
-        params.put(CgmesExport.CIM_VERSION, "100");
-        ZipArchiveDataSource zip = new ZipArchiveDataSource(tmpDir.resolve("."), cimZipFilename);
-        new CgmesExport().export(network, params, zip);
-
-        Properties importParams = new Properties();
-        importParams.put(CgmesImport.IMPORT_CGM_WITH_SUBNETWORKS, "false");
-        Network network100 = Network.read(zip, importParams);
-
-        CgmesModel cgmesModel100 = network100.getExtension(CgmesModelExtension.class).getCgmesModel();
-        assertTrue(cgmesModel100.isNodeBreaker());
     }
 
     @Test

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/TopologyExportCornerCasesTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/TopologyExportCornerCasesTest.java
@@ -75,9 +75,9 @@ class TopologyExportCornerCasesTest extends AbstractSerDeTest {
             checkAllTerminalsConnected(network, name);
         }
 
-        // Export as CGMES 3
+        // Export as node-breaker
         Properties params = new Properties();
-        params.put(CgmesExport.CIM_VERSION, "100");
+        params.put(CgmesExport.TOPOLOGY_KIND, "NODE_BREAKER");
         ZipArchiveDataSource zip = new ZipArchiveDataSource(tmpDir.resolve("."), name);
         new CgmesExport().export(network, params, zip);
         Properties importParams = new Properties();

--- a/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
+++ b/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java
@@ -175,7 +175,7 @@ public class CgmesModelTripleStore extends AbstractCgmesModel {
         if (r == null) {
             return false;
         }
-        if (allEqCgmes3OrGreater(r)) {
+        if (allEqCgmes3OrGreater(r) && !connectivityNodes().isEmpty()) {
             return true;
         }
         // Only consider is node breaker if all models that have profile

--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -162,7 +162,7 @@ By default, the export topology kind is computed from the IIDM network's `Voltag
 * If some `VoltageLevel` of the network are at `node/breaker` and some other at `bus/breaker` connectivity level, then the export's topology kind depends on the CIM version for export: 
 it is `BUS_BRANCH` for CIM 16 and `NODE_BREAKER` for CIM 100
 
-It is however possible to ignore the computed export topology kind and force it to be `NODE_BREAKER` or `BUS_BRANCH` by setting the parameter `iidm.export.cgmes.topology-kind`.
+It is however possible to ignore the computed export topology kind and force it to be `NODE_BREAKER` or `BUS_BRANCH` by setting the parameter [`iidm.export.cgmes.topology-kind`](#options).
 
 The various configurations and the differences in what's written are summarized in the following table:
 
@@ -174,7 +174,7 @@ The various configurations and the differences in what's written are summarized 
 | 100         | `BUS_BRANCH`             | Yes (**)                              | Yes                                                 |
 
 ### Connectivity elements
-* non-retained `Switch` are always written in the case of a `NODE_BREAKER` export, and never written in the case of a `BUS_BRANCH` export
+* Non-retained `Switch` are always written in the case of a `NODE_BREAKER` export, and never written in the case of a `BUS_BRANCH` export
 * `ConnectivityNode` are:
   * Never exported in the case of a CIM 16 `BUS_BRANCH` export
   * (*) Always exported in the case of a `NODE_BREAKER` export. If the VoltageLevel's connectivity level is `node/breaker`,
@@ -413,9 +413,9 @@ Optional property related to the naming strategy specified in `iidm.export.cgmes
 Optional property that determines which instance files will be exported.
 By default, it is a full CGMES export: the instance files for the profiles EQ, TP, SSH and SV are exported.
 
-**iidm.export.cgmes.topology-kind**
+**iidm.export.cgmes.topology-kind**  
 Optional property that defines the topology kind of the export. Allowed values are: `NODE_BREAKER` and `BUS_BRANCH`.
-By default, the export topology kind reflects the network's voltage levels connectivity level detail: node/breaker, bus/breaker, mixed (CIM 100/CGMES 3.0 only).
+By default, the export topology kind reflects the network's voltage levels connectivity level detail: node/breaker or bus/breaker.
 This property is used to bypass the natural export topology kind and force a desired one (e.g. export as bus/branch a node/breaker network).
 
 **iidm.export.cgmes.modeling-authority-set**  
@@ -440,11 +440,11 @@ the sums of active power and reactive power at the bus are higher than a thresho
 `iidm.export.cgmes.max-p-mismatch-converged` and `iidm.export.cgmes.max-q-mismatch-converged`.
 This property is set to `true` by default.
 
-**iidm.export.cgmes.export-all-limits-group**
+**iidm.export.cgmes.export-all-limits-group**  
 Optional property that defines whether all OperationalLimitsGroup should be exported, or only the selected (active) ones.
 This property is set to `true` by default, which means all groups are exported (not only the active ones).
 
-**iidm.export.cgmes.export-generators-in-local-regulation-mode**
+**iidm.export.cgmes.export-generators-in-local-regulation-mode**  
 Optional property that allows to export voltage regulating generators in local regulation mode. This doesn't concern reactive power regulating generators.
 If set to true, the generator's regulating terminal is set to the generator's own terminal and the target voltage is rescaled accordingly.
 This property is set to `false` by default.
@@ -473,9 +473,9 @@ Its default value is 1.
 The business process in which the export takes place. This is used to generate unique UUIDs for the EQ, TP, SSH and SV file `FullModel`.
 Its default value is `1D`.
 
-**iidm.export.cgmes.cgm_export**
+**iidm.export.cgmes.cgm_export**  
 Optional property to specify the export use-case: IGM (Individual Grid Model) or CGM (Common Grid Model).
 To export instance files of a CGM, set the value to `True`. The default value is `False` to export network as an IGM.
 
-**iidm.export.cgmes.update-dependencies**
+**iidm.export.cgmes.update-dependencies**  
 Optional property to determine if dependencies in the exported instance files should be managed automatically. The default value is `True`.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
New feature.


**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [X] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
CGMES export's topology kind depends on the network's topology kind computation. A network with at least one node/breaker voltage level will be exported as `NODE_BREAKER`, and a full bus/breaker network will always be exported as `BUS_BRANCH`.


**What is the new behavior (if this is a feature change)?**
<!-- -->
The network topology kind computation has been revised. The network has to be a full node/breaker to be exported in CGMES as `NODE_BREAKER`, likewise it has to be a full bus/breaker to be exported in CGMES as `BUS_BRANCH`. In case of a hybrid (mixed topology) network, the computed topology kind depends on the CIM version for export: it is `BUS_BRANCH` in case of a CIM 16 export and `NODE_BREAKER` for a CIM 100 export.

A new parameter has been added to override the computed export topology kind and force a desired one. It allows for example to export a node/breaker network as `BUS_BRANCH`. The allowed values for this parameter are `NODE_BREAKER` and `BUS_BRANCH`.

The differences in the various configurations of CIM version and topology kind are:
* In case of a CIM 16 `BUS_BRANCH` export:
  * `ConnectivityNode` are not exported
  * non-retained `Switch` are not exported

* In case of a CIM 100 `BUS_BRANCH` export,
  * `ConnectivityNode` are exported from buses of the BusBreakerView
  * non-retained `Switch` are not exported

* In case of a `NODE_BREAKER` export:
  * `ConnectivityNode` are always exported, either from nodes if the VoltageLevel is at node/breaker connectivity level, or from buses if the VoltageLevel is at bus/breaker connectivity level.
  * non-retained `Switch` are always exported.

Also, there is a specificity for the CIM 16 `BUS_BRANCH` export where this export intrinsically means not writting the equipment operation profile. This means the following classes won't be written:
* ConnectivityNode
* StationSupply
* GroundDisconnector
* ActivePowerLimit
* ApparentPowerLimit
* LoadArea
* SubLoadArea
* SvStatus

As well as the following attributes:
* LoadGroup.LoadArea
* LoadGroup.SubLoadArea
* ControlArea.EnergyArea

Note: the CGMES EquipmentOperation profile contains more elements, but they don't exist in PowSyBl and are already not exported.

**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No


**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
In case of a network with mixed topology, that is with some `VoltageLevel` in `node/breaker` topology kind and some other `VoltageLevel` in `bus/breaker` topology kind, the CGMES export without this feature was always a `NODE_BREAKER` one. The change introduced here is that the export will now be a `BUS_BRANCH` one if the CIM version for export is 16 (default value).
In order to restore a `NODE_BREAKER` export for a mixed-topology network, one has to set the TOPOLOGY_KIND CgmesExport parameter as follows:
``` java
Network network = ...;

// Export to CGMES as node-breaker
Properties exportParameters = new Properties();
exportParameters.put(CgmesExport.TOPOLOGY_KIND, "NODE_BREAKER");
network.write("CGMES", exportParameters, Path.of("cgmes_file")); 
```


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
