### PR TITLE
Add space character in IdWithWildcardsNetworkElementIdentifier regex

### DIFF
--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/NetworkElementIdentifierContingencyListTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/NetworkElementIdentifierContingencyListTest.java
@@ -205,7 +205,7 @@ class NetworkElementIdentifierContingencyListTest {
         String message = Assertions.assertThrows(PowsyblException.class, () -> new IdWithWildcardsNetworkElementIdentifier("NHV1_NHV2_?_?_?_?_?_?_?")).getMessage();
         Assertions.assertEquals("There can be a maximum of 5 wildcards ('?')", message);
         String message2 = Assertions.assertThrows(PowsyblException.class, () -> new IdWithWildcardsNetworkElementIdentifier("NHV1_NHV2_ç")).getMessage();
-        Assertions.assertEquals("Only characters allowed for this identifier are letters, numbers, '_', '-', '.' and the wildcard character '?'", message2);
+        Assertions.assertEquals("Only characters allowed for this identifier are letters, numbers, '_', '-', '.', spaces and the wildcard character '?'", message2);
         NetworkElementIdentifier elementIdentifier = new IdWithWildcardsNetworkElementIdentifier("NHV1_NHV?_?");
         Network network = EurostagTutorialExample1Factory.create();
         List<String> identifiables = elementIdentifier.filterIdentifiable(network).stream().map(Identifiable::getId).toList();

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/NetworkElementIdentifierContingencyListTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/NetworkElementIdentifierContingencyListTest.java
@@ -219,6 +219,14 @@ class NetworkElementIdentifierContingencyListTest {
         Assertions.assertEquals(1, identifiables.size());
         assertTrue(identifiables.contains("NHV1.NHV2-1"));
 
+        // Test with space character in identifier
+        network.newSubstation().setId(".NHV1 3 .NHV2 1").add();
+        network.newSubstation().setId(".NHV1 2 .NHV2 2").add();
+        elementIdentifier = new IdWithWildcardsNetworkElementIdentifier(".NHV1 ? .NHV2 ?");
+        identifiables = elementIdentifier.filterIdentifiable(network).stream().map(Identifiable::getId).toList();
+        Assertions.assertEquals(2, identifiables.size());
+        assertTrue(identifiables.containsAll(Arrays.asList(".NHV1 2 .NHV2 2", ".NHV1 3 .NHV2 1")));
+
         String message3 = assertThrows(PowsyblException.class, () -> new IdWithWildcardsNetworkElementIdentifier("TEST_WITH_NO_WILDCARDS")).getMessage();
         assertEquals("There is no wildcard in your identifier, please use IdBasedNetworkElementIdentifier instead", message3);
     }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/identifiers/IdWithWildcardsNetworkElementIdentifier.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/identifiers/IdWithWildcardsNetworkElementIdentifier.java
@@ -50,7 +50,7 @@ public class IdWithWildcardsNetworkElementIdentifier implements NetworkElementId
         String allowedCharactersRegex = "^[A-Za-z0-9_? .-]*$";
 
         if (!identifier.matches(allowedCharactersRegex)) {
-            throw new PowsyblException("Only characters allowed for this identifier are letters, numbers, '_', '-', '.' and the wildcard character '?'");
+            throw new PowsyblException("Only characters allowed for this identifier are letters, numbers, '_', '-', '.', spaces and the wildcard character '?'");
         }
         int separatorNumber = StringUtils.countMatches(identifier, WILDCARD);
         if (separatorNumber > ALLOWED_WILDCARDS_NUMBER) {

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/identifiers/IdWithWildcardsNetworkElementIdentifier.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/identifiers/IdWithWildcardsNetworkElementIdentifier.java
@@ -47,7 +47,7 @@ public class IdWithWildcardsNetworkElementIdentifier implements NetworkElementId
     }
 
     private void initialize() {
-        String allowedCharactersRegex = "^[A-Za-z0-9_?.-]*$";
+        String allowedCharactersRegex = "^[A-Za-z0-9_? .-]*$";
 
         if (!identifier.matches(allowedCharactersRegex)) {
             throw new PowsyblException("Only characters allowed for this identifier are letters, numbers, '_', '-', '.' and the wildcard character '?'");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
Add new use case for the existing feature: search for all the `Identifiable` matching an id pattern a given network.

**What is the current behavior?**
The pattern to match in order to search for identifiables in a network does not allow the presence of the "space" character.

**What is the new behavior (if this is a feature change)?**
The pattern to match in order to search for identifiables in a network allows the presence of the "space" character.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
Maybe think of other characters that could be useful to include in the possible patterns (for UCTE possibilities compliance for instance).