### PR TITLE
Replace XMLStreamReader.getText with getElementText in unit test

### DIFF
--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CommonGridModelExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CommonGridModelExportTest.java
@@ -594,15 +594,10 @@ class CommonGridModelExportTest extends AbstractSerDeTest {
     private static Optional<Integer> readVersion(InputStream is) {
         try {
             XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(is);
-            boolean insideModelVersion = false;
             while (reader.hasNext()) {
                 int next = reader.next();
                 if (next == XMLStreamConstants.START_ELEMENT && reader.getLocalName().equals("Model.version")) {
-                    insideModelVersion = true;
-                } else if (next == XMLStreamConstants.END_ELEMENT) {
-                    insideModelVersion = false;
-                } else if (next == XMLStreamConstants.CHARACTERS && insideModelVersion) {
-                    String version = reader.getText();
+                    String version = reader.getElementText();
                     reader.close();
                     return Optional.of(Integer.parseInt(version));
                 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix in unit test

**What is the current behavior?**
Unit test is using XMLStreamReader.getText() which does not ensure that the full content is read.

**What is the new behavior (if this is a feature change)?**
Unit test is using XMLStreamReader.getElementText() which ensures that the full content is read.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
`getText()` was used in another repo to read an xml content, which lead to corrupted data, as it was often cut in two and only the second half of the string was kept. In powsybl-core this is the only place where it's used. It should still be replaced as we sometimes take unit test code as model code.
