### PR TITLE
Handle negative zero case in reactive capability curves

### DIFF
--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImplTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImplTest.java
@@ -82,4 +82,13 @@ class ReactiveCapabilityCurveImplTest {
         assertEquals(extrapolate ? 350.0 : 310.0, curve.getMinQ(1500.0, extrapolate), 0.0);
         assertEquals(extrapolate ? 350.0 : 390.0, curve.getMaxQ(1500.0, extrapolate), 0.0);
     }
+
+    @Test
+    void testWithNegativeZeroValue() {
+        ReactiveCapabilityCurveImpl curve = createCurve(new PointImpl(0.0, 200.0, 300.0),
+                new PointImpl(200.0, 300.0, 400.0));
+        // "-0.0 == 0.0" (JLS), but "Double.compareTo(-0.0, 0.0) = -1"
+        // This test asserts that -0.0 is considered as equal to 0.0 by the reactive capability curve.
+        assertEquals(200.0, curve.getMinQ(-0.0), 0.0);
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When the lowest point of a reactive capability curve has a `p` equals to `0.0`, calling `curve.getMinQ(-0.0);` leads to a `NullPointerException`.


**What is the new behavior (if this is a feature change)?**
When the lowest point of a reactive capability curve has a `p` equals to `0.0`, calling `curve.getMinQ(-0.0);` return the `minQ` of the lowest point.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

The [JLS](https://docs.oracle.com/javase/specs/jls/se17/html/jls-4.html#jls-4.2.3) states that `0.0 == -0.0`, but [`Double.compareTo(Double)`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Double.html#compareTo(java.lang.Double)) considers that `0.0 > -0.0`.

For a curve whose lowest point has `p == 0`, this inconsistency leads to calling [`points.floorEntry(-0.0).getValue()`](https://github.com/powsybl/powsybl-core/blob/ac44e4462e7e80ad3d6c00b452d4b0a258a2abaf/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveImpl.java#L127) (because `p >= this.getMinP()` — `-0.0 >= 0.0`) but the `TreeMap` considers that there's no entry with a `p` lower or equal to `-0.0` (it uses `Double.compareTo(Double)`).
Therefore, a `NullPointerException` is thrown:

```
java.lang.NullPointerException: Cannot invoke "java.util.Map$Entry.getValue()" because the return value of "java.util.TreeMap.floorEntry(Object)" is null
```

<br/>
This PR sets a comparator to the tree map for it to consider `0.0 == -0.0`.
