### PR TITLE
Fix duplicate EquipmentOperation profile in header

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportUtil.java
@@ -169,15 +169,13 @@ public final class CgmesExportUtil {
             writer.writeEmptyElement(MD_NAMESPACE, CgmesNames.SUPERSEDES);
             writer.writeAttribute(RDF_NAMESPACE, CgmesNames.RESOURCE, supersedes);
         }
+        if (subset == CgmesSubset.EQUIPMENT && context.getTopologyKind() == CgmesTopologyKind.NODE_BREAKER && context.getCimVersion() < 100) {
+            // From CGMES 3 EquipmentOperation is not required to write operational limits, connectivity nodes
+            modelDescription.addProfiles(List.of(context.getCim().getProfileUri("EQ_OP")));
+        }
         for (String profile : modelDescription.getProfiles()) {
             writer.writeStartElement(MD_NAMESPACE, CgmesNames.PROFILE);
             writer.writeCharacters(profile);
-            writer.writeEndElement();
-        }
-        if (subset == CgmesSubset.EQUIPMENT && context.getTopologyKind() == CgmesTopologyKind.NODE_BREAKER && context.getCimVersion() < 100) {
-            // From CGMES 3 EquipmentOperation is not required to write operational limits, connectivity nodes
-            writer.writeStartElement(MD_NAMESPACE, CgmesNames.PROFILE);
-            writer.writeCharacters(context.getCim().getProfileUri("EQ_OP"));
             writer.writeEndElement();
         }
         writer.writeStartElement(MD_NAMESPACE, CgmesNames.MODELING_AUTHORITY_SET);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesExportTest.java
@@ -37,7 +37,10 @@ import java.io.InputStream;
 import java.nio.file.*;
 import java.util.List;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import static com.powsybl.cgmes.conversion.test.ConversionUtil.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -405,6 +408,23 @@ class CgmesExportTest {
             // Verify that we re-import the exported CGMES data without problems
             Network networkReimported = Network.read(exportedCgmes, importParams);
             assertNotNull(networkReimported);
+        }
+    }
+
+    @Test
+    void testModelEquipmentOperationProfile() throws IOException {
+        String importDir = "/issues/switches/";
+        Network network = readCgmesResources(importDir, "disconnected_terminal_EQ.xml");
+
+        String exportDir = "/testModelProfile";
+        try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
+            Path tmpDir = Files.createDirectory(fs.getPath(exportDir));
+            String eqFile = writeCgmesProfile(network, "EQ", tmpDir);
+
+            String regex = "<md:Model.profile>http://entsoe.eu/CIM/EquipmentOperation/3/1</md:Model.profile>";
+            Pattern pattern = Pattern.compile(regex);
+            Matcher matcher = pattern.matcher(eqFile);
+            assertEquals(1, matcher.results().count());
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When reading a CGMES EQ file that's defining the CIM16 EquimentOperation profile in its header, and when exporting back to CGMES the network, the EquipmentOperation profile is written twice.
```xml
<md:FullModel rdf:about="urn:uuid:ModelID_EQ">
    <md:Model.scenarioTime>2021-03-01T23:00:00Z</md:Model.scenarioTime>
    <md:Model.created>2025-03-14T09:50:11Z</md:Model.created>
    <md:Model.description>Model description</md:Model.description>
    <md:Model.version>1</md:Model.version>
    <md:Model.profile>http://entsoe.eu/CIM/EquipmentCore/3/1</md:Model.profile>
    <md:Model.profile>http://entsoe.eu/CIM/EquipmentOperation/3/1</md:Model.profile>
    <md:Model.profile>http://entsoe.eu/CIM/EquipmentOperation/3/1</md:Model.profile>
    <md:Model.modelingAuthoritySet>powsybl.org</md:Model.modelingAuthoritySet>
</md:FullModel>
```

**What is the new behavior (if this is a feature change)?**
<!-- -->
EquipmentOperation profile is not written twice.

```xml
<md:FullModel rdf:about="urn:uuid:ModelID_EQ">
    <md:Model.scenarioTime>2021-03-01T23:00:00Z</md:Model.scenarioTime>
    <md:Model.created>2025-03-14T09:50:11Z</md:Model.created>
    <md:Model.description>Model description</md:Model.description>
    <md:Model.version>1</md:Model.version>
    <md:Model.profile>http://entsoe.eu/CIM/EquipmentCore/3/1</md:Model.profile>
    <md:Model.profile>http://entsoe.eu/CIM/EquipmentOperation/3/1</md:Model.profile>
    <md:Model.modelingAuthoritySet>powsybl.org</md:Model.modelingAuthoritySet>
</md:FullModel>
```


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
