### PR TITLE
Fix LoadFlowParameters selection when 'load-flow' module is defined

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
@@ -10,7 +10,6 @@ package com.powsybl.loadflow;
 import com.fasterxml.jackson.core.util.ByteArrayBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.commons.config.ModuleConfig;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.extensions.AbstractExtendable;
 import com.powsybl.commons.extensions.Extension;
@@ -211,8 +210,9 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
         // Check default-parameters-loader config parameter
         String selectedLoaderName;
         Optional<LoadFlowDefaultParametersLoader> selectedLoader = Optional.empty();
-        Optional<ModuleConfig> module = config.getOptionalModuleConfig("load-flow");
-        selectedLoaderName = module.map(moduleConfig -> moduleConfig.getStringProperty("default-parameters-loader")).orElse(null);
+        selectedLoaderName = config.getOptionalModuleConfig("load-flow")
+                .flatMap(moduleConfig -> moduleConfig.getOptionalStringProperty("default-parameters-loader"))
+                .orElse(null);
         if (selectedLoaderName != null) {
             selectedLoader = defaultParametersLoaders.stream()
                     .filter(loader -> loader.getSourceName().equals(selectedLoaderName))

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowDefaultParametersLoaderTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowDefaultParametersLoaderTest.java
@@ -51,6 +51,32 @@ class LoadFlowDefaultParametersLoaderTest {
     }
 
     @Test
+    void testWithAModuleButNoProperty() {
+        LoadFlowDefaultParametersLoaderMock loader = new LoadFlowDefaultParametersLoaderMock("test");
+
+        platformConfig.createModuleConfig("load-flow");
+
+        LoadFlowParameters parameters = new LoadFlowParameters(List.of(loader), platformConfig);
+        JsonLoadFlowParametersTest.DummyExtension extension = parameters.getExtension(JsonLoadFlowParametersTest.DummyExtension.class);
+        // The module is present in configuration, but no "default-parameters-loader" is set.
+        // A unique loader is found: it is used.
+        assertNotNull(extension);
+        assertEquals("Hello", extension.getParameterString());
+    }
+
+    @Test
+    void testLoaderButWrongDefault() {
+        LoadFlowDefaultParametersLoaderMock loader = new LoadFlowDefaultParametersLoaderMock("test1");
+
+        MapModuleConfig moduleConfig = platformConfig.createModuleConfig("load-flow");
+        moduleConfig.setStringProperty("default-parameters-loader", "test2");
+
+        LoadFlowParameters parameters = new LoadFlowParameters(List.of(loader), platformConfig);
+        // The loader was not used since it doesn't match the expected one. No exception is thrown.
+        assertNull(parameters.getExtension(JsonLoadFlowParametersTest.DummyExtension.class));
+    }
+
+    @Test
     void testConflictBetweenDefaultParametersLoader() {
         LoadFlowDefaultParametersLoaderMock loader1 = new LoadFlowDefaultParametersLoaderMock("test1");
         LoadFlowDefaultParametersLoaderMock loader2 = new LoadFlowDefaultParametersLoaderMock("test2");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When `load-flow` module is defined in configuration but the `default-parameters-loader` property is absent, an exception is thrown when loading the loadflow parameters


**What is the new behavior (if this is a feature change)?**
No exception is thrown
\+ Add another unit test


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

Bug detected via the CI Snapshot, during powsybl-open-rao unit tests execution.