### PR TITLE
CGMES export as bus/branch: unit test to clarify behaviour with non-retained open switches

### DIFF
--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -173,12 +173,11 @@ The various configurations and the differences in what's written are summarized 
 | 100         | `NODE_BREAKER`           | Yes (*)                               | Yes                                                 |
 | 100         | `BUS_BRANCH`             | Yes (**)                              | Yes                                                 |
 
-Having non-retained open switches in a node/breaker network that is exported as bus/branch may result in multiple connectivity components in the exported network.
-To avoid this, it would be best to close all non-retained switches in the case before exporting it.
-Then, the maximum amount of connectivity will be preserved in the export, and the bus/branch exported files can more easily be used for later calculations.
-
 ### Connectivity elements
-* Non-retained `Switch` are always written in the case of a `NODE_BREAKER` export, and never written in the case of a `BUS_BRANCH` export
+* Non-retained `Switch` are always written in the case of a `NODE_BREAKER` export, and never written in the case of a `BUS_BRANCH` export.
+  * Having non-retained open switches in a node/breaker network that is exported as bus/branch may result in multiple connectivity components in the exported network. 
+  * To avoid this, it would be best to close all non-retained switches in the case before exporting it. 
+  * Then, the maximum amount of connectivity will be preserved in the export, and the bus/branch exported files can more easily be used for later calculations.
 * `ConnectivityNode` are:
   * Never exported in the case of a CIM 16 `BUS_BRANCH` export
   * (*) Always exported in the case of a `NODE_BREAKER` export. If the VoltageLevel's connectivity level is `node/breaker`,

--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -174,7 +174,7 @@ The various configurations and the differences in what's written are summarized 
 | 100         | `BUS_BRANCH`             | Yes (**)                              | Yes                                                 |
 
 Having non-retained open switches in a node/breaker network that is exported as bus/branch may result in multiple connectivity components in the exported network.
-To avoid this, it would best to close all non-retained switches in the case before exporting it.
+To avoid this, it would be best to close all non-retained switches in the case before exporting it.
 Then, the maximum amount of connectivity will be preserved in the export, and the bus/branch exported files can more easily be used for later calcuations.
 
 ### Connectivity elements

--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -173,6 +173,10 @@ The various configurations and the differences in what's written are summarized 
 | 100         | `NODE_BREAKER`           | Yes (*)                               | Yes                                                 |
 | 100         | `BUS_BRANCH`             | Yes (**)                              | Yes                                                 |
 
+Having non-retained open switches in a node/breaker network that is exported as bus/branch may result in multiple connectivity components in the exported network.
+To avoid this, it would best to close all non-retained switches in the case before exporting it.
+Then, the maximum amount of connectivity will be preserved in the export, and the bus/branch exported files can more easily be used for later calcuations.
+
 ### Connectivity elements
 * Non-retained `Switch` are always written in the case of a `NODE_BREAKER` export, and never written in the case of a `BUS_BRANCH` export
 * `ConnectivityNode` are:

--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -175,7 +175,7 @@ The various configurations and the differences in what's written are summarized 
 
 Having non-retained open switches in a node/breaker network that is exported as bus/branch may result in multiple connectivity components in the exported network.
 To avoid this, it would be best to close all non-retained switches in the case before exporting it.
-Then, the maximum amount of connectivity will be preserved in the export, and the bus/branch exported files can more easily be used for later calcuations.
+Then, the maximum amount of connectivity will be preserved in the export, and the bus/branch exported files can more easily be used for later calculations.
 
 ### Connectivity elements
 * Non-retained `Switch` are always written in the case of a `NODE_BREAKER` export, and never written in the case of a `BUS_BRANCH` export


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

Related to #3318

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Additional unit test.

The goal is to show that when using bus/branch exports of a node/breaker network, you should  close all non-retained open switches in your case before exporting it, if you plan to use the exported files for later calculations (and want to keep the maximum amount of connectivity). 

**What is the current behavior?**
<!-- You can also link to an open issue here -->

Having non-retained open switches in a network that is exported as bus/branch may result in multiple connectivity components in the exported network.

**What is the new behavior (if this is a feature change)?**

No behaviour is changed. The unit tests tries to clarify potential issues with bus/branch export of node/breaker networks that contain non-retained open switches.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

The unit test uses a simple node/breaker network:
<img width="704" alt="Screenshot 2025-03-16 at 23 22 57" src="https://github.com/user-attachments/assets/9c863ae0-9c05-45cb-bc54-86ab8d51586c" />
where the disconnectors are open and marked as non-retained, and the breakers are also open and retained. 

Exporting the network as bus/branch from this situation produces the following:
<img width="796" alt="Screenshot 2025-03-16 at 23 24 42" src="https://github.com/user-attachments/assets/f90001c1-7cfe-43b8-9800-7bb407e370ad" />
In this exported network, the generator and the load can not be reconnected to the rest of the network, even after closing the retained breakers.

If the non-retained switches are closed BEFORE exporting to bus/branch, the exported network will keep the possibility of reconnecting these equipment:
<img width="711" alt="Screenshot 2025-03-18 at 12 21 47" src="https://github.com/user-attachments/assets/1e0283be-7e7d-4004-a335-d0a886c5b19d" />
