### PR TITLE
Rework nodes mapping to allow export of isolated nodes

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -117,9 +117,7 @@ public final class EquipmentExport {
             for (VoltageLevel vl : network.getVoltageLevels()) {
                 String cgmesVlId = context.getNamingStrategy().getCgmesId(vl);
                 if (vl.getTopologyKind() == TopologyKind.NODE_BREAKER && !context.isBusBranchExport()) {
-                    writeNodes(vl, cgmesVlId, new VoltageLevelAdjacency(vl, context), mapNodeKey2NodeId, cimNamespace, writer, context);
-                    writeSwitchesConnectivity(vl, cgmesVlId, mapNodeKey2NodeId, cimNamespace, writer, context);
-                    writeBusbarSectionsConnectivity(vl, mapNodeKey2NodeId, cimNamespace, writer, context);
+                    writeNodes(vl, cgmesVlId, new VoltageLevelAdjacency(vl.getNodeBreakerView(), context), mapNodeKey2NodeId, cimNamespace, writer, context);
                 } else {
                     writeBuses(vl, cgmesVlId, mapNodeKey2NodeId, cimNamespace, writer, context);
                 }
@@ -127,53 +125,9 @@ public final class EquipmentExport {
         }
     }
 
-    private static void writeSwitchesConnectivity(VoltageLevel vl, String cgmesVlId, Map <String, String> mapNodeKey2NodeId, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) {
-        String[] nodeKeys = new String[2];
-        for (Switch sw : vl.getSwitches()) {
-            fillSwitchNodeKeys(vl, sw, nodeKeys, context);
-            // We have to go through all switches, even if they are not exported as equipment,
-            // to be sure that all required mappings between IIDM node number and CGMES Connectivity Node are created
-            writeSwitchConnectivity(nodeKeys[0], vl, cgmesVlId, mapNodeKey2NodeId, cimNamespace, writer, context);
-            writeSwitchConnectivity(nodeKeys[1], vl, cgmesVlId, mapNodeKey2NodeId, cimNamespace, writer, context);
-        }
-    }
-
-    private static void writeSwitchConnectivity(String nodeKey, VoltageLevel vl, String cgmesVlId, Map <String, String> mapNodeKey2NodeId, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) {
-        mapNodeKey2NodeId.computeIfAbsent(nodeKey, k -> {
-            try {
-                String node = context.getNamingStrategy().getCgmesId(refTyped(vl), ref(nodeKey), CONNECTIVITY_NODE);
-                ConnectivityNodeEq.write(node, nodeKey, cgmesVlId, cimNamespace, writer, context);
-                return node;
-            } catch (XMLStreamException e) {
-                throw new UncheckedXmlStreamException(e);
-            }
-        });
-    }
-
-    private static String buildNodeKey(VoltageLevel vl, int node) {
-        return vl.getId() + "_" + node;
-    }
-
-    private static String buildNodeKey(Bus bus) {
-        return bus.getId();
-    }
-
-    private static void writeBusbarSectionsConnectivity(VoltageLevel vl, Map <String, String> mapNodeKey2NodeId, String cimNamespace,
-                                                        XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
-        for (BusbarSection bbs : vl.getNodeBreakerView().getBusbarSections()) {
-            String connectivityNodeId = connectivityNodeId(mapNodeKey2NodeId, bbs.getTerminal(), context);
-            if (connectivityNodeId == null) {
-                String node = context.getNamingStrategy().getCgmesId(refTyped(bbs), CONNECTIVITY_NODE);
-                ConnectivityNodeEq.write(node, bbs.getNameOrId(), context.getNamingStrategy().getCgmesId(vl), cimNamespace, writer, context);
-                String key = buildNodeKey(vl, bbs.getTerminal().getNodeBreakerView().getNode());
-                mapNodeKey2NodeId.put(key, node);
-            }
-        }
-    }
-
     private static void writeNodes(VoltageLevel vl, String cgmesVlId, VoltageLevelAdjacency vlAdjacencies, Map <String, String> mapNodeKey2NodeId, String cimNamespace,
                                    XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
-        for (List<Integer> nodes : vlAdjacencies.getNodes()) {
+        for (List<Integer> nodes : vlAdjacencies.getAdjacencies()) {
             String cgmesNodeId = context.getNamingStrategy().getCgmesId(refTyped(vl), ref(nodes.get(0)), CONNECTIVITY_NODE);
             ConnectivityNodeEq.write(cgmesNodeId, CgmesExportUtil.format(nodes.get(0)), cgmesVlId, cimNamespace, writer, context);
             for (Integer nodeNumber : nodes) {
@@ -188,6 +142,14 @@ public final class EquipmentExport {
             ConnectivityNodeEq.write(cgmesNodeId, bus.getNameOrId(), cgmesVlId, cimNamespace, writer, context);
             mapNodeKey2NodeId.put(buildNodeKey(bus), cgmesNodeId);
         }
+    }
+
+    private static String buildNodeKey(VoltageLevel vl, int node) {
+        return vl.getId() + "_" + node;
+    }
+
+    private static String buildNodeKey(Bus bus) {
+        return bus.getId();
     }
 
     private static void writeSwitches(Network network, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
@@ -208,16 +170,6 @@ public final class EquipmentExport {
         Bus bus1 = sw.getVoltageLevel().getBusBreakerView().getBus1(sw.getId());
         Bus bus2 = sw.getVoltageLevel().getBusBreakerView().getBus2(sw.getId());
         return bus1 != bus2;
-    }
-
-    private static void fillSwitchNodeKeys(VoltageLevel vl, Switch sw, String[] nodeKeys, CgmesExportContext context) {
-        if (vl.getTopologyKind().equals(TopologyKind.NODE_BREAKER) && !context.isBusBranchExport()) {
-            nodeKeys[0] = buildNodeKey(vl, vl.getNodeBreakerView().getNode1(sw.getId()));
-            nodeKeys[1] = buildNodeKey(vl, vl.getNodeBreakerView().getNode2(sw.getId()));
-        } else {
-            nodeKeys[0] = buildNodeKey(vl.getBusBreakerView().getBus1(sw.getId()));
-            nodeKeys[1] = buildNodeKey(vl.getBusBreakerView().getBus2(sw.getId()));
-        }
     }
 
     private static void writeSubstations(Network network, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
@@ -1499,6 +1451,16 @@ public final class EquipmentExport {
         }
     }
 
+    private static void fillSwitchNodeKeys(VoltageLevel vl, Switch sw, String[] nodeKeys, CgmesExportContext context) {
+        if (vl.getTopologyKind().equals(TopologyKind.NODE_BREAKER) && !context.isBusBranchExport()) {
+            nodeKeys[0] = buildNodeKey(vl, vl.getNodeBreakerView().getNode1(sw.getId()));
+            nodeKeys[1] = buildNodeKey(vl, vl.getNodeBreakerView().getNode2(sw.getId()));
+        } else {
+            nodeKeys[0] = buildNodeKey(vl.getBusBreakerView().getBus1(sw.getId()));
+            nodeKeys[1] = buildNodeKey(vl.getBusBreakerView().getBus2(sw.getId()));
+        }
+    }
+
     private static void writeTerminal(Terminal t, Map<Terminal, String> mapTerminal2Id, Map<String, String> mapNodeKey2NodeId,
                                       String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) {
         String equipmentId = context.getNamingStrategy().getCgmesId(t.getConnectable());
@@ -1537,83 +1499,66 @@ public final class EquipmentExport {
 
     private static class VoltageLevelAdjacency {
 
-        private final List<List<Integer>> voltageLevelNodes;
+        private final List<List<Integer>> adjacencies;
 
-        VoltageLevelAdjacency(VoltageLevel vl, CgmesExportContext context) {
-            voltageLevelNodes = new ArrayList<>();
-
-            NodeAdjacency adjacency = new NodeAdjacency(vl, context);
+        VoltageLevelAdjacency(VoltageLevel.NodeBreakerView nodeBreakerView, CgmesExportContext context) {
+            adjacencies = new ArrayList<>();
             Set<Integer> visitedNodes = new HashSet<>();
-            adjacency.get().keySet().forEach(node -> {
-                if (visitedNodes.contains(node)) {
-                    return;
+
+            // Build a list of adjacent nodes.
+            for (Integer node : nodeBreakerView.getNodes()) {
+                if (!visitedNodes.contains(node)) {
+                    List<Integer> adjacentNodes = new ArrayList<>(1);
+                    computeAdjacentNodes(nodeBreakerView, List.of(node), adjacentNodes, visitedNodes, context);
+                    adjacencies.add(adjacentNodes);
                 }
-                List<Integer> adjacentNodes = computeAdjacentNodes(node, adjacency, visitedNodes);
-                voltageLevelNodes.add(adjacentNodes);
-            });
-        }
-
-        private List<Integer> computeAdjacentNodes(int nodeId, NodeAdjacency adjacency, Set<Integer> visitedNodes) {
-
-            List<Integer> adjacentNodes = new ArrayList<>();
-            adjacentNodes.add(nodeId);
-            visitedNodes.add(nodeId);
-
-            int k = 0;
-            while (k < adjacentNodes.size()) {
-                Integer node = adjacentNodes.get(k);
-                if (adjacency.get().containsKey(node)) {
-                    adjacency.get().get(node).forEach(adjacent -> {
-                        if (visitedNodes.contains(adjacent)) {
-                            return;
-                        }
-                        adjacentNodes.add(adjacent);
-                        visitedNodes.add(adjacent);
-                    });
-                }
-                k++;
             }
-            return adjacentNodes;
+
+            // Sort adjacencies so that nodes that have been created first are exported first.
+            adjacencies.sort(Comparator.comparing(Collections::min));
         }
 
-        List<List<Integer>> getNodes() {
-            return voltageLevelNodes;
+        public List<List<Integer>> getAdjacencies() {
+            return adjacencies;
         }
-    }
 
-    private static class NodeAdjacency {
+        // Recursively build a list of nodes adjacent to the given ones.
+        // Nodes are adjacent if they are connected through an internal connection or non-exported switch.
+        private void computeAdjacentNodes(VoltageLevel.NodeBreakerView nodeBreakerView,
+                                          List<Integer> nodes,
+                                          List<Integer> adjacentNodes,
+                                          Set<Integer> visitedNodes,
+                                          CgmesExportContext context) {
+            for (Integer node : nodes) {
+                if (!visitedNodes.contains(node)) {
+                    // If the node hasn't been visited yet,
+                    // add it to the list of adjacencies and mark it as visited.
+                    visitedNodes.add(node);
+                    adjacentNodes.add(node);
 
-        private final Map<Integer, List<Integer>> adjacency;
+                    // The next nodes to be checked for adjacency.
+                    List<Integer> nextNodes = new ArrayList<>();
 
-        NodeAdjacency(VoltageLevel vl, CgmesExportContext context) {
-            adjacency = new HashMap<>();
-            if (vl.getTopologyKind().equals(TopologyKind.NODE_BREAKER)) {
-                vl.getNodeBreakerView().getInternalConnections().forEach(this::addAdjacency);
-                // When computing the connectivity nodes for the voltage level,
-                // switches that are not exported as equipment (they are fictitious)
-                // are equivalent to internal connections
-                vl.getNodeBreakerView().getSwitchStream()
-                        .filter(Objects::nonNull)
-                        .filter(sw -> !context.isExportedEquipment(sw))
-                        .forEach(this::addAdjacency);
+                    // Get nodes adjacent through internal connections.
+                    nextNodes.addAll(nodeBreakerView.getNodesInternalConnectedTo(node));
+
+                    // Get nodes adjacent through not exported switches (fictitious ones).
+                    nextNodes.addAll(nodeBreakerView.getSwitchStream(node)
+                            .filter(sw -> !context.isExportedEquipment(sw))
+                            .map(sw -> getAdjacentNode(nodeBreakerView, sw, node))
+                            .toList());
+
+                    // Recursively look for more adjacent nodes.
+                    computeAdjacentNodes(nodeBreakerView, nextNodes, adjacentNodes, visitedNodes, context);
+                }
             }
         }
 
-        private void addAdjacency(VoltageLevel.NodeBreakerView.InternalConnection ic) {
-            addAdjacency(ic.getNode1(), ic.getNode2());
-        }
-
-        private void addAdjacency(Switch sw) {
-            addAdjacency(sw.getVoltageLevel().getNodeBreakerView().getNode1(sw.getId()), sw.getVoltageLevel().getNodeBreakerView().getNode2(sw.getId()));
-        }
-
-        private void addAdjacency(int node1, int node2) {
-            adjacency.computeIfAbsent(node1, k -> new ArrayList<>()).add(node2);
-            adjacency.computeIfAbsent(node2, k -> new ArrayList<>()).add(node1);
-        }
-
-        Map<Integer, List<Integer>> get() {
-            return adjacency;
+        private Integer getAdjacentNode(VoltageLevel.NodeBreakerView nodeBreakerView, Switch sw, Integer node) {
+            if (nodeBreakerView.getNode1(sw.getId()) == node) {
+                return nodeBreakerView.getNode2(sw.getId());
+            }
+            return nodeBreakerView.getNode1(sw.getId());
         }
     }
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/NodeMappingTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/NodeMappingTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.powsybl.cgmes.conversion.test;
+
+import com.powsybl.cgmes.conversion.Conversion;
+import com.powsybl.commons.test.AbstractSerDeTest;
+import com.powsybl.iidm.network.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static com.powsybl.cgmes.conversion.test.ConversionUtil.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Romain Courtier {@literal <romain.courtier at rte-france.com>}
+ */
+
+class NodeMappingTest extends AbstractSerDeTest {
+
+    @Test
+    void nodeMappingTest() throws IOException {
+        // Export test network to CGMES EQ
+        Network network = networkWithMultipleConnectionKinds();
+        String eqFile = writeCgmesProfile(network, "EQ", tmpDir);
+
+        // IIDM nodes 0, 1, 2 are mapped to CGMES node VL_VL_0_CN
+        assertNotNull(getElement(eqFile, "ConnectivityNode", "VL_VL_0_CN"));
+        String nodeAssociation = "<cim:Terminal.ConnectivityNode rdf:resource=\"#_VL_VL_0_CN\"/>";
+        assertTrue(getElement(eqFile, "Terminal", "BBS_BS_T_1").contains(nodeAssociation));
+        assertTrue(getElement(eqFile, "Terminal", "LD1_EC_T_1").contains(nodeAssociation));
+        assertTrue(getElement(eqFile, "Terminal", "LD2_EC_T_1").contains(nodeAssociation));
+        assertTrue(getElement(eqFile, "Terminal", "DIS_SW_T_1").contains(nodeAssociation));
+
+        // IIDM node 3 is mapped to CGMES node VL_VL_3_CN
+        assertNotNull(getElement(eqFile, "ConnectivityNode", "VL_VL_3_CN"));
+        nodeAssociation = "<cim:Terminal.ConnectivityNode rdf:resource=\"#_VL_VL_3_CN\"/>";
+        assertTrue(getElement(eqFile, "Terminal", "LD3_EC_T_1").contains(nodeAssociation));
+        assertTrue(getElement(eqFile, "Terminal", "DIS_SW_T_2").contains(nodeAssociation));
+
+        // IIDM node 4 is mapped to CGMES node VL_VL_4_CN
+        assertNotNull(getElement(eqFile, "ConnectivityNode", "VL_VL_4_CN"));
+        nodeAssociation = "<cim:Terminal.ConnectivityNode rdf:resource=\"#_VL_VL_4_CN\"/>";
+        assertTrue(getElement(eqFile, "Terminal", "GEN_SM_T_1").contains(nodeAssociation));
+    }
+
+    private Network networkWithMultipleConnectionKinds() {
+        // This test network contains 4 nodes connection kinds:
+        // - Connection through internal connection: 0-1
+        // - Connection through not-exported fictitious switch: 0-2
+        // - Connection through regular switch: 0-3
+        // - No connection (isolated node): 4
+
+        //             BBS
+        //   --------- (0) ---------
+        //     |        |        |
+        //    (1)      FICT     DIS      (4)
+        //    LD1       |        |       GEN
+        //             (2)      (3)
+        //             LD2      LD3
+
+        Network network = NetworkFactory.findDefault().createNetwork("network", "test");
+        Substation substation = network.newSubstation()
+                .setId("ST")
+                .add();
+        VoltageLevel voltageLevel = substation.newVoltageLevel()
+                .setId("VL")
+                .setNominalV(100.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        voltageLevel.getNodeBreakerView().newBusbarSection()
+                .setId("BBS")
+                .setNode(0)
+                .add();
+        voltageLevel.getNodeBreakerView().newInternalConnection()
+                .setNode1(0)
+                .setNode2(1)
+                .add();
+        voltageLevel.newLoad()
+                .setId("LD1")
+                .setNode(1)
+                .setP0(1.0)
+                .setQ0(0.0)
+                .add();
+        voltageLevel.getNodeBreakerView().newSwitch()
+                .setId("FICT")
+                .setNode1(0)
+                .setNode2(2)
+                .setKind(SwitchKind.BREAKER)
+                .setOpen(true)
+                .setRetained(false)
+                .setFictitious(true)
+                .add()
+                .setProperty(Conversion.PROPERTY_IS_CREATED_FOR_DISCONNECTED_TERMINAL, "true");
+        voltageLevel.newLoad()
+                .setId("LD2")
+                .setNode(2)
+                .setP0(1.0)
+                .setQ0(0.0)
+                .add();
+        voltageLevel.getNodeBreakerView().newSwitch()
+                .setId("DIS")
+                .setNode1(0)
+                .setNode2(3)
+                .setKind(SwitchKind.DISCONNECTOR)
+                .setOpen(false)
+                .setRetained(false)
+                .add();
+        voltageLevel.newLoad()
+                .setId("LD3")
+                .setNode(3)
+                .setP0(1.0)
+                .setQ0(0.0)
+                .add();
+        // Isolated generator
+        voltageLevel.newGenerator()
+                .setId("GEN")
+                .setNode(4)
+                .setTargetP(3.0)
+                .setTargetQ(0.0)
+                .setMinP(0.0)
+                .setMaxP(3.0)
+                .setVoltageRegulatorOn(false)
+                .add();
+
+        return network;
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/TopologyExportCornerCasesTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/TopologyExportCornerCasesTest.java
@@ -30,7 +30,7 @@ class TopologyExportCornerCasesTest extends AbstractSerDeTest {
     @Test
     void testExportSwitchesNodeBreaker() {
         test(createSwitchesNBNetwork(), true, true,
-                new String[] {"voltageLevel1_0", "voltageLevel1_2", "voltageLevel1_8"});
+                new String[] {"voltageLevel1_0", "voltageLevel1_1", "voltageLevel1_3"});
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The node of an isolated IIDM equipment (a connectable not linked to any other element either through switch or internal connection) isn't exported to CGMES. This leads to a cardinality issue in the CGMES EQ file where the terminal of the isolated equipment doesn't have a ConnectivityNode association.


**What is the new behavior (if this is a feature change)?**
<!-- -->
The node of an isolated IIDM equipment is exported to CGMES.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Nodes are now exported in order of their number. This shall ensure that nodes are exported in the same order they have been imported and thus in the case of a round-trip import/export the numbers should be the same.
