### PR TITLE
Fix append method on compressed datachunks

### DIFF
--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompressedDoubleDataChunk.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompressedDoubleDataChunk.java
@@ -171,7 +171,7 @@ public class CompressedDoubleDataChunk extends AbstractCompressedDataChunk imple
             //Step lengths
             newStepLengths = new int[stepLengths.length + chunk.getStepLengths().length - 1];
             System.arraycopy(stepLengths, 0, newStepLengths, 0, stepLengths.length);
-            newStepLengths[stepLengths.length - 1] = stepLengths[stepLengths.length - 1] + newStepLengths[0];
+            newStepLengths[stepLengths.length - 1] = stepLengths[stepLengths.length - 1] + chunk.getStepLengths()[0];
             System.arraycopy(chunk.getStepLengths(), 1, newStepLengths, stepLengths.length, chunk.getStepLengths().length - 1);
 
             //Step values

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompressedStringDataChunk.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CompressedStringDataChunk.java
@@ -190,7 +190,7 @@ public class CompressedStringDataChunk extends AbstractCompressedDataChunk imple
             //Step lengths
             newStepLengths = new int[stepLengths.length + chunk.getStepLengths().length - 1];
             System.arraycopy(stepLengths, 0, newStepLengths, 0, stepLengths.length);
-            newStepLengths[stepLengths.length - 1] = stepLengths[stepLengths.length - 1] + newStepLengths[0];
+            newStepLengths[stepLengths.length - 1] = stepLengths[stepLengths.length - 1] + chunk.getStepLengths()[0];
             System.arraycopy(chunk.getStepLengths(), 1, newStepLengths, stepLengths.length, chunk.getStepLengths().length - 1);
 
             //Step values

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/DoubleDataChunkTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/DoubleDataChunkTest.java
@@ -225,7 +225,7 @@ class DoubleDataChunkTest {
     void compressedMergeTest() {
         CompressedDoubleDataChunk chunk1 = new CompressedDoubleDataChunk(1, 5, new double[]{1d, 2d}, new int[]{2, 3});
         CompressedDoubleDataChunk chunk2 = new CompressedDoubleDataChunk(6, 5, new double[]{3d, 4d}, new int[]{2, 3});
-        CompressedDoubleDataChunk chunk3 = new CompressedDoubleDataChunk(11, 3, new double[]{4d, 5d}, new int[]{2, 1});
+        CompressedDoubleDataChunk chunk3 = new CompressedDoubleDataChunk(11, 6, new double[]{4d, 5d}, new int[]{5, 1});
 
         //Merge chunk1 + chunk2
         DoubleDataChunk merge = chunk1.append(chunk2);
@@ -241,9 +241,9 @@ class DoubleDataChunkTest {
         assertNotNull(merge);
         assertInstanceOf(CompressedDoubleDataChunk.class, merge);
         assertEquals(6, merge.getOffset());
-        assertEquals(8, merge.getLength());
+        assertEquals(11, merge.getLength());
         assertArrayEquals(new double[] {3d, 4d, 5d}, ((CompressedDoubleDataChunk) merge).getStepValues(), 0d);
-        assertArrayEquals(new int[] {2, 5, 1}, ((CompressedDoubleDataChunk) merge).getStepLengths());
+        assertArrayEquals(new int[] {2, 8, 1}, ((CompressedDoubleDataChunk) merge).getStepLengths());
 
         //Merge chunk1 + chunk3
         try {

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/StringDataChunkTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/StringDataChunkTest.java
@@ -198,7 +198,7 @@ class StringDataChunkTest {
     void compressedMergeTest() {
         CompressedStringDataChunk chunk1 = new CompressedStringDataChunk(1, 5, new String[]{"a", "b"}, new int[]{2, 3});
         CompressedStringDataChunk chunk2 = new CompressedStringDataChunk(6, 5, new String[]{"c", "d"}, new int[]{2, 3});
-        CompressedStringDataChunk chunk3 = new CompressedStringDataChunk(11, 3, new String[]{"d", "e"}, new int[]{2, 1});
+        CompressedStringDataChunk chunk3 = new CompressedStringDataChunk(11, 6, new String[]{"d", "e"}, new int[]{5, 1});
 
         //Merge chunk1 + chunk2
         StringDataChunk merge = chunk1.append(chunk2);
@@ -214,9 +214,9 @@ class StringDataChunkTest {
         assertNotNull(merge);
         assertInstanceOf(CompressedStringDataChunk.class, merge);
         assertEquals(6, merge.getOffset());
-        assertEquals(8, merge.getLength());
+        assertEquals(11, merge.getLength());
         assertArrayEquals(new String[] {"c", "d", "e"}, ((CompressedStringDataChunk) merge).getStepValues());
-        assertArrayEquals(new int[] {2, 5, 1}, ((CompressedStringDataChunk) merge).getStepLengths());
+        assertArrayEquals(new int[] {2, 8, 1}, ((CompressedStringDataChunk) merge).getStepLengths());
 
         //Merge chunk1 + chunk3
         try {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
When a compressed datachunk is append to another one, if the last value of the first datachunk is equal to the first value of the second datachunk, the corresponding length should be added together.
However, in the current version, the last length of the first datachunk was added to the first length of the **new datachunk**, which was initialized with the first datachunk so the wrong length was added.

Tests `compressedMergeTest()` in `StringDataChunkTest` and in `DoubleDataChunkTest` used the same length value in the two datachunks so the bug wasn't apparent.

**What is the new behavior (if this is a feature change)?**
The last length of the first datachunk is now added to the first length of the second datachunk to create the length in the new datachunk.

Tests `compressedMergeTest()` in `StringDataChunkTest` and in `DoubleDataChunkTest` have been modified to test this.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
