### PR TITLE
Fix: CreateVoltageLevelTopology should also work in non empty voltage levels

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateVoltageLevelTopology.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateVoltageLevelTopology.java
@@ -183,7 +183,7 @@ public class CreateVoltageLevelTopology extends AbstractNetworkModification {
     }
 
     private void createBusbarSections(VoltageLevel voltageLevel, NamingStrategy namingStrategy) {
-        int node = 0;
+        int node = voltageLevel.getNodeBreakerView().getMaximumNodeIndex() + 1;
         for (int sectionNum = lowSectionIndex; sectionNum < lowSectionIndex + sectionCount; sectionNum++) {
             for (int busbarNum = lowBusOrBusbarIndex; busbarNum < lowBusOrBusbarIndex + alignedBusesOrBusbarCount; busbarNum++) {
                 BusbarSection bbs = voltageLevel.getNodeBreakerView().newBusbarSection()

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateVoltageLevelTopologyTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/CreateVoltageLevelTopologyTest.java
@@ -9,8 +9,8 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.PowsyblCoreReportResourceBundle;
-import com.powsybl.commons.test.PowsyblCoreTestReportResourceBundle;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.test.PowsyblCoreTestReportResourceBundle;
 import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.modification.AbstractNetworkModification;
 import com.powsybl.iidm.modification.NetworkModification;
@@ -20,6 +20,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.iidm.network.extensions.BusbarSectionPosition;
+import com.powsybl.iidm.network.extensions.BusbarSectionPositionAdder;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.jupiter.api.Test;
 
@@ -326,6 +327,34 @@ class CreateVoltageLevelTopologyTest extends AbstractModificationTest {
             .withSectionCount(4)
             .build();
         assertEquals(NetworkModificationImpact.HAS_IMPACT_ON_NETWORK, modification7.hasImpactOnNetwork(network));
+    }
+
+    @Test
+    void testWithAlreadyExistingTopology() {
+        Network network = createNbNetwork();
+        // Add busbar section position extension to the busbar section of voltage level C
+        network.getBusbarSection("D").newExtension(BusbarSectionPositionAdder.class)
+            .withBusbarIndex(1)
+            .withSectionIndex(1)
+            .add();
+
+        // Add a busbar section with one section "below" the busbar section D with default naming strategy
+        CreateVoltageLevelTopology modification = new CreateVoltageLevelTopologyBuilder()
+            .withVoltageLevelId("C")
+            .withAlignedBusesOrBusbarCount(1)
+            .withSectionCount(1)
+            .withLowSectionIndex(1)
+            .withSwitchKinds()
+            .withLowBusOrBusbarIndex(2)
+            .build();
+        modification.apply(network);
+
+        BusbarSection bbs = network.getBusbarSection("C_2_1");
+        assertNotNull(bbs);
+        BusbarSectionPosition bbsPosition = bbs.getExtension(BusbarSectionPosition.class);
+        assertEquals(2, bbsPosition.getBusbarIndex());
+        assertEquals(1, bbsPosition.getSectionIndex());
+        assertEquals(2, network.getVoltageLevel("C").getNodeBreakerView().getBusbarSectionCount());
     }
 
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The nodes used for the creation of new busbar sections in a voltage level start at 0.


**What is the new behavior (if this is a feature change)?**
The node 0 will usually be taken if the voltage level is not empty. Instead, the first available node will be used so that it is possible to add busbar sections in voltage levels that already contains busbar sections (from a diagram point of view, below or next to them). 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
