### PR TITLE
Add null check for return value of CsvParser::parseLine

### DIFF
--- a/psse/psse-model/src/main/java/com/powsybl/psse/model/io/AbstractRecordGroup.java
+++ b/psse/psse-model/src/main/java/com/powsybl/psse/model/io/AbstractRecordGroup.java
@@ -170,6 +170,12 @@ public abstract class AbstractRecordGroup<T> {
         context.resetCurrentRecordGroup();
         for (String record : records) {
             String[] fields = parser.parseLine(record);
+            
+            // CsvParser::parseLine could return null for malformed record
+            if (fields == null) {
+                throw new PsseException("Parsing error");
+            }
+            
             context.setCurrentRecordNumFields(fields.length);
         }
         List<T> beans = processor.getBeans();


### PR DESCRIPTION
This is a proposed fix to stability issue discovered by OSS-Fuzz when fuzzing the powsybl-core module. The original OSS-Fuzz issue can be found in https://issues.oss-fuzz.com/u/1/issues/406925425.