### PR TITLE
Use all resources bundles in dynamic simulation tool report node

### DIFF
--- a/dynamic-simulation/dynamic-simulation-dsl/src/main/java/com/powsybl/dynamicsimulation/groovy/DynamicSimulationReports.java
+++ b/dynamic-simulation/dynamic-simulation-dsl/src/main/java/com/powsybl/dynamicsimulation/groovy/DynamicSimulationReports.java
@@ -7,7 +7,6 @@
  */
 package com.powsybl.dynamicsimulation.groovy;
 
-import com.powsybl.commons.report.PowsyblCoreReportResourceBundle;
 import com.powsybl.commons.report.ReportNode;
 
 /**
@@ -17,7 +16,7 @@ public final class DynamicSimulationReports {
 
     public static ReportNode buildRootDynamicSimulationTool() {
         return ReportNode.newRootReportNode()
-                .withResourceBundles(PowsyblCoreReportResourceBundle.BASE_NAME)
+                .withAllResourceBundlesFromClasspath()
                 .withMessageTemplate("core.dynasim.dynamicSimulationTool")
                 .build();
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Dynamic simulation tool root report node use only the core resources bundle and thus will not use the simulation provider specific resources bundle.


**What is the new behavior (if this is a feature change)?**
Use `withAllResourceBundlesFromClasspath` in dynamic simulation tool root report node.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
