### PR TITLE
Network.getIdentifiableStream completeness

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Network.java
@@ -1511,6 +1511,8 @@ public interface Network extends Container<Network> {
             case HVDC_CONVERTER_STATION -> getHvdcConverterStationStream().map(Function.identity());
             case STATIC_VAR_COMPENSATOR -> getStaticVarCompensatorStream().map(Function.identity());
             case GROUND -> getGroundStream().map(Function.identity());
+            case AREA -> getAreaStream().map(Function.identity());
+            case OVERLOAD_MANAGEMENT_SYSTEM -> getOverloadManagementSystemStream().map(Function.identity());
             default -> throw new PowsyblException("can get a stream of " + identifiableType + " from a network.");
         };
     }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAreaTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAreaTest.java
@@ -221,6 +221,7 @@ public abstract class AbstractAreaTest {
         List<Area> areas = List.of(controlAreaA, controlAreaB, regionAB);
         List<String> areaTypes = List.of(CONTROL_AREA_TYPE, REGION_AREA_TYPE);
 
+        assertEquals(areas, network.getIdentifiableStream(IdentifiableType.AREA).toList());
         assertEquals(areas, network.getAreaStream().toList());
         assertEquals(areaTypes, network.getAreaTypeStream().toList());
         assertEquals(areaTypes, network.getAreaTypes());

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractOverloadManagementSystemTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractOverloadManagementSystemTest.java
@@ -7,7 +7,6 @@
  */
 package com.powsybl.iidm.network.tck;
 
-import com.google.common.collect.ImmutableSet;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.SecurityAnalysisTestNetworkFactory;
@@ -16,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.StreamSupport;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -70,13 +70,18 @@ public abstract class AbstractOverloadManagementSystemTest {
         assertEquals(2, substation.getOverloadManagementSystemCount());
 
         Iterable<OverloadManagementSystem> iterable = substation.getOverloadManagementSystems();
-        List<OverloadManagementSystem> retreived = StreamSupport.stream(iterable.spliterator(), false).toList();
-        assertEquals(2, retreived.size());
-        assertTrue(retreived.containsAll(ImmutableSet.of(oms1, oms2)));
+        List<OverloadManagementSystem> retrieved = StreamSupport.stream(iterable.spliterator(), false).toList();
+        assertEquals(2, retrieved.size());
+        assertTrue(retrieved.containsAll(Set.of(oms1, oms2)));
 
-        retreived = substation.getOverloadManagementSystemStream().toList();
-        assertEquals(2, retreived.size());
-        assertTrue(retreived.containsAll(ImmutableSet.of(oms1, oms2)));
+        retrieved = substation.getOverloadManagementSystemStream().toList();
+        assertEquals(2, retrieved.size());
+        assertTrue(retrieved.containsAll(Set.of(oms1, oms2)));
+
+        retrieved = network.getIdentifiableStream(IdentifiableType.OVERLOAD_MANAGEMENT_SYSTEM)
+            .map(OverloadManagementSystem.class::cast).toList();
+        assertEquals(2, retrieved.size());
+        assertTrue(retrieved.containsAll(Set.of(oms2, oms1)));
 
         assertEquals("OMS1", oms1.getId());
         assertEquals("OMS2", oms2.getId());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Cannot get stream of `AREA`-s and `OVERLOAD_MANAGEMENT_SYSTEM`-s with `Network.getIdentifiableStream(IdentifiableType identifiableType)`


**What is the new behavior (if this is a feature change)?**
Can get stream of areas and overload management systems.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
