### PR TITLE
Fix legacy version for the battery short circuit extension

### DIFF
--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/BatteryShortCircuitSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/BatteryShortCircuitSerDe.java
@@ -31,30 +31,33 @@ import java.util.Objects;
 public class BatteryShortCircuitSerDe extends AbstractVersionableNetworkExtensionSerDe<Battery, BatteryShortCircuit> {
 
     public static final String V1_0_LEGACY = "1.0-legacy";
+    public static final String V1_0_LEGACY_2 = "1.0-legacy-2";
+    private static final ImmutableSortedSet<String> LEGACY_VERSIONS = ImmutableSortedSet.<String>reverseOrder().add(V1_0_LEGACY, V1_0_LEGACY_2).build();
 
     public BatteryShortCircuitSerDe() {
         super(BatteryShortCircuit.NAME, BatteryShortCircuit.class, "bsc",
                 new ImmutableMap.Builder<IidmVersion, ImmutableSortedSet<String>>()
-                        .put(IidmVersion.V_1_0, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_1, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_2, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_3, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_4, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_5, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_6, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_7, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_8, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_9, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_10, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_11, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_12, ImmutableSortedSet.of(V1_0_LEGACY))
-                        .put(IidmVersion.V_1_13, ImmutableSortedSet.<String>reverseOrder().add(V1_0_LEGACY, "1.0").build())
+                        .put(IidmVersion.V_1_0, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_1, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_2, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_3, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_4, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_5, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_6, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_7, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_8, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_9, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_10, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_11, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_12, LEGACY_VERSIONS)
+                        .put(IidmVersion.V_1_13, ImmutableSortedSet.<String>reverseOrder().add(V1_0_LEGACY, V1_0_LEGACY_2, "1.0").build())
                         .build(),
                 new ImmutableMap.Builder<String, String>()
                         .put(V1_0_LEGACY, "http://www.itesla_project.eu/schema/iidm/ext/battery_short_circuits/1_0")
+                        .put(V1_0_LEGACY_2, "http://www.itesla_project.eu/schema/iidm/ext/batteryshortcircuits/1_0")
                         .put("1.0", "http://www.itesla_project.eu/schema/iidm/ext/battery_short_circuit/1_0")
                         .build(),
-                List.of(new AlternativeSerializationData("batteryShortCircuits", List.of(V1_0_LEGACY)))
+                List.of(new AlternativeSerializationData("batteryShortCircuits", List.copyOf(LEGACY_VERSIONS)))
         );
     }
 
@@ -66,7 +69,8 @@ public class BatteryShortCircuitSerDe extends AbstractVersionableNetworkExtensio
     @Override
     public List<InputStream> getXsdAsStreamList() {
         return List.of(Objects.requireNonNull(getClass().getResourceAsStream("/xsd/batteryShortCircuit_V1_0.xsd")),
-                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/batteryShortCircuit_V1_0_legacy.xsd")));
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/batteryShortCircuit_V1_0_legacy.xsd")),
+                Objects.requireNonNull(getClass().getResourceAsStream("/xsd/batteryShortCircuit_V1_0_legacy_2.xsd")));
     }
 
     @Override
@@ -74,7 +78,7 @@ public class BatteryShortCircuitSerDe extends AbstractVersionableNetworkExtensio
         NetworkSerializerContext networkContext = (NetworkSerializerContext) context;
         String extVersionStr = networkContext.getExtensionVersion(getExtensionName())
                 .orElseGet(() -> getVersion(networkContext.getVersion()));
-        if (V1_0_LEGACY.compareTo(extVersionStr) == 0) {
+        if (LEGACY_VERSIONS.contains(extVersionStr)) {
             context.getWriter().writeFloatAttribute("transientReactance", (float) batteryShortCircuit.getDirectTransX());
             context.getWriter().writeFloatAttribute("stepUpTransformerReactance", (float) batteryShortCircuit.getStepUpTransformerX());
         } else {
@@ -89,7 +93,7 @@ public class BatteryShortCircuitSerDe extends AbstractVersionableNetworkExtensio
         NetworkDeserializerContext networkContext = (NetworkDeserializerContext) context;
         String extVersionStr = networkContext.getExtensionVersion(this).orElseThrow(IllegalStateException::new);
         BatteryShortCircuitAdder batteryShortCircuitAdder = battery.newExtension(BatteryShortCircuitAdder.class);
-        if (V1_0_LEGACY.compareTo(extVersionStr) == 0) {
+        if (LEGACY_VERSIONS.contains(extVersionStr)) {
             batteryShortCircuitAdder
                     .withDirectTransX(context.getReader().readFloatAttribute("transientReactance"))
                     .withStepUpTransformerX(context.getReader().readFloatAttribute("stepUpTransformerReactance"));

--- a/iidm/iidm-serde/src/main/resources/xsd/batteryShortCircuit_V1_0_legacy_2.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/batteryShortCircuit_V1_0_legacy_2.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.itesla_project.eu/schema/iidm/ext/batteryshortcircuits/1_0"
+           elementFormDefault="qualified">
+    <xs:element name="batteryShortCircuits">
+        <xs:complexType>
+            <xs:attribute name="transientReactance" use="required" type="xs:float"/>
+            <xs:attribute name="stepUpTransformerReactance" use="required" type="xs:float"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/BatteryShortCircuitXmlSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/BatteryShortCircuitXmlSerDeTest.java
@@ -65,6 +65,27 @@ class BatteryShortCircuitXmlSerDeTest extends AbstractIidmSerDeTest {
         assertTrue(Double.isNaN(batteryShortCircuits2.getDirectSubtransX())); // This attribute is not exported in V0.1
     }
 
+    @Test
+    void roundTripTestV10Legacy2() throws IOException {
+        NetworkData networkData = getNetworkData();
+        Network network = networkData.network();
+        BatteryShortCircuit batteryShortCircuit = networkData.batteryShortCircuit();
+
+        // Use an extension version which serialization name is not the default
+        ExportOptions exportOptions = new ExportOptions()
+                .addExtensionVersion(BatteryShortCircuit.NAME, "1.0-legacy-2");
+        Network network2 = allFormatsRoundTripTest(network, "/shortcircuits/batteryShortCircuitRef_V1_0-legacy-2.xml", exportOptions);
+
+        Battery bat2 = network2.getBattery("BAT");
+        assertNotNull(bat2);
+        BatteryShortCircuit batteryShortCircuits2 = bat2.getExtension(BatteryShortCircuit.class);
+        assertNotNull(batteryShortCircuits2);
+
+        assertEquals(batteryShortCircuit.getDirectTransX(), batteryShortCircuits2.getDirectTransX(), 0.001d);
+        assertEquals(batteryShortCircuit.getStepUpTransformerX(), batteryShortCircuits2.getStepUpTransformerX(), 0.001d);
+        assertTrue(Double.isNaN(batteryShortCircuits2.getDirectSubtransX())); // This attribute is not exported in V0.1
+    }
+
     private static NetworkData getNetworkData() {
         Network network = BatteryNetworkFactory.create();
         network.setCaseDate(ZonedDateTime.parse("2017-06-25T17:43:00.000+01:00"));

--- a/iidm/iidm-serde/src/test/resources/shortcircuits/batteryShortCircuitRef_V1_0-legacy-2.xml
+++ b/iidm/iidm-serde/src/test/resources/shortcircuits/batteryShortCircuitRef_V1_0-legacy-2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_13" xmlns:bsc="http://www.itesla_project.eu/schema/iidm/ext/batteryshortcircuits/1_0" id="fictitious" caseDate="2017-06-25T17:43:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="R" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.0" q="-225.0">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="R" geographicalTags="B">
+        <iidm:voltageLevel id="VLBAT" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NBAT"/>
+            </iidm:busBreakerTopology>
+            <iidm:battery id="BAT" targetP="9999.99" targetQ="9999.99" minP="-9999.99" maxP="9999.99" bus="NBAT" connectableBus="NBAT" p="-605.0" q="-225.0">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:battery>
+            <iidm:battery id="BAT2" targetP="100.0" targetQ="200.0" minP="-200.0" maxP="200.0" bus="NBAT" connectableBus="NBAT" p="-605.0" q="-225.0">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>
+                    <iidm:point p="70.0" minQ="-54.55" maxQ="46.25"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:battery>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NBAT" connectableBus="NBAT"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" voltageLevelId1="VLGEN" bus1="NGEN" connectableBus1="NGEN" voltageLevelId2="VLBAT" bus2="NBAT" connectableBus2="NBAT"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" voltageLevelId1="VLGEN" bus1="NGEN" connectableBus1="NGEN" voltageLevelId2="VLBAT" bus2="NBAT" connectableBus2="NBAT"/>
+    <iidm:extension id="BAT">
+        <bsc:batteryShortCircuits transientReactance="1.0" stepUpTransformerReactance="3.0"/>
+    </iidm:extension>
+</iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The legacy version for the battery short circuit extension has 2 distinct namespaces, and both can be used.
But only one (the less commonly used) was declared:
- Actually supported: `"http://www.itesla_project.eu/schema/iidm/ext/battery_short_circuits/1_0"`
- Most commonly used: `"http://www.itesla_project.eu/schema/iidm/ext/batteryshortcircuits/1_0"` - not supported.

**What is the new behavior (if this is a feature change)?**
Both legacy namespaces are supported.
To avoid a breaking change, the missing legacy namespace is added as a `1.0-legacy-2` version.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
