### PR TITLE
Refactor AbstractThreeWindingsTransformerTest to have only one invocation possibly throwing a runtime exception

### DIFF
--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractThreeWindingsTransformerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractThreeWindingsTransformerTest.java
@@ -566,57 +566,57 @@ public abstract class AbstractThreeWindingsTransformerTest extends AbstractTrans
                 .setNode(0)
                 .add();
 
-        ValidationException e = assertThrows(ValidationException.class, () -> substation.newThreeWindingsTransformer()
-                .setId("twt")
-                .setName(TWT_NAME)
-                .newLeg1()
-                .setR(1.3)
-                .setX(1.4)
-                .setG(1.6)
-                .setB(1.7)
-                .setRatedU(1.1)
-                .setRatedS(1.2)
-                .setNode(0)
-                .add()
-                .add());
+        ThreeWindingsTransformerAdder adder = substation.newThreeWindingsTransformer()
+            .setId("twt")
+            .setName(TWT_NAME)
+            .newLeg1()
+            .setR(1.3)
+            .setX(1.4)
+            .setG(1.6)
+            .setB(1.7)
+            .setRatedU(1.1)
+            .setRatedS(1.2)
+            .setNode(0)
+            .add();
+        ValidationException e = assertThrows(ValidationException.class, adder::add);
         assertTrue(e.getMessage().contains("3 windings transformer leg1 in substation sub: voltage level is not set"));
     }
 
     @Test
     public void invalidLeg1ArgumentVoltageLevelNotFound() {
-        ValidationException e = assertThrows(ValidationException.class, () -> substation.newThreeWindingsTransformer()
-                .setId("twt")
-                .setName(TWT_NAME)
-                .newLeg1()
-                .setR(1.3)
-                .setX(1.4)
-                .setG(1.6)
-                .setB(1.7)
-                .setRatedU(1.1)
-                .setRatedS(1.2)
-                .setVoltageLevel("invalid")
-                .setConnectableBus("busA")
-                .setBus("busA")
-                .add()
-                .add());
+        ThreeWindingsTransformerAdder adder = substation.newThreeWindingsTransformer()
+            .setId("twt")
+            .setName(TWT_NAME)
+            .newLeg1()
+            .setR(1.3)
+            .setX(1.4)
+            .setG(1.6)
+            .setB(1.7)
+            .setRatedU(1.1)
+            .setRatedS(1.2)
+            .setVoltageLevel("invalid")
+            .setConnectableBus("busA")
+            .setBus("busA")
+            .add();
+        ValidationException e = assertThrows(ValidationException.class, adder::add);
         assertTrue(e.getMessage().contains("3 windings transformer leg1 in substation sub: voltage level 'invalid' not found"));
     }
 
     @Test
     public void invalidLeg1ArgumentConnectableBusNotSet() {
-        ValidationException e = assertThrows(ValidationException.class, () -> substation.newThreeWindingsTransformer()
-                .setId("twt")
-                .setName(TWT_NAME)
-                .newLeg1()
-                .setR(1.3)
-                .setX(1.4)
-                .setG(1.6)
-                .setB(1.7)
-                .setRatedU(1.1)
-                .setRatedS(1.2)
-                .setVoltageLevel("vl1")
-                .add()
-                .add());
+        ThreeWindingsTransformerAdder adder = substation.newThreeWindingsTransformer()
+            .setId("twt")
+            .setName(TWT_NAME)
+            .newLeg1()
+            .setR(1.3)
+            .setX(1.4)
+            .setG(1.6)
+            .setB(1.7)
+            .setRatedU(1.1)
+            .setRatedS(1.2)
+            .setVoltageLevel("vl1")
+            .add();
+        ValidationException e = assertThrows(ValidationException.class, adder::add);
         assertTrue(e.getMessage().contains("connectable bus is not set"));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Code refacto

**What is the current behavior?**
In some tests in `AbstractThreeWindingsTransformerTest`, multiple methods are called at once in `assertThrows` assertions, which raises a Sonar issue.

**What is the new behavior (if this is a feature change)?**
Only one invocation possibly throwing a runtime exception is called in the `assertThrows` assertions.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
While it was possible before, checks on the 3WT legs now have to be done during the construction of the 3WT (in the `adder.add()` method) and not during the construction of the legs.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
