### PR TITLE
iIDM v1.14: Add PhaseTapChanger.loadTapChangingCapabilities flag

### DIFF
--- a/docs/grid_model/additional.md
+++ b/docs/grid_model/additional.md
@@ -193,6 +193,7 @@ A phase tap changer is described by a set of tap positions (or steps) within whi
 - the regulation value (either a current value in `A` or an active power value in `MW`)
 - the regulating terminal, which can be local or remote: it is the specific connection point on the network where the setpoint is measured.
 - the target deadband, which defines a margin on the regulation so as to avoid an excessive update of controls
+- whether the phase tap changer can change tap positions onload or only offload
 
 The phase tap changer can always switch tap positions while loaded, which is not the case of the ratio tap changer described below.
 
@@ -218,6 +219,7 @@ This example shows how to add a phase tap changer to a two-winding transformer:
 twoWindingsTransformer.newPhaseTapChanger()
     .setLowTapPosition(-1)
     .setTapPosition(0)
+    .setLoadTapChangingCapabilities(true)
     .setRegulating(true)
     .setRegulationMode(PhaseTapChanger.RegulationMode.CURRENT_LIMITER)
     .setRegulationValue(25)

--- a/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee300cdf.xiidm
+++ b/ieee-cdf/ieee-cdf-converter/src/test/resources/ieee300cdf.xiidm
@@ -1766,7 +1766,7 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="T196-2040-1" r="0.013225" x="2.645" g="0.0" b="0.0" ratedU1="115.0" ratedU2="115.0" bus1="B196" connectableBus1="B196" voltageLevelId1="VL196" bus2="B2040" connectableBus2="B2040" voltageLevelId2="VL196">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="0" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="11.4"/>
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/RatioTapChanger.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/RatioTapChanger.java
@@ -77,15 +77,4 @@ public interface RatioTapChanger extends TapChanger<
      * @return itself for method chaining.
      */
     RatioTapChanger setTargetV(double targetV);
-
-    /**
-     * Get the load tap changing capabilities status.
-     */
-    boolean hasLoadTapChangingCapabilities();
-
-    /**
-     * Set the load tap changing capabilities status.
-     * @return itself for method chaining.
-     */
-    RatioTapChanger setLoadTapChangingCapabilities(boolean status);
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/RatioTapChangerAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/RatioTapChangerAdder.java
@@ -28,7 +28,5 @@ public interface RatioTapChangerAdder extends TapChangerAdder<
 
     RatioTapChangerAdder setRegulationValue(double regulationValue);
 
-    RatioTapChangerAdder setLoadTapChangingCapabilities(boolean loadTapChangingCapabilities);
-
     RatioTapChangerAdder setTargetV(double targetV);
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TapChanger.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TapChanger.java
@@ -23,6 +23,17 @@ public interface TapChanger<
     A extends TapChangerStepAdder<A, R>> {
 
     /**
+     * Get the load tap changing capabilities status.
+     */
+    boolean hasLoadTapChangingCapabilities();
+
+    /**
+     * Set the load tap changing capabilities status.
+     * @return itself for method chaining.
+     */
+    C setLoadTapChangingCapabilities(boolean status);
+
+    /**
      * Get the lowest tap position corresponding to the first step of the tap changer.
      */
     int getLowTapPosition();

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TapChangerAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TapChangerAdder.java
@@ -26,6 +26,8 @@ public interface TapChangerAdder<
     R extends TapChangerStepsReplacer<R, B>,
     C extends TapChanger<C, D, R, B>> {
 
+    S setLoadTapChangingCapabilities(boolean loadTapChangingCapabilities);
+
     S setLowTapPosition(int lowTapPosition);
 
     S setTapPosition(int tapPosition);

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
@@ -418,7 +418,7 @@ public final class ValidationUtil {
         }
     }
 
-    private static ValidationLevel errorOrWarningForRtc(Validable validable, boolean loadTapChangingCapabilities, String message, boolean throwException, ReportNode reportNode) {
+    private static ValidationLevel errorOrWarningForTapChanger(Validable validable, boolean loadTapChangingCapabilities, String message, boolean throwException, ReportNode reportNode) {
         if (loadTapChangingCapabilities) {
             throwExceptionOrLogError(validable, message, throwException, reportNode);
             return ValidationLevel.EQUIPMENT;
@@ -444,16 +444,16 @@ public final class ValidationUtil {
         ValidationLevel validationLevel = ValidationLevel.STEADY_STATE_HYPOTHESIS;
         if (regulating) {
             if (Objects.isNull(regulationMode)) {
-                validationLevel = ValidationLevel.min(validationLevel, errorOrWarningForRtc(validable, loadTapChangingCapabilities, "regulation mode of regulating ratio tap changer must be given", throwException, reportNode));
+                validationLevel = ValidationLevel.min(validationLevel, errorOrWarningForTapChanger(validable, loadTapChangingCapabilities, "regulation mode of regulating ratio tap changer must be given", throwException, reportNode));
             }
             if (Double.isNaN(regulationValue)) {
-                validationLevel = ValidationLevel.min(validationLevel, errorOrWarningForRtc(validable, loadTapChangingCapabilities, "a regulation value has to be set for a regulating ratio tap changer", throwException, reportNode));
+                validationLevel = ValidationLevel.min(validationLevel, errorOrWarningForTapChanger(validable, loadTapChangingCapabilities, "a regulation value has to be set for a regulating ratio tap changer", throwException, reportNode));
             }
             if (regulationMode == RatioTapChanger.RegulationMode.VOLTAGE && regulationValue <= 0) {
                 throw new ValidationException(validable, "bad target voltage " + regulationValue);
             }
             if (regulationTerminal == null) {
-                validationLevel = ValidationLevel.min(validationLevel, errorOrWarningForRtc(validable, loadTapChangingCapabilities, "a regulation terminal has to be set for a regulating ratio tap changer", throwException, reportNode));
+                validationLevel = ValidationLevel.min(validationLevel, errorOrWarningForTapChanger(validable, loadTapChangingCapabilities, "a regulation terminal has to be set for a regulating ratio tap changer", throwException, reportNode));
             }
         }
         if (regulationTerminal != null && regulationTerminal.getVoltageLevel().getNetwork() != network) {
@@ -463,32 +463,28 @@ public final class ValidationUtil {
     }
 
     public static ValidationLevel checkPhaseTapChangerRegulation(Validable validable, PhaseTapChanger.RegulationMode regulationMode,
-                                                                 double regulationValue, boolean regulating, Terminal regulationTerminal,
+                                                                 double regulationValue, boolean regulating, boolean loadTapChangingCapabilities, Terminal regulationTerminal,
                                                                  Network network, ValidationLevel validationLevel, ReportNode reportNode) {
-        return checkPhaseTapChangerRegulation(validable, regulationMode, regulationValue, regulating, regulationTerminal,
+        return checkPhaseTapChangerRegulation(validable, regulationMode, regulationValue, regulating, loadTapChangingCapabilities, regulationTerminal,
                 network, checkValidationLevel(validationLevel), reportNode);
     }
 
     private static ValidationLevel checkPhaseTapChangerRegulation(Validable validable, PhaseTapChanger.RegulationMode regulationMode,
-                                                                  double regulationValue, boolean regulating, Terminal regulationTerminal,
+                                                                  double regulationValue, boolean regulating, boolean loadTapChangingCapabilities, Terminal regulationTerminal,
                                                                   Network network, boolean throwException, ReportNode reportNode) {
         ValidationLevel validationLevel = ValidationLevel.STEADY_STATE_HYPOTHESIS;
         if (regulationMode == null) {
-            throwExceptionOrLogError(validable, "phase regulation mode is not set", throwException, reportNode);
-            validationLevel = ValidationLevel.min(validationLevel, ValidationLevel.EQUIPMENT);
+            validationLevel = ValidationLevel.min(validationLevel, errorOrWarningForTapChanger(validable, loadTapChangingCapabilities, "phase regulation mode is not set", throwException, reportNode));
         }
         if (regulating && regulationMode != null) {
             if (regulationMode != PhaseTapChanger.RegulationMode.FIXED_TAP && Double.isNaN(regulationValue)) {
-                throwExceptionOrLogError(validable, "phase regulation is on and threshold/setpoint value is not set", throwException, reportNode);
-                validationLevel = ValidationLevel.min(validationLevel, ValidationLevel.EQUIPMENT);
+                validationLevel = ValidationLevel.min(validationLevel, errorOrWarningForTapChanger(validable, loadTapChangingCapabilities, "phase regulation is on and threshold/setpoint value is not set", throwException, reportNode));
             }
             if (regulationMode != PhaseTapChanger.RegulationMode.FIXED_TAP && regulationTerminal == null) {
-                throwExceptionOrLogError(validable, "phase regulation is on and regulated terminal is not set", throwException, reportNode);
-                validationLevel = ValidationLevel.min(validationLevel, ValidationLevel.EQUIPMENT);
+                validationLevel = ValidationLevel.min(validationLevel, errorOrWarningForTapChanger(validable, loadTapChangingCapabilities, "phase regulation is on and regulated terminal is not set", throwException, reportNode));
             }
             if (regulationMode == PhaseTapChanger.RegulationMode.FIXED_TAP) {
-                throwExceptionOrLogError(validable, "phase regulation cannot be on if mode is FIXED", throwException, reportNode);
-                validationLevel = ValidationLevel.min(validationLevel, ValidationLevel.EQUIPMENT);
+                validationLevel = ValidationLevel.min(validationLevel, errorOrWarningForTapChanger(validable, loadTapChangingCapabilities, "phase regulation cannot be on if mode is FIXED", throwException, reportNode));
             }
         }
         if (regulationTerminal != null && regulationTerminal.getVoltageLevel().getNetwork() != network) {
@@ -619,7 +615,7 @@ public final class ValidationUtil {
             throwExceptionOrLogError(validable, "tap position is not set", throwException, reportNode);
             validationLevel = ValidationLevel.min(validationLevel, ValidationLevel.EQUIPMENT);
         }
-        validationLevel = ValidationLevel.min(validationLevel, checkPhaseTapChangerRegulation(validable, ptc.getRegulationMode(), ptc.getRegulationValue(), ptc.isRegulating(), ptc.getRegulationTerminal(), network, throwException, reportNode));
+        validationLevel = ValidationLevel.min(validationLevel, checkPhaseTapChangerRegulation(validable, ptc.getRegulationMode(), ptc.getRegulationValue(), ptc.isRegulating(), ptc.hasLoadTapChangingCapabilities(), ptc.getRegulationTerminal(), network, throwException, reportNode));
         validationLevel = ValidationLevel.min(validationLevel, checkTargetDeadband(validable, "phase tap changer", ptc.isRegulating(), ptc.getTargetDeadband(), throwException, reportNode));
         return validationLevel;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChanger.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChanger.java
@@ -27,6 +27,8 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
 
     protected final H parent;
 
+    protected boolean loadTapChangingCapabilities;
+
     protected int lowTapPosition;
 
     protected Integer relativeNeutralPosition;
@@ -45,11 +47,13 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
 
     protected AbstractTapChanger(H parent,
                                  int lowTapPosition, List<S> steps, TerminalExt regulationTerminal,
+                                 boolean loadTapChangingCapabilities,
                                  Integer tapPosition, boolean regulating, double targetDeadband, String type) {
         // The Ref object should be the one corresponding to the subnetwork of the tap changer holder
         // (to avoid errors when the subnetwork is detached)
         this.network = parent.getParentNetwork().getRootNetworkRef();
         this.parent = parent;
+        this.loadTapChangingCapabilities = loadTapChangingCapabilities;
         this.lowTapPosition = lowTapPosition;
         this.steps = steps;
         steps.forEach(s -> s.setParent(this));

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChangerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTapChangerAdderImpl.java
@@ -36,10 +36,12 @@ abstract class AbstractTapChangerAdderImpl<
     private boolean regulating = false;
     private double targetDeadband = Double.NaN;
     private TerminalExt regulationTerminal;
+    private boolean loadTapChangingCapabilities;
 
-    protected AbstractTapChangerAdderImpl(H parent) {
+    protected AbstractTapChangerAdderImpl(H parent, boolean loadTapChangingCapabilities) {
         this.parent = parent;
         this.steps = new ArrayList<>();
+        this.loadTapChangingCapabilities = loadTapChangingCapabilities;
     }
 
     public A setLowTapPosition(int lowTapPosition) {
@@ -72,6 +74,11 @@ abstract class AbstractTapChangerAdderImpl<
         return self();
     }
 
+    public A setLoadTapChangingCapabilities(boolean loadTapChangingCapabilities) {
+        this.loadTapChangingCapabilities = loadTapChangingCapabilities;
+        return self();
+    }
+
     NetworkImpl getNetwork() {
         return parent.getNetwork();
     }
@@ -96,11 +103,11 @@ abstract class AbstractTapChangerAdderImpl<
             }
         }
 
-        network.setValidationLevelIfGreaterThan(checkTapChangerRegulation(parent, regulationValue, regulating, regulationTerminal));
+        network.setValidationLevelIfGreaterThan(checkTapChangerRegulation(parent, regulationValue, regulating, loadTapChangingCapabilities, regulationTerminal));
         network.setValidationLevelIfGreaterThan(ValidationUtil.checkTargetDeadband(parent, getValidableType(), regulating,
                 targetDeadband, network.getMinValidationLevel(), network.getReportNodeContext().getReportNode()));
 
-        T tapChanger = createTapChanger(parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, regulationValue, targetDeadband);
+        T tapChanger = createTapChanger(parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, loadTapChangingCapabilities, regulationValue, targetDeadband);
 
         Set<TapChanger<?, ?, ?, ?>> otherTapChangers = new HashSet<>(parent.getAllTapChangers());
         otherTapChangers.remove(tapChanger);
@@ -115,11 +122,11 @@ abstract class AbstractTapChangerAdderImpl<
         return tapChanger;
     }
 
-    protected abstract T createTapChanger(H parent, int lowTapPosition, List<S> steps, TerminalExt regulationTerminal, Integer tapPosition, boolean regulating, double regulationValue, double targetDeadband);
+    protected abstract T createTapChanger(H parent, int lowTapPosition, List<S> steps, TerminalExt regulationTerminal, Integer tapPosition, boolean regulating, boolean loadTapChangingCapabilities, double regulationValue, double targetDeadband);
 
     protected abstract A self();
 
-    protected abstract ValidationLevel checkTapChangerRegulation(H parent, double regulationValue, boolean regulating, TerminalExt regulationTerminal);
+    protected abstract ValidationLevel checkTapChangerRegulation(H parent, double regulationValue, boolean regulating, boolean loadTapChangingCapabilities, TerminalExt regulationTerminal);
 
     protected abstract String getValidableType();
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/PhaseTapChangerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/PhaseTapChangerAdderImpl.java
@@ -83,7 +83,7 @@ class PhaseTapChangerAdderImpl extends AbstractTapChangerAdderImpl<PhaseTapChang
     }
 
     PhaseTapChangerAdderImpl(PhaseTapChangerParent parent) {
-        super(parent);
+        super(parent, true);
     }
 
     @Override
@@ -98,8 +98,8 @@ class PhaseTapChangerAdderImpl extends AbstractTapChangerAdderImpl<PhaseTapChang
     }
 
     @Override
-    protected PhaseTapChanger createTapChanger(PhaseTapChangerParent parent, int lowTapPosition, List<PhaseTapChangerStepImpl> steps, TerminalExt regulationTerminal, Integer tapPosition, boolean regulating, double regulationValue, double targetDeadband) {
-        PhaseTapChangerImpl tapChanger = new PhaseTapChangerImpl(parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, regulationMode, regulationValue, targetDeadband);
+    protected PhaseTapChanger createTapChanger(PhaseTapChangerParent parent, int lowTapPosition, List<PhaseTapChangerStepImpl> steps, TerminalExt regulationTerminal, Integer tapPosition, boolean regulating, boolean loadTapChangingCapabilities, double regulationValue, double targetDeadband) {
+        PhaseTapChangerImpl tapChanger = new PhaseTapChangerImpl(parent, lowTapPosition, steps, regulationTerminal, loadTapChangingCapabilities, tapPosition, regulating, regulationMode, regulationValue, targetDeadband);
         parent.setPhaseTapChanger(tapChanger);
         return tapChanger;
     }
@@ -110,8 +110,8 @@ class PhaseTapChangerAdderImpl extends AbstractTapChangerAdderImpl<PhaseTapChang
     }
 
     @Override
-    protected ValidationLevel checkTapChangerRegulation(PhaseTapChangerParent parent, double regulationValue, boolean regulating, TerminalExt regulationTerminal) {
-        return ValidationUtil.checkPhaseTapChangerRegulation(parent, regulationMode, regulationValue, regulating,
+    protected ValidationLevel checkTapChangerRegulation(PhaseTapChangerParent parent, double regulationValue, boolean regulating, boolean loadTapChangingCapabilities, TerminalExt regulationTerminal) {
+        return ValidationUtil.checkPhaseTapChangerRegulation(parent, regulationMode, regulationValue, regulating, loadTapChangingCapabilities,
                 regulationTerminal, getNetwork(), getNetwork().getMinValidationLevel(), getNetwork().getReportNodeContext().getReportNode());
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerAdderImpl.java
@@ -20,8 +20,6 @@ import java.util.List;
  */
 class RatioTapChangerAdderImpl extends AbstractTapChangerAdderImpl<RatioTapChangerAdderImpl, RatioTapChangerParent, RatioTapChanger, RatioTapChangerStepImpl> implements RatioTapChangerAdder {
 
-    private boolean loadTapChangingCapabilities = false;
-
     private RatioTapChanger.RegulationMode regulationMode = null;
 
     class StepAdderImpl implements RatioTapChangerAdder.StepAdder {
@@ -77,13 +75,7 @@ class RatioTapChangerAdderImpl extends AbstractTapChangerAdderImpl<RatioTapChang
     }
 
     RatioTapChangerAdderImpl(RatioTapChangerParent parent) {
-        super(parent);
-    }
-
-    @Override
-    public RatioTapChangerAdder setLoadTapChangingCapabilities(boolean loadTapChangingCapabilities) {
-        this.loadTapChangingCapabilities = loadTapChangingCapabilities;
-        return this;
+        super(parent, false);
     }
 
     @Override
@@ -106,7 +98,7 @@ class RatioTapChangerAdderImpl extends AbstractTapChangerAdderImpl<RatioTapChang
     }
 
     @Override
-    protected RatioTapChanger createTapChanger(RatioTapChangerParent parent, int lowTapPosition, List<RatioTapChangerStepImpl> steps, TerminalExt regulationTerminal, Integer tapPosition, boolean regulating, double regulationValue, double targetDeadband) {
+    protected RatioTapChanger createTapChanger(RatioTapChangerParent parent, int lowTapPosition, List<RatioTapChangerStepImpl> steps, TerminalExt regulationTerminal, Integer tapPosition, boolean regulating, boolean loadTapChangingCapabilities, double regulationValue, double targetDeadband) {
         RatioTapChangerImpl tapChanger = new RatioTapChangerImpl(parent, lowTapPosition, steps, regulationTerminal, loadTapChangingCapabilities,
                 tapPosition, regulating, regulationMode, regulationValue, targetDeadband);
         parent.setRatioTapChanger(tapChanger);
@@ -119,7 +111,7 @@ class RatioTapChangerAdderImpl extends AbstractTapChangerAdderImpl<RatioTapChang
     }
 
     @Override
-    protected ValidationLevel checkTapChangerRegulation(RatioTapChangerParent parent, double regulationValue, boolean regulating, TerminalExt regulationTerminal) {
+    protected ValidationLevel checkTapChangerRegulation(RatioTapChangerParent parent, double regulationValue, boolean regulating, boolean loadTapChangingCapabilities, TerminalExt regulationTerminal) {
         return ValidationUtil.checkRatioTapChangerRegulation(parent, regulating, loadTapChangingCapabilities, regulationTerminal,
                 regulationMode, regulationValue, getNetwork(), getNetwork().getMinValidationLevel(), getNetwork().getReportNodeContext().getReportNode());
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/RatioTapChangerImpl.java
@@ -19,8 +19,6 @@ import java.util.function.Supplier;
  */
 class RatioTapChangerImpl extends AbstractTapChanger<RatioTapChangerParent, RatioTapChangerImpl, RatioTapChangerStepImpl> implements RatioTapChanger {
 
-    private boolean loadTapChangingCapabilities;
-
     private RatioTapChanger.RegulationMode regulationMode;
 
     // attributes depending on the variant
@@ -30,8 +28,7 @@ class RatioTapChangerImpl extends AbstractTapChanger<RatioTapChangerParent, Rati
     RatioTapChangerImpl(RatioTapChangerParent parent, int lowTapPosition,
                         List<RatioTapChangerStepImpl> steps, TerminalExt regulationTerminal, boolean loadTapChangingCapabilities,
                         Integer tapPosition, Boolean regulating, RatioTapChanger.RegulationMode regulationMode, double regulationValue, double targetDeadband) {
-        super(parent, lowTapPosition, steps, regulationTerminal, tapPosition, regulating, targetDeadband, "ratio tap changer");
-        this.loadTapChangingCapabilities = loadTapChangingCapabilities;
+        super(parent, lowTapPosition, steps, regulationTerminal, loadTapChangingCapabilities, tapPosition, regulating, targetDeadband, "ratio tap changer");
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
         this.regulationMode = regulationMode;
         this.regulationValue = new TDoubleArrayList(variantArraySize);

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/util/TransformerUtils.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/util/TransformerUtils.java
@@ -124,6 +124,7 @@ public final class TransformerUtils {
 
     private static void copyCommonPhaseTapChanger(PhaseTapChangerAdder ptcAdder, PhaseTapChanger ptc) {
         ptcAdder.setTapPosition(ptc.getTapPosition())
+                .setLoadTapChangingCapabilities(ptc.hasLoadTapChangingCapabilities())
                 .setRegulationMode(ptc.getRegulationMode())
                 .setRegulationValue(ptc.getRegulationValue())
                 .setLowTapPosition(ptc.getLowTapPosition())

--- a/iidm/iidm-modification/src/test/resources/create-vl-topo-test-complete.xiidm
+++ b/iidm/iidm-modification/src/test/resources/create-vl-topo-test-complete.xiidm
@@ -103,7 +103,7 @@
             <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" node="22" p="-5.102249" q="4.9081216"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0" node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N" selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
                 <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>

--- a/iidm/iidm-modification/src/test/resources/create-vl-topo-test.xiidm
+++ b/iidm/iidm-modification/src/test/resources/create-vl-topo-test.xiidm
@@ -103,7 +103,7 @@
             <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" node="22" p="-5.102249" q="4.9081216"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0" node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N" selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
                 <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>

--- a/iidm/iidm-modification/src/test/resources/fictitious-line-split-l-complete.xml
+++ b/iidm/iidm-modification/src/test/resources/fictitious-line-split-l-complete.xml
@@ -79,7 +79,7 @@
             <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" node="22" p="-5.102249" q="4.9081216"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0" node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N" selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
                 <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>

--- a/iidm/iidm-modification/src/test/resources/fictitious-line-split-l.xml
+++ b/iidm/iidm-modification/src/test/resources/fictitious-line-split-l.xml
@@ -105,7 +105,7 @@
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0"
                                      node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N"
                                      selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER"
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
                                   regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>

--- a/iidm/iidm-modification/src/test/resources/fictitious-line-split-vl-complete.xml
+++ b/iidm/iidm-modification/src/test/resources/fictitious-line-split-vl-complete.xml
@@ -102,7 +102,7 @@
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0"
                                      node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N"
                                      selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER"
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
                                   regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>

--- a/iidm/iidm-modification/src/test/resources/fictitious-line-split-vl.xml
+++ b/iidm/iidm-modification/src/test/resources/fictitious-line-split-vl.xml
@@ -101,7 +101,7 @@
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0"
                                      node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N"
                                      selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER"
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
                                   regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>

--- a/iidm/iidm-modification/src/test/resources/fictitious-replace-tee-point-by-voltage-level-on-line-nb.xml
+++ b/iidm/iidm-modification/src/test/resources/fictitious-replace-tee-point-by-voltage-level-on-line-nb.xml
@@ -113,7 +113,7 @@
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0"
                                      node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N"
                                      selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER"
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
                                   regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>

--- a/iidm/iidm-modification/src/test/resources/fictitious-revert-connect-voltage-level-on-line-vl.xml
+++ b/iidm/iidm-modification/src/test/resources/fictitious-revert-connect-voltage-level-on-line-vl.xml
@@ -102,7 +102,7 @@
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0"
                                      node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N"
                                      selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER"
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
                                   regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>

--- a/iidm/iidm-modification/src/test/resources/fictitious-revert-create-line-on-line-l.xml
+++ b/iidm/iidm-modification/src/test/resources/fictitious-revert-create-line-on-line-l.xml
@@ -102,7 +102,7 @@
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0"
                                      node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N"
                                      selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER"
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
                                   regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>

--- a/iidm/iidm-modification/src/test/resources/network_one_voltage_level.xiidm
+++ b/iidm/iidm-modification/src/test/resources/network_one_voltage_level.xiidm
@@ -103,7 +103,7 @@
             <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" node="22" p="-5.102249" q="4.9081216"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0" node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N" selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
                 <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>

--- a/iidm/iidm-modification/src/test/resources/testNetwork3BusbarSections.xiidm
+++ b/iidm/iidm-modification/src/test/resources/testNetwork3BusbarSections.xiidm
@@ -103,7 +103,7 @@
             <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" node="22" p="-5.102249" q="4.9081216"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0" node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N" selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
                 <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>

--- a/iidm/iidm-modification/src/test/resources/testNetwork3BusbarSectionsWithCouplingDevice.xiidm
+++ b/iidm/iidm-modification/src/test/resources/testNetwork3BusbarSectionsWithCouplingDevice.xiidm
@@ -108,7 +108,7 @@
             <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" node="22" p="-5.102249" q="4.9081216"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0" node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N" selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
                 <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_14.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_14.xsd
@@ -609,6 +609,7 @@
         <xs:attribute name="lowTapPosition" use="required" type="xs:int"/>
         <xs:attribute name="tapPosition" use="required" type="xs:int"/>
         <xs:attribute name="targetDeadband" use="optional" type="xs:double"/>
+        <xs:attribute name="loadTapChangingCapabilities" use="required" type="xs:boolean"/>
         <xs:attribute name="regulationMode" use="required" type="iidm:PhaseRegulationMode"/>
         <xs:attribute name="regulationValue" use="optional" type="xs:double"/>
         <xs:attribute name="regulating" use="optional" type="xs:boolean"/>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_14.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_14.xsd
@@ -609,6 +609,7 @@
         <xs:attribute name="lowTapPosition" use="required" type="xs:int"/>
         <xs:attribute name="tapPosition" use="optional" type="xs:int"/>
         <xs:attribute name="targetDeadband" use="optional" type="xs:double"/>
+        <xs:attribute name="loadTapChangingCapabilities" use="required" type="xs:boolean"/>
         <xs:attribute name="regulationMode" use="optional" type="iidm:PhaseRegulationMode"/>
         <xs:attribute name="regulationValue" use="optional" type="xs:double"/>
         <xs:attribute name="regulating" use="optional" type="xs:boolean"/>

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ThreeWindingsTransformerXmlTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ThreeWindingsTransformerXmlTest.java
@@ -51,17 +51,18 @@ class ThreeWindingsTransformerXmlTest extends AbstractIidmSerDeTest {
                 .endStep()
                 .add();
 
-        createPtc(twt.getLeg1().newPhaseTapChanger());
-        createPtc(twt.getLeg2().newPhaseTapChanger());
-        createPtc(twt.getLeg3().newPhaseTapChanger());
+        createPtc(twt.getLeg1().newPhaseTapChanger(), true);
+        createPtc(twt.getLeg2().newPhaseTapChanger(), true);
+        createPtc(twt.getLeg3().newPhaseTapChanger(), false);
 
         allFormatsRoundTripTest(network, "completeThreeWindingsTransformerRoundTripRef.xml", CURRENT_IIDM_VERSION);
     }
 
-    private void createPtc(PhaseTapChangerAdder adder) {
+    private void createPtc(PhaseTapChangerAdder adder, boolean loadTapChangingCapabilities) {
         adder.setTapPosition(2)
                 .setLowTapPosition(1)
                 .setRegulating(false)
+                .setLoadTapChangingCapabilities(loadTapChangingCapabilities)
                 .setRegulationMode(PhaseTapChanger.RegulationMode.FIXED_TAP)
                 .beginStep().setRho(1.f).setAlpha(-50f).setR(0.1f).setX(0.1f).setG(0.1f).setB(0.1f).endStep()
                 .beginStep().setRho(1.f).setAlpha(-25f).setR(0.1f).setX(0.1f).setG(0.1f).setB(0.1f).endStep()

--- a/iidm/iidm-serde/src/test/resources/V1_14/completeThreeWindingsTransformerRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/completeThreeWindingsTransformerRoundTripRef.xml
@@ -40,7 +40,7 @@
             <iidm:ratioTapChanger1 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="false">
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
             </iidm:ratioTapChanger1>
-            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612"
                            b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612"
@@ -54,7 +54,7 @@
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
                 <iidm:step r="1.1979" x="0.11979" g="0.10101010101010101" b="0.0101010101010101" rho="1.1"/>
             </iidm:ratioTapChanger2>
-            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612"
                            b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612"
@@ -67,7 +67,7 @@
                 <iidm:step r="0.121" x="0.0121" g="0.8264462809917356" b="0.08264462809917356" rho="1.0"/>
                 <iidm:step r="0.1331" x="0.01331" g="0.9090909090909092" b="0.09090909090909093" rho="1.1"/>
             </iidm:ratioTapChanger3>
-            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" loadTapChangingCapabilities="false" regulationMode="FIXED_TAP">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612"
                            b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612"

--- a/iidm/iidm-serde/src/test/resources/V1_14/disMeasRef.xiidm
+++ b/iidm/iidm-serde/src/test/resources/V1_14/disMeasRef.xiidm
@@ -90,7 +90,7 @@
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.15"/>
             </iidm:ratioTapChanger>
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="15" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="15" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:terminalRef id="TWT" side="ONE"/>
                 <iidm:step r="39.78473" x="29.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
                 <iidm:step r="31.720245" x="21.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>

--- a/iidm/iidm-serde/src/test/resources/V1_14/fictitiousSwitchRef-bbk.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/fictitiousSwitchRef-bbk.xml
@@ -56,7 +56,7 @@
                                      bus1="C_0" connectableBus1="C_0" voltageLevelId1="C" bus2="N_1"
                                      connectableBus2="N_1" voltageLevelId2="N" selectedOperationalLimitsGroupId1="DEFAULT"
                                      selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER"
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
                                   regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>

--- a/iidm/iidm-serde/src/test/resources/V1_14/fictitiousSwitchRef-bbr.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/fictitiousSwitchRef-bbr.xml
@@ -49,7 +49,7 @@
                                      bus1="C_0" connectableBus1="C_0" voltageLevelId1="C" bus2="N_0"
                                      connectableBus2="N_0" voltageLevelId2="N" selectedOperationalLimitsGroupId1="DEFAULT"
                                      selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER"
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
                                   regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>

--- a/iidm/iidm-serde/src/test/resources/V1_14/fictitiousSwitchRef-fict-inj.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/fictitiousSwitchRef-fict-inj.xml
@@ -92,7 +92,7 @@
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0"
                                      node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N" selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER"
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
                                   regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>

--- a/iidm/iidm-serde/src/test/resources/V1_14/fictitiousSwitchRef.jiidm
+++ b/iidm/iidm-serde/src/test/resources/V1_14/fictitiousSwitchRef.jiidm
@@ -454,6 +454,7 @@
         "regulating" : false,
         "lowTapPosition" : 0,
         "tapPosition" : 22,
+        "loadTapChangingCapabilities" : true,
         "regulationMode" : "CURRENT_LIMITER",
         "regulationValue" : 930.6667,
         "terminalRef" : {

--- a/iidm/iidm-serde/src/test/resources/V1_14/fictitiousSwitchRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/fictitiousSwitchRef.xml
@@ -90,7 +90,7 @@
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0"
                                      node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N"
                                      selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER"
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
                                   regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>

--- a/iidm/iidm-serde/src/test/resources/V1_14/nodebreaker-busproperties.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/nodebreaker-busproperties.xml
@@ -92,7 +92,7 @@
         <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0"
                                      node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N"
                                      selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER"
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
                                   regulationValue="930.6667" regulating="false">
                 <iidm:terminalRef id="CI" side="ONE"/>
                 <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>

--- a/iidm/iidm-serde/src/test/resources/V1_14/phaseShifterRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/phaseShifterRoundTripRef.xml
@@ -15,7 +15,7 @@
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="PS1" r="2.0" x="100.0" g="0.0" b="0.0" ratedU1="380.0" ratedU2="380.0" bus1="B1" connectableBus1="B1" voltageLevelId1="VL1" bus2="B3" connectableBus2="B3" voltageLevelId2="VL3" p1="50.08403" q1="29.201416" p2="-50.042015" q2="-27.100708">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" targetDeadband="10.0" regulationMode="FIXED_TAP" regulationValue="200.0">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" targetDeadband="10.0" regulationMode="FIXED_TAP" regulationValue="200.0">
                 <iidm:terminalRef id="PS1" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-20.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_14/scadaNetwork.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/scadaNetwork.xml
@@ -41,7 +41,7 @@
             <iidm:ratioTapChanger lowTapPosition="0" loadTapChangingCapabilities="false" regulating="true">
                 <iidm:step r="1.0" x="1.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger>
-            <iidm:phaseTapChanger lowTapPosition="0">
+            <iidm:phaseTapChanger lowTapPosition="0" loadTapChangingCapabilities="true">
                 <iidm:step r="1.0" x="1.0" g="0.0" b="0.0" rho="1.0" alpha="1.0"/>
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
@@ -49,7 +49,7 @@
             <iidm:ratioTapChanger1 lowTapPosition="0" loadTapChangingCapabilities="false" regulating="true">
                 <iidm:step r="1.0" x="1.0" g="0.0" b="0.0" rho="1.0"/>
             </iidm:ratioTapChanger1>
-            <iidm:phaseTapChanger2 lowTapPosition="0">
+            <iidm:phaseTapChanger2 lowTapPosition="0" loadTapChangingCapabilities="true">
                 <iidm:step r="1.0" x="1.0" g="0.0" b="0.0" rho="1.0" alpha="1.0"/>
             </iidm:phaseTapChanger2>
         </iidm:threeWindingsTransformer>

--- a/iidm/iidm-serde/src/test/resources/V1_14/terminalRef.xiidm
+++ b/iidm/iidm-serde/src/test/resources/V1_14/terminalRef.xiidm
@@ -40,7 +40,7 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="VLY643" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="VL41" connectableBus1="VL41" voltageLevelId1="VL4" bus2="VL61" connectableBus2="VL61" voltageLevelId2="VL6">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP" regulationValue="200.0">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP" regulationValue="200.0">
                 <iidm:terminalRef id="VLY643" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191" alpha="-1.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666" alpha="0.0"/>
@@ -48,7 +48,7 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="VLY644" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="VL41" connectableBus1="VL41" voltageLevelId1="VL4" bus2="VL61" connectableBus2="VL61" voltageLevelId2="VL6">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP" regulationValue="200.0">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP" regulationValue="200.0">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191" alpha="-1.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914" alpha="1.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_14/twoWindingsTransformerPhaseAndRatioTap.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/twoWindingsTransformerPhaseAndRatioTap.xml
@@ -39,7 +39,7 @@
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
             </iidm:ratioTapChanger>
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulating="false" regulationMode="FIXED_TAP" targetDeadband="0.0">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="false" regulationMode="FIXED_TAP" targetDeadband="0.0">
                 <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191" alpha="1"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666" alpha="1"/>

--- a/iidm/iidm-serde/src/test/resources/V1_14/twoWindingsTransformerPhaseAndRatioTapWithExtensions.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/twoWindingsTransformerPhaseAndRatioTapWithExtensions.xml
@@ -42,7 +42,7 @@
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
             </iidm:ratioTapChanger>
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulating="false" regulationMode="FIXED_TAP" targetDeadband="0.0">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="false" regulationMode="FIXED_TAP" targetDeadband="0.0">
                 <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191" alpha="1"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666" alpha="1"/>
@@ -56,7 +56,7 @@
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
             </iidm:ratioTapChanger>
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulating="false" regulationMode="FIXED_TAP" targetDeadband="0.0">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="false" regulationMode="FIXED_TAP" targetDeadband="0.0">
                 <iidm:terminalRef id="NHV2_NLOAD_2" side="TWO"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191" alpha="1"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666" alpha="1"/>

--- a/matpower/matpower-converter/src/test/resources/ieee14-phase-shifter-zero-ratio-issue.xiidm
+++ b/matpower/matpower-converter/src/test/resources/ieee14-phase-shifter-zero-ratio-issue.xiidm
@@ -46,7 +46,7 @@
             </iidm:shunt>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="TWT-4-7" r="0.0" x="0.0020912" g="0.0" b="0.0" ratedU1="1.0" ratedU2="1.0" voltageLevelId1="VL-4" bus1="BUS-4" connectableBus1="BUS-4" voltageLevelId2="VL-4" bus2="BUS-7" connectableBus2="BUS-7">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="0" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.0"/>
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>

--- a/matpower/matpower-converter/src/test/resources/ieee14-phase-shifter.xiidm
+++ b/matpower/matpower-converter/src/test/resources/ieee14-phase-shifter.xiidm
@@ -46,7 +46,7 @@
             </iidm:shunt>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="TWT-4-7" r="0.0" x="0.0020912" g="0.0" b="0.0" ratedU1="0.978" ratedU2="1.0" voltageLevelId1="VL-4" bus1="BUS-4" connectableBus1="BUS-4" voltageLevelId2="VL-4" bus2="BUS-7" connectableBus2="BUS-7">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="0" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.0"/>
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>

--- a/powerfactory/powerfactory-converter/src/test/resources/Slack_bustp.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Slack_bustp.xiidm
@@ -30,7 +30,7 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL14" node2="6" voltageLevelId2="VL14">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.8799999952316284"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.8799999952316284"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Slack_ip_ctrl.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Slack_ip_ctrl.xiidm
@@ -30,7 +30,7 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL14" node2="6" voltageLevelId2="VL14">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.8799999952316284"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.8799999952316284"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_solved.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_solved.xiidm
@@ -67,7 +67,7 @@
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.23699951171875" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.998000144958496" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL31" node2="5" voltageLevelId2="VL28" node3="2" voltageLevelId3="VL34">
-            <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="2" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1.xiidm
@@ -74,7 +74,7 @@
         <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="11" voltageLevelId1="VL35" node2="9" voltageLevelId2="VL32"/>
         <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="12" voltageLevelId1="VL35" node2="3" voltageLevelId2="VL38"/>
         <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL35" node2="5" voltageLevelId2="VL32" node3="2" voltageLevelId3="VL38">
-            <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-25.0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding12.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding12.xiidm
@@ -74,7 +74,7 @@
         <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="11" voltageLevelId1="VL35" node2="9" voltageLevelId2="VL32"/>
         <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="12" voltageLevelId1="VL35" node2="3" voltageLevelId2="VL38"/>
         <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="500.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.0" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL35" node2="5" voltageLevelId2="VL32" node3="2" voltageLevelId3="VL38">
-            <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-25.0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_complete.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_complete.xiidm
@@ -66,7 +66,7 @@
         <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="10" voltageLevelId1="VL81" node2="9" voltageLevelId2="VL78"/>
         <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="11" voltageLevelId1="VL81" node2="2" voltageLevelId2="VL84"/>
         <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799050892384979E-7" x1="1.1395910252132228E-4" g1="0.14457200622558594" b1="-0.1079031910636207" ratedU1="500.0" ratedS1="101.0" r2="2.506555016520443E-6" x2="1.9130874466647454E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.3908508670836E-7" x3="5.517908790607979E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="4" voltageLevelId1="VL81" node2="6" voltageLevelId2="VL78" node3="3" voltageLevelId3="VL84">
-            <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-25.0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_ratio.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding1_ratio.xiidm
@@ -74,7 +74,7 @@
         <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="11" voltageLevelId1="VL35" node2="9" voltageLevelId2="VL32"/>
         <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="12" voltageLevelId1="VL35" node2="3" voltageLevelId2="VL38"/>
         <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL35" node2="5" voltageLevelId2="VL32" node3="2" voltageLevelId3="VL38">
-            <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger1 lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-25.0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding2.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding2.xiidm
@@ -74,7 +74,7 @@
         <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="11" voltageLevelId1="VL35" node2="9" voltageLevelId2="VL32"/>
         <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="12" voltageLevelId1="VL35" node2="3" voltageLevelId2="VL38"/>
         <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.0" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="15.680000305175781" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL35" node2="5" voltageLevelId2="VL32" node3="2" voltageLevelId3="VL38">
-            <iidm:phaseTapChanger2 lowTapPosition="0" tapPosition="0" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger2 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding3.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/ThreeMIB_T3W_phase_winding3.xiidm
@@ -74,7 +74,7 @@
         <iidm:twoWindingsTransformer id="trf_5_3_1" r="0.0" x="0.036288000154495244" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="18.0" ratedS="100.0" node1="11" voltageLevelId1="VL35" node2="9" voltageLevelId2="VL32"/>
         <iidm:twoWindingsTransformer id="trf_5_7_1" r="0.0" x="0.028672000122070315" g="0.0" b="-0.0" ratedU1="500.0" ratedU2="16.0" ratedS="100.0" node1="12" voltageLevelId1="VL35" node2="3" voltageLevelId2="VL38"/>
         <iidm:threeWindingsTransformer id="tr3_4_2_7_1" r1="-7.799049110263946E-7" x1="1.1395922102037156E-4" g1="0.14457200622558594" b1="-0.10790173166599534" ratedU1="515.0" ratedS1="101.0" r2="2.5065552122616057E-6" x2="1.9130867337766516E-4" g2="0.0" b2="0.0" ratedU2="18.360000610351562" ratedS2="201.0" r3="8.390848909671972E-7" x3="5.517907605617501E-4" g3="0.0" b3="0.0" ratedU3="16.0" ratedS3="301.0" ratedU0="1.0" node1="3" voltageLevelId1="VL35" node2="5" voltageLevelId2="VL32" node3="2" voltageLevelId3="VL38">
-            <iidm:phaseTapChanger3 lowTapPosition="0" tapPosition="0" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger3 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral-with-mTaps.xiidm
@@ -30,7 +30,7 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL12" node2="6" voltageLevelId2="VL12">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.979999542236328"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-9.979999542236328"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-Neutral.xiidm
@@ -30,7 +30,7 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL12" node2="6" voltageLevelId2="VL12">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.001999855041504"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.001999855041504"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-complete.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-complete.xiidm
@@ -27,7 +27,7 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="4"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08272846419289497" x="8.356852297791427" g="3.1227095417161836E-4" b="-0.002902681037437016" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL65" node2="6" voltageLevelId2="VL65">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.98"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.002"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-9.98"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB-with-mTaps.xiidm
@@ -30,7 +30,7 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL12" node2="6" voltageLevelId2="VL12">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.979999542236328"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.001999855041504"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-9.979999542236328"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-GB.xiidm
@@ -30,7 +30,7 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.08712000000000002" x="8.306373889178623" g="3.1588613406795225E-4" b="-0.002920117307584649" ratedU1="165.0" ratedU2="165.0" ratedS="400.0" node1="2" voltageLevelId1="VL12" node2="6" voltageLevelId2="VL12">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.001999855041504"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.001999855041504"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral-with-mTaps.xiidm
@@ -30,7 +30,7 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL14" node2="6" voltageLevelId2="VL14">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-10.0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-Neutral.xiidm
@@ -30,7 +30,7 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL14" node2="6" voltageLevelId2="VL14">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.8799999952316284"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.8799999952316284"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-with-mTaps.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase-with-mTaps.xiidm
@@ -30,7 +30,7 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL14" node2="6" voltageLevelId2="VL14">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.8799999952316284"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-10.0"/>

--- a/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase.xiidm
+++ b/powerfactory/powerfactory-converter/src/test/resources/Transformer-Phase.xiidm
@@ -30,7 +30,7 @@
             <iidm:load id="lod_3_1" loadType="UNDEFINED" p0="50.0" q0="25.0" node="5"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="trf_2_3_1" r="0.0" x="7.392000213382751" g="0.0" b="-0.0" ratedU1="400.0" ratedU2="400.0" ratedS="1524.0" node1="2" voltageLevelId1="VL14" node2="6" voltageLevelId2="VL14">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.8799999952316284"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.8799999952316284"/>

--- a/psse/psse-converter/src/test/resources/IsolatedSlackBus.xiidm
+++ b/psse/psse-converter/src/test/resources/IsolatedSlackBus.xiidm
@@ -12,7 +12,7 @@
             <iidm:load id="B2-L1 " loadType="UNDEFINED" p0="21.7" q0="12.7" bus="B2" connectableBus="B2"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T-1-2-1 " r="0.0" x="39.8248128" g="0.0" b="0.0" ratedU1="138.0" ratedU2="138.0" bus1="B1" connectableBus1="B1" voltageLevelId1="VL1-2" bus2="B2" connectableBus2="B2" voltageLevelId2="VL1-2">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="0" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="-4.351599999999978" b="-4.351599999999978" rho="1.0224948875255624" alpha="-2.0"/>
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>

--- a/psse/psse-converter/src/test/resources/ThreeMIB_T3W_phase.xiidm
+++ b/psse/psse-converter/src/test/resources/ThreeMIB_T3W_phase.xiidm
@@ -36,7 +36,7 @@
         <iidm:threeWindingsTransformer id="T-4-2-7-1 " r1="-7.799051701646568E-7" x1="1.1395911508266792E-4" g1="0.144572" b1="-0.1079031826036656" ratedU1="500.0" r2="2.506552897437384E-6" x2="1.913087291200171E-4" g2="0.0" b2="0.0" ratedU2="18.0" r3="8.39084857664657E-7" x3="5.51790882287039E-4" g3="0.0" b3="0.0" ratedU3="16.0" ratedU0="1.0" voltageLevelId1="VL4" bus1="B4" connectableBus1="B4" voltageLevelId2="VL1-2" bus2="B2" connectableBus2="B2" voltageLevelId3="VL7" bus3="B7" connectableBus3="B7" selectedOperationalLimitsGroupId1="DEFAULT" selectedOperationalLimitsGroupId2="DEFAULT" selectedOperationalLimitsGroupId3="DEFAULT">
             <iidm:property name="v" value="0.98627"/>
             <iidm:property name="angle" value="-10.1187"/>
-            <iidm:phaseTapChanger1 regulating="true" lowTapPosition="0" tapPosition="2" targetDeadband="2.0" regulationMode="ACTIVE_POWER_CONTROL" regulationValue="9.0">
+            <iidm:phaseTapChanger1 regulating="true" lowTapPosition="0" loadTapChangingCapabilities="true" tapPosition="2" targetDeadband="2.0" regulationMode="ACTIVE_POWER_CONTROL" regulationValue="9.0">
                 <iidm:terminalRef id="B2-G1 "/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.1904761904761905"/>

--- a/psse/psse-converter/src/test/resources/TwoWindingsTransformerPhase.xiidm
+++ b/psse/psse-converter/src/test/resources/TwoWindingsTransformerPhase.xiidm
@@ -12,7 +12,7 @@
             <iidm:load id="B2-L1 " loadType="UNDEFINED" p0="21.7" q0="12.7" bus="B2" connectableBus="B2"/>
         </iidm:voltageLevel>
         <iidm:twoWindingsTransformer id="T-1-2-1 " r="0.0" x="39.8248128" g="0.0" b="0.0" ratedU1="138.0" ratedU2="138.0" bus1="B1" connectableBus1="B1" voltageLevelId1="VL1-2" bus2="B2" connectableBus2="B2" voltageLevelId2="VL1-2">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="0" regulationMode="FIXED_TAP">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulationMode="FIXED_TAP">
                 <iidm:step r="0.0" x="0.0" g="-4.351599999999978" b="-4.351599999999978" rho="1.0224948875255624" alpha="-2.0"/>
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)
  - [ ] TODO on powsybl-open-loadflow
  - [ ] TODO on powsybl-core / CGMES import&export


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`iidm:PhaseTapChanger`-s do not have a `loadTapChangingCapabilities` attribute.
Only `iidm:RatioTapChanger`-s have a `loadTapChangingCapabilities` attribute.


**What is the new behavior (if this is a feature change)?**
`iidm:PhaseTapChanger`-s has a `loadTapChangingCapabilities` attribute, indicating if tap position can be changed while the transformer is carrying current.

CGMES use case: the corresponding flag in CIM is `cim:TapChanger.ltcFlag`, which exists then for both `cim:RatioTapcChanger` and `cim:PhaseTapChanger`. Today's CGMES importer handles the lack of corresponding iIDM attribute for PTC by modifying the regulating mode, but this distorts the data, which can be problematic according to CGMES QoCDC rule IgmSSHvsCgmSSH stating that cim:RegulatingControl.enabled cannot be modified.

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

Network simulators implementing simulation of phase shifter control should not modify the tap position of phase tap changers without load tap changing capabilities.

For backward compatibility of existing external code, PhaseTapChangerAdder assumes a default value of `true` (unlike RatioTapChangerAdder in which default is false).


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
