### PR TITLE
Hvdc adjustments

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/CgmesDcConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/CgmesDcConversion.java
@@ -384,12 +384,12 @@ public class CgmesDcConversion {
             double pDcRectifier = pAC2 - poleLossP2;
             return HvdcUtils.getHvdcLineLosses(pDcRectifier, ratedUdc, r);
         } else if (HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER.equals(operatingMode) && pAC2 != 0.0) {
-            double pDcInverter = -1 * pAC2 + poleLossP2;
-            double idc = (ratedUdc - Math.sqrt(ratedUdc * ratedUdc - 4 * r * pDcInverter)) / (2 * r);
+            double pDcInverter = -1 * (Math.abs(pAC2) + poleLossP2);
+            double idc = (ratedUdc - Math.sqrt(ratedUdc * ratedUdc + 4 * r * pDcInverter)) / (2 * r);
             return r * idc * idc;
         } else if (HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER.equals(operatingMode) && pAC1 != 0.0) {
-            double pDcInverter = -1 * pAC1 + poleLossP1;
-            double idc = (ratedUdc - Math.sqrt(ratedUdc * ratedUdc - 4 * r * pDcInverter)) / (2 * r);
+            double pDcInverter = -1 * (Math.abs(pAC1) + poleLossP1);
+            double idc = (ratedUdc - Math.sqrt(ratedUdc * ratedUdc + 4 * r * pDcInverter)) / (2 * r);
             return r * idc * idc;
         } else {
             return 0.0;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/CgmesDcConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/CgmesDcConversion.java
@@ -164,7 +164,7 @@ public class CgmesDcConversion {
         if (!convertCommonData(acDcConverterNodes, adjacency, acDcConverterIdEnd1, acDcConverterIdEnd2, dcLineSegmentId)) {
             return;
         }
-        this.r = 2.0 * computeR(this.dcLineSegment);
+        this.r = computeR(this.dcLineSegment) / 2.0;
 
         if (createHvdc(isDuplicated)) {
             setCommonDataUsed();

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/CgmesDcConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/CgmesDcConversion.java
@@ -256,18 +256,15 @@ public class CgmesDcConversion {
                 return HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER;
             } else if (rectifier(mode1) && inverter(mode2)) {
                 return HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER;
-            } else if (cconverter1.asDouble(TARGET_PPCC) == 0 && cconverter2.asDouble(TARGET_PPCC) == 0) {
-                // Both ends are rectifier or inverter
-                return HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER;
             } else {
                 LOG.warn("Undefined converter mode for the HVDC, assumed to be of type \"Side1 Rectifier - Side2 Inverter\"");
                 return HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER;
             }
         } else {
-            if (cconverter1.asDouble(TARGET_PPCC) > 0 || cconverter2.asDouble(TARGET_PPCC) < 0) {
-                return HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER;
-            } else {
+            if (cconverter1.asDouble(TARGET_PPCC) < 0 || cconverter2.asDouble(TARGET_PPCC) > 0) {
                 return HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER;
+            } else {
+                return HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER;
             }
         }
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/CgmesDcConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/CgmesDcConversion.java
@@ -180,7 +180,7 @@ public class CgmesDcConversion {
         if (dcLineSegment2 == null) {
             return;
         }
-        this.r = 1.0 / (1.0 / computeR(this.dcLineSegment) + 1.0 / computeR(dcLineSegment2));
+        this.r = computeR(this.dcLineSegment) + computeR(dcLineSegment2);
 
         if (createHvdc()) {
             setCommonDataUsed();

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/DcLineSegmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/DcLineSegmentConversion.java
@@ -93,20 +93,19 @@ public class DcLineSegmentConversion extends AbstractIdentifiedObjectConversion 
     }
 
     private double getActivePowerSetpoint() {
-        if (mode.equals(HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER)) {
-            if (converter1.pAC != 0) {
-                return converter1.pAC;
-            } else if (converter2.pAC != 0) {
-                return Math.abs(converter2.pAC) + converter2.poleLossP + converter2.resistiveLosses + converter1.poleLossP;
-            }
-        } else if (mode.equals(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER)) {
-            if (converter2.pAC != 0) {
-                return converter2.pAC;
-            } else if (converter1.pAC != 0) {
-                return Math.abs(converter1.pAC) + converter1.poleLossP + converter1.resistiveLosses + converter2.poleLossP;
-            }
+        return switch (mode) {
+            case SIDE_1_RECTIFIER_SIDE_2_INVERTER -> getActivePowerSetpoint(converter1, converter2);
+            case SIDE_1_INVERTER_SIDE_2_RECTIFIER -> getActivePowerSetpoint(converter2, converter1);
+        };
+    }
+
+    private static double getActivePowerSetpoint(DcLineSegmentConverter rectifier, DcLineSegmentConverter inverter) {
+        if (rectifier.pAC != 0.0) {
+            return rectifier.pAC;
+        } else if (inverter.pAC != 0.0) {
+            return Math.abs(inverter.pAC) + inverter.poleLossP + inverter.resistiveLosses + rectifier.poleLossP;
         }
-        return 0;
+        return 0.0;
     }
 
     static class DcLineSegmentConverter {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/DcLineSegmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/DcLineSegmentConversion.java
@@ -97,13 +97,13 @@ public class DcLineSegmentConversion extends AbstractIdentifiedObjectConversion 
             if (converter1.pAC != 0) {
                 return converter1.pAC;
             } else if (converter2.pAC != 0) {
-                return Math.abs(converter2.pAC) + converter2.poleLossP + converter1.poleLossP;
+                return Math.abs(converter2.pAC) + converter2.poleLossP + converter2.resistiveLosses + converter1.poleLossP;
             }
         } else if (mode.equals(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER)) {
             if (converter2.pAC != 0) {
                 return converter2.pAC;
             } else if (converter1.pAC != 0) {
-                return Math.abs(converter1.pAC) + converter1.poleLossP + converter2.poleLossP;
+                return Math.abs(converter1.pAC) + converter1.poleLossP + converter1.resistiveLosses + converter2.poleLossP;
             }
         }
         return 0;
@@ -113,11 +113,13 @@ public class DcLineSegmentConversion extends AbstractIdentifiedObjectConversion 
         String converterId;
         double poleLossP;
         double pAC;
+        double resistiveLosses;
 
-        DcLineSegmentConverter(String stationId, double poleLossP, double pAC) {
+        DcLineSegmentConverter(String stationId, double poleLossP, double pAC, double resistiveLosses) {
             this.converterId = stationId;
             this.poleLossP = poleLossP;
             this.pAC = pAC;
+            this.resistiveLosses = resistiveLosses;
         }
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/Hvdc.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/hvdc/Hvdc.java
@@ -145,7 +145,7 @@ class Hvdc {
     }
 
     private static Optional<String> nextDcLineSegment(HvdcEnd hvdc1, Set<String> used) {
-        return hvdc1.dcLineSegmentsEnd.stream().filter(adConverterEnd -> !used.contains(adConverterEnd)).findAny();
+        return hvdc1.dcLineSegmentsEnd.stream().filter(adConverterEnd -> !used.contains(adConverterEnd)).sorted().findFirst();
     }
 
     private static HvdcConverter computeConverter(NodeEquipment nodeEquipment, String dcLineSegment, HvdcEnd hvdc1,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
@@ -687,13 +687,15 @@ public final class StateVariablesExport {
             poleLoss = p * converterStation.getLossFactor() / 100;
         } else {
             double p = converterStation.getTerminal().getP();
-            if (Double.isNaN(p)) {
+            if (!Double.isNaN(p)) {
+                poleLoss = Math.abs(p) * converterStation.getLossFactor() / (100 - converterStation.getLossFactor());
+            } else {
                 p = hvdcLine.getActivePowerSetpoint();
+                double otherConverterStationLossFactor = converterStation.getOtherConverterStation().map(HvdcConverterStation::getLossFactor).orElse(0.0f);
+                double pDCRectifier = Math.abs(p) * (1 - otherConverterStationLossFactor / 100);
+                double pDCInverter = pDCRectifier - HvdcUtils.getHvdcLineLosses(pDCRectifier, hvdcLine.getNominalV(), hvdcLine.getR());
+                poleLoss = pDCInverter * converterStation.getLossFactor() / 100;
             }
-            double otherConverterStationLossFactor = converterStation.getOtherConverterStation().map(HvdcConverterStation::getLossFactor).orElse(0.0f);
-            double pDCRectifier = Math.abs(p) * (1 - otherConverterStationLossFactor / 100);
-            double pDCInverter = pDCRectifier - HvdcUtils.getHvdcLineLosses(pDCRectifier, hvdcLine.getNominalV(), hvdcLine.getR());
-            poleLoss = pDCInverter * converterStation.getLossFactor() / 100;
         }
         return poleLoss;
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/SteadyStateHypothesisExport.java
@@ -21,6 +21,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.ActivePowerControl;
 import com.powsybl.iidm.network.extensions.ReferencePriority;
 import com.powsybl.iidm.network.extensions.RemoteReactivePowerControl;
+import com.powsybl.iidm.network.util.HvdcUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -683,8 +684,10 @@ public final class SteadyStateHypothesisExport {
             if (CgmesExportUtil.isConverterStationRectifier(converterStation)) {
                 ppcc = converterStation.getHvdcLine().getActivePowerSetpoint();
             } else {
+                HvdcLine hvdcLine = converterStation.getHvdcLine();
                 double otherConverterStationLossFactor = converterStation.getOtherConverterStation().map(HvdcConverterStation::getLossFactor).orElse(0.0f);
-                double pDCInverter = converterStation.getHvdcLine().getActivePowerSetpoint() * (1 - otherConverterStationLossFactor / 100);
+                double pDCRectifier = hvdcLine.getActivePowerSetpoint() * (1 - otherConverterStationLossFactor / 100);
+                double pDCInverter = pDCRectifier - HvdcUtils.getHvdcLineLosses(pDCRectifier, hvdcLine.getNominalV(), hvdcLine.getR());
                 double poleLoss = converterStation.getLossFactor() / 100 * pDCInverter;
                 ppcc = -(pDCInverter - poleLoss);
             }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcConversionTest.java
@@ -59,10 +59,10 @@ class HvdcConversionTest extends AbstractSerDeTest {
         // Same test as with EQ only, but this time the SSH is also read.
         Network network = readCgmesResources(DIR, "monopole_EQ.xml", "monopole_SSH.xml");
 
-        // SSH provides converter state data (operating kinds, powers and voltages).
+        // SSH provides converter state data (operating kinds, powers). From those we calculate resistive losses.
         assertContainsLccConverter(network, "CSC_1", "Current source converter 1", "DCL_12", 0.0, -0.8251);
         assertContainsLccConverter(network, "CSC_2", "Current source converter 2", "DCL_12", 0.0, 0.8);
-        assertContainsHvdcLine(network, "DCL_12", SIDE_1_INVERTER_SIDE_2_RECTIFIER, "DC line 12", "CSC_1", "CSC_2", 4.64, 99.0, 118.8);
+        assertContainsHvdcLine(network, "DCL_12", SIDE_1_INVERTER_SIDE_2_RECTIFIER, "DC line 12", "CSC_1", "CSC_2", 4.64, 99.198, 119.038);
 
         assertContainsVscConverter(network, "VSC_3", "Voltage source converter 3", "DCL_34", 0.0, 95.0, 0.0);
         assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34", 0.0, 90.0, 0.0);
@@ -76,11 +76,11 @@ class HvdcConversionTest extends AbstractSerDeTest {
 
         // SV gives losses in converters.
         assertContainsLccConverter(network, "CSC_1", "Current source converter 1", "DCL_12", 0.4024, -0.8251);
-        assertContainsLccConverter(network, "CSC_2", "Current source converter 2", "DCL_12", 0.4008, 0.8);
-        assertContainsHvdcLine(network, "DCL_12", SIDE_1_INVERTER_SIDE_2_RECTIFIER, "DC line 12", "CSC_1", "CSC_2", 4.64, 99.8, 119.76);
+        assertContainsLccConverter(network, "CSC_2", "Current source converter 2", "DCL_12", 0.4, 0.8);
+        assertContainsHvdcLine(network, "DCL_12", SIDE_1_INVERTER_SIDE_2_RECTIFIER, "DC line 12", "CSC_1", "CSC_2", 4.64, 100.0, 120.0);
 
         assertContainsVscConverter(network, "VSC_3", "Voltage source converter 3", "DCL_34", 0.6, 95.0, 0.0);
-        assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34", 0.6036, 90.0, 0.0);
+        assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34", 0.6085, 90.0, 0.0);
         assertContainsHvdcLine(network, "DCL_34", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 34", "VSC_3", "VSC_4", 9.92, 100.0, 120.0);
     }
 
@@ -131,13 +131,13 @@ class HvdcConversionTest extends AbstractSerDeTest {
         Network network = readCgmesResources(DIR, "monopole_EQ.xml", "monopole_Ppcc_SSH.xml", "monopole_SV.xml", "monopole_TP.xml");
 
         // This gives more precise loss and power factor compared to dc voltage control kind at rectifier side.
-        assertContainsLccConverter(network, "CSC_1", "Current source converter 1", "DCL_12", 0.4016, -0.8251);
+        assertContainsLccConverter(network, "CSC_1", "Current source converter 1", "DCL_12", 0.4024, -0.8251);
         assertContainsLccConverter(network, "CSC_2", "Current source converter 2", "DCL_12", 0.4, 0.9119);
         assertContainsHvdcLine(network, "DCL_12", SIDE_1_INVERTER_SIDE_2_RECTIFIER, "DC line 12", "CSC_1", "CSC_2", 4.64, 100.0, 120.0);
 
         // This doesn't change calculations when control kind at rectifier side was already active power at point of common coupling.
         assertContainsVscConverter(network, "VSC_3", "Voltage source converter 3", "DCL_34", 0.6, 95.0, 0.0);
-        assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34", 0.6036, 90.0, 0.0);
+        assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34", 0.6085, 90.0, 0.0);
         assertContainsHvdcLine(network, "DCL_34", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 34", "VSC_3", "VSC_4", 9.92, 100.0, 120.0);
     }
 
@@ -149,7 +149,7 @@ class HvdcConversionTest extends AbstractSerDeTest {
 
         // Control variable is reactive power at PCC.
         assertContainsVscConverter(network, "VSC_3", "Voltage source converter 3", "DCL_34", 0.6, 0.0, -22.5);
-        assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34", 0.6036, 0.0, -30.0);
+        assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34", 0.6085, 0.0, -30.0);
         assertContainsHvdcLine(network, "DCL_34", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 34", "VSC_3", "VSC_4", 9.92, 100.0, 120.0);
     }
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcConversionTest.java
@@ -77,7 +77,7 @@ class HvdcConversionTest extends AbstractSerDeTest {
         // SV gives losses in converters.
         assertContainsLccConverter(network, "CSC_1", "Current source converter 1", "DCL_12", 0.4024, -0.8251);
         assertContainsLccConverter(network, "CSC_2", "Current source converter 2", "DCL_12", 0.4008, 0.8);
-        assertContainsHvdcLine(network, "DCL_12", SIDE_1_INVERTER_SIDE_2_RECTIFIER, "DC line 12", "CSC_1", "CSC_2", 4.64, 99.8, 118.8);
+        assertContainsHvdcLine(network, "DCL_12", SIDE_1_INVERTER_SIDE_2_RECTIFIER, "DC line 12", "CSC_1", "CSC_2", 4.64, 99.8, 119.76);
 
         assertContainsVscConverter(network, "VSC_3", "Voltage source converter 3", "DCL_34", 0.6, 95.0, 0.0);
         assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34", 0.6036, 90.0, 0.0);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcConversionTest.java
@@ -117,12 +117,12 @@ class HvdcConversionTest extends AbstractSerDeTest {
         // HvdcLine DCL_12 links LccConverterStation CSC_1A and CSC_2A with an equivalent resistance.
         assertContainsLccConverter(network, "CSC_1A", "Current source converter 1A", "DCL_12", 0.0, 0.8);
         assertContainsLccConverter(network, "CSC_2A", "Current source converter 2A", "DCL_12", 0.0, 0.8);
-        assertContainsHvdcLine(network, "DCL_12", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 12", "CSC_1A", "CSC_2A", 9.28, 0.0, 0.0);
+        assertContainsHvdcLine(network, "DCL_12", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 12", "CSC_1A", "CSC_2A", 2.32, 0.0, 0.0);
 
         // HvdcLine DCL_12-1 links LccConverterStation CSC_1B and CSC_2B with an equivalent resistance.
         assertContainsLccConverter(network, "CSC_1B", "Current source converter 1B", "DCL_12-1", 0.0, 0.8);
         assertContainsLccConverter(network, "CSC_2B", "Current source converter 2B", "DCL_12-1", 0.0, 0.8);
-        assertContainsHvdcLine(network, "DCL_12-1", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 12-1", "CSC_1B", "CSC_2B", 9.28, 0.0, 0.0);
+        assertContainsHvdcLine(network, "DCL_12-1", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 12-1", "CSC_1B", "CSC_2B", 2.32, 0.0, 0.0);
     }
 
     @Test

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcConversionTest.java
@@ -51,7 +51,7 @@ class HvdcConversionTest extends AbstractSerDeTest {
 
         assertContainsVscConverter(network, "VSC_3", "Voltage source converter 3", "DCL_34", 0.0, Double.NaN, 0.0);
         assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34", 0.0, Double.NaN, 0.0);
-        assertContainsHvdcLine(network, "DCL_34", SIDE_1_INVERTER_SIDE_2_RECTIFIER, "DC line 34", "VSC_3", "VSC_4", 9.92, 0.0, 0.0);
+        assertContainsHvdcLine(network, "DCL_34", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 34", "VSC_3", "VSC_4", 9.92, 0.0, 0.0);
     }
 
     @Test
@@ -97,7 +97,7 @@ class HvdcConversionTest extends AbstractSerDeTest {
         // A single HvdcLine has been created with an equivalent resistance.
         assertContainsVscConverter(network, "VSC_3", "Voltage source converter 3", "DCL_34P", 0.0, Double.NaN, 0.0);
         assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34P", 0.0, Double.NaN, 0.0);
-        assertContainsHvdcLine(network, "DCL_34P", SIDE_1_INVERTER_SIDE_2_RECTIFIER, "DC line 34P", "VSC_3", "VSC_4", 2.48, 0.0, 0.0);
+        assertContainsHvdcLine(network, "DCL_34P", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 34P", "VSC_3", "VSC_4", 2.48, 0.0, 0.0);
 
         // The other DCLineSegment identifier is kept as an alias.
         assertEquals("DCL_34N", network.getHvdcLine("DCL_34P").getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "DCLineSegment2").orElse(""));
@@ -205,7 +205,7 @@ class HvdcConversionTest extends AbstractSerDeTest {
         // it's not possible anymore to compute which side is inverter and which is rectifier without P.
         assertContainsVscConverter(network, "VSC_3", "Voltage source converter 3", "DCL_34", 0.0, 95.0, 0.0);
         assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34", 0.0, 90.0, 0.0);
-        assertContainsHvdcLine(network, "DCL_34", SIDE_1_INVERTER_SIDE_2_RECTIFIER, "DC line 34", "VSC_3", "VSC_4", 9.92, 0.0, 0.0);
+        assertContainsHvdcLine(network, "DCL_34", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 34", "VSC_3", "VSC_4", 9.92, 0.0, 0.0);
     }
 
     @Test

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcConversionTest.java
@@ -95,12 +95,12 @@ class HvdcConversionTest extends AbstractSerDeTest {
         Network network = readCgmesResources(DIR, "monopole_with_metallic_return.xml");
 
         // A single HvdcLine has been created with an equivalent resistance.
-        assertContainsVscConverter(network, "VSC_3", "Voltage source converter 3", "DCL_34P", 0.0, Double.NaN, 0.0);
-        assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34P", 0.0, Double.NaN, 0.0);
-        assertContainsHvdcLine(network, "DCL_34P", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 34P", "VSC_3", "VSC_4", 2.48, 0.0, 0.0);
+        assertContainsVscConverter(network, "VSC_3", "Voltage source converter 3", "DCL_34N", 0.0, Double.NaN, 0.0);
+        assertContainsVscConverter(network, "VSC_4", "Voltage source converter 4", "DCL_34N", 0.0, Double.NaN, 0.0);
+        assertContainsHvdcLine(network, "DCL_34N", SIDE_1_RECTIFIER_SIDE_2_INVERTER, "DC line 34N", "VSC_3", "VSC_4", 9.92, 0.0, 0.0);
 
         // The other DCLineSegment identifier is kept as an alias.
-        assertEquals("DCL_34N", network.getHvdcLine("DCL_34P").getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "DCLineSegment2").orElse(""));
+        assertEquals("DCL_34P", network.getHvdcLine("DCL_34N").getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "DCLineSegment2").orElse(""));
     }
 
     @Test

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportXmlCompare.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportXmlCompare.java
@@ -770,7 +770,7 @@ final class ExportXmlCompare {
             return name.equals("p") || name.equals("q") || name.equals("p0") || name.equals("q0")
                 || name.equals("r") || name.equals("x") || name.equals("g") || name.equals("b") || name.equals("rho") || name.equals("alpha")
                 || name.equals("b1") || name.equals("b2") || name.equals("g1") || name.equals("g2")
-                || name.equals("bPerSection") || name.equals("activePowerSetpoint")
+                || name.equals("bPerSection") || name.equals("activePowerSetpoint") || name.equals("maxP")
                 || isAttrValueOfNumericProperty((Attr) n);
         }
         return false;
@@ -803,7 +803,8 @@ final class ExportXmlCompare {
                 || n.getLocalName().equals("b1") || n.getLocalName().equals("b2")
                 || n.getLocalName().equals("g1") || n.getLocalName().equals("g2")
                 || n.getLocalName().equals("alpha") || n.getLocalName().equals("rho")
-                || n.getLocalName().equals("bPerSection") || n.getLocalName().equals("activePowerSetpoint")) {
+                || n.getLocalName().equals("bPerSection") || n.getLocalName().equals("activePowerSetpoint")
+                || n.getLocalName().equals("maxP")) {
             return 1e-5;
         }
         return 1e-10;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
There are a few things at CGMES import of a DC model that give non-uniform or erroneous result:
* `HvdcLine.mode` can't be determined when importing an EQ only because there isn't enough information in the EQ to determine which converter (side) is rectifier and which is inverter. A default value has to be given. This default value depends on the order the converters appear in the EQ file, and on the type of the hvdc line: it is `SIDE_1_RECTIFIER_SIDE_2_INVERTER` for a LCC and `SIDE_1_INVERTER_SIDE_2_RECTIFIER` for a VSC.
* In the case the active power at **p**oint of **c**ommon **c**oupling (pcc) is defined at the inverter side (and the rectifier side sets the rated dc voltage), the inverter pcc active power is brought back to the rectifier side by adding losses on the converters, and that makes the `HvdcLine.activePowerSetpoint`. However, the `HvdcLine.maxP` is still calculated as 120% of the inverter pcc active power. This can be a problem and lead to situations where the `activePowerSetpoint` is greater than the `maxP`.
* `HvdcLine` resistive losses are not considered. This has an impact when the active power is defined at the inverter pcc, and is brought back to the rectifier side by adding the losses. 
* In the case of a DC configuration with 2 CGMES `DCLineSegment` per `ACDCConverter` pair (typically a monopole with metallic return), only 1 `HvdcLine` is created, with the following equivalent resistance: $`\frac{1}{req} = \frac{1}{r1} + \frac{1}{r2}`$
* In the case of a DC configuration with 2 CGMES `ACDCConverter` pair per `DCLineSegment` (typicall a monopole with 2*6-pulses bridge per converter unit), 2 `HvdcLine` are created, each having the following resistance: $`r1 = r2 = 2 \times r`$


**What is the new behavior (if this is a feature change)?**
The CGMES import of a DC model gives now more uniform and precise results:
* The default `HvdcLine` mode in case of an EQ only import is always `SIDE_1_RECTIFIER_SIDE_2_INVERTER` for all hvdc line types, where side 1 is the side with the lowest converter id.
* `HvdcLine.maxP` is always equal to 120% of `HvdcLine.activePowerSetpoint`.
* `HvdcLine` resistive losses are now considered. They are calculated as: $`r \times idc²`$, where:
  * If CGMES defines active power at rectifier pcc:
$`pDcRecifier = rectifierPccActivePower - rectifierPoleLosses`$
$`idc = r \times \frac{pDcRectifier^2}{nominalV^2}`$
  * If CGMES defines active power at inverter pcc:
$`pDcInverter = -(abs(inverterPccActivePower) + inverterPoleLosses)`$
$`idc = \frac{nominalV - \sqrt{nominalV^2 - 4 \times r \times abs(pDcInverter)}}{2 \times r}`$;
* In the case of a DC configuration with 2 CGMES `DCLineSegment` per `ACDCConverter` pair (typically a monopole with metallic return), only 1 `HvdcLine` is created, with the following equivalent resistance: $`req = r1 + r2`$
* In the case of a DC configuration with 2 CGMES `ACDCConverter` pair per `DCLineSegment` (typicall a monopole with 2*6-pulses bridge per converter unit), 2 `HvdcLine` are created, each having the following resistance: $`r1 = r2 = \frac {r}{2}`$

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
