### PR TITLE
Fix logs on "CreateCouplingDevice" network modification

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateCouplingDevice.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateCouplingDevice.java
@@ -17,12 +17,15 @@ import com.powsybl.iidm.network.extensions.BusbarSectionPosition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
 
+import static com.powsybl.iidm.modification.topology.TopologyModificationUtils.*;
 import static com.powsybl.iidm.modification.util.ModificationLogs.busOrBbsDoesNotExist;
 import static com.powsybl.iidm.modification.util.ModificationLogs.logOrThrow;
 import static com.powsybl.iidm.modification.util.ModificationReports.*;
-import static com.powsybl.iidm.modification.topology.TopologyModificationUtils.*;
 
 /**
  * Adds a coupling device between two busbar sections. If topology extensions are present, then it creates open
@@ -94,7 +97,7 @@ public class CreateCouplingDevice extends AbstractNetworkModification {
             LOGGER.error("Voltage level associated to {} or {} not found.", busOrBbs1, busOrBbs2);
             notFoundBusOrBusbarSectionVoltageLevelReport(reportNode, busOrBbsId1, busOrBbsId2);
             if (throwException) {
-                throw new PowsyblException(String.format("Voltage level associated to %s or %s not found.", busOrBbs1, busOrBbs2));
+                throw new PowsyblException(String.format("Voltage level associated to %s or %s not found.", busOrBbs1.getId(), busOrBbs2.getId()));
             }
             return;
         }
@@ -116,7 +119,7 @@ public class CreateCouplingDevice extends AbstractNetworkModification {
             // busbar sections exist: voltage level is NODE_BREAKER
             applyOnBusbarSections(voltageLevel1, voltageLevel2, bbs1, bbs2, namingStrategy, reportNode);
         }
-        LOGGER.info("New coupling device was added to voltage level {} between {} and {}", voltageLevel1.getId(), busOrBbs1, busOrBbs2);
+        LOGGER.info("New coupling device was added to voltage level {} between {} and {}", voltageLevel1.getId(), busOrBbs1.getId(), busOrBbs2.getId());
         newCouplingDeviceAddedReport(reportNode, voltageLevel1.getId(), busOrBbsId1, busOrBbsId2);
     }
 

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateCouplingDevice.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateCouplingDevice.java
@@ -17,10 +17,7 @@ import com.powsybl.iidm.network.extensions.BusbarSectionPosition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.OptionalInt;
+import java.util.*;
 
 import static com.powsybl.iidm.modification.topology.TopologyModificationUtils.*;
 import static com.powsybl.iidm.modification.util.ModificationLogs.busOrBbsDoesNotExist;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
For createCouplingDevice, the error threw contains the busbar object and not the busbar id.


**What is the new behavior (if this is a feature change)?**
Fix it


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
