### PR TITLE
Remove DynamicSimulationResult deprecated method

### DIFF
--- a/dynamic-simulation/dynamic-simulation-api/src/main/java/com/powsybl/dynamicsimulation/DynamicSimulationResult.java
+++ b/dynamic-simulation/dynamic-simulation-api/src/main/java/com/powsybl/dynamicsimulation/DynamicSimulationResult.java
@@ -13,8 +13,6 @@ import java.util.Map;
 
 import com.powsybl.timeseries.DoubleTimeSeries;
 
-import static com.powsybl.dynamicsimulation.DynamicSimulationResult.Status.SUCCESS;
-
 /**
  * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  * @author Laurent Issertial {@literal <laurent.issertial at rte-france.com>}
@@ -29,14 +27,6 @@ public interface DynamicSimulationResult {
     Status getStatus();
 
     String getStatusText();
-
-    /**
-     * @deprecated use DynamicSimulationResult.Status instead
-     */
-    @Deprecated(since = "6.1.0")
-    default boolean isOk() {
-        return SUCCESS == getStatus();
-    }
 
     Map<String, DoubleTimeSeries> getCurves();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Deprecated method removal


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`DynamicSimulationResult.isOk` is deprecated since 6.1.0.


**What is the new behavior (if this is a feature change)?**

Remove `DynamicSimulationResult.isOk`.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Remove `DynamicSimulationResult.isOk`, use `DynamicSimulationResult.Status` instead.

