### PR TITLE
Execute each deserialization end task's step only once

### DIFF
--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkDeserializerContext.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkDeserializerContext.java
@@ -35,6 +35,7 @@ public class NetworkDeserializerContext extends AbstractNetworkSerDeContext<Impo
     private ValidationLevel networkValidationLevel;
 
     private Set<String> ignoredEquipments = new HashSet<>();
+    private EnumSet<DeserializationEndTask.Step> alreadyProcessedEndTasksSteps = EnumSet.noneOf(DeserializationEndTask.Step.class);
 
     public NetworkDeserializerContext(Anonymizer anonymizer, TreeDataReader reader) {
         this(anonymizer, reader, new ImportOptions(), CURRENT_IIDM_VERSION, Collections.emptyMap());
@@ -58,6 +59,11 @@ public class NetworkDeserializerContext extends AbstractNetworkSerDeContext<Impo
     }
 
     public void executeEndTasks(Network network, DeserializationEndTask.Step step, ReportNode reportNode) {
+        if (alreadyProcessedEndTasksSteps.contains(step)) {
+            // Skip if step was already processed
+            return;
+        }
+        alreadyProcessedEndTasksSteps.add(step);
         Networks.executeWithReportNode(network, reportNode, () -> endTasks.stream()
                 .filter(t -> t.getStep() == step
                         || step == DeserializationEndTask.Step.AFTER_EXTENSIONS &&


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix / performance fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When importing an XIIDM network file, `executeEndTasks` is executed for the `BEFORE_EXTENSIONS` step a lot of times (before each `<extension>` tag) instead of once.
Since only `OverloadManagementSystem` related tasks are defined for this step, only network file with this type of equipment may encountered import problems.
But since every end task is checked for every `<extension>` tag of the file, this slows the import unnecessarily.


**What is the new behavior (if this is a feature change)?**
Each step is only processed once, as expected. `executeEndTasks` is always called before each `<extension>` tag, but it immediately exits except for the first one.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
