### PR TITLE
Use solved values in CGMES import and export

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -502,12 +502,6 @@ public class CgmesImport implements Importer {
                                 p,
                                 IMPORT_CONTROL_AREAS_PARAMETER,
                                 defaultValueConfig))
-                .setProfileForInitialValuesShuntSectionsTapPositions(
-                        Parameter.readString(
-                                getFormat(),
-                                p,
-                                PROFILE_FOR_INITIAL_VALUES_SHUNT_SECTIONS_TAP_POSITIONS_PARAMETER,
-                                defaultValueConfig))
                 .setStoreCgmesModelAsNetworkExtension(
                         Parameter.readBoolean(
                                 getFormat(),
@@ -621,7 +615,6 @@ public class CgmesImport implements Importer {
     public static final String PRE_PROCESSORS = "iidm.import.cgmes.pre-processors";
     public static final String POST_PROCESSORS = "iidm.import.cgmes.post-processors";
     public static final String POWSYBL_TRIPLESTORE = "iidm.import.cgmes.powsybl-triplestore";
-    public static final String PROFILE_FOR_INITIAL_VALUES_SHUNT_SECTIONS_TAP_POSITIONS = "iidm.import.cgmes.profile-for-initial-values-shunt-sections-tap-positions";
     public static final String SOURCE_FOR_IIDM_ID = "iidm.import.cgmes.source-for-iidm-id";
     public static final String STORE_CGMES_MODEL_AS_NETWORK_EXTENSION = "iidm.import.cgmes.store-cgmes-model-as-network-extension";
     public static final String STORE_CGMES_CONVERSION_CONTEXT_AS_NETWORK_EXTENSION = "iidm.import.cgmes.store-cgmes-conversion-context-as-network-extension";
@@ -676,13 +669,6 @@ public class CgmesImport implements Importer {
             null,
             ParameterScope.TECHNICAL)
             .addAdditionalNames("powsyblTripleStore");
-    private static final Parameter PROFILE_FOR_INITIAL_VALUES_SHUNT_SECTIONS_TAP_POSITIONS_PARAMETER = new Parameter(
-            PROFILE_FOR_INITIAL_VALUES_SHUNT_SECTIONS_TAP_POSITIONS,
-            ParameterType.STRING,
-            "Profile used for initial state values",
-            "SSH",
-            List.of("SSH", "SV"))
-            .addAdditionalNames("iidm.import.cgmes.profile-used-for-initial-state-values");
     private static final Parameter STORE_CGMES_CONVERSION_CONTEXT_AS_NETWORK_EXTENSION_PARAMETER = new Parameter(
             STORE_CGMES_CONVERSION_CONTEXT_AS_NETWORK_EXTENSION,
             ParameterType.BOOLEAN,
@@ -759,7 +745,6 @@ public class CgmesImport implements Importer {
             NAMING_STRATEGY_PARAMETER,
             IMPORT_CONTROL_AREAS_PARAMETER,
             POWSYBL_TRIPLESTORE_PARAMETER,
-            PROFILE_FOR_INITIAL_VALUES_SHUNT_SECTIONS_TAP_POSITIONS_PARAMETER,
             SOURCE_FOR_IIDM_ID_PARAMETER,
             STORE_CGMES_CONVERSION_CONTEXT_AS_NETWORK_EXTENSION_PARAMETER,
             STORE_CGMES_MODEL_AS_NETWORK_EXTENSION_PARAMETER,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -858,20 +858,6 @@ public class Conversion {
             return this;
         }
 
-        public StateProfile getProfileForInitialValuesShuntSectionsTapPositions() {
-            return profileForInitialValuesShuntSectionsTapPositions;
-        }
-
-        public Config setProfileForInitialValuesShuntSectionsTapPositions(String profileForInitialValuesShuntSectionsTapPositions) {
-            String forInitialValuesShuntSectionsTapPositions = Objects.requireNonNull(profileForInitialValuesShuntSectionsTapPositions);
-            if (forInitialValuesShuntSectionsTapPositions.equals("SSH") || forInitialValuesShuntSectionsTapPositions.equals("SV")) {
-                this.profileForInitialValuesShuntSectionsTapPositions = StateProfile.valueOf(profileForInitialValuesShuntSectionsTapPositions);
-            } else {
-                throw new CgmesModelException("Unexpected profile used for shunt sections / tap positions state hypothesis: " + profileForInitialValuesShuntSectionsTapPositions);
-            }
-            return this;
-        }
-
         public boolean storeCgmesModelAsNetworkExtension() {
             return storeCgmesModelAsNetworkExtension;
         }
@@ -1017,7 +1003,6 @@ public class Conversion {
 
         private boolean createBusbarSectionForEveryConnectivityNode = false;
         private boolean convertSvInjections = true;
-        private StateProfile profileForInitialValuesShuntSectionsTapPositions = SSH;
         private boolean storeCgmesModelAsNetworkExtension = true;
         private boolean storeCgmesConversionContextAsNetworkExtension = false;
         private boolean createActivePowerControlExtension = false;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -36,7 +36,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import static com.powsybl.cgmes.conversion.Conversion.Config.StateProfile.SSH;
 import static java.util.stream.Collectors.groupingBy;
 
 /**

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -804,11 +804,6 @@ public class Conversion {
 
     public static class Config {
 
-        public enum StateProfile {
-            SSH,
-            SV
-        }
-
         public List<String> substationIdsExcludedFromMapping() {
             return Collections.emptyList();
         }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
@@ -36,7 +36,7 @@ public class ShuntConversion extends AbstractConductingEquipmentConversion {
         int normalSections = p.asInt("normalSections", 0);
         int sections = fromContinuous(p.asDouble("SSHsections", p.asDouble("SVsections", normalSections)));
         Integer solvedSections = null;
-        double solvedSectionFromSV = p.asDouble("SVsections", Double.NaN);
+        double solvedSectionFromSV = p.asDouble("SVsections");
         if (!Double.isNaN(solvedSectionFromSV)) {
             solvedSections = fromContinuous(solvedSectionFromSV);
         }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/ShuntConversion.java
@@ -35,7 +35,11 @@ public class ShuntConversion extends AbstractConductingEquipmentConversion {
         int maximumSections = p.asInt("maximumSections", 0);
         int normalSections = p.asInt("normalSections", 0);
         int sections = fromContinuous(p.asDouble("SSHsections", p.asDouble("SVsections", normalSections)));
-        int solvedSections = fromContinuous(p.asDouble("SVsections", p.asDouble("SSHsections", normalSections)));
+        Integer solvedSections = null;
+        double solvedSectionFromSV = p.asDouble("SVsections", Double.NaN);
+        if (!Double.isNaN(solvedSectionFromSV)) {
+            solvedSections = fromContinuous(solvedSectionFromSV);
+        }
         sections = Math.abs(sections);
         maximumSections = Math.max(maximumSections, sections);
         ShuntCompensatorAdder adder = voltageLevel().newShuntCompensator().setSectionCount(sections).setSolvedSectionCount(solvedSections);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractCgmesTapChangerBuilder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractCgmesTapChangerBuilder.java
@@ -57,7 +57,7 @@ abstract class AbstractCgmesTapChangerBuilder {
             position = neutralStep;
         }
         Integer solvedPosition = null;
-        double solvedPositionFromSv = p.asDouble(CgmesNames.SV_TAP_STEP, Double.NaN);
+        double solvedPositionFromSv = p.asDouble(CgmesNames.SV_TAP_STEP);
         if (!Double.isNaN(solvedPositionFromSv)) {
             solvedPosition = AbstractObjectConversion.fromContinuous(solvedPositionFromSv);
             if (solvedPosition > highStep || solvedPosition < lowStep) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractCgmesTapChangerBuilder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractCgmesTapChangerBuilder.java
@@ -10,7 +10,6 @@ package com.powsybl.cgmes.conversion.elements.transformers;
 
 import com.powsybl.cgmes.conversion.Context;
 import com.powsybl.cgmes.conversion.elements.AbstractObjectConversion;
-import com.powsybl.cgmes.model.CgmesModelException;
 import com.powsybl.cgmes.model.CgmesNames;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.triplestore.api.PropertyBag;
@@ -47,28 +46,21 @@ abstract class AbstractCgmesTapChangerBuilder {
         return new CgmesPhaseTapChangerBuilder(phaseTapChanger, xtx, context);
     }
 
-    protected int initialTapPosition(int defaultStep) {
-        switch (context.config().getProfileForInitialValuesShuntSectionsTapPositions()) {
-            case SSH:
-                return AbstractObjectConversion.fromContinuous(p.asDouble(CgmesNames.STEP, p.asDouble(CgmesNames.SV_TAP_STEP, defaultStep)));
-            case SV:
-                return AbstractObjectConversion.fromContinuous(p.asDouble(CgmesNames.SV_TAP_STEP, p.asDouble(CgmesNames.STEP, defaultStep)));
-            default:
-                throw new CgmesModelException("Unexpected profile used for initial values: " + context.config().getProfileForInitialValuesShuntSectionsTapPositions());
-        }
-    }
-
     protected TapChanger build() {
         lowStep = p.asInt(CgmesNames.LOW_STEP);
         highStep = p.asInt(CgmesNames.HIGH_STEP);
         addSteps();
         int neutralStep = p.asInt(CgmesNames.NEUTRAL_STEP);
         int normalStep = p.asInt(CgmesNames.NORMAL_STEP, neutralStep);
-        int position = initialTapPosition(normalStep);
+        int position = AbstractObjectConversion.fromContinuous(p.asDouble(CgmesNames.STEP, p.asDouble(CgmesNames.SV_TAP_STEP, normalStep)));
         if (position > highStep || position < lowStep) {
             position = neutralStep;
         }
-        tapChanger.setLowTapPosition(lowStep).setTapPosition(position);
+        int solvedPosition = AbstractObjectConversion.fromContinuous(p.asDouble(CgmesNames.SV_TAP_STEP, p.asDouble(CgmesNames.STEP, normalStep)));
+        if (solvedPosition > highStep || solvedPosition < lowStep) {
+            solvedPosition = position;
+        }
+        tapChanger.setLowTapPosition(lowStep).setTapPosition(position).setSolvedTapPosition(solvedPosition);
 
         boolean ltcFlag = p.asBoolean(CgmesNames.LTC_FLAG, false);
         tapChanger.setLtcFlag(ltcFlag);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractCgmesTapChangerBuilder.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractCgmesTapChangerBuilder.java
@@ -56,9 +56,13 @@ abstract class AbstractCgmesTapChangerBuilder {
         if (position > highStep || position < lowStep) {
             position = neutralStep;
         }
-        int solvedPosition = AbstractObjectConversion.fromContinuous(p.asDouble(CgmesNames.SV_TAP_STEP, p.asDouble(CgmesNames.STEP, normalStep)));
-        if (solvedPosition > highStep || solvedPosition < lowStep) {
-            solvedPosition = position;
+        Integer solvedPosition = null;
+        double solvedPositionFromSv = p.asDouble(CgmesNames.SV_TAP_STEP, Double.NaN);
+        if (!Double.isNaN(solvedPositionFromSv)) {
+            solvedPosition = AbstractObjectConversion.fromContinuous(solvedPositionFromSv);
+            if (solvedPosition > highStep || solvedPosition < lowStep) {
+                solvedPosition = position;
+            }
         }
         tapChanger.setLowTapPosition(lowStep).setTapPosition(position).setSolvedTapPosition(solvedPosition);
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
@@ -37,7 +37,8 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
         boolean isLtcFlag = rtc.isLtcFlag();
         int lowStep = rtc.getLowTapPosition();
         int position = rtc.getTapPosition();
-        rtca.setLoadTapChangingCapabilities(isLtcFlag).setLowTapPosition(lowStep).setTapPosition(position);
+        int solvedPosition = rtc.getSolvedTapPosition();
+        rtca.setLoadTapChangingCapabilities(isLtcFlag).setLowTapPosition(lowStep).setTapPosition(position).setSolvedTapPosition(solvedPosition);
 
         rtc.getSteps().forEach(step -> {
             double ratio = step.getRatio();
@@ -63,7 +64,8 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
         boolean isLtcFlag = ptc.isLtcFlag();
         int lowStep = ptc.getLowTapPosition();
         int position = ptc.getTapPosition();
-        ptca.setLoadTapChangingCapabilities(isLtcFlag).setLowTapPosition(lowStep).setTapPosition(position);
+        int solvedPosition = ptc.getSolvedTapPosition();
+        ptca.setLoadTapChangingCapabilities(isLtcFlag).setLowTapPosition(lowStep).setTapPosition(position).setSolvedTapPosition(solvedPosition);
 
         ptc.getSteps().forEach(step -> {
             double ratio = step.getRatio();

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/AbstractTransformerConversion.java
@@ -37,7 +37,7 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
         boolean isLtcFlag = rtc.isLtcFlag();
         int lowStep = rtc.getLowTapPosition();
         int position = rtc.getTapPosition();
-        int solvedPosition = rtc.getSolvedTapPosition();
+        Integer solvedPosition = rtc.getSolvedTapPosition();
         rtca.setLoadTapChangingCapabilities(isLtcFlag).setLowTapPosition(lowStep).setTapPosition(position).setSolvedTapPosition(solvedPosition);
 
         rtc.getSteps().forEach(step -> {
@@ -64,7 +64,7 @@ abstract class AbstractTransformerConversion extends AbstractConductingEquipment
         boolean isLtcFlag = ptc.isLtcFlag();
         int lowStep = ptc.getLowTapPosition();
         int position = ptc.getTapPosition();
-        int solvedPosition = ptc.getSolvedTapPosition();
+        Integer solvedPosition = ptc.getSolvedTapPosition();
         ptca.setLoadTapChangingCapabilities(isLtcFlag).setLowTapPosition(lowStep).setTapPosition(position).setSolvedTapPosition(solvedPosition);
 
         ptc.getSteps().forEach(step -> {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TapChanger.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TapChanger.java
@@ -48,6 +48,7 @@ public class TapChanger {
 
     private int lowTapPosition = 0;
     private Integer tapPosition;
+    private Integer solvedTapPosition;
     private final List<Step> steps = new ArrayList<>();
     private boolean ltcFlag = false;
     private String id = null;
@@ -156,6 +157,11 @@ public class TapChanger {
         return this;
     }
 
+    public TapChanger setSolvedTapPosition(int solvedTapPosition) {
+        this.solvedTapPosition = solvedTapPosition;
+        return this;
+    }
+
     public TapChanger setLtcFlag(boolean ltcFlag) {
         this.ltcFlag = ltcFlag;
         return this;
@@ -206,6 +212,10 @@ public class TapChanger {
 
     public Integer getTapPosition() {
         return tapPosition;
+    }
+
+    public Integer getSolvedTapPosition() {
+        return solvedTapPosition;
     }
 
     public List<Step> getSteps() {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TapChanger.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TapChanger.java
@@ -157,7 +157,7 @@ public class TapChanger {
         return this;
     }
 
-    public TapChanger setSolvedTapPosition(int solvedTapPosition) {
+    public TapChanger setSolvedTapPosition(Integer solvedTapPosition) {
         this.solvedTapPosition = solvedTapPosition;
         return this;
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TapChangerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TapChangerConversion.java
@@ -220,6 +220,7 @@ public class TapChangerConversion {
         });
         tapChanger.setLowTapPosition(tc.getLowTapPosition());
         tapChanger.setTapPosition(tc.getTapPosition());
+        tapChanger.setSolvedTapPosition(tc.getSolvedTapPosition());
     }
 
     /**
@@ -395,10 +396,12 @@ public class TapChangerConversion {
         boolean isTapChangerControlEnabled = rtc.isTapChangerControlEnabled();
         int lowStep = rtc.getLowTapPosition();
         int position = rtc.getTapPosition();
+        int solvedPosition = rtc.getSolvedTapPosition();
         String type = rtc.getType();
         TapChanger hiddenCombinedTapChanger = rtc.getHiddenCombinedTapChanger();
         tapChanger.setLowTapPosition(lowStep)
             .setTapPosition(position)
+            .setSolvedTapPosition(solvedPosition)
             .setLtcFlag(isLtcFlag)
             .setId(id)
             .setRegulating(isRegulating)

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TapChangerConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/transformers/TapChangerConversion.java
@@ -396,7 +396,7 @@ public class TapChangerConversion {
         boolean isTapChangerControlEnabled = rtc.isTapChangerControlEnabled();
         int lowStep = rtc.getLowTapPosition();
         int position = rtc.getTapPosition();
-        int solvedPosition = rtc.getSolvedTapPosition();
+        Integer solvedPosition = rtc.getSolvedTapPosition();
         String type = rtc.getType();
         TapChanger hiddenCombinedTapChanger = rtc.getHiddenCombinedTapChanger();
         tapChanger.setLowTapPosition(lowStep)

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
@@ -571,12 +571,14 @@ public final class StateVariablesExport {
         for (ThreeWindingsTransformer.Leg leg : Arrays.asList(twt.getLeg1(), twt.getLeg2(), twt.getLeg3())) {
             if (leg.hasPhaseTapChanger()) {
                 String ptcId = context.getNamingStrategy().getCgmesIdFromAlias(twt, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.PHASE_TAP_CHANGER + endNumber);
-                writeSvTapStep(ptcId, leg.getPhaseTapChanger().getTapPosition(), cimNamespace, writer, context);
+                PhaseTapChanger phaseTapChanger = leg.getPhaseTapChanger();
+                writeSvTapStep(ptcId, phaseTapChanger.findSolvedTapPosition().orElse(phaseTapChanger.getTapPosition()), cimNamespace, writer, context);
                 writeSvTapStepHidden(twt, ptcId, cimNamespace, writer, context);
             }
             if (leg.hasRatioTapChanger()) {
                 String rtcId = context.getNamingStrategy().getCgmesIdFromAlias(twt, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.RATIO_TAP_CHANGER + endNumber);
-                writeSvTapStep(rtcId, leg.getRatioTapChanger().getTapPosition(), cimNamespace, writer, context);
+                RatioTapChanger ratioTapChanger = leg.getRatioTapChanger();
+                writeSvTapStep(rtcId, ratioTapChanger.findTapPosition().orElse(ratioTapChanger.getTapPosition()), cimNamespace, writer, context);
                 writeSvTapStepHidden(twt, rtcId, cimNamespace, writer, context);
             }
             endNumber++;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
@@ -528,7 +528,7 @@ public final class StateVariablesExport {
             CgmesExportUtil.writeStartId("SvShuntCompensatorSections", CgmesExportUtil.getUniqueRandomId(), false, cimNamespace, writer, context);
             CgmesExportUtil.writeReference("SvShuntCompensatorSections.ShuntCompensator", context.getNamingStrategy().getCgmesId(s), cimNamespace, writer, context);
             writer.writeStartElement(cimNamespace, "SvShuntCompensatorSections.sections");
-            writer.writeCharacters(CgmesExportUtil.format(s.getSectionCount()));
+            writer.writeCharacters(CgmesExportUtil.format(s.findSolvedSectionCount().orElse(s.getSectionCount())));
             writer.writeEndElement();
             writer.writeEndElement();
         }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
@@ -551,15 +551,17 @@ public final class StateVariablesExport {
      */
     private static void writeTapStepsTwoWindingsTransformer(TwoWindingsTransformer twt, String cimNamespace, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
         if (twt.hasPhaseTapChanger()) {
+            PhaseTapChanger phaseTapChanger = twt.getPhaseTapChanger();
             int endNumber = twt.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.PHASE_TAP_CHANGER + 1).isPresent() ? 1 : 2;
             String ptcId = context.getNamingStrategy().getCgmesIdFromAlias(twt, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.PHASE_TAP_CHANGER + endNumber);
-            writeSvTapStep(ptcId, twt.getPhaseTapChanger().getTapPosition(), cimNamespace, writer, context);
+            writeSvTapStep(ptcId, phaseTapChanger.findSolvedTapPosition().orElse(phaseTapChanger.getTapPosition()), cimNamespace, writer, context);
             writeSvTapStepHidden(twt, ptcId, cimNamespace, writer, context);
         }
         if (twt.hasRatioTapChanger()) {
+            RatioTapChanger ratioTapChanger = twt.getRatioTapChanger();
             int endNumber = twt.getAliasFromType(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.RATIO_TAP_CHANGER + 1).isPresent() ? 1 : 2;
             String rtcId = context.getNamingStrategy().getCgmesIdFromAlias(twt, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + CgmesNames.RATIO_TAP_CHANGER + endNumber);
-            writeSvTapStep(rtcId, twt.getRatioTapChanger().getTapPosition(), cimNamespace, writer, context);
+            writeSvTapStep(rtcId, ratioTapChanger.findSolvedTapPosition().orElse(ratioTapChanger.getTapPosition()), cimNamespace, writer, context);
             writeSvTapStepHidden(twt, rtcId, cimNamespace, writer, context);
         }
     }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
@@ -26,9 +26,8 @@ import com.powsybl.commons.datasource.DirectoryDataSource;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ZipArchiveDataSource;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.PhaseTapChangerHolder;
-import com.powsybl.iidm.network.RatioTapChangerHolder;
 import com.powsybl.iidm.network.impl.NetworkFactoryImpl;
+import com.powsybl.iidm.network.util.Networks;
 import com.powsybl.iidm.serde.XMLExporter;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.resultscompletion.LoadFlowResultsCompletion;
@@ -46,7 +45,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -227,7 +225,7 @@ public class ConversionTester {
             ValidationConfig config = loadFlowValidationConfig(validateBusBalancesThreshold);
             Path working = Files.createDirectories(fs.getPath("lf-validation"));
 
-            computeMissingFlows(network, config.getLoadFlowParameters());
+            computeMissingFlows(network, config.getLoadFlowParameters(), true);
             assertTrue(ValidationType.BUSES.check(network, config, working));
         }
     }
@@ -242,15 +240,16 @@ public class ConversionTester {
         return config;
     }
 
-    public static void computeMissingFlows(Network network, LoadFlowParameters lfparams) {
+    public static void computeMissingFlows(Network network, LoadFlowParameters lfparams, boolean useSv) {
         LoadFlowResultsCompletionParameters p = new LoadFlowResultsCompletionParameters(
             LoadFlowResultsCompletionParameters.EPSILON_X_DEFAULT,
             LoadFlowResultsCompletionParameters.APPLY_REACTANCE_CORRECTION_DEFAULT,
             LoadFlowResultsCompletionParameters.Z0_THRESHOLD_DIFF_VOLTAGE_ANGLE);
         LoadFlowResultsCompletion lf = new LoadFlowResultsCompletion(p, lfparams);
         try {
-            network.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(rtc -> rtc.findSolvedTapPosition().ifPresent(rtc::setTapPosition));
-            network.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(ptc -> ptc.findSolvedTapPosition().ifPresent(ptc::setTapPosition));
+            if (useSv) { // Replace "input" variables from SSH by SV ones
+                Networks.applySolvedValues(network);
+            }
             lf.run(network, null);
         } catch (Exception e) {
             LOG.error("computeFlows, error {}", e.getMessage());

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
@@ -17,12 +17,17 @@ import com.powsybl.cgmes.conversion.CgmesModelExtension;
 import com.powsybl.cgmes.conversion.Conversion;
 import com.powsybl.cgmes.conversion.test.network.compare.Comparison;
 import com.powsybl.cgmes.conversion.test.network.compare.ComparisonConfig;
-import com.powsybl.cgmes.model.*;
+import com.powsybl.cgmes.model.CgmesModel;
+import com.powsybl.cgmes.model.CgmesOnDataSource;
+import com.powsybl.cgmes.model.CgmesSubset;
+import com.powsybl.cgmes.model.GridModelReference;
 import com.powsybl.commons.datasource.DataSource;
 import com.powsybl.commons.datasource.DirectoryDataSource;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ZipArchiveDataSource;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.PhaseTapChangerHolder;
+import com.powsybl.iidm.network.RatioTapChangerHolder;
 import com.powsybl.iidm.network.impl.NetworkFactoryImpl;
 import com.powsybl.iidm.serde.XMLExporter;
 import com.powsybl.loadflow.LoadFlowParameters;
@@ -41,6 +46,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -243,6 +249,8 @@ public class ConversionTester {
             LoadFlowResultsCompletionParameters.Z0_THRESHOLD_DIFF_VOLTAGE_ANGLE);
         LoadFlowResultsCompletion lf = new LoadFlowResultsCompletion(p, lfparams);
         try {
+            network.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(rtc -> rtc.findSolvedTapPosition().ifPresent(rtc::setTapPosition));
+            network.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(ptc -> ptc.findSolvedTapPosition().ifPresent(ptc::setTapPosition));
             lf.run(network, null);
         } catch (Exception e) {
             LOG.error("computeFlows, error {}", e.getMessage());

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TransformerConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TransformerConversionTest.java
@@ -46,7 +46,7 @@ class TransformerConversionTest {
     void microGridBaseCaseBExfmr2ShuntDefault() {
         Conversion.Config config = new Conversion.Config();
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
         assertTrue(ok);
     }
 
@@ -55,7 +55,7 @@ class TransformerConversionTest {
         Conversion.Config config = new Conversion.Config();
         config.setXfmr2Shunt(Xfmr2ShuntInterpretationAlternative.END1);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
         assertTrue(ok);
     }
 
@@ -65,7 +65,7 @@ class TransformerConversionTest {
         config.setXfmr2Shunt(Xfmr2ShuntInterpretationAlternative.END2);
         // Same result as End1, IIDM model and LoadFlowParameters does not allow this configuration
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
         assertTrue(ok);
     }
 
@@ -75,7 +75,7 @@ class TransformerConversionTest {
         config.setXfmr2Shunt(Xfmr2ShuntInterpretationAlternative.END1_END2);
         // Same result as End1, IIDM model and LoadFlowParameters does not allow this configuration
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
         assertTrue(ok);
     }
 
@@ -85,7 +85,7 @@ class TransformerConversionTest {
         config.setXfmr2Shunt(Xfmr2ShuntInterpretationAlternative.SPLIT);
         config.setXfmr3Shunt(Xfmr3ShuntInterpretationAlternative.SPLIT);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.685727, 57.132482, 90.000015, -51.115681);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.970891, -15.839366, 94.275697, 20.952066);
         assertTrue(ok);
     }
 
@@ -94,10 +94,10 @@ class TransformerConversionTest {
         Conversion.Config config = new Conversion.Config();
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
         assertTrue(ok);
     }
 
@@ -107,10 +107,10 @@ class TransformerConversionTest {
         config.setXfmr2RatioPhase(Xfmr2RatioPhaseInterpretationAlternative.END1);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -90.220362, 21.586854, 90.516482, -16.668693);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -91.807775, 98.389959, 92.184500, -89.747219);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
         assertTrue(ok);
     }
 
@@ -120,10 +120,10 @@ class TransformerConversionTest {
         config.setXfmr2RatioPhase(Xfmr2RatioPhaseInterpretationAlternative.END2);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 930.007734, -323.332715, -914.617278, 405.857814);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 58.877292, -201.626411, -58.176878, 205.382102);
         assertTrue(ok);
     }
 
@@ -133,10 +133,10 @@ class TransformerConversionTest {
         config.setXfmr2RatioPhase(Xfmr2RatioPhaseInterpretationAlternative.END1_END2);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
         assertTrue(ok);
     }
 
@@ -146,10 +146,10 @@ class TransformerConversionTest {
         config.setXfmr2RatioPhase(Xfmr2RatioPhaseInterpretationAlternative.X);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 930.007734, -323.332715, -914.617278, 405.857814);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 58.877292, -201.626411, -58.176878, 205.382102);
         assertTrue(ok);
     }
 
@@ -158,10 +158,10 @@ class TransformerConversionTest {
         Conversion.Config config = new Conversion.Config();
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
         assertTrue(ok);
     }
 
@@ -171,10 +171,10 @@ class TransformerConversionTest {
         config.setXfmr2StructuralRatio(Xfmr2StructuralRatioInterpretationAlternative.END1);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -0.811048, 0.522343, 0.813942, -0.467631);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -0.849849, -0.138409, 0.852591, 0.184615);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 4.227753, -16.453624, -4.167085, 16.778929);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 70.106993, -25.657663, -68.935391, 31.939905);
         assertTrue(ok);
     }
 
@@ -184,10 +184,10 @@ class TransformerConversionTest {
         config.setXfmr2StructuralRatio(Xfmr2StructuralRatioInterpretationAlternative.END2);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
         assertTrue(ok);
     }
 
@@ -197,10 +197,10 @@ class TransformerConversionTest {
         config.setXfmr2StructuralRatio(Xfmr2StructuralRatioInterpretationAlternative.X);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
         assertTrue(ok);
     }
 
@@ -452,7 +452,7 @@ class TransformerConversionTest {
         double threshold = 0.01;
         ValidationConfig vconfig = loadFlowValidationConfig(threshold);
         LoadFlowParameters lfParameters = defineLoadflowParameters(vconfig.getLoadFlowParameters(), config);
-        ConversionTester.computeMissingFlows(n, lfParameters);
+        ConversionTester.computeMissingFlows(n, lfParameters, false);
 
         return n;
     }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TransformerConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TransformerConversionTest.java
@@ -46,7 +46,7 @@ class TransformerConversionTest {
     void microGridBaseCaseBExfmr2ShuntDefault() {
         Conversion.Config config = new Conversion.Config();
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
         assertTrue(ok);
     }
 
@@ -55,7 +55,7 @@ class TransformerConversionTest {
         Conversion.Config config = new Conversion.Config();
         config.setXfmr2Shunt(Xfmr2ShuntInterpretationAlternative.END1);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
         assertTrue(ok);
     }
 
@@ -65,7 +65,7 @@ class TransformerConversionTest {
         config.setXfmr2Shunt(Xfmr2ShuntInterpretationAlternative.END2);
         // Same result as End1, IIDM model and LoadFlowParameters does not allow this configuration
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
         assertTrue(ok);
     }
 
@@ -75,7 +75,7 @@ class TransformerConversionTest {
         config.setXfmr2Shunt(Xfmr2ShuntInterpretationAlternative.END1_END2);
         // Same result as End1, IIDM model and LoadFlowParameters does not allow this configuration
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
         assertTrue(ok);
     }
 
@@ -85,7 +85,7 @@ class TransformerConversionTest {
         config.setXfmr2Shunt(Xfmr2ShuntInterpretationAlternative.SPLIT);
         config.setXfmr3Shunt(Xfmr3ShuntInterpretationAlternative.SPLIT);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.970891, -15.839366, 94.275697, 20.952066);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.685727, 57.132482, 90.000015, -51.115681);
         assertTrue(ok);
     }
 
@@ -94,10 +94,10 @@ class TransformerConversionTest {
         Conversion.Config config = new Conversion.Config();
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
         assertTrue(ok);
     }
 
@@ -107,10 +107,10 @@ class TransformerConversionTest {
         config.setXfmr2RatioPhase(Xfmr2RatioPhaseInterpretationAlternative.END1);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -91.807775, 98.389959, 92.184500, -89.747219);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -90.220362, 21.586854, 90.516482, -16.668693);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
         assertTrue(ok);
     }
 
@@ -120,10 +120,10 @@ class TransformerConversionTest {
         config.setXfmr2RatioPhase(Xfmr2RatioPhaseInterpretationAlternative.END2);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 58.877292, -201.626411, -58.176878, 205.382102);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 930.007734, -323.332715, -914.617278, 405.857814);
         assertTrue(ok);
     }
 
@@ -133,10 +133,10 @@ class TransformerConversionTest {
         config.setXfmr2RatioPhase(Xfmr2RatioPhaseInterpretationAlternative.END1_END2);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
         assertTrue(ok);
     }
 
@@ -146,10 +146,10 @@ class TransformerConversionTest {
         config.setXfmr2RatioPhase(Xfmr2RatioPhaseInterpretationAlternative.X);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 58.877292, -201.626411, -58.176878, 205.382102);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 930.007734, -323.332715, -914.617278, 405.857814);
         assertTrue(ok);
     }
 
@@ -158,10 +158,10 @@ class TransformerConversionTest {
         Conversion.Config config = new Conversion.Config();
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
         assertTrue(ok);
     }
 
@@ -171,10 +171,10 @@ class TransformerConversionTest {
         config.setXfmr2StructuralRatio(Xfmr2StructuralRatioInterpretationAlternative.END1);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -0.849849, -0.138409, 0.852591, 0.184615);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -0.811048, 0.522343, 0.813942, -0.467631);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 70.106993, -25.657663, -68.935391, 31.939905);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 4.227753, -16.453624, -4.167085, 16.778929);
         assertTrue(ok);
     }
 
@@ -184,10 +184,10 @@ class TransformerConversionTest {
         config.setXfmr2StructuralRatio(Xfmr2StructuralRatioInterpretationAlternative.END2);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
         assertTrue(ok);
     }
 
@@ -197,10 +197,10 @@ class TransformerConversionTest {
         config.setXfmr2StructuralRatio(Xfmr2StructuralRatioInterpretationAlternative.X);
         Network n = networkModel(CgmesConformity1Catalog.microGridBaseCaseBE(), config);
         // RatioTapChanger
-        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -93.855301, -15.285520, 94.158074, 20.388478);
+        boolean ok = t2xCompareFlow(n, "e482b89a-fa84-4ea9-8e70-a83d44790957", -89.570137, 57.686328, 89.889742, -51.644053);
         assertTrue(ok);
         // PhaseTapChanger
-        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 927.034612, -339.274880, -911.542354, 422.345850);
+        ok = t2xCompareFlow(n, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", 55.904170, -217.568577, -55.101954, 221.870138);
         assertTrue(ok);
     }
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/CgmesConformity1ConversionTest.java
@@ -134,7 +134,6 @@ class CgmesConformity1ConversionTest {
         // Validating bus balance of buses after conversion verifies that
         // the interpretation of the location of tap changer
         // relative to the transmission impedance is correct
-        importParams.put(CgmesImport.PROFILE_FOR_INITIAL_VALUES_SHUNT_SECTIONS_TAP_POSITIONS, "SV");
         importParams.put(CgmesImport.IMPORT_CGM_WITH_SUBNETWORKS, "false");
         ConversionTester t = new ConversionTester(
             importParams,
@@ -184,7 +183,6 @@ class CgmesConformity1ConversionTest {
         // This test will check that IIDM buses,
         // that will be computed by IIDM from CGMES node-breaker ConnectivityNodes,
         // have proper balances from SV values
-        importParams.put(CgmesImport.PROFILE_FOR_INITIAL_VALUES_SHUNT_SECTIONS_TAP_POSITIONS, "SV");
         importParams.put(CgmesImport.IMPORT_CGM_WITH_SUBNETWORKS, "false");
         ConversionTester t = new ConversionTester(
             importParams,
@@ -201,7 +199,6 @@ class CgmesConformity1ConversionTest {
         // This test will check that IIDM buses,
         // that will be created during conversion from CGMES TopologicalNodes,
         // have proper balances from SV values
-        importParams.put(CgmesImport.PROFILE_FOR_INITIAL_VALUES_SHUNT_SECTIONS_TAP_POSITIONS, "SV");
         importParams.put(CgmesImport.IMPORT_NODE_BREAKER_AS_BUS_BREAKER, "true");
         ConversionTester t = new ConversionTester(
                 importParams,

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
@@ -205,6 +205,8 @@ class EquipmentExportTest extends AbstractSerDeTest {
         TwoWindingsTransformer twta = actual.getTwoWindingsTransformerStream().findFirst().orElseThrow();
         network.getTwoWindingsTransformers().forEach(twtn -> twtn.setRatedS(twta.getRatedS()));
 
+        actual.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount); // FIXME
+
         // Ignore OperationalLimitsGroup id
         DifferenceEvaluator knownDiffs = DifferenceEvaluators.chain(
                 DifferenceEvaluators.Default,
@@ -230,6 +232,8 @@ class EquipmentExportTest extends AbstractSerDeTest {
         // we reset the default imported ratedS values before comparing
         TwoWindingsTransformer twta = actual.getTwoWindingsTransformerStream().findFirst().orElseThrow();
         network.getTwoWindingsTransformers().forEach(twtn -> twtn.setRatedS(twta.getRatedS()));
+
+        actual.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount); // FIXME
 
         // Ignore OperationalLimitsGroup id
         DifferenceEvaluator knownDiffs = DifferenceEvaluators.chain(

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
@@ -81,11 +81,6 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1Catalog.smallNodeBreakerHvdc().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportNodeBreaker(expected, dataSource);
-        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -94,11 +89,6 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1Catalog.smallNodeBreaker().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportNodeBreaker(expected, dataSource);
-        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -107,11 +97,6 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1Catalog.smallBusBranch().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportBusBranch(expected, dataSource);
-        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -130,11 +115,6 @@ class EquipmentExportTest extends AbstractSerDeTest {
             generator.setTargetP(generator.getTargetP() + 0.0);
             generator.setTargetQ(generator.getTargetQ() + 0.0);
         });
-
-        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
 
         assertTrue(compareNetworksEQdata(expected, actual));
     }
@@ -155,11 +135,6 @@ class EquipmentExportTest extends AbstractSerDeTest {
             generator.setTargetQ(generator.getTargetQ() + 0.0);
         });
 
-        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -168,11 +143,6 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1ModifiedCatalog.microGridBaseCaseBEWithTieFlowMappedToEquivalentInjection().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportBusBranch(expected, dataSource);
-        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -204,11 +174,6 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1Catalog.microGridType4BE().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportBusBranch(expected, dataSource);
-        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -222,11 +187,6 @@ class EquipmentExportTest extends AbstractSerDeTest {
             danglingLine.removeProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "EquivalentInjectionTerminal");
         }
         Network actual = exportImportBusBranch(expected, dataSource);
-        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -244,8 +204,6 @@ class EquipmentExportTest extends AbstractSerDeTest {
         // we reset the default imported ratedS values before comparing
         TwoWindingsTransformer twta = actual.getTwoWindingsTransformerStream().findFirst().orElseThrow();
         network.getTwoWindingsTransformers().forEach(twtn -> twtn.setRatedS(twta.getRatedS()));
-
-        actual.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount); // FIXME
 
         // Ignore OperationalLimitsGroup id
         DifferenceEvaluator knownDiffs = DifferenceEvaluators.chain(
@@ -272,8 +230,6 @@ class EquipmentExportTest extends AbstractSerDeTest {
         // we reset the default imported ratedS values before comparing
         TwoWindingsTransformer twta = actual.getTwoWindingsTransformerStream().findFirst().orElseThrow();
         network.getTwoWindingsTransformers().forEach(twtn -> twtn.setRatedS(twta.getRatedS()));
-
-        actual.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount); // FIXME
 
         // Ignore OperationalLimitsGroup id
         DifferenceEvaluator knownDiffs = DifferenceEvaluators.chain(
@@ -599,11 +555,6 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1ModifiedCatalog.microGridBaseCaseBEConformNonConformLoads().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportBusBranch(expected, dataSource);
-        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
@@ -81,6 +81,11 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1Catalog.smallNodeBreakerHvdc().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportNodeBreaker(expected, dataSource);
+        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -89,6 +94,11 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1Catalog.smallNodeBreaker().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportNodeBreaker(expected, dataSource);
+        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -97,6 +107,11 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1Catalog.smallBusBranch().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportBusBranch(expected, dataSource);
+        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -115,6 +130,11 @@ class EquipmentExportTest extends AbstractSerDeTest {
             generator.setTargetP(generator.getTargetP() + 0.0);
             generator.setTargetQ(generator.getTargetQ() + 0.0);
         });
+
+        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
 
         assertTrue(compareNetworksEQdata(expected, actual));
     }
@@ -135,6 +155,11 @@ class EquipmentExportTest extends AbstractSerDeTest {
             generator.setTargetQ(generator.getTargetQ() + 0.0);
         });
 
+        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -143,10 +168,11 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1ModifiedCatalog.microGridBaseCaseBEWithTieFlowMappedToEquivalentInjection().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportBusBranch(expected, dataSource);
-        actual.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        actual.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -178,10 +204,11 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1Catalog.microGridType4BE().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportBusBranch(expected, dataSource);
-        actual.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        actual.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -195,10 +222,11 @@ class EquipmentExportTest extends AbstractSerDeTest {
             danglingLine.removeProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "EquivalentInjectionTerminal");
         }
         Network actual = exportImportBusBranch(expected, dataSource);
-        actual.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        actual.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -571,10 +599,11 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1ModifiedCatalog.microGridBaseCaseBEConformNonConformLoads().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportBusBranch(expected, dataSource);
-        actual.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
-        actual.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getThreeWindingsTransformerStream().flatMap(ThreeWindingsTransformer::getLegStream).map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getShuntCompensatorStream().forEach(ShuntCompensator::unsetSolvedSectionCount);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
@@ -143,6 +143,10 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1ModifiedCatalog.microGridBaseCaseBEWithTieFlowMappedToEquivalentInjection().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportBusBranch(expected, dataSource);
+        actual.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        actual.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -174,6 +178,10 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1Catalog.microGridType4BE().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportBusBranch(expected, dataSource);
+        actual.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        actual.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -187,6 +195,10 @@ class EquipmentExportTest extends AbstractSerDeTest {
             danglingLine.removeProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + "EquivalentInjectionTerminal");
         }
         Network actual = exportImportBusBranch(expected, dataSource);
+        actual.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        actual.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 
@@ -559,6 +571,10 @@ class EquipmentExportTest extends AbstractSerDeTest {
         ReadOnlyDataSource dataSource = CgmesConformity1ModifiedCatalog.microGridBaseCaseBEConformNonConformLoads().dataSource();
         Network expected = new CgmesImport().importData(dataSource, NetworkFactory.findDefault(), importParams);
         Network actual = exportImportBusBranch(expected, dataSource);
+        actual.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        actual.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(RatioTapChangerHolder::getRatioTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
+        expected.getTwoWindingsTransformerStream().map(PhaseTapChangerHolder::getPhaseTapChanger).filter(Objects::nonNull).forEach(TapChanger::unsetSolvedTapPosition);
         assertTrue(compareNetworksEQdata(expected, actual));
     }
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportXmlCompare.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/ExportXmlCompare.java
@@ -138,12 +138,14 @@ final class ExportXmlCompare {
                 ignored = attr.getLocalName().equals("converterStation1") || attr.getLocalName().equals("converterStation2") || attr.getLocalName().equals("convertersMode");
             } else if (elementName.contains("TapChanger")) {
                 ignored = attr.getLocalName().equals("regulating") || attr.getLocalName().equals("regulationMode") || attr.getLocalName().equals("regulationValue")
-                        || attr.getLocalName().equals("targetV") || attr.getLocalName().equals("targetDeadband");
+                        || attr.getLocalName().equals("targetV") || attr.getLocalName().equals("targetDeadband") || attr.getLocalName().equals("solvedTapPosition");
             } else if (elementName.startsWith("generator")) {
                 // ratedS is optional for generators,
                 // but we always export it to keep up with the quality of datasets rules.
                 // So we do not enforce this attribute to be equal in the original and exported network
                 ignored = attr.getLocalName().equals("ratedS");
+            } else if (elementName.startsWith("shunt")) {
+                ignored = attr.getLocalName().equals("solvedSectionCount");
             } else {
                 ignored = attr.getLocalName().contains("node") || attr.getLocalName().contains("bus") || attr.getLocalName().contains("Bus");
             }

--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -301,7 +301,7 @@ PowSyBl [`Load`](../../grid_model/network_subnetwork.md#load) is exported as `Co
 
 PowSyBl [`ShuntCompensator`](../../grid_model/network_subnetwork.md#shunt-compensator) is exported as `LinearShuntCompensator` or `NonlinearShuntCompensator` depending on their models.
 The CGMES SSH `sections` is written from the IIDM `SectionCount`, and the CGMES SV `SvShuntCompensatorSections.sections` 
-is written from the IIDM `solvedSectionCount` if present, otherwise `sectionCount`.
+is written from the IIDM `SolvedSectionCount` if present, otherwise `SectionCount`.
 
 #### Regulating control
 

--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -373,8 +373,8 @@ when `PhaseTapChanger` `regulationMode` is set to `CURRENT_LIMITER`.
 
 PowSyBl [`TwoWindingsTransformer`](../../grid_model/network_subnetwork.md#two-winding-transformer) is exported as `PowerTransformer` with two `PowerTransformerEnds`.
 
-If the transformer has a `TapChanger`, the CGMES SSH `step` is written from the IIDM `tapPosition` and the CGMES SV
-`SVtapStep` is written from the IIDM `solvedTapPosition` if it is not null, otherwise `tapPosition`.
+If the transformer has a `TapChanger`, the CGMES SSH `step` is written from the IIDM `TapPosition` and the CGMES SV
+`SVtapStep` is written from the IIDM `SolvedTapPosition` if it is not null, otherwise `TapPosition`.
 
 Tap changer controls for two-winding transformers are exported following the same rules explained in the previous section about three-winding transformers. See [tap changer control](#tap-changer-control).
 

--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -349,8 +349,8 @@ PowSyBl [`Switch`](../../grid_model/network_subnetwork.md#breakerswitch) is expo
 ### ThreeWindingsTransformer
 
 PowSyBl [`ThreeWindingsTransformer`](../../grid_model/network_subnetwork.md#three-winding-transformer) is exported as `PowerTransformer` with three `PowerTransformerEnds`.
-If the transformer has a `TapChanger`, the CGMES SSH `step` is written from the IIDM `tapPosition` and the CGMES SV
-`SVtapStep` is written from the IIDM `solvedTapPosition` if it is not null, otherwise `tapPosition`.
+If the transformer has a `TapChanger`, the CGMES SSH `step` is written from the IIDM `TapPosition` and the CGMES SV
+`SVtapStep` is written from the IIDM `SolvedTapPosition` if it is not null, otherwise `TapPosition`.
 
 #### Tap changer control
 

--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -300,6 +300,8 @@ PowSyBl [`Load`](../../grid_model/network_subnetwork.md#load) is exported as `Co
 ### Shunt compensator
 
 PowSyBl [`ShuntCompensator`](../../grid_model/network_subnetwork.md#shunt-compensator) is exported as `LinearShuntCompensator` or `NonlinearShuntCompensator` depending on their models.
+The CGMES SSH `sections` is written from the IIDM `SectionCount`, and the CGMES SV `SvShuntCompensatorSections.sections` 
+is written from the IIDM `solvedSectionCount` if present, otherwise `sectionCount`.
 
 #### Regulating control
 
@@ -347,6 +349,8 @@ PowSyBl [`Switch`](../../grid_model/network_subnetwork.md#breakerswitch) is expo
 ### ThreeWindingsTransformer
 
 PowSyBl [`ThreeWindingsTransformer`](../../grid_model/network_subnetwork.md#three-winding-transformer) is exported as `PowerTransformer` with three `PowerTransformerEnds`.
+If the transformer has a `TapChanger`, the CGMES SSH `step` is written from the IIDM `tapPosition` and the CGMES SV
+`SVtapStep` is written from the IIDM `solvedTapPosition` if it is not null, otherwise `tapPosition`.
 
 #### Tap changer control
 
@@ -368,6 +372,9 @@ when `PhaseTapChanger` `regulationMode` is set to `CURRENT_LIMITER`.
 ### TwoWindingsTransformer
 
 PowSyBl [`TwoWindingsTransformer`](../../grid_model/network_subnetwork.md#two-winding-transformer) is exported as `PowerTransformer` with two `PowerTransformerEnds`.
+
+If the transformer has a `TapChanger`, the CGMES SSH `step` is written from the IIDM `tapPosition` and the CGMES SV
+`SVtapStep` is written from the IIDM `solvedTapPosition` if it is not null, otherwise `tapPosition`.
 
 Tap changer controls for two-winding transformers are exported following the same rules explained in the previous section about three-winding transformers. See [tap changer control](#tap-changer-control).
 

--- a/docs/grid_exchange_formats/cgmes/import.md
+++ b/docs/grid_exchange_formats/cgmes/import.md
@@ -288,7 +288,7 @@ An `ExternalNetworkinjection` is mapped to a PowSyBl [`Generator`](../../grid_mo
 Linear shunt compensators represent shunt compensators with banks or sections with equal admittance values.
 
 A `LinearShuntCompensator` is mapped to a PowSyBl [`ShuntCompensator`](../../grid_model/network_subnetwork.md#shunt-compensator) with `SectionCount` copied from CGMES SSH `sections` if present. If not, it is copied from CGMES `SvShuntCompensatorSections.sections` or `normalSections`.
-The `solvedSectionCount` is copied from `SvShuntCompensatorSections.sections` is the SV is imported, and left to `null` otherwise.
+The `SolvedSectionCount` is copied from `SvShuntCompensatorSections.sections` if the SV is imported, and left to `null` otherwise.
 The created PowSyBl shunt compensator is linear, and its attributes are defined as described below:
 - `BPerSection` is copied from CGMES `bPerSection` if defined. Else, it is `Float.MIN_VALUE`.
 - `GPerSection` is copied from CGMES `gPerSection` if defined. Else, it is left undefined.

--- a/docs/grid_exchange_formats/cgmes/import.md
+++ b/docs/grid_exchange_formats/cgmes/import.md
@@ -635,9 +635,6 @@ One implementation of such a post-processor is available in PowSyBl in the [pows
 **iidm.import.cgmes.powsybl-triplestore**  
 Optional property that defines which Triplestore implementation is used. Currently, PowSyBl only supports [RDF4J](https://rdf4j.org/). `rdf4j` by default.
 
-**iidm.import.cgmes.profile-for-initial-values-shunt-sections-tap-positions**  
-Optional property that defines which CGMES profile is used to initialize tap positions and section counts. It can be `SSH` or `SV`. The default value is `SSH`.
-
 **iidm.import.cgmes.source-for-iidm-id**  
 Optional property that defines if IIDM IDs must be obtained from the CGMES `mRID` (master resource identifier) or the CGMES `rdfID` (Resource Description Framework identifier). The default value is `mRID`.
 

--- a/docs/grid_exchange_formats/cgmes/import.md
+++ b/docs/grid_exchange_formats/cgmes/import.md
@@ -573,8 +573,8 @@ This extension is provided by the `com.powsybl:powsybl-cgmes-extensions` module.
 
 <span style="color: red">TODO</span>
 
-The `tapPosition` of the IIDM `TapChanger` is copied from the CGMES SSH `step` if present. If not, it is copied from CGMES `SVtapStep` or `normalStep` from EQ.
-The `solvedTapPosition` is copied from `SVtapStep` is the SV is imported, and left to `null` otherwise.
+The `TapPosition` of the IIDM `TapChanger` is copied from the CGMES SSH `step` if present. If not, it is copied from CGMES `SVtapStep` or `normalStep` from EQ.
+The `SolvedTapPosition` is copied from `SVtapStep` if the SV is imported, and left to `null` otherwise.
 
 (cgmes-metadata-model-import)=
 ### CGMES metadata model

--- a/docs/grid_exchange_formats/cgmes/import.md
+++ b/docs/grid_exchange_formats/cgmes/import.md
@@ -287,7 +287,8 @@ An `ExternalNetworkinjection` is mapped to a PowSyBl [`Generator`](../../grid_mo
 
 Linear shunt compensators represent shunt compensators with banks or sections with equal admittance values.
 
-A `LinearShuntCompensator` is mapped to a PowSyBl [`ShuntCompensator`](../../grid_model/network_subnetwork.md#shunt-compensator) with `SectionCount` copied from CGMES SSH `sections` or CGMES `SvShuntCompensatorSections.sections`, depending on the import option. If none is defined, it is copied from CGMES `normalSections`.
+A `LinearShuntCompensator` is mapped to a PowSyBl [`ShuntCompensator`](../../grid_model/network_subnetwork.md#shunt-compensator) with `SectionCount` copied from CGMES SSH `sections` if present. If not, it is copied from CGMES `SvShuntCompensatorSections.sections` or `normalSections`.
+The `solvedSectionCount` is copied from `SvShuntCompensatorSections.sections` is the SV is imported, and left to `null` otherwise.
 The created PowSyBl shunt compensator is linear, and its attributes are defined as described below:
 - `BPerSection` is copied from CGMES `bPerSection` if defined. Else, it is `Float.MIN_VALUE`.
 - `GPerSection` is copied from CGMES `gPerSection` if defined. Else, it is left undefined.
@@ -300,7 +301,8 @@ The created PowSyBl shunt compensator is linear, and its attributes are defined 
 
 Non-linear shunt compensators represent shunt compensators with banks or section admittance values that differ.
 
-A `NonlinearShuntCompensator` is mapped to a PowSyBl [`ShuntCompensator`](../../grid_model/network_subnetwork.md#shunt-compensator) with `SectionCount` copied from CGMES SSH `sections` or CGMES `SvShuntCompensatorSections.sections`, depending on the import option. If none is defined, it is copied from CGMES `normalSections`.
+A `NonlinearShuntCompensator` is mapped to a PowSyBl [`ShuntCompensator`](../../grid_model/network_subnetwork.md#shunt-compensator) with `SectionCount` copied from CGMES SSH `sections` if present. If not, it is copied from CGMES `SvShuntCompensatorSections.sections` or `normalSections`.
+The `solvedSectionCount` is copied from `SvShuntCompensatorSections.sections` is the SV is imported, and left to `null` otherwise.
 The created PowSyBl shunt compensator is non-linear and has as many `Sections` as there are `NonlinearShuntCompensatorPoint` associated with the `NonlinearShuntCompensator` it is mapped to.
 
 Sections are created from the lowest CGMES `sectionNumber` to the highest and each section has its attributes created as described below:
@@ -570,6 +572,9 @@ This extension is provided by the `com.powsybl:powsybl-cgmes-extensions` module.
 ### CGMES Tap Changers
 
 <span style="color: red">TODO</span>
+
+The `tapPosition` of the IIDM `TapChanger` is copied from the CGMES SSH `step` if present. If not, it is copied from CGMES `SVtapStep` or `normalStep` from EQ.
+The `solvedTapPosition` is copied from `SVtapStep` is the SV is imported, and left to `null` otherwise.
 
 (cgmes-metadata-model-import)=
 ### CGMES metadata model

--- a/docs/grid_exchange_formats/cgmes/import.md
+++ b/docs/grid_exchange_formats/cgmes/import.md
@@ -302,7 +302,7 @@ The created PowSyBl shunt compensator is linear, and its attributes are defined 
 Non-linear shunt compensators represent shunt compensators with banks or section admittance values that differ.
 
 A `NonlinearShuntCompensator` is mapped to a PowSyBl [`ShuntCompensator`](../../grid_model/network_subnetwork.md#shunt-compensator) with `SectionCount` copied from CGMES SSH `sections` if present. If not, it is copied from CGMES `SvShuntCompensatorSections.sections` or `normalSections`.
-The `solvedSectionCount` is copied from `SvShuntCompensatorSections.sections` is the SV is imported, and left to `null` otherwise.
+The `SolvedSectionCount` is copied from `SvShuntCompensatorSections.sections` if the SV is imported, and left to `null` otherwise.
 The created PowSyBl shunt compensator is non-linear and has as many `Sections` as there are `NonlinearShuntCompensatorPoint` associated with the `NonlinearShuntCompensator` it is mapped to.
 
 Sections are created from the lowest CGMES `sectionNumber` to the highest and each section has its attributes created as described below:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #3414 


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

CGMES import parameter `CgmesImport.PROFILE_FOR_INITIAL_VALUES_SHUNT_SECTIONS_TAP_POSITIONS` (`"iidm.import.cgmes.profile-for-initial-values-shunt-sections-tap-positions"`) was removed.
Now that there are distinct attributes for initial values (`sectionCount` and `tapPosition`) and solved values (resp. `solvedSectionCount` and `solvedTapPosition`), this parameter was no more pertinent.

If you need to have the SV values in the initial values' attributes (which corresponds to the `"SV"` value of the removed parameter), you can copy the solved values in the initial values' attributes by calling
`Networks.applySolvedTapPositionAndSolvedSectionCount(network);`
