### PR TITLE
Migrate to Java 21

### DIFF
--- a/action-api/pom.xml
+++ b/action-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-action-api</artifactId>

--- a/action-ial/action-ial-dsl-spi/pom.xml
+++ b/action-ial/action-ial-dsl-spi/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-action-ial</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-action-ial-dsl-spi</artifactId>

--- a/action-ial/action-ial-dsl/pom.xml
+++ b/action-ial/action-ial-dsl/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-action-ial</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-action-ial-dsl</artifactId>

--- a/action-ial/action-ial-simulator/pom.xml
+++ b/action-ial/action-ial-simulator/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-action-ial</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-action-ial-simulator</artifactId>

--- a/action-ial/action-ial-util/pom.xml
+++ b/action-ial/action-ial-util/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-action-ial</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-action-ial-util</artifactId>

--- a/action-ial/pom.xml
+++ b/action-ial/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/ampl-converter/pom.xml
+++ b/ampl-converter/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-ampl-converter</artifactId>

--- a/ampl-executor/pom.xml
+++ b/ampl-executor/pom.xml
@@ -15,7 +15,7 @@ this
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-ampl-executor</artifactId>

--- a/cgmes/cgmes-completion/pom.xml
+++ b/cgmes/cgmes-completion/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-cgmes</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-cgmes-completion</artifactId>

--- a/cgmes/cgmes-conformity/pom.xml
+++ b/cgmes/cgmes-conformity/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-cgmes</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-cgmes-conformity</artifactId>

--- a/cgmes/cgmes-conversion/pom.xml
+++ b/cgmes/cgmes-conversion/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-cgmes</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-cgmes-conversion</artifactId>

--- a/cgmes/cgmes-extensions/pom.xml
+++ b/cgmes/cgmes-extensions/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-cgmes</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-cgmes-extensions</artifactId>

--- a/cgmes/cgmes-gl/pom.xml
+++ b/cgmes/cgmes-gl/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>powsybl-cgmes</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-cgmes-gl</artifactId>

--- a/cgmes/cgmes-measurements/pom.xml
+++ b/cgmes/cgmes-measurements/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-cgmes</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cgmes/cgmes-model-alternatives/pom.xml
+++ b/cgmes/cgmes-model-alternatives/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-cgmes</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-cgmes-model-alternatives</artifactId>

--- a/cgmes/cgmes-model-test/pom.xml
+++ b/cgmes/cgmes-model-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-cgmes</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-cgmes-model-test</artifactId>

--- a/cgmes/cgmes-model/pom.xml
+++ b/cgmes/cgmes-model/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-cgmes</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-cgmes-model</artifactId>

--- a/cgmes/cgmes-shortcircuit/pom.xml
+++ b/cgmes/cgmes-shortcircuit/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-cgmes</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-cgmes-shortcircuit</artifactId>

--- a/cgmes/pom.xml
+++ b/cgmes/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-cgmes</artifactId>

--- a/cim-anonymiser/pom.xml
+++ b/cim-anonymiser/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-cim-anonymiser</artifactId>

--- a/commons-test/pom.xml
+++ b/commons-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-commons-test</artifactId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-commons</artifactId>

--- a/computation-local-test/pom.xml
+++ b/computation-local-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-computation-local-test</artifactId>

--- a/computation-local/pom.xml
+++ b/computation-local/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>powsybl-computation-local</artifactId>

--- a/computation/pom.xml
+++ b/computation/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-computation</artifactId>

--- a/config-classic/pom.xml
+++ b/config-classic/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-config-classic</artifactId>

--- a/config-test/pom.xml
+++ b/config-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-config-test</artifactId>

--- a/contingency/contingency-api/pom.xml
+++ b/contingency/contingency-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-contingency</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-contingency-api</artifactId>

--- a/contingency/contingency-dsl/pom.xml
+++ b/contingency/contingency-dsl/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-contingency</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-contingency-dsl</artifactId>

--- a/contingency/pom.xml
+++ b/contingency/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/distribution-core/pom.xml
+++ b/distribution-core/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/dsl/pom.xml
+++ b/dsl/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dynamic-security-analysis/pom.xml
+++ b/dynamic-security-analysis/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-dynamic-security-analysis</artifactId>

--- a/dynamic-simulation/dynamic-simulation-api/pom.xml
+++ b/dynamic-simulation/dynamic-simulation-api/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-dynamic-simulation</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-dynamic-simulation-api</artifactId>

--- a/dynamic-simulation/dynamic-simulation-dsl/pom.xml
+++ b/dynamic-simulation/dynamic-simulation-dsl/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-dynamic-simulation</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-dynamic-simulation-dsl</artifactId>

--- a/dynamic-simulation/dynamic-simulation-tool/pom.xml
+++ b/dynamic-simulation/dynamic-simulation-tool/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-dynamic-simulation</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-dynamic-simulation-tool</artifactId>

--- a/dynamic-simulation/pom.xml
+++ b/dynamic-simulation/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/entsoe-util/pom.xml
+++ b/entsoe-util/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-entsoe-util</artifactId>

--- a/ieee-cdf/ieee-cdf-converter/pom.xml
+++ b/ieee-cdf/ieee-cdf-converter/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-ieee-cdf</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-ieee-cdf-converter</artifactId>

--- a/ieee-cdf/ieee-cdf-model/pom.xml
+++ b/ieee-cdf/ieee-cdf-model/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-ieee-cdf</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-ieee-cdf-model</artifactId>

--- a/ieee-cdf/pom.xml
+++ b/ieee-cdf/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/iidm/iidm-api/pom.xml
+++ b/iidm/iidm-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-iidm</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-api</artifactId>

--- a/iidm/iidm-comparator/pom.xml
+++ b/iidm/iidm-comparator/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-iidm</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-comparator</artifactId>

--- a/iidm/iidm-criteria/pom.xml
+++ b/iidm/iidm-criteria/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>powsybl-iidm</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-criteria</artifactId>

--- a/iidm/iidm-extensions/pom.xml
+++ b/iidm/iidm-extensions/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-iidm</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-extensions</artifactId>

--- a/iidm/iidm-geodata/pom.xml
+++ b/iidm/iidm-geodata/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>powsybl-iidm</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-geodata</artifactId>

--- a/iidm/iidm-impl/pom.xml
+++ b/iidm/iidm-impl/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-iidm</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-impl</artifactId>

--- a/iidm/iidm-modification/pom.xml
+++ b/iidm/iidm-modification/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-iidm</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-modification</artifactId>

--- a/iidm/iidm-reducer/pom.xml
+++ b/iidm/iidm-reducer/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-iidm</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-reducer</artifactId>

--- a/iidm/iidm-scripting/pom.xml
+++ b/iidm/iidm-scripting/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-iidm</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-scripting</artifactId>

--- a/iidm/iidm-serde/pom.xml
+++ b/iidm/iidm-serde/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-iidm</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-serde</artifactId>

--- a/iidm/iidm-tck/pom.xml
+++ b/iidm/iidm-tck/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-iidm</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-tck</artifactId>

--- a/iidm/iidm-test/pom.xml
+++ b/iidm/iidm-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-iidm</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-iidm-test</artifactId>

--- a/iidm/pom.xml
+++ b/iidm/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/itools-packager/pom.xml
+++ b/itools-packager/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-itools-packager-maven-plugin</artifactId>

--- a/loadflow/loadflow-api/pom.xml
+++ b/loadflow/loadflow-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-loadflow</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-loadflow-api</artifactId>

--- a/loadflow/loadflow-results-completion/pom.xml
+++ b/loadflow/loadflow-results-completion/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-loadflow</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-loadflow-results-completion</artifactId>

--- a/loadflow/loadflow-scripting/pom.xml
+++ b/loadflow/loadflow-scripting/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-loadflow</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-loadflow-scripting</artifactId>

--- a/loadflow/loadflow-validation/pom.xml
+++ b/loadflow/loadflow-validation/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-loadflow</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-loadflow-validation</artifactId>

--- a/loadflow/pom.xml
+++ b/loadflow/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/math/pom.xml
+++ b/math/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-math</artifactId>

--- a/matpower/matpower-converter/pom.xml
+++ b/matpower/matpower-converter/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-matpower</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-matpower-converter</artifactId>

--- a/matpower/matpower-model/pom.xml
+++ b/matpower/matpower-model/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-matpower</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-matpower-model</artifactId>

--- a/matpower/pom.xml
+++ b/matpower/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>20.2</version>
+        <version>23</version>
         <relativePath/>
     </parent>
 
@@ -89,7 +89,7 @@
     </modules>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <argLine/> <!--  This is required for later correct replacement of argline -->
         <sonar.coverage.jacoco.xmlReportPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </parent>
 
     <artifactId>powsybl-core</artifactId>
-    <version>6.9.0-SNAPSHOT</version>
+    <version>7.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>powsybl</name>

--- a/powerfactory/pom.xml
+++ b/powerfactory/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/powerfactory/powerfactory-converter/pom.xml
+++ b/powerfactory/powerfactory-converter/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-powerfactory</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-powerfactory-converter</artifactId>

--- a/powerfactory/powerfactory-db/pom.xml
+++ b/powerfactory/powerfactory-db/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-powerfactory</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-powerfactory-db</artifactId>

--- a/powerfactory/powerfactory-dgs/pom.xml
+++ b/powerfactory/powerfactory-dgs/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-powerfactory</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-powerfactory-dgs</artifactId>

--- a/powerfactory/powerfactory-model/pom.xml
+++ b/powerfactory/powerfactory-model/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-powerfactory</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-powerfactory-model</artifactId>

--- a/psse/pom.xml
+++ b/psse/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/psse/psse-converter/pom.xml
+++ b/psse/psse-converter/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>powsybl-psse</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/psse/psse-model-test/pom.xml
+++ b/psse/psse-model-test/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-psse</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-psse-model-test</artifactId>

--- a/psse/psse-model/pom.xml
+++ b/psse/psse-model/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-psse</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-psse-model</artifactId>

--- a/scripting-test/pom.xml
+++ b/scripting-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-scripting-test</artifactId>

--- a/scripting/pom.xml
+++ b/scripting/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-scripting</artifactId>

--- a/security-analysis/pom.xml
+++ b/security-analysis/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/security-analysis/security-analysis-api/pom.xml
+++ b/security-analysis/security-analysis-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-security-analysis</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-security-analysis-api</artifactId>

--- a/security-analysis/security-analysis-default/pom.xml
+++ b/security-analysis/security-analysis-default/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-security-analysis</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-security-analysis-default</artifactId>

--- a/sensitivity-analysis-api/pom.xml
+++ b/sensitivity-analysis-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-sensitivity-analysis-api</artifactId>

--- a/shortcircuit-api/pom.xml
+++ b/shortcircuit-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-shortcircuit-api</artifactId>

--- a/time-series/pom.xml
+++ b/time-series/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/time-series/time-series-api/pom.xml
+++ b/time-series/time-series-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-time-series</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-time-series-api</artifactId>

--- a/time-series/time-series-dsl/pom.xml
+++ b/time-series/time-series-dsl/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-time-series</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-time-series-dsl</artifactId>

--- a/tools-test/pom.xml
+++ b/tools-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-tools-test</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-core</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-tools</artifactId>

--- a/triple-store/pom.xml
+++ b/triple-store/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/triple-store/triple-store-api/pom.xml
+++ b/triple-store/triple-store-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-triple-store</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-triple-store-api</artifactId>

--- a/triple-store/triple-store-impl-rdf4j/pom.xml
+++ b/triple-store/triple-store-impl-rdf4j/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-triple-store</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-triple-store-impl-rdf4j</artifactId>

--- a/triple-store/triple-store-test/pom.xml
+++ b/triple-store/triple-store-test/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-triple-store</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-triple-store-test</artifactId>

--- a/ucte/pom.xml
+++ b/ucte/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-core</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/ucte/ucte-converter/pom.xml
+++ b/ucte/ucte-converter/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-ucte</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-ucte-converter</artifactId>

--- a/ucte/ucte-network/pom.xml
+++ b/ucte/ucte-network/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-ucte</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-ucte-network</artifactId>

--- a/ucte/ucte-util/pom.xml
+++ b/ucte/ucte-util/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-ucte</artifactId>
-        <version>6.9.0-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-ucte-util</artifactId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Dependency update

**What is the current behavior?**
Java 17 is used

**What is the new behavior (if this is a feature change)?**
Java 21 is used

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
PowSyBl-Core now only supports Java 21 and higher. Please check that your installed SDK is still compatible. If you are using Ubuntu 20.04 LTS and the preinstalled Maven version, you will need to upgrade your Maven version too at least up to a version 3.9.x.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
