### PR TITLE
Use NO_FALLBACK_CONTROL for all MessageTemplateProvider

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/report/BundleMessageTemplateProvider.java
+++ b/commons/src/main/java/com/powsybl/commons/report/BundleMessageTemplateProvider.java
@@ -21,7 +21,6 @@ public class BundleMessageTemplateProvider implements MessageTemplateProvider {
     private final String bundleBaseName;
     private final boolean throwIfUnknownKey;
     private final Map<Locale, ResourceBundle> resourceBundlesMap = new HashMap<>();
-    public static final ResourceBundle.Control NO_FALLBACK_CONTROL = ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT);
 
     public BundleMessageTemplateProvider(String bundleBaseName) {
         this(bundleBaseName, false);

--- a/commons/src/main/java/com/powsybl/commons/report/MessageTemplateProvider.java
+++ b/commons/src/main/java/com/powsybl/commons/report/MessageTemplateProvider.java
@@ -19,10 +19,12 @@ public interface MessageTemplateProvider {
 
     MessageTemplateProvider EMPTY = new EmptyMessageTemplateProvider();
 
+    ResourceBundle.Control NO_FALLBACK_CONTROL = ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_DEFAULT);
+
     String getTemplate(String key, Locale locale);
 
     static String getMissingKeyMessage(String key, Locale locale) {
-        String pattern = ResourceBundle.getBundle(PowsyblCoreReportResourceBundle.BASE_NAME, locale)
+        String pattern = ResourceBundle.getBundle(PowsyblCoreReportResourceBundle.BASE_NAME, locale, NO_FALLBACK_CONTROL)
                 .getString("core.commons.missingKey");
         return new MessageFormat(pattern, locale).format(new Object[]{key});
     }

--- a/commons/src/main/java/com/powsybl/commons/report/MultiBundleMessageTemplateProvider.java
+++ b/commons/src/main/java/com/powsybl/commons/report/MultiBundleMessageTemplateProvider.java
@@ -33,7 +33,7 @@ public class MultiBundleMessageTemplateProvider implements MessageTemplateProvid
     @Override
     public String getTemplate(String key, Locale locale) {
         for (String bundleBaseName : bundleBaseNames) {
-            ResourceBundle bundle = ResourceBundle.getBundle(bundleBaseName, locale);
+            ResourceBundle bundle = ResourceBundle.getBundle(bundleBaseName, locale, NO_FALLBACK_CONTROL);
             if (bundle.containsKey(key)) {
                 return bundle.getString(key);
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix to fallback on default `reports.properties` message templates for all existing `MessageTemplateProvider`.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The fallback on default `reports.properties` message templates is not set for all existing `MessageTemplateProvider` (not set for `EmptyMessageTemplateProvider` and `MultiBundleMessageTemplateProvider`)

**What is the new behavior (if this is a feature change)?**
The fallback on default `reports.properties` message templates is set for all existing `MessageTemplateProvider`.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
