### PR TITLE
PhaseTapChanger SerDe: Backward compatibility with old IIDM <= 1.5 versions

### DIFF
--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTransformerSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTransformerSerDe.java
@@ -199,7 +199,7 @@ abstract class AbstractTransformerSerDe<T extends Connectable<T>, A extends Iden
         );
         if (context.getVersion().compareTo(IidmVersion.V_1_5) <= 0
                 && (Double.isNaN(ptc.getRegulationValue()) || ptc.getRegulationTerminal() == null)) {
-            // Backward compatibility for <= IIDM 1.5 where import was failing when regulation mode != FIXED_TAD
+            // Backward compatibility for <= IIDM 1.5 where import was failing when regulation mode != FIXED_TAP
             // and either regulating value is NaN or regulation terminal is null.
             context.getWriter().writeEnumAttribute(ATTR_REGULATION_MODE, PhaseTapChangerRegulationModeSerDe.FIXED_TAP);
         } else {

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTransformerSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTransformerSerDe.java
@@ -197,7 +197,13 @@ abstract class AbstractTransformerSerDe<T extends Connectable<T>, A extends Iden
         IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_14, context, () ->
             context.getWriter().writeBooleanAttribute(ATTR_LOAD_TAP_CHANGING_CAPABILITIES, ptc.hasLoadTapChangingCapabilities())
         );
-        context.getWriter().writeEnumAttribute(ATTR_REGULATION_MODE, regMode);
+        if (context.getVersion().compareTo(IidmVersion.V_1_5) <= 0
+                && !ptc.isRegulating() && Double.isNaN(ptc.getRegulationValue())) {
+            // Backward compatibility for <= IIDM 1.5 where import was failing when regulation mode != FIXED_TAD and regulating value is NaN
+            context.getWriter().writeEnumAttribute(ATTR_REGULATION_MODE, PhaseTapChangerRegulationModeSerDe.FIXED_TAP);
+        } else {
+            context.getWriter().writeEnumAttribute(ATTR_REGULATION_MODE, regMode);
+        }
         context.getWriter().writeDoubleAttribute(ATTR_REGULATION_VALUE, ptc.getRegulationValue());
         TerminalRefSerDe.writeTerminalRef(ptc.getRegulationTerminal(), context, ELEM_TERMINAL_REF);
 

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTransformerSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTransformerSerDe.java
@@ -198,7 +198,7 @@ abstract class AbstractTransformerSerDe<T extends Connectable<T>, A extends Iden
             context.getWriter().writeBooleanAttribute(ATTR_LOAD_TAP_CHANGING_CAPABILITIES, ptc.hasLoadTapChangingCapabilities())
         );
         if (context.getVersion().compareTo(IidmVersion.V_1_5) <= 0
-                && !ptc.isRegulating() && (Double.isNaN(ptc.getRegulationValue()) || ptc.getRegulationTerminal() == null)) {
+                && (Double.isNaN(ptc.getRegulationValue()) || ptc.getRegulationTerminal() == null)) {
             // Backward compatibility for <= IIDM 1.5 where import was failing when regulation mode != FIXED_TAD
             // and either regulating value is NaN or regulation terminal is null.
             context.getWriter().writeEnumAttribute(ATTR_REGULATION_MODE, PhaseTapChangerRegulationModeSerDe.FIXED_TAP);

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTransformerSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTransformerSerDe.java
@@ -198,8 +198,9 @@ abstract class AbstractTransformerSerDe<T extends Connectable<T>, A extends Iden
             context.getWriter().writeBooleanAttribute(ATTR_LOAD_TAP_CHANGING_CAPABILITIES, ptc.hasLoadTapChangingCapabilities())
         );
         if (context.getVersion().compareTo(IidmVersion.V_1_5) <= 0
-                && !ptc.isRegulating() && Double.isNaN(ptc.getRegulationValue())) {
-            // Backward compatibility for <= IIDM 1.5 where import was failing when regulation mode != FIXED_TAD and regulating value is NaN
+                && !ptc.isRegulating() && (Double.isNaN(ptc.getRegulationValue()) || ptc.getRegulationTerminal() == null)) {
+            // Backward compatibility for <= IIDM 1.5 where import was failing when regulation mode != FIXED_TAD
+            // and either regulating value is NaN or regulation terminal is null.
             context.getWriter().writeEnumAttribute(ATTR_REGULATION_MODE, PhaseTapChangerRegulationModeSerDe.FIXED_TAP);
         } else {
             context.getWriter().writeEnumAttribute(ATTR_REGULATION_MODE, regMode);

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/PhaseShifterXmlTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/PhaseShifterXmlTest.java
@@ -79,7 +79,20 @@ class PhaseShifterXmlTest extends AbstractIidmSerDeTest {
                 .setRegulationValue(Double.NaN)
                 .setRegulationMode(PhaseTapChanger.RegulationMode.CURRENT_LIMITER)
                 .setRegulating(false);
+        assertOldIidmWithFixedTap(network);
+    }
 
+    @Test
+    void phaseTapChangerWithFixedTapAndNoRegulationTerminalTest() {
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        network.getTwoWindingsTransformer("TWT").getPhaseTapChanger()
+                .setRegulationMode(PhaseTapChanger.RegulationMode.CURRENT_LIMITER)
+                .setRegulationTerminal(null)
+                .setRegulating(false);
+        assertOldIidmWithFixedTap(network);
+    }
+
+    private void assertOldIidmWithFixedTap(Network network) {
         Map<String, String> expectedAttributesOld = new HashMap<>();
         expectedAttributesOld.put("regulating", "false");
         expectedAttributesOld.put("regulationMode", "FIXED_TAP");

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/PhaseShifterXmlTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/PhaseShifterXmlTest.java
@@ -7,14 +7,25 @@
  */
 package com.powsybl.iidm.serde;
 
+import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.PhaseTapChanger;
+import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 import com.powsybl.iidm.network.test.PhaseShifterTestCaseFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -53,7 +64,90 @@ class PhaseShifterXmlTest extends AbstractIidmSerDeTest {
     }
 
     private void checkPhaseTapChangerRegulation(Network network) {
-        Assertions.assertEquals(PhaseTapChanger.RegulationMode.CURRENT_LIMITER, network.getTwoWindingsTransformer("PS1").getPhaseTapChanger().getRegulationMode());
-        Assertions.assertFalse(network.getTwoWindingsTransformer("PS1").getPhaseTapChanger().isRegulating());
+        checkPhaseTapChangerRegulation(network, "PS1");
+    }
+
+    private void checkPhaseTapChangerRegulation(Network network, String twtId) {
+        Assertions.assertEquals(PhaseTapChanger.RegulationMode.CURRENT_LIMITER, network.getTwoWindingsTransformer(twtId).getPhaseTapChanger().getRegulationMode());
+        Assertions.assertFalse(network.getTwoWindingsTransformer(twtId).getPhaseTapChanger().isRegulating());
+    }
+
+    @Test
+    void phaseTapChangerWithFixedTapAndNoValueTest() {
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        network.getTwoWindingsTransformer("TWT").getPhaseTapChanger()
+                .setRegulationValue(Double.NaN)
+                .setRegulationMode(PhaseTapChanger.RegulationMode.CURRENT_LIMITER)
+                .setRegulating(false);
+
+        Map<String, String> expectedAttributesOld = new HashMap<>();
+        expectedAttributesOld.put("regulating", "false");
+        expectedAttributesOld.put("regulationMode", "FIXED_TAP");
+        expectedAttributesOld.put("regulationValue", null);
+
+        Map<String, String> expectedAttributesNew = new HashMap<>();
+        expectedAttributesNew.put("regulating", "false");
+        expectedAttributesNew.put("regulationMode", "CURRENT_LIMITER");
+        expectedAttributesNew.put("regulationValue", null);
+
+        testForAllPreviousVersions(IidmVersion.V_1_6, iidmVersion -> assertPhaseTapChangerAttributesCompatibility(network, iidmVersion, expectedAttributesOld));
+        testForAllVersionsSince(IidmVersion.V_1_6, iidmVersion -> assertPhaseTapChangerAttributesCompatibility(network, iidmVersion, expectedAttributesNew));
+    }
+
+    private void assertPhaseTapChangerAttributesCompatibility(Network network, IidmVersion iidmVersion,
+                                                              Map<String, String> expectedAttributes) {
+        // Export network and read it again
+        ExportOptions exportOptions = new ExportOptions();
+        exportOptions.setVersion(iidmVersion.toString("."));
+        Path exportedPath = tmpDir.resolve("exported.xml");
+        NetworkSerDe.write(network, exportOptions, exportedPath);
+
+        assertXmlAttributes(expectedAttributes, exportedPath);
+        Network network2 = NetworkSerDe.read(exportedPath);
+        checkPhaseTapChangerRegulation(network2, "TWT");
+    }
+
+    private void assertXmlAttributes(Map<String, String> expectedAttributes, Path xmlPath) {
+        Optional<Boolean> result = Optional.empty();
+        StringBuilder errors = new StringBuilder("Errors:");
+        XMLStreamReader reader = null;
+        try {
+            try (InputStream is = Files.newInputStream(xmlPath)) {
+                reader = XmlUtil.getXMLInputFactory().createXMLStreamReader(is);
+                while (result.isEmpty() && reader.hasNext()) {
+                    if (reader.next() == XMLStreamConstants.START_ELEMENT && "phaseTapChanger".equals(reader.getLocalName())) {
+                        boolean res = true;
+                        for (Map.Entry<String, String> attribute : expectedAttributes.entrySet()) {
+                            String val = reader.getAttributeValue(null, attribute.getKey());
+                            String expectedVal = attribute.getValue();
+                            if (expectedVal != null && !expectedVal.equals(val)
+                                    || expectedVal == null && val != null) {
+                                errors.append(System.lineSeparator())
+                                        .append("Attribute \"")
+                                        .append(attribute.getKey())
+                                        .append("\": expected: ").append(expectedVal)
+                                        .append(" - encountered: ").append(val);
+                                res = false;
+                            }
+                        }
+                        result = Optional.of(res);
+                    }
+                }
+            } finally {
+                if (reader != null) {
+                    reader.close();
+                }
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+
+        if (result.isPresent()) {
+            if (!result.get()) {
+                throw new RuntimeException(errors.toString());
+            }
+        } else {
+            throw new RuntimeException("No \"phaseTapChanger\" attribute found.");
+        }
     }
 }

--- a/iidm/iidm-serde/src/test/resources/V1_0/terminalRef.xiidm
+++ b/iidm/iidm-serde/src/test/resources/V1_0/terminalRef.xiidm
@@ -42,7 +42,7 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="VLY644" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="VL41" connectableBus1="VL41" voltageLevelId1="VL4" bus2="VL61" connectableBus2="VL61" voltageLevelId2="VL6">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="CURRENT_LIMITER" regulationValue="200.0" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP" regulationValue="200.0" regulating="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191" alpha="-1.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914" alpha="1.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_1/completeThreeWindingsTransformerRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_1/completeThreeWindingsTransformerRoundTripRef.xml
@@ -25,7 +25,7 @@
             <iidm:ratioTapChanger1 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="false">
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
             </iidm:ratioTapChanger1>
-            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger1>
@@ -35,7 +35,7 @@
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
                 <iidm:step r="1.1979" x="0.11979" g="0.10101010101010101" b="0.0101010101010101" rho="1.1"/>
             </iidm:ratioTapChanger2>
-            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger2>
@@ -45,7 +45,7 @@
                 <iidm:step r="0.121" x="0.0121" g="0.8264462809917356" b="0.08264462809917356" rho="1.0"/>
                 <iidm:step r="0.1331" x="0.01331" g="0.9090909090909092" b="0.09090909090909093" rho="1.1"/>
             </iidm:ratioTapChanger3>
-            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger3>

--- a/iidm/iidm-serde/src/test/resources/V1_1/terminalRef.xiidm
+++ b/iidm/iidm-serde/src/test/resources/V1_1/terminalRef.xiidm
@@ -42,7 +42,7 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="VLY644" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="VL41" connectableBus1="VL41" voltageLevelId1="VL4" bus2="VL61" connectableBus2="VL61" voltageLevelId2="VL6">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="CURRENT_LIMITER" regulationValue="200.0" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP" regulationValue="200.0" regulating="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191" alpha="-1.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914" alpha="1.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_2/completeThreeWindingsTransformerRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_2/completeThreeWindingsTransformerRoundTripRef.xml
@@ -25,7 +25,7 @@
             <iidm:ratioTapChanger1 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="false">
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
             </iidm:ratioTapChanger1>
-            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger1>
@@ -35,7 +35,7 @@
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
                 <iidm:step r="1.1979" x="0.11979" g="0.10101010101010101" b="0.0101010101010101" rho="1.1"/>
             </iidm:ratioTapChanger2>
-            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger2>
@@ -45,7 +45,7 @@
                 <iidm:step r="0.121" x="0.0121" g="0.8264462809917356" b="0.08264462809917356" rho="1.0"/>
                 <iidm:step r="0.1331" x="0.01331" g="0.9090909090909092" b="0.09090909090909093" rho="1.1"/>
             </iidm:ratioTapChanger3>
-            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger3>

--- a/iidm/iidm-serde/src/test/resources/V1_2/terminalRef.xiidm
+++ b/iidm/iidm-serde/src/test/resources/V1_2/terminalRef.xiidm
@@ -42,7 +42,7 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="VLY644" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="VL41" connectableBus1="VL41" voltageLevelId1="VL4" bus2="VL61" connectableBus2="VL61" voltageLevelId2="VL6">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="CURRENT_LIMITER" regulationValue="200.0" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP" regulationValue="200.0" regulating="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191" alpha="-1.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914" alpha="1.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_3/completeThreeWindingsTransformerRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_3/completeThreeWindingsTransformerRoundTripRef.xml
@@ -25,7 +25,7 @@
             <iidm:ratioTapChanger1 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="false">
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
             </iidm:ratioTapChanger1>
-            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger1>
@@ -35,7 +35,7 @@
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
                 <iidm:step r="1.1979" x="0.11979" g="0.10101010101010101" b="0.0101010101010101" rho="1.1"/>
             </iidm:ratioTapChanger2>
-            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger2>
@@ -45,7 +45,7 @@
                 <iidm:step r="0.121" x="0.0121" g="0.8264462809917356" b="0.08264462809917356" rho="1.0"/>
                 <iidm:step r="0.1331" x="0.01331" g="0.9090909090909092" b="0.09090909090909093" rho="1.1"/>
             </iidm:ratioTapChanger3>
-            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger3>

--- a/iidm/iidm-serde/src/test/resources/V1_3/terminalRef.xiidm
+++ b/iidm/iidm-serde/src/test/resources/V1_3/terminalRef.xiidm
@@ -48,7 +48,7 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="VLY644" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="VL41" connectableBus1="VL41" voltageLevelId1="VL4" bus2="VL61" connectableBus2="VL61" voltageLevelId2="VL6">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="CURRENT_LIMITER" regulationValue="200.0" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP" regulationValue="200.0" regulating="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191" alpha="-1.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914" alpha="1.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_4/completeThreeWindingsTransformerRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_4/completeThreeWindingsTransformerRoundTripRef.xml
@@ -25,7 +25,7 @@
             <iidm:ratioTapChanger1 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="false">
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
             </iidm:ratioTapChanger1>
-            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger1>
@@ -35,7 +35,7 @@
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
                 <iidm:step r="1.1979" x="0.11979" g="0.10101010101010101" b="0.0101010101010101" rho="1.1"/>
             </iidm:ratioTapChanger2>
-            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger2>
@@ -45,7 +45,7 @@
                 <iidm:step r="0.121" x="0.0121" g="0.8264462809917356" b="0.08264462809917356" rho="1.0"/>
                 <iidm:step r="0.1331" x="0.01331" g="0.9090909090909092" b="0.09090909090909093" rho="1.1"/>
             </iidm:ratioTapChanger3>
-            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger3>

--- a/iidm/iidm-serde/src/test/resources/V1_4/terminalRef.xiidm
+++ b/iidm/iidm-serde/src/test/resources/V1_4/terminalRef.xiidm
@@ -48,7 +48,7 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="VLY644" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="VL41" connectableBus1="VL41" voltageLevelId1="VL4" bus2="VL61" connectableBus2="VL61" voltageLevelId2="VL6">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="CURRENT_LIMITER" regulationValue="200.0" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP" regulationValue="200.0" regulating="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191" alpha="-1.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914" alpha="1.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_5/completeThreeWindingsTransformerRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_5/completeThreeWindingsTransformerRoundTripRef.xml
@@ -25,7 +25,7 @@
             <iidm:ratioTapChanger1 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="false">
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
             </iidm:ratioTapChanger1>
-            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger1 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger1>
@@ -35,7 +35,7 @@
                 <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
                 <iidm:step r="1.1979" x="0.11979" g="0.10101010101010101" b="0.0101010101010101" rho="1.1"/>
             </iidm:ratioTapChanger2>
-            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger2 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger2>
@@ -45,7 +45,7 @@
                 <iidm:step r="0.121" x="0.0121" g="0.8264462809917356" b="0.08264462809917356" rho="1.0"/>
                 <iidm:step r="0.1331" x="0.01331" g="0.9090909090909092" b="0.09090909090909093" rho="1.1"/>
             </iidm:ratioTapChanger3>
-            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger3 lowTapPosition="1" tapPosition="2" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-50.0"/>
                 <iidm:step r="0.10000000149011612" x="0.10000000149011612" g="0.10000000149011612" b="0.10000000149011612" rho="1.0" alpha="-25.0"/>
             </iidm:phaseTapChanger3>

--- a/iidm/iidm-serde/src/test/resources/V1_5/disMeasRef.xiidm
+++ b/iidm/iidm-serde/src/test/resources/V1_5/disMeasRef.xiidm
@@ -90,7 +90,7 @@
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.15"/>
             </iidm:ratioTapChanger>
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="15" regulationMode="CURRENT_LIMITER" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="15" regulationMode="FIXED_TAP" regulating="false">
                 <iidm:terminalRef id="TWT" side="ONE"/>
                 <iidm:step r="39.78473" x="29.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
                 <iidm:step r="31.720245" x="21.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>

--- a/iidm/iidm-serde/src/test/resources/V1_5/terminalRef.xiidm
+++ b/iidm/iidm-serde/src/test/resources/V1_5/terminalRef.xiidm
@@ -48,7 +48,7 @@
             </iidm:phaseTapChanger>
         </iidm:twoWindingsTransformer>
         <iidm:twoWindingsTransformer id="VLY644" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="VL41" connectableBus1="VL41" voltageLevelId1="VL4" bus2="VL61" connectableBus2="VL61" voltageLevelId2="VL6">
-            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="CURRENT_LIMITER" regulationValue="200.0" regulating="false">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="1" regulationMode="FIXED_TAP" regulationValue="200.0" regulating="false">
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191" alpha="-1.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666" alpha="0.0"/>
                 <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914" alpha="1.0"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In all IIDM versions, non-regulating phase tap changers are exported with the following characteristics:
- regulating: false
- regulation mode: CURRENT_LIMITER
- regulation value: NaN (attribute non included)

Having the CURRENT_LIMITER regulation mode and either no regulation value or no regulation terminal is problematic for old PowSyBl versions and softwares/libraries reading old IIDM versions (<= 1.5), such as iidm4cpp.

**What is the new behavior (if this is a feature change)?**
In IIDM 1.5, these phase tap changer are exporter with the following characteristics:
- regulating: false
- regulation mode: **FIXED_TAD**
- regulation value: NaN (attribute non included)

For newer IIDM versions, the regulation mode is still exported as CURRENT_LIMITER.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
