### PR TITLE
Fix XIIDM's xsd to allow empty sourceFormat (de)serialization

### DIFF
--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_0.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_0.xsd
@@ -39,7 +39,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_1.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_1.xsd
@@ -39,7 +39,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_10.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_10.xsd
@@ -45,7 +45,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
             <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
         </xs:complexType>
     </xs:element>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_11.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_11.xsd
@@ -47,7 +47,7 @@
         <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
         <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
         <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-        <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+        <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
     </xs:complexType>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_12.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_12.xsd
@@ -47,7 +47,7 @@
         <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
         <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
         <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-        <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+        <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
     </xs:complexType>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_13.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_13.xsd
@@ -48,7 +48,7 @@
         <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
         <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
         <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-        <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+        <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
     </xs:complexType>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_14.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_14.xsd
@@ -49,7 +49,7 @@
         <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
         <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
         <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-        <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+        <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
     </xs:complexType>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_2.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_2.xsd
@@ -39,7 +39,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_3.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_3.xsd
@@ -40,7 +40,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_4.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_4.xsd
@@ -40,7 +40,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_5.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_5.xsd
@@ -40,7 +40,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_6.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_6.xsd
@@ -45,7 +45,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_7.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_7.xsd
@@ -45,7 +45,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
             <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
         </xs:complexType>
     </xs:element>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_8.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_8.xsd
@@ -45,7 +45,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
             <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
         </xs:complexType>
     </xs:element>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_9.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_9.xsd
@@ -45,7 +45,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
             <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
         </xs:complexType>
     </xs:element>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_10.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_10.xsd
@@ -45,7 +45,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
             <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
         </xs:complexType>
     </xs:element>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_11.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_11.xsd
@@ -46,7 +46,7 @@
         <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
         <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
         <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-        <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+        <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
     </xs:complexType>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_12.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_12.xsd
@@ -47,7 +47,7 @@
         <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
         <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
         <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-        <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+        <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
     </xs:complexType>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_13.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_13.xsd
@@ -48,7 +48,7 @@
         <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
         <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
         <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-        <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+        <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
     </xs:complexType>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_14.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_14.xsd
@@ -49,7 +49,7 @@
         <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
         <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
         <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-        <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+        <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
         <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
     </xs:complexType>
     <xs:complexType name="Identifiable">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_7.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_7.xsd
@@ -45,7 +45,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
             <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
         </xs:complexType>
     </xs:element>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_8.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_8.xsd
@@ -45,7 +45,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
             <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
         </xs:complexType>
     </xs:element>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_9.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_9.xsd
@@ -45,7 +45,7 @@
             <xs:attribute name="id" use="required" type="iidm:nonEmptyString"/>
             <xs:attribute name="caseDate" use="required" type="xs:dateTime"/>
             <xs:attribute name="forecastDistance" use="required" type="xs:int"/>
-            <xs:attribute name="sourceFormat" use="required" type="iidm:nonEmptyString"/>
+            <xs:attribute name="sourceFormat" use="required" type="xs:string"/>
             <xs:attribute name="minimumValidationLevel" use="required" type="iidm:nonEmptyString"/>
         </xs:complexType>
     </xs:element>

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
@@ -350,7 +350,7 @@ class NetworkSerDeTest extends AbstractIidmSerDeTest {
     void emptySourceFormatTest() {
         Network network = Network.create("id", "");
         Path xmlFile = tmpDir.resolve("emptySourceFormat.xml");
-        testForAllVersionsSince(IidmVersion.V_1_14, iidmVersion -> {
+        testForAllVersionsSince(IidmVersion.V_1_0, iidmVersion -> {
             ExportOptions options = new ExportOptions().setVersion(iidmVersion.toString("."));
             NetworkSerDe.write(network, options, xmlFile);
             Network readNetwork = NetworkSerDe.validateAndRead(xmlFile);

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
@@ -15,8 +15,8 @@ import com.powsybl.commons.io.DeserializerContext;
 import com.powsybl.commons.io.SerializerContext;
 import com.powsybl.commons.io.TreeDataFormat;
 import com.powsybl.commons.report.PowsyblCoreReportResourceBundle;
-import com.powsybl.commons.test.PowsyblTestReportResourceBundle;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.test.PowsyblTestReportResourceBundle;
 import com.powsybl.commons.test.TestUtil;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.*;
@@ -344,5 +344,17 @@ class NetworkSerDeTest extends AbstractIidmSerDeTest {
             load.addExtension(TerminalMockExt.class, terminalMockExt);
         }
         return network;
+    }
+
+    @Test
+    void emptySourceFormatTest() {
+        Network network = Network.create("id", "");
+        Path xmlFile = tmpDir.resolve("emptySourceFormat.xml");
+        testForAllVersionsSince(IidmVersion.V_1_14, iidmVersion -> {
+            ExportOptions options = new ExportOptions().setVersion(iidmVersion.toString("."));
+            NetworkSerDe.write(network, options, xmlFile);
+            Network readNetwork = NetworkSerDe.validateAndRead(xmlFile);
+            assertEquals("", readNetwork.getSourceFormat());
+        });
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
It is possible to create a network with an empty source format, to export it in XIIDM and to import it, but only if the XSD format validation is disabled (this is the default behavior). When the XSD validation is enabled, the import fails.


**What is the new behavior (if this is a feature change)?**
The IIDM XSDs now allow empty strings as source format ; the import with validation succeeds.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
