### PR TITLE
Fix RemoteReactivePowerControl regulating terminal replacement

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/RemoteReactivePowerControlImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/RemoteReactivePowerControlImpl.java
@@ -139,7 +139,7 @@ public class RemoteReactivePowerControlImpl extends AbstractMultiVariantIdentifi
     @Override
     public void onReferencedReplacement(Terminal oldReferenced, Terminal newReferenced) {
         if (regulatingTerminal == oldReferenced) {
-            regulatingTerminal = newReferenced;
+            setRegulatingTerminal(newReferenced);
         }
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/RemoteReactivePowerControlImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/RemoteReactivePowerControlImpl.java
@@ -77,8 +77,12 @@ public class RemoteReactivePowerControlImpl extends AbstractMultiVariantIdentifi
     @Override
     public RemoteReactivePowerControl setRegulatingTerminal(Terminal regulatingTerminal) {
         Objects.requireNonNull(regulatingTerminal);
-        checkRegulatingTerminal(regulatingTerminal, getExtendable().getTerminal().getVoltageLevel().getNetwork());
-        this.regulatingTerminal = regulatingTerminal;
+        if (this.regulatingTerminal != regulatingTerminal) {
+            ((TerminalExt) this.regulatingTerminal).getReferrerManager().unregister(this);
+            checkRegulatingTerminal(regulatingTerminal, getExtendable().getTerminal().getVoltageLevel().getNetwork());
+            this.regulatingTerminal = regulatingTerminal;
+            ((TerminalExt) regulatingTerminal).getReferrerManager().register(this);
+        }
         return this;
     }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractRemoteReactivePowerControlTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractRemoteReactivePowerControlTest.java
@@ -233,4 +233,28 @@ public abstract class AbstractRemoteReactivePowerControlTest {
         // extension should be removed
         assertNull(g.getExtension(RemoteReactivePowerControl.class));
     }
+
+    @Test
+    void replacementTest() {
+        Network network = createNetwork();
+        Generator g = network.getGenerator("g4");
+        Line l = network.getLine("l34");
+        Terminal lTerminal = l.getTerminal(TwoSides.ONE);
+        RemoteReactivePowerControl remoteReactivePowerControl = g.newExtension(RemoteReactivePowerControlAdder.class)
+                .withTargetQ(200.0)
+                .withRegulatingTerminal(lTerminal)
+                .withEnabled(true)
+                .add();
+
+        assertEquals(lTerminal, remoteReactivePowerControl.getRegulatingTerminal());
+
+        // Replacement
+        Terminal.BusBreakerView bbView = lTerminal.getBusBreakerView();
+        bbView.moveConnectable("b4", true);
+        assertNotEquals(lTerminal, remoteReactivePowerControl.getRegulatingTerminal());
+
+        // Extension should be removed
+        l.remove();
+        assertNull(g.getExtension(RemoteReactivePowerControl.class));
+    }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractRemoteReactivePowerControlTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractRemoteReactivePowerControlTest.java
@@ -212,4 +212,25 @@ public abstract class AbstractRemoteReactivePowerControlTest {
         // extension has been removed because regulating terminal is invalid
         assertNull(g.getExtension(RemoteReactivePowerControl.class));
     }
+
+    @Test
+    public void terminalReplacementTest() {
+        Network network = createNetwork();
+        Generator g = network.getGenerator("g4");
+        Line l = network.getLine("l34");
+        Line l2 = network.getLine("l12");
+        RemoteReactivePowerControl remoteReactivePowerControl = g.newExtension(RemoteReactivePowerControlAdder.class)
+                .withTargetQ(200.0)
+                .withRegulatingTerminal(l.getTerminal(TwoSides.ONE))
+                .withEnabled(true)
+                .add();
+        assertNotNull(g.getExtension(RemoteReactivePowerControl.class));
+        remoteReactivePowerControl.setRegulatingTerminal(l2.getTerminal(TwoSides.ONE));
+        l.remove();
+        // extension should not be removed
+        assertNotNull(g.getExtension(RemoteReactivePowerControl.class));
+        l2.remove();
+        // extension should be removed
+        assertNull(g.getExtension(RemoteReactivePowerControl.class));
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When `setRegulatingTerminal(...)` is called on a `RemoteReactivePowerControl` extension, and the previous terminal is removed, the extension is automatically removed.


**What is the new behavior (if this is a feature change)?**
When `setRegulatingTerminal(...)` is called on a `RemoteReactivePowerControl` extension, and the previous terminal is removed, the extension is **not** removed.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
