### PR TITLE
Fix replacementTest in AbstractRemoteReactivePowerControlTest

### DIFF
--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractRemoteReactivePowerControlTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractRemoteReactivePowerControlTest.java
@@ -247,11 +247,12 @@ public abstract class AbstractRemoteReactivePowerControlTest {
                 .add();
 
         assertEquals(lTerminal, remoteReactivePowerControl.getRegulatingTerminal());
+        assertEquals("b3", remoteReactivePowerControl.getRegulatingTerminal().getBusBreakerView().getBus().getId());
 
         // Replacement
         Terminal.BusBreakerView bbView = lTerminal.getBusBreakerView();
-        bbView.moveConnectable("b4", true);
-        assertNotEquals(lTerminal, remoteReactivePowerControl.getRegulatingTerminal());
+        bbView.moveConnectable("b2", true);
+        assertEquals("b2", remoteReactivePowerControl.getRegulatingTerminal().getBusBreakerView().getBus().getId());
 
         // Extension should be removed
         l.remove();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Test fix

**What is the current behavior?**
- The test assert that the remote controlled Terminal object after a connectable is moved is not equals to the remote controlled Terminal object before the move. It works in powsybl-core since a new terminal is created when moving a connectable, but it can break some implementation where the terminal is simply modified and not recreated.
- Also, the side of the line was moved on the same bus as the other side.

**What is the new behavior (if this is a feature change)?**
- The test now check that the remote controlled Terminal after the move is on the right bus, which means that it has followed the move.
- The line is moved to another bus

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
