### PR TITLE
Fix standby automaton adder checks

### DIFF
--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/StaticVarCompensatorImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/StaticVarCompensatorImpl.java
@@ -16,9 +16,9 @@ import gnu.trove.list.array.TDoubleArrayList;
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
-class StaticVarCompensatorImpl extends AbstractConnectable<StaticVarCompensator> implements StaticVarCompensator {
+public class StaticVarCompensatorImpl extends AbstractConnectable<StaticVarCompensator> implements StaticVarCompensator {
 
-    static final String TYPE_DESCRIPTION = "staticVarCompensator";
+    static final String TYPE_DESCRIPTION = "Static var compensator";
 
     private double bMin;
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/StandbyAutomatonAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/StandbyAutomatonAdderImpl.java
@@ -11,6 +11,7 @@ import com.powsybl.commons.extensions.AbstractExtensionAdder;
 import com.powsybl.iidm.network.StaticVarCompensator;
 import com.powsybl.iidm.network.extensions.StandbyAutomaton;
 import com.powsybl.iidm.network.extensions.StandbyAutomatonAdder;
+import com.powsybl.iidm.network.impl.StaticVarCompensatorImpl;
 
 /**
  * @author Jérémy Labous {@literal <jlabous at silicom.fr>}
@@ -18,17 +19,17 @@ import com.powsybl.iidm.network.extensions.StandbyAutomatonAdder;
 public class StandbyAutomatonAdderImpl extends AbstractExtensionAdder<StaticVarCompensator, StandbyAutomaton>
         implements StandbyAutomatonAdder {
 
-    private double b0;
+    private double b0 = Double.NaN;
 
-    private boolean standby;
+    private boolean standby = false;
 
-    private double lowVoltageSetpoint;
+    private double lowVoltageSetpoint = Double.NaN;
 
-    private double highVoltageSetpoint;
+    private double highVoltageSetpoint = Double.NaN;
 
-    private double lowVoltageThreshold;
+    private double lowVoltageThreshold = Double.NaN;
 
-    private double highVoltageThreshold;
+    private double highVoltageThreshold = Double.NaN;
 
     public StandbyAutomatonAdderImpl(StaticVarCompensator svc) {
         super(svc);
@@ -36,7 +37,7 @@ public class StandbyAutomatonAdderImpl extends AbstractExtensionAdder<StaticVarC
 
     @Override
     protected StandbyAutomaton createExtension(StaticVarCompensator staticVarCompensator) {
-        return new StandbyAutomatonImpl(staticVarCompensator, b0, standby,
+        return new StandbyAutomatonImpl((StaticVarCompensatorImpl) staticVarCompensator, b0, standby,
                 lowVoltageSetpoint, highVoltageSetpoint, lowVoltageThreshold, highVoltageThreshold);
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/StandbyAutomatonImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/StandbyAutomatonImpl.java
@@ -9,8 +9,10 @@ package com.powsybl.iidm.network.impl.extensions;
 
 import com.powsybl.commons.util.trove.TBooleanArrayList;
 import com.powsybl.iidm.network.StaticVarCompensator;
+import com.powsybl.iidm.network.ValidationException;
 import com.powsybl.iidm.network.extensions.StandbyAutomaton;
 import com.powsybl.iidm.network.impl.AbstractMultiVariantIdentifiableExtension;
+import com.powsybl.iidm.network.impl.StaticVarCompensatorImpl;
 import gnu.trove.list.array.TDoubleArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,71 +31,55 @@ public class StandbyAutomatonImpl extends AbstractMultiVariantIdentifiableExtens
     private final TDoubleArrayList lowVoltageThreshold;
     private final TDoubleArrayList highVoltageThreshold;
 
-    private static double checkB0(double b0) {
+    private static double checkB0(StaticVarCompensatorImpl svc, double b0) {
         if (Double.isNaN(b0)) {
-            throw new IllegalArgumentException("b0 is invalid");
+            throw new ValidationException(svc, "b0 is invalid");
         }
         return b0;
     }
 
-    private static void checkVoltageConfig(double lowVoltageSetpoint, double highVoltageSetpoint,
+    private static void checkVoltageConfig(StaticVarCompensatorImpl svc, double lowVoltageSetpoint, double highVoltageSetpoint,
                                            double lowVoltageThreshold, double highVoltageThreshold,
-                                           StaticVarCompensator staticVarCompensator, boolean standby) {
+                                           boolean standby) {
         if (Double.isNaN(lowVoltageSetpoint)) {
-            throw new IllegalArgumentException(
-                String.format("lowVoltageSetpoint (%s) is invalid for StaticVarCompensator %s",
-                    lowVoltageSetpoint,
-                    staticVarCompensator.getId()));
+            throw new ValidationException(svc, String.format("low voltage setpoint (%s) is invalid", lowVoltageSetpoint));
         }
         if (Double.isNaN(highVoltageSetpoint)) {
-            throw new IllegalArgumentException(
-                String.format("highVoltageSetpoint (%s) is invalid for StaticVarCompensator %s",
-                    highVoltageSetpoint,
-                    staticVarCompensator.getId()));
+            throw new ValidationException(svc, String.format("high voltage setpoint (%s) is invalid", highVoltageSetpoint));
         }
         if (Double.isNaN(lowVoltageThreshold)) {
-            throw new IllegalArgumentException(
-                String.format("lowVoltageThreshold (%s) is invalid for StaticVarCompensator %s",
-                    lowVoltageThreshold,
-                    staticVarCompensator.getId()));
+            throw new ValidationException(svc, String.format("low voltage threshold (%s) is invalid", lowVoltageThreshold));
         }
         if (Double.isNaN(highVoltageThreshold)) {
-            throw new IllegalArgumentException(
-                String.format("highVoltageThreshold (%s) is invalid for StaticVarCompensator %s",
-                    highVoltageThreshold,
-                    staticVarCompensator.getId()));
+            throw new ValidationException(svc, String.format("high voltage threshold (%s) is invalid", highVoltageThreshold));
         }
         if (lowVoltageThreshold >= highVoltageThreshold) {
             if (standby) {
-                throw new IllegalArgumentException(
-                        String.format("Inconsistent low (%s) and high (%s) voltage thresholds for StaticVarCompensator %s",
+                throw new ValidationException(svc,
+                        String.format("Inconsistent low (%s) and high (%s) voltage thresholds",
                                 lowVoltageThreshold,
-                                highVoltageThreshold,
-                                staticVarCompensator.getId()));
+                                highVoltageThreshold));
             } else {
                 LOGGER.warn("Inconsistent low {} and high ({}) voltage thresholds for StaticVarCompensator {}",
-                        lowVoltageSetpoint, lowVoltageThreshold,
-                        staticVarCompensator.getId());
+                        lowVoltageSetpoint, lowVoltageThreshold, svc.getId());
             }
         }
         if (lowVoltageSetpoint < lowVoltageThreshold) {
             LOGGER.warn("Invalid low voltage setpoint {} < threshold {} for StaticVarCompensator {}",
-                lowVoltageSetpoint, lowVoltageThreshold,
-                staticVarCompensator.getId());
+                lowVoltageSetpoint, lowVoltageThreshold, svc.getId());
         }
         if (highVoltageSetpoint > highVoltageThreshold) {
             LOGGER.warn("Invalid high voltage setpoint {} > threshold {} for StaticVarCompensator {}",
-                highVoltageSetpoint, highVoltageThreshold,
-                staticVarCompensator.getId());
+                highVoltageSetpoint, highVoltageThreshold, svc.getId());
         }
     }
 
-    public StandbyAutomatonImpl(StaticVarCompensator svc, double b0, boolean standby, double lowVoltageSetpoint, double highVoltageSetpoint,
+    public StandbyAutomatonImpl(StaticVarCompensatorImpl svc, double b0, boolean standby, double lowVoltageSetpoint, double highVoltageSetpoint,
                                 double lowVoltageThreshold, double highVoltageThreshold) {
         super(svc);
         int variantArraySize = getVariantManagerHolder().getVariantManager().getVariantArraySize();
-        checkVoltageConfig(lowVoltageSetpoint, highVoltageSetpoint, lowVoltageThreshold, highVoltageThreshold, svc, standby);
-        this.b0 = checkB0(b0);
+        checkVoltageConfig(svc, lowVoltageSetpoint, highVoltageSetpoint, lowVoltageThreshold, highVoltageThreshold, standby);
+        this.b0 = checkB0(svc, b0);
         this.standby = new TBooleanArrayList(variantArraySize);
         this.lowVoltageSetpoint = new TDoubleArrayList(variantArraySize);
         this.highVoltageSetpoint = new TDoubleArrayList(variantArraySize);
@@ -115,10 +101,10 @@ public class StandbyAutomatonImpl extends AbstractMultiVariantIdentifiableExtens
 
     @Override
     public StandbyAutomatonImpl setStandby(boolean standby) {
-        checkVoltageConfig(
+        checkVoltageConfig((StaticVarCompensatorImpl) getExtendable(),
                 lowVoltageSetpoint.get(getVariantIndex()), highVoltageSetpoint.get(getVariantIndex()),
                 lowVoltageThreshold.get(getVariantIndex()), highVoltageThreshold.get(getVariantIndex()),
-                this.getExtendable(), standby);
+                standby);
         this.standby.set(getVariantIndex(), standby);
         return this;
     }
@@ -130,7 +116,7 @@ public class StandbyAutomatonImpl extends AbstractMultiVariantIdentifiableExtens
 
     @Override
     public StandbyAutomatonImpl setB0(double b0) {
-        this.b0 = checkB0(b0);
+        this.b0 = checkB0((StaticVarCompensatorImpl) getExtendable(), b0);
         return this;
     }
 
@@ -141,9 +127,8 @@ public class StandbyAutomatonImpl extends AbstractMultiVariantIdentifiableExtens
 
     @Override
     public StandbyAutomatonImpl setHighVoltageSetpoint(double highVoltageSetpoint) {
-        checkVoltageConfig(lowVoltageSetpoint.get(getVariantIndex()), highVoltageSetpoint,
-            lowVoltageThreshold.get(getVariantIndex()), highVoltageThreshold.get(getVariantIndex()),
-            this.getExtendable(), standby.get(getVariantIndex()));
+        checkVoltageConfig((StaticVarCompensatorImpl) getExtendable(), lowVoltageSetpoint.get(getVariantIndex()), highVoltageSetpoint,
+            lowVoltageThreshold.get(getVariantIndex()), highVoltageThreshold.get(getVariantIndex()), standby.get(getVariantIndex()));
         this.highVoltageSetpoint.set(getVariantIndex(), highVoltageSetpoint);
         return this;
     }
@@ -155,9 +140,8 @@ public class StandbyAutomatonImpl extends AbstractMultiVariantIdentifiableExtens
 
     @Override
     public StandbyAutomatonImpl setHighVoltageThreshold(double highVoltageThreshold) {
-        checkVoltageConfig(lowVoltageSetpoint.get(getVariantIndex()), highVoltageSetpoint.get(getVariantIndex()),
-            lowVoltageThreshold.get(getVariantIndex()), highVoltageThreshold,
-            this.getExtendable(), standby.get(getVariantIndex()));
+        checkVoltageConfig((StaticVarCompensatorImpl) getExtendable(), lowVoltageSetpoint.get(getVariantIndex()), highVoltageSetpoint.get(getVariantIndex()),
+            lowVoltageThreshold.get(getVariantIndex()), highVoltageThreshold, standby.get(getVariantIndex()));
         this.highVoltageThreshold.set(getVariantIndex(), highVoltageThreshold);
         return this;
     }
@@ -169,9 +153,8 @@ public class StandbyAutomatonImpl extends AbstractMultiVariantIdentifiableExtens
 
     @Override
     public StandbyAutomatonImpl setLowVoltageSetpoint(double lowVoltageSetpoint) {
-        checkVoltageConfig(lowVoltageSetpoint, highVoltageSetpoint.get(getVariantIndex()),
-            lowVoltageThreshold.get(getVariantIndex()), highVoltageThreshold.get(getVariantIndex()),
-            this.getExtendable(), standby.get(getVariantIndex()));
+        checkVoltageConfig((StaticVarCompensatorImpl) getExtendable(), lowVoltageSetpoint, highVoltageSetpoint.get(getVariantIndex()),
+            lowVoltageThreshold.get(getVariantIndex()), highVoltageThreshold.get(getVariantIndex()), standby.get(getVariantIndex()));
         this.lowVoltageSetpoint.set(getVariantIndex(), lowVoltageSetpoint);
         return this;
     }
@@ -183,9 +166,8 @@ public class StandbyAutomatonImpl extends AbstractMultiVariantIdentifiableExtens
 
     @Override
     public StandbyAutomatonImpl setLowVoltageThreshold(double lowVoltageThreshold) {
-        checkVoltageConfig(lowVoltageSetpoint.get(getVariantIndex()), highVoltageSetpoint.get(getVariantIndex()),
-            lowVoltageThreshold, highVoltageThreshold.get(getVariantIndex()),
-            this.getExtendable(), standby.get(getVariantIndex()));
+        checkVoltageConfig((StaticVarCompensatorImpl) getExtendable(), lowVoltageSetpoint.get(getVariantIndex()), highVoltageSetpoint.get(getVariantIndex()),
+            lowVoltageThreshold, highVoltageThreshold.get(getVariantIndex()), standby.get(getVariantIndex()));
         this.lowVoltageThreshold.set(getVariantIndex(), lowVoltageThreshold);
         return this;
     }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/extensions/StandbyAutomatonTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/extensions/StandbyAutomatonTest.java
@@ -12,6 +12,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.StaticVarCompensator;
+import com.powsybl.iidm.network.ValidationException;
 import com.powsybl.iidm.network.extensions.StandbyAutomatonAdder;
 import com.powsybl.iidm.network.impl.extensions.StandbyAutomatonImpl;
 import com.powsybl.iidm.network.tck.extensions.AbstractStandbyAutomatonTest;
@@ -44,8 +45,8 @@ class StandbyAutomatonTest extends AbstractStandbyAutomatonTest {
             .withHighVoltageSetpoint(345f)
             .withLowVoltageThreshold(385f)
             .withHighVoltageThreshold(350f);
-        IllegalArgumentException e0 = assertThrows(IllegalArgumentException.class, standbyAutomatonAdder::add);
-        assertEquals("Inconsistent low (385.0) and high (350.0) voltage thresholds for StaticVarCompensator SVC2",
+        ValidationException e0 = assertThrows(ValidationException.class, standbyAutomatonAdder::add);
+        assertEquals("Static var compensator 'SVC2': Inconsistent low (385.0) and high (350.0) voltage thresholds",
             e0.getMessage());
 
         // lowVoltageSetpoint invalid
@@ -53,8 +54,8 @@ class StandbyAutomatonTest extends AbstractStandbyAutomatonTest {
             .withHighVoltageSetpoint(400f)
             .withLowVoltageThreshold(385f)
             .withHighVoltageThreshold(405f);
-        e0 = assertThrows(IllegalArgumentException.class, standbyAutomatonAdder::add);
-        assertEquals("lowVoltageSetpoint (NaN) is invalid for StaticVarCompensator SVC2",
+        e0 = assertThrows(ValidationException.class, standbyAutomatonAdder::add);
+        assertEquals("Static var compensator 'SVC2': low voltage setpoint (NaN) is invalid",
             e0.getMessage());
 
         // highVoltageSetpoint invalid
@@ -62,8 +63,8 @@ class StandbyAutomatonTest extends AbstractStandbyAutomatonTest {
             .withHighVoltageSetpoint(Double.NaN)
             .withLowVoltageThreshold(385f)
             .withHighVoltageThreshold(405f);
-        e0 = assertThrows(IllegalArgumentException.class, standbyAutomatonAdder::add);
-        assertEquals("highVoltageSetpoint (NaN) is invalid for StaticVarCompensator SVC2",
+        e0 = assertThrows(ValidationException.class, standbyAutomatonAdder::add);
+        assertEquals("Static var compensator 'SVC2': high voltage setpoint (NaN) is invalid",
             e0.getMessage());
 
         // lowVoltageSetpoint invalid
@@ -71,8 +72,8 @@ class StandbyAutomatonTest extends AbstractStandbyAutomatonTest {
             .withHighVoltageSetpoint(400f)
             .withLowVoltageThreshold(Double.NaN)
             .withHighVoltageThreshold(405f);
-        e0 = assertThrows(IllegalArgumentException.class, standbyAutomatonAdder::add);
-        assertEquals("lowVoltageThreshold (NaN) is invalid for StaticVarCompensator SVC2",
+        e0 = assertThrows(ValidationException.class, standbyAutomatonAdder::add);
+        assertEquals("Static var compensator 'SVC2': low voltage threshold (NaN) is invalid",
             e0.getMessage());
 
         // highVoltageSetpoint invalid
@@ -80,8 +81,8 @@ class StandbyAutomatonTest extends AbstractStandbyAutomatonTest {
             .withHighVoltageSetpoint(400f)
             .withLowVoltageThreshold(385f)
             .withHighVoltageThreshold(Double.NaN);
-        e0 = assertThrows(IllegalArgumentException.class, standbyAutomatonAdder::add);
-        assertEquals("highVoltageThreshold (NaN) is invalid for StaticVarCompensator SVC2",
+        e0 = assertThrows(ValidationException.class, standbyAutomatonAdder::add);
+        assertEquals("Static var compensator 'SVC2': high voltage threshold (NaN) is invalid",
             e0.getMessage());
     }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractStandbyAutomatonTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractStandbyAutomatonTest.java
@@ -10,6 +10,7 @@ package com.powsybl.iidm.network.tck.extensions;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.StaticVarCompensator;
+import com.powsybl.iidm.network.ValidationException;
 import com.powsybl.iidm.network.VariantManager;
 import com.powsybl.iidm.network.extensions.StandbyAutomaton;
 import com.powsybl.iidm.network.extensions.StandbyAutomatonAdder;
@@ -74,7 +75,20 @@ public abstract class AbstractStandbyAutomatonTest {
         assertEquals(200f, standbyAutomaton.getHighVoltageThreshold(), 0.0);
 
         // but an exception is thrown when the standby mode is latter used
-        assertThrows(IllegalArgumentException.class, () -> standbyAutomaton.setStandby(true));
+        assertThrows(ValidationException.class, () -> standbyAutomaton.setStandby(true));
+    }
+
+    @Test
+    public void testIncompleteAdderBadException() {
+        Network network = SvcTestCaseFactory.create();
+        StaticVarCompensator svc = network.getStaticVarCompensator("SVC2");
+        assertNotNull(svc);
+
+        StandbyAutomatonAdder standbyAutomatonAdder = svc.newExtension(StandbyAutomatonAdder.class)
+                .withStandbyStatus(true);
+        var e = assertThrows(ValidationException.class, standbyAutomatonAdder::add);
+        // instead of "Static var compensator 'SVC2': Inconsistent low (0.0) and high (0.0) voltage thresholds"
+        assertEquals("Static var compensator 'SVC2': low voltage setpoint (NaN) is invalid", e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When creating a standby automaton extension with incomplete attibutes, we can a strange error message. This is because setpoint and threshold are intiliazed to 0 in the adder instead of nan (undefined)


**What is the new behavior (if this is a feature change)?**
We can a correct error message and also a ValidationException which is more consistent with the actual design.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
