### PR TITLE
Fix CIM version available for export in documentation

### DIFF
--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -423,7 +423,7 @@ If this property is defined, then this ID will be written in the header of the e
 
 **iidm.export.cgmes.cim-version**  
 Optional property that defines the CIM version number in which the user wants the CGMES files to be exported.
-CIM versions 14, 16 and 100 are supported i.e. its valid values are `14`, `16` and `100`.
+CIM versions 16 and 100 are supported i.e. its valid values are `16` and `100`.
 If not defined, and the network has the extension `CimCharacteristics`, the CIM version will be the one indicated in the extension. If not, its default value is `16`.
 CIM version 16 corresponds to CGMES 2.4.15.
 CIM version 100 corresponds to CGMES 3.0.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation update.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
CIM 14 is marked available for export in the documentation.


**What is the new behavior (if this is a feature change)?**
<!-- -->
CIM 14 is removed from the available versions for export in the documentation.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
