### PR TITLE
AC/DC Converters have terminal number instead of side

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AbstractEquipmentTopologyVisitor.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AbstractEquipmentTopologyVisitor.java
@@ -71,7 +71,7 @@ public abstract class AbstractEquipmentTopologyVisitor extends DefaultTopologyVi
     }
 
     @Override
-    public void visitAcDcConverter(AcDcConverter<?> converter, TwoSides side) {
+    public void visitAcDcConverter(AcDcConverter<?> converter, TerminalNumber terminalNumber) {
         visitEquipment(converter);
     }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AbstractTerminalTopologyVisitor.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AbstractTerminalTopologyVisitor.java
@@ -84,7 +84,7 @@ public abstract class AbstractTerminalTopologyVisitor extends DefaultTopologyVis
     }
 
     @Override
-    public void visitAcDcConverter(AcDcConverter<?> converter, TwoSides side) {
-        visitTerminal(converter.getTerminal(side));
+    public void visitAcDcConverter(AcDcConverter<?> converter, TerminalNumber terminalNumber) {
+        visitTerminal(converter.getTerminal(terminalNumber));
     }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
@@ -131,14 +131,14 @@ public interface AcDcConverter<I extends AcDcConverter<I>> extends Connectable<I
     Optional<Terminal> getTerminal2();
 
     /**
-     * Get the side the AC terminal is connected to.
+     * Get the terminal number of the AC terminal is connected to.
      */
-    TwoSides getSide(Terminal terminal);
+    TerminalNumber getTerminalNumber(Terminal terminal);
 
     /**
-     * Get the AC terminal at provided side.
+     * Get the AC terminal of provided terminal number.
      */
-    Terminal getTerminal(TwoSides side);
+    Terminal getTerminal(TerminalNumber terminalNumber);
 
     /**
      * Get the first DC terminal.
@@ -151,14 +151,14 @@ public interface AcDcConverter<I extends AcDcConverter<I>> extends Connectable<I
     DcTerminal getDcTerminal2();
 
     /**
-     * Get the side the DC terminal is connected to.
+     * Get the terminal number the DC terminal is connected to.
      */
-    TwoSides getSide(DcTerminal dcTerminal);
+    TerminalNumber getTerminalNumber(DcTerminal dcTerminal);
 
     /**
-     * Get the DC terminal at provided side.
+     * Get the DC terminal of provided terminal number.
      */
-    DcTerminal getDcTerminal(TwoSides side);
+    DcTerminal getDcTerminal(TerminalNumber terminalNumber);
 
     /**
      * Set the idle loss (MW).

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcTerminal.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcTerminal.java
@@ -25,6 +25,11 @@ public interface DcTerminal {
     TwoSides getSide();
 
     /**
+     * @return the DC equipment terminal number
+     */
+    TerminalNumber getTerminalNumber();
+
+    /**
      * @return the DC node the DC terminal connects to
      */
     DcNode getDcNode();

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DefaultTopologyVisitor.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DefaultTopologyVisitor.java
@@ -74,7 +74,7 @@ public class DefaultTopologyVisitor implements TopologyVisitor {
     }
 
     @Override
-    public void visitAcDcConverter(AcDcConverter<?> converter, TwoSides side) {
+    public void visitAcDcConverter(AcDcConverter<?> converter, TerminalNumber terminalNumber) {
         // empty default implementation
     }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Terminal.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Terminal.java
@@ -235,8 +235,8 @@ public interface Terminal {
             return Optional.of(branch.getSide(terminal).toThreeSides());
         } else if (c instanceof ThreeWindingsTransformer transformer) {
             return Optional.of(transformer.getSide(terminal));
-        } else if (c instanceof AcDcConverter<?> acDcConverter) {
-            return Optional.of(acDcConverter.getSide(terminal).toThreeSides());
+        } else if (c instanceof AcDcConverter<?>) {
+            return Optional.empty();
         } else {
             throw new IllegalStateException("Unexpected Connectable instance: " + c.getClass());
         }
@@ -249,14 +249,31 @@ public interface Terminal {
             return branch.getTerminal(side.toTwoSides());
         } else if (identifiable instanceof ThreeWindingsTransformer transformer) {
             return transformer.getTerminal(side);
-        } else if (identifiable instanceof AcDcConverter<?> acDcConverter) {
-            return acDcConverter.getTerminal(side.toTwoSides());
+        } else {
+            throw new PowsyblException("Unexpected terminal reference identifiable instance: " + identifiable.getClass());
+        }
+    }
+
+    static Optional<TerminalNumber> getConnectableTerminalNumber(Terminal terminal) {
+        Connectable<?> c = terminal.getConnectable();
+        if (c instanceof AcDcConverter<?> acDcConverter) {
+            return Optional.of(acDcConverter.getTerminalNumber(terminal));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    static Terminal getTerminal(Identifiable<?> identifiable, TerminalNumber terminalNumber) {
+        if (identifiable instanceof AcDcConverter<?> acDcConverter) {
+            return acDcConverter.getTerminal(terminalNumber);
         } else {
             throw new PowsyblException("Unexpected terminal reference identifiable instance: " + identifiable.getClass());
         }
     }
 
     ThreeSides getSide();
+
+    TerminalNumber getTerminalNumber();
 
     /**
      * Retrieves a list of objects that refer to the terminal.

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TerminalNumber.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TerminalNumber.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2025, Coreso SA (https://www.coreso.eu/) and TSCNET Services GmbH (https://www.tscnet.eu/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network;
+
+/**
+ * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
+ */
+public enum TerminalNumber {
+    ONE,
+    TWO,
+}

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TopologyVisitor.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/TopologyVisitor.java
@@ -40,5 +40,5 @@ public interface TopologyVisitor {
 
     void visitGround(Ground connectable);
 
-    void visitAcDcConverter(AcDcConverter<?> converter, TwoSides side);
+    void visitAcDcConverter(AcDcConverter<?> converter, TerminalNumber terminalNumber);
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverter.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverter.java
@@ -76,27 +76,27 @@ abstract class AbstractAcDcConverter<I extends AcDcConverter<I>> extends Abstrac
     }
 
     @Override
-    public TwoSides getSide(Terminal terminal) {
+    public TerminalNumber getTerminalNumber(Terminal terminal) {
         Objects.requireNonNull(terminal);
         if (getTerminal1() == terminal) {
-            return TwoSides.ONE;
+            return TerminalNumber.ONE;
         } else if (getTerminal2().orElse(null) == terminal) {
-            return TwoSides.TWO;
+            return TerminalNumber.TWO;
         } else {
             throw new IllegalStateException("The terminal is not connected to this AC/DC converter");
         }
     }
 
     @Override
-    public Terminal getTerminal(TwoSides side) {
-        Objects.requireNonNull(side);
+    public Terminal getTerminal(TerminalNumber terminalNumber) {
+        Objects.requireNonNull(terminalNumber);
         ValidationUtil.checkAccessOfRemovedEquipment(this.id, this.removed, "terminal");
-        if (side == TwoSides.ONE) {
+        if (terminalNumber == TerminalNumber.ONE) {
             return getTerminal1();
-        } else if (side == TwoSides.TWO) {
+        } else if (terminalNumber == TerminalNumber.TWO) {
             return getTerminal2().orElseThrow(() -> new IllegalStateException("This AC/DC converter does not have a second AC Terminal"));
         }
-        throw new IllegalStateException("Unexpected side: " + side);
+        throw new IllegalStateException("Unexpected side: " + terminalNumber);
     }
 
     @Override
@@ -112,27 +112,27 @@ abstract class AbstractAcDcConverter<I extends AcDcConverter<I>> extends Abstrac
     }
 
     @Override
-    public TwoSides getSide(DcTerminal dcTerminal) {
+    public TerminalNumber getTerminalNumber(DcTerminal dcTerminal) {
         Objects.requireNonNull(dcTerminal);
         if (getDcTerminal1() == dcTerminal) {
-            return TwoSides.ONE;
+            return TerminalNumber.ONE;
         } else if (getDcTerminal2() == dcTerminal) {
-            return TwoSides.TWO;
+            return TerminalNumber.TWO;
         } else {
             throw new IllegalStateException("The DC terminal is not connected to this AC/DC converter");
         }
     }
 
     @Override
-    public DcTerminal getDcTerminal(TwoSides side) {
-        Objects.requireNonNull(side);
+    public DcTerminal getDcTerminal(TerminalNumber terminalNumber) {
+        Objects.requireNonNull(terminalNumber);
         ValidationUtil.checkAccessOfRemovedEquipment(this.id, this.removed, "terminal");
-        if (side == TwoSides.ONE) {
+        if (terminalNumber == TerminalNumber.ONE) {
             return this.dcTerminals.get(0);
-        } else if (side == TwoSides.TWO) {
+        } else if (terminalNumber == TerminalNumber.TWO) {
             return this.dcTerminals.get(1);
         }
-        throw new IllegalStateException("Unexpected side: " + side);
+        throw new IllegalStateException("Unexpected side: " + terminalNumber);
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverterAdder.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverterAdder.java
@@ -89,7 +89,7 @@ abstract class AbstractAcDcConverterAdder<T extends AbstractAcDcConverterAdder<T
     }
 
     protected TerminalExt checkAndGetTerminal1() {
-        return new TerminalBuilder(voltageLevel.getNetworkRef(), this, ThreeSides.ONE)
+        return new TerminalBuilder(voltageLevel.getNetworkRef(), this, null, TerminalNumber.ONE)
                 .setNode(node1)
                 .setBus(bus1)
                 .setConnectableBus(connectableBus1)
@@ -113,7 +113,7 @@ abstract class AbstractAcDcConverterAdder<T extends AbstractAcDcConverterAdder<T
 
     protected Optional<TerminalExt> checkAndGetTerminal2() {
         if (hasTwoAcTerminals()) {
-            return Optional.of(new TerminalBuilder(voltageLevel.getNetworkRef(), this, ThreeSides.TWO)
+            return Optional.of(new TerminalBuilder(voltageLevel.getNetworkRef(), this, null, TerminalNumber.TWO)
                     .setNode(node2)
                     .setBus(bus2)
                     .setConnectableBus(connectableBus2)
@@ -184,8 +184,8 @@ abstract class AbstractAcDcConverterAdder<T extends AbstractAcDcConverterAdder<T
             dcConverter.addTerminal(terminal);
             voltageLevel.getTopologyModel().attach(terminal, false);
         });
-        DcTerminalImpl dcTerminal1 = new DcTerminalImpl(voltageLevel.getNetworkRef(), TwoSides.ONE, dcNode1, dcConnected1);
-        DcTerminalImpl dcTerminal2 = new DcTerminalImpl(voltageLevel.getNetworkRef(), TwoSides.TWO, dcNode2, dcConnected2);
+        DcTerminalImpl dcTerminal1 = new DcTerminalImpl(voltageLevel.getNetworkRef(), null, TerminalNumber.ONE, dcNode1, dcConnected1);
+        DcTerminalImpl dcTerminal2 = new DcTerminalImpl(voltageLevel.getNetworkRef(), null, TerminalNumber.TWO, dcNode2, dcConnected2);
         dcConverter.addDcTerminal(dcTerminal1);
         dcConverter.addDcTerminal(dcTerminal2);
         getNetwork().getIndex().checkAndAdd(dcConverter);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractBranchAdder.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractBranchAdder.java
@@ -54,7 +54,7 @@ abstract class AbstractBranchAdder<T extends AbstractBranchAdder<T>> extends Abs
 
     protected TerminalExt checkAndGetTerminal1() {
         VoltageLevelExt voltageLevel = checkAndGetVoltageLevel1();
-        return new TerminalBuilder(voltageLevel.getNetworkRef(), this, ThreeSides.ONE)
+        return new TerminalBuilder(voltageLevel.getNetworkRef(), this, ThreeSides.ONE, null)
                 .setNode(node1)
                 .setBus(bus1)
                 .setConnectableBus(connectableBus1)
@@ -99,7 +99,7 @@ abstract class AbstractBranchAdder<T extends AbstractBranchAdder<T>> extends Abs
 
     protected TerminalExt checkAndGetTerminal2() {
         VoltageLevelExt voltageLevel = checkAndGetVoltageLevel2();
-        return new TerminalBuilder(voltageLevel.getNetworkRef(), this, ThreeSides.TWO)
+        return new TerminalBuilder(voltageLevel.getNetworkRef(), this, ThreeSides.TWO, null)
                 .setNode(node2)
                 .setBus(bus2)
                 .setConnectableBus(connectableBus2)

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractBus.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractBus.java
@@ -296,7 +296,7 @@ abstract class AbstractBus extends AbstractIdentifiable<Bus> implements Bus {
                 case GROUND -> visitor.visitGround((GroundImpl) connectable);
                 case LINE_COMMUTATED_CONVERTER, VOLTAGE_SOURCE_CONVERTER -> {
                     AcDcConverter<?> converter = (AcDcConverter<?>) connectable;
-                    visitor.visitAcDcConverter(converter, converter.getSide(terminal));
+                    visitor.visitAcDcConverter(converter, converter.getTerminalNumber(terminal));
                 }
                 default -> throw new IllegalStateException();
             }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractConnectable.java
@@ -147,7 +147,7 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
         }
 
         // create the new terminal and attach it to the given voltage level and to the connectable
-        TerminalExt terminalExt = new TerminalBuilder(voltageLevel.getNetworkRef(), this, oldTerminal.getSide())
+        TerminalExt terminalExt = new TerminalBuilder(voltageLevel.getNetworkRef(), this, oldTerminal.getSide(), oldTerminal.getTerminalNumber())
                 .setNode(node)
                 .build();
 
@@ -169,7 +169,7 @@ abstract class AbstractConnectable<I extends Connectable<I>> extends AbstractIde
         }
 
         // create the new terminal and attach it to the voltage level of the given bus and links it to the connectable
-        TerminalExt terminalExt = new TerminalBuilder(((VoltageLevelExt) bus.getVoltageLevel()).getNetworkRef(), this, oldTerminal.getSide())
+        TerminalExt terminalExt = new TerminalBuilder(((VoltageLevelExt) bus.getVoltageLevel()).getNetworkRef(), this, oldTerminal.getSide(), oldTerminal.getTerminalNumber())
                 .setBus(connected ? bus.getId() : null)
                 .setConnectableBus(bus.getId())
                 .build();

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractInjectionAdder.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractInjectionAdder.java
@@ -48,7 +48,7 @@ abstract class AbstractInjectionAdder<T extends AbstractInjectionAdder<T>> exten
     }
 
     protected TerminalExt checkAndGetTerminal() {
-        return new TerminalBuilder(getNetworkRef(), this, null)
+        return new TerminalBuilder(getNetworkRef(), this, null, null)
                 .setNode(node)
                 .setBus(bus)
                 .setConnectableBus(connectableBus)

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTerminal.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractTerminal.java
@@ -28,6 +28,8 @@ abstract class AbstractTerminal implements TerminalExt {
 
     protected final ThreeSides side;
 
+    protected final TerminalNumber terminalNumber;
+
     protected AbstractConnectable connectable;
 
     protected VoltageLevelExt voltageLevel;
@@ -42,8 +44,9 @@ abstract class AbstractTerminal implements TerminalExt {
 
     protected boolean removed = false;
 
-    AbstractTerminal(Ref<? extends VariantManagerHolder> network, ThreeSides side) {
+    AbstractTerminal(Ref<? extends VariantManagerHolder> network, ThreeSides side, TerminalNumber terminalNumber) {
         this.side = side;
+        this.terminalNumber = terminalNumber;
         this.network = network;
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
         p = new TDoubleArrayList(variantArraySize);
@@ -57,6 +60,11 @@ abstract class AbstractTerminal implements TerminalExt {
     @Override
     public ThreeSides getSide() {
         return side;
+    }
+
+    @Override
+    public TerminalNumber getTerminalNumber() {
+        return terminalNumber;
     }
 
     protected String getAttributeSideSuffix() {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTerminal.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusTerminal.java
@@ -10,6 +10,7 @@ package com.powsybl.iidm.network.impl;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.util.trove.TBooleanArrayList;
 import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.TerminalNumber;
 import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.iidm.network.TopologyPoint;
 import com.powsybl.commons.ref.Ref;
@@ -124,8 +125,8 @@ class BusTerminal extends AbstractTerminal {
 
     private final ArrayList<String> connectableBusId;
 
-    BusTerminal(Ref<? extends VariantManagerHolder> network, ThreeSides side, String connectableBusId, boolean connected) {
-        super(network, side);
+    BusTerminal(Ref<? extends VariantManagerHolder> network, ThreeSides side, TerminalNumber terminalNumber, String connectableBusId, boolean connected) {
+        super(network, side, terminalNumber);
         Objects.requireNonNull(connectableBusId);
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
         this.connected = new TBooleanArrayList(variantArraySize);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusbarSectionAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BusbarSectionAdderImpl.java
@@ -47,7 +47,7 @@ class BusbarSectionAdderImpl extends AbstractIdentifiableAdder<BusbarSectionAdde
         if (node == null) {
             throw new ValidationException(this, "node is not set");
         }
-        TerminalExt terminal = new NodeTerminal(voltageLevel.getNetworkRef(), null, node);
+        TerminalExt terminal = new NodeTerminal(voltageLevel.getNetworkRef(), null, null, node);
         BusbarSectionImpl section = new BusbarSectionImpl(voltageLevel.getNetworkRef(), id, getName(), isFictitious());
         section.addTerminal(terminal);
         voltageLevel.getTopologyModel().attach(terminal, false);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcGroundAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcGroundAdderImpl.java
@@ -55,7 +55,7 @@ public class DcGroundAdderImpl extends AbstractIdentifiableAdder<DcGroundAdderIm
         ValidationUtil.checkSameParentNetwork(this.getParentNetwork(), this, dcNode);
         ValidationUtil.checkDoubleParamPositive(this, r, DcGroundImpl.R_ATTRIBUTE);
         DcGroundImpl dcGround = new DcGroundImpl(networkRef, subnetworkRef, id, getName(), isFictitious(), r);
-        DcTerminalImpl dcTerminal = new DcTerminalImpl(networkRef, null, dcNode, connected);
+        DcTerminalImpl dcTerminal = new DcTerminalImpl(networkRef, null, null, dcNode, connected);
         dcGround.addDcTerminal(dcTerminal);
         getNetwork().getIndex().checkAndAdd(dcGround);
         getNetwork().getListeners().notifyCreation(dcGround);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcLineAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcLineAdderImpl.java
@@ -70,8 +70,8 @@ public class DcLineAdderImpl extends AbstractIdentifiableAdder<DcLineAdderImpl> 
         ValidationUtil.checkSameParentNetwork(this.getParentNetwork(), this, dcNode1, dcNode2);
         ValidationUtil.checkDoubleParamPositive(this, this.r, DcLineImpl.R_ATTRIBUTE);
         DcLineImpl dcLine = new DcLineImpl(networkRef, subnetworkRef, id, getName(), isFictitious(), this.r);
-        DcTerminalImpl dcTerminal1 = new DcTerminalImpl(networkRef, TwoSides.ONE, dcNode1, connected1);
-        DcTerminalImpl dcTerminal2 = new DcTerminalImpl(networkRef, TwoSides.TWO, dcNode2, connected2);
+        DcTerminalImpl dcTerminal1 = new DcTerminalImpl(networkRef, TwoSides.ONE, null, dcNode1, connected1);
+        DcTerminalImpl dcTerminal2 = new DcTerminalImpl(networkRef, TwoSides.TWO, null, dcNode2, connected2);
         dcLine.addDcTerminal(dcTerminal1);
         dcLine.addDcTerminal(dcTerminal2);
         getNetwork().getIndex().checkAndAdd(dcLine);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcTerminalImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcTerminalImpl.java
@@ -22,15 +22,17 @@ public class DcTerminalImpl implements DcTerminal, MultiVariantObject {
     private final Ref<? extends VariantManagerHolder> network;
     private DcConnectable<?> dcConnectable;
     private final TwoSides side;
+    private final TerminalNumber terminalNumber;
     private final DcNode dcNode;
     protected final TDoubleArrayList p;
     protected final TDoubleArrayList i;
     private final TBooleanArrayList connected;
     private boolean removed = false;
 
-    DcTerminalImpl(Ref<? extends VariantManagerHolder> network, TwoSides side, DcNode dcNode, boolean connected) {
+    DcTerminalImpl(Ref<? extends VariantManagerHolder> network, TwoSides side, TerminalNumber terminalNumber, DcNode dcNode, boolean connected) {
         this.network = Objects.requireNonNull(network);
         this.side = side;
+        this.terminalNumber = terminalNumber;
         this.dcNode = Objects.requireNonNull(dcNode);
         int variantArraySize = getVariantManagerHolder().getVariantManager().getVariantArraySize();
         this.connected = new TBooleanArrayList(variantArraySize);
@@ -57,6 +59,12 @@ public class DcTerminalImpl implements DcTerminal, MultiVariantObject {
     public TwoSides getSide() {
         ValidationUtil.checkAccessOfRemovedEquipment(dcConnectable.getId(), this.removed);
         return this.side;
+    }
+
+    @Override
+    public TerminalNumber getTerminalNumber() {
+        ValidationUtil.checkAccessOfRemovedEquipment(dcConnectable.getId(), this.removed);
+        return this.terminalNumber;
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeTerminal.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NodeTerminal.java
@@ -8,10 +8,7 @@
 package com.powsybl.iidm.network.impl;
 
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.iidm.network.Terminal;
-import com.powsybl.iidm.network.ThreeSides;
-import com.powsybl.iidm.network.TopologyPoint;
-import com.powsybl.iidm.network.ValidationException;
+import com.powsybl.iidm.network.*;
 import com.powsybl.commons.ref.Ref;
 import com.powsybl.math.graph.TraversalType;
 import gnu.trove.list.array.TDoubleArrayList;
@@ -119,8 +116,8 @@ class NodeTerminal extends AbstractTerminal {
 
     };
 
-    NodeTerminal(Ref<? extends VariantManagerHolder> network, ThreeSides side, int node) {
-        super(network, side);
+    NodeTerminal(Ref<? extends VariantManagerHolder> network, ThreeSides side, TerminalNumber terminalNumber, int node) {
+        super(network, side, terminalNumber);
         this.node = node;
         int variantArraySize = network.get().getVariantManager().getVariantArraySize();
         v = new TDoubleArrayList(variantArraySize);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TerminalBuilder.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TerminalBuilder.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.iidm.network.impl;
 
+import com.powsybl.iidm.network.TerminalNumber;
 import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.commons.ref.Ref;
 import com.powsybl.iidm.network.Validable;
@@ -24,7 +25,9 @@ class TerminalBuilder {
 
     private final Validable validable;
 
-    private ThreeSides side;
+    private final ThreeSides side;
+
+    private final TerminalNumber terminalNumber;
 
     private Integer node;
 
@@ -32,10 +35,11 @@ class TerminalBuilder {
 
     private String connectableBus;
 
-    TerminalBuilder(Ref<? extends VariantManagerHolder> network, Validable validable, ThreeSides side) {
+    TerminalBuilder(Ref<? extends VariantManagerHolder> network, Validable validable, ThreeSides side, TerminalNumber terminalNumber) {
         this.network = Objects.requireNonNull(network);
         this.validable = Objects.requireNonNull(validable);
         this.side = side;
+        this.terminalNumber = terminalNumber;
     }
 
     TerminalBuilder setBus(String bus) {
@@ -65,9 +69,9 @@ class TerminalBuilder {
                 throw new ValidationException(validable, "connectable bus is not set");
             }
 
-            return new BusTerminal(network, side, connectionBus, bus != null);
+            return new BusTerminal(network, side, terminalNumber, connectionBus, bus != null);
         } else {
-            return new NodeTerminal(network, side, node);
+            return new NodeTerminal(network, side, terminalNumber, node);
         }
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ThreeWindingsTransformerAdderImpl.java
@@ -121,7 +121,7 @@ class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder<ThreeW
 
         protected TerminalExt checkAndGetTerminal() {
             VoltageLevelExt voltageLevel = checkAndGetVoltageLevel();
-            return new TerminalBuilder(voltageLevel.getNetworkRef(), this, side)
+            return new TerminalBuilder(voltageLevel.getNetworkRef(), this, side, null)
                 .setNode(node)
                 .setBus(bus)
                 .setConnectableBus(connectableBus)

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageLevelImpl.java
@@ -708,7 +708,7 @@ class VoltageLevelImpl extends AbstractIdentifiable<VoltageLevel> implements Vol
             AbstractConnectable<?> connectable = oldTerminalExt.getConnectable();
 
             // create the new terminal with new type
-            TerminalExt newTerminalExt = new TerminalBuilder(networkRef, this, oldTerminalExt.getSide())
+            TerminalExt newTerminalExt = new TerminalBuilder(networkRef, this, oldTerminalExt.getSide(), oldTerminalExt.getTerminalNumber())
                     .setBus(infos.connected ? infos.connectableBusId() : null)
                     .setConnectableBus(infos.connectableBusId())
                     .build();

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/DcDetailedNetworkTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/DcDetailedNetworkTest.java
@@ -106,8 +106,8 @@ class DcDetailedNetworkTest {
         assertEquals(2, visited.size());
         var lccFr = network.getLineCommutatedConverter("LccFr");
         visited.forEach(t -> assertSame(lccFr, t.getConnectable()));
-        var terminalBySide = visited.stream().collect(Collectors.toMap(Terminal::getSide, Function.identity()));
-        assertSame(lccFr.getTerminal1(), terminalBySide.get(ThreeSides.ONE));
-        assertSame(lccFr.getTerminal2().orElseThrow(), terminalBySide.get(ThreeSides.TWO));
+        var terminalBySide = visited.stream().collect(Collectors.toMap(Terminal::getTerminalNumber, Function.identity()));
+        assertSame(lccFr.getTerminal1(), terminalBySide.get(TerminalNumber.ONE));
+        assertSame(lccFr.getTerminal2().orElseThrow(), terminalBySide.get(TerminalNumber.TWO));
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
@@ -233,23 +233,23 @@ public abstract class AbstractAcDcConverterTest {
     private void checkBaseCommonLccVsc() {
         assertEquals("converterA", acDcConverterA.getId());
 
-        assertSame(TwoSides.ONE, acDcConverterA.getDcTerminal1().getSide());
-        assertSame(TwoSides.TWO, acDcConverterA.getDcTerminal2().getSide());
-        assertSame(TwoSides.ONE, acDcConverterA.getSide(acDcConverterA.getDcTerminal1()));
-        assertSame(TwoSides.TWO, acDcConverterA.getSide(acDcConverterA.getDcTerminal2()));
-        assertSame(acDcConverterA.getDcTerminal1(), acDcConverterA.getDcTerminal(TwoSides.ONE));
-        assertSame(acDcConverterA.getDcTerminal2(), acDcConverterA.getDcTerminal(TwoSides.TWO));
+        assertSame(TerminalNumber.ONE, acDcConverterA.getDcTerminal1().getTerminalNumber());
+        assertSame(TerminalNumber.TWO, acDcConverterA.getDcTerminal2().getTerminalNumber());
+        assertSame(TerminalNumber.ONE, acDcConverterA.getTerminalNumber(acDcConverterA.getDcTerminal1()));
+        assertSame(TerminalNumber.TWO, acDcConverterA.getTerminalNumber(acDcConverterA.getDcTerminal2()));
+        assertSame(acDcConverterA.getDcTerminal1(), acDcConverterA.getDcTerminal(TerminalNumber.ONE));
+        assertSame(acDcConverterA.getDcTerminal2(), acDcConverterA.getDcTerminal(TerminalNumber.TWO));
 
-        assertSame(ThreeSides.ONE, acDcConverterA.getTerminal1().getSide());
-        assertSame(ThreeSides.TWO, acDcConverterA.getTerminal2().orElseThrow().getSide());
-        assertSame(TwoSides.ONE, acDcConverterA.getSide(acDcConverterA.getTerminal1()));
-        assertSame(TwoSides.TWO, acDcConverterA.getSide(acDcConverterA.getTerminal2().orElseThrow()));
-        assertSame(acDcConverterA.getTerminal1(), acDcConverterA.getTerminal(TwoSides.ONE));
-        assertSame(acDcConverterA.getTerminal2().orElseThrow(), acDcConverterA.getTerminal(TwoSides.TWO));
-        assertSame(ThreeSides.ONE, Terminal.getConnectableSide(acDcConverterA.getTerminal1()).orElseThrow());
-        assertSame(ThreeSides.TWO, Terminal.getConnectableSide(acDcConverterA.getTerminal2().orElseThrow()).orElseThrow());
-        assertSame(acDcConverterA.getTerminal1(), Terminal.getTerminal(acDcConverterA, ThreeSides.ONE));
-        assertSame(acDcConverterA.getTerminal2().orElseThrow(), Terminal.getTerminal(acDcConverterA, ThreeSides.TWO));
+        assertSame(TerminalNumber.ONE, acDcConverterA.getTerminal1().getTerminalNumber());
+        assertSame(TerminalNumber.TWO, acDcConverterA.getTerminal2().orElseThrow().getTerminalNumber());
+        assertSame(TerminalNumber.ONE, acDcConverterA.getTerminalNumber(acDcConverterA.getTerminal1()));
+        assertSame(TerminalNumber.TWO, acDcConverterA.getTerminalNumber(acDcConverterA.getTerminal2().orElseThrow()));
+        assertSame(acDcConverterA.getTerminal1(), acDcConverterA.getTerminal(TerminalNumber.ONE));
+        assertSame(acDcConverterA.getTerminal2().orElseThrow(), acDcConverterA.getTerminal(TerminalNumber.TWO));
+        assertSame(TerminalNumber.ONE, Terminal.getConnectableTerminalNumber(acDcConverterA.getTerminal1()).orElseThrow());
+        assertSame(TerminalNumber.TWO, Terminal.getConnectableTerminalNumber(acDcConverterA.getTerminal2().orElseThrow()).orElseThrow());
+        assertSame(acDcConverterA.getTerminal1(), Terminal.getTerminal(acDcConverterA, TerminalNumber.ONE));
+        assertSame(acDcConverterA.getTerminal2().orElseThrow(), Terminal.getTerminal(acDcConverterA, TerminalNumber.TWO));
 
         assertSame(b1a, acDcConverterA.getTerminal1().getBusBreakerView().getBus());
         assertTrue(acDcConverterA.getTerminal2().isPresent());
@@ -780,7 +780,7 @@ public abstract class AbstractAcDcConverterTest {
                 .add();
         assertTrue(acDcConverterA.getTerminal2().isEmpty());
         assertSame(acDcConverterA.getPccTerminal(), acDcConverterA.getTerminal1());
-        IllegalStateException e = assertThrows(IllegalStateException.class, () -> acDcConverterA.getTerminal(TwoSides.TWO));
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> acDcConverterA.getTerminal(TerminalNumber.TWO));
         assertEquals("This AC/DC converter does not have a second AC Terminal", e.getMessage());
     }
 

--- a/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/resultscompletion/z0flows/Z0FlowFromBusBalance.java
+++ b/loadflow/loadflow-results-completion/src/main/java/com/powsybl/loadflow/resultscompletion/z0flows/Z0FlowFromBusBalance.java
@@ -147,8 +147,8 @@ public class Z0FlowFromBusBalance implements TopologyVisitor {
     }
 
     @Override
-    public void visitAcDcConverter(AcDcConverter<?> converter, TwoSides side) {
-        addFlow(converter.getTerminal(side));
+    public void visitAcDcConverter(AcDcConverter<?> converter, TerminalNumber terminalNumber) {
+        addFlow(converter.getTerminal(terminalNumber));
     }
 
     private final Bus bus;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Between bugfix and feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Relates to the DC detailed model introduced as beta feature in iIDM v1.14 June 2025 release (#3439).

There were criticisms about usage of Side.ONE and Side.TWO for the AC/DC Converters terminals, because these aren't really sides as e.g. the sides of a line or a transformer.


**What is the new behavior (if this is a feature change)?**
A new enum TerminalNumber is introduced specifically for AC/DC converters, and is used for both the AC and the DC terminals of the AC/DC converter.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

TODO

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
