### PR TITLE
Fix typos "can not" -> "cannot"

### DIFF
--- a/action-api/src/main/java/com/powsybl/action/PhaseTapChangerRegulationAction.java
+++ b/action-api/src/main/java/com/powsybl/action/PhaseTapChangerRegulationAction.java
@@ -31,7 +31,7 @@ public class PhaseTapChangerRegulationAction extends AbstractTapChangerRegulatio
         this.regulationMode = regulationMode;
         this.regulationValue = regulationValue;
         if (!regulating && this.regulationMode != null) {
-            throw new IllegalArgumentException("PhaseTapChangerRegulationAction can not have a regulation mode " +
+            throw new IllegalArgumentException("PhaseTapChangerRegulationAction cannot have a regulation mode " +
                     "if it is not regulating");
         }
     }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -98,7 +98,7 @@ public class CgmesImport implements Importer {
                 .map(dir -> dir.resolve(FORMAT).resolve("boundary"))
                 .map(Path::toString)
                 .orElse(null);
-        // Boundary location parameter can not be static
+        // Boundary location parameter cannot be static
         // because we want its default value
         // to depend on the received platformConfig
         boundaryLocationParameter = new Parameter(

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForStaticVarCompensators.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RegulatingControlMappingForStaticVarCompensators.java
@@ -92,7 +92,7 @@ public class RegulatingControlMappingForStaticVarCompensators {
 
     private boolean setRegulatingControl(CgmesRegulatingControlForStaticVarCompensator rc, RegulatingControl control, StaticVarCompensator svc) {
         // Always save the original RC id,
-        // even if we can not complete setting all the regulation data
+        // even if we cannot complete setting all the regulation data
         svc.setProperty(Conversion.PROPERTY_REGULATING_CONTROL, rc.regulatingControlId);
 
         // Take default terminal if it has not been defined in CGMES files (it is never null)

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/BusbarSectionConversion.java
@@ -54,7 +54,7 @@ public class BusbarSectionConversion extends AbstractConductingEquipmentConversi
 
     private void addBusbarSectionTerminalToBus() {
         // Some isolated busbar sections may not have a topological node.
-        // This means that we can not determine the voltage level of the busbar section in bus/branch model,
+        // This means that we cannot determine the voltage level of the busbar section in bus/branch model,
         // So we need to check if the voltage level is present before trying to access the bus
         // voltageLevel() assumes voltage level is present, throws an exception if not available
         // voltageLevel(1) returns the optional voltage level of the first terminal

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/NodeConversion.java
@@ -168,7 +168,7 @@ public class NodeConversion extends AbstractIdentifiedObjectConversion {
             String containerId = p.getId(CgmesNames.CONNECTIVITY_NODE_CONTAINER);
             String cgmesId = context.cgmes().container(containerId).voltageLevel();
             if (cgmesId == null) {
-                // A CGMES Voltage Level can not be obtained from the connectivity node container
+                // A CGMES Voltage Level cannot be obtained from the connectivity node container
                 // The connectivity node container is a cim:Line, and
                 // the conversion has created a fictitious voltage level in IIDM
                 cgmesId = context.nodeContainerMapping().getFictitiousVoltageLevelForContainer(containerId, this.id);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java
@@ -281,7 +281,7 @@ public class CgmesExportContext {
                 substation.setProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + REGION_NAME, regionName);
             } else {
                 // Only add with this name if the id is not already mapped
-                // We can not have the same id mapped to two different names
+                // We cannot have the same id mapped to two different names
                 String regionId = namingStrategy.getCgmesIdFromProperty(substation, Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + REGION_ID);
                 regionName = substation.getProperty(Conversion.CGMES_PREFIX_ALIAS_PROPERTIES + REGION_NAME);
                 if (!regionsIdsByRegionName.containsValue(regionId)) {
@@ -556,7 +556,7 @@ public class CgmesExportContext {
         for (TwoWindingsTransformer twt : network.getTwoWindingsTransformers()) {
             addIidmTransformerEnd(twt, 1);
             addIidmTransformerEnd(twt, 2);
-            //  For two winding transformers we can not check-and-add based on endNumber
+            //  For two winding transformers we cannot check-and-add based on endNumber
             //  The resulting IIDM tap changer is always at end1
             //  But the original position of tap changer could be 1 or 2
             addIidmTapChanger2wt(twt, twt.getPhaseTapChanger(), CgmesNames.PHASE_TAP_CHANGER);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/StateVariablesExport.java
@@ -257,7 +257,7 @@ public final class StateVariablesExport {
             // Instead of checking switch flows, we check that the corresponding bus view bus is balanced
             Optional<Bus> optionalBusViewBus = BusTools.getBusViewBus(bus);
             if (optionalBusViewBus.isEmpty()) {
-                LOG.error("Can not check if bus is in accordance with Kirchhoff's first law. No BusView bus can be found for: {}", bus);
+                LOG.error("Cannot check if bus is in accordance with Kirchhoff's first law. No BusView bus can be found for: {}", bus);
                 return false;
             }
             Bus busViewBus = optionalBusViewBus.get();

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TopologyTester.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TopologyTester.java
@@ -35,7 +35,7 @@ class TopologyTester {
     // When we create the voltage-level connectivity at node-breaker level we will
     // be able to
     // set the retained flag for each switch and this problem will be avoided
-    // For connectivity created at bus-breaker level we can not set the "retained"
+    // For connectivity created at bus-breaker level we cannot set the "retained"
     // flag
     boolean test(boolean strict) {
         // Only makes sense if the network has been obtained

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesTopologyKindTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesTopologyKindTest.java
@@ -64,7 +64,7 @@ class CgmesTopologyKindTest extends AbstractSerDeTest {
         assertEquals(1, network.getBusView().getConnectedComponents().size());
 
         // Even if we close all switches in the re-imported network we will have two connected components
-        // In the exported network we can not get all equipment in a single connected component
+        // In the exported network we cannot get all equipment in a single connected component
         network1.getSwitchStream().forEach(sw -> sw.setOpen(false));
         assertEquals(2, network1.getBusView().getConnectedComponents().size());
         // If we force the reconnection of the line we have 3 connected components

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/issues/ExportNumberMaxValueTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/issues/ExportNumberMaxValueTest.java
@@ -65,7 +65,7 @@ class ExportNumberMaxValueTest extends AbstractSerDeTest {
         double value = Double.parseDouble(tatl60Value.group(1));
 
         // Check that we have read a very big number,
-        // we can not compare exactly with Float.MAX_VALUE because it has not been written with enough precision
+        // we cannot compare exactly with Float.MAX_VALUE because it has not been written with enough precision
         assertTrue(value > Float.MAX_VALUE / 10);
         // And check that we have not written Double.MAX_VALUE
         assertTrue(value < Double.MAX_VALUE / 10);

--- a/computation/src/main/java/com/powsybl/computation/ComputationExceptionBuilder.java
+++ b/computation/src/main/java/com/powsybl/computation/ComputationExceptionBuilder.java
@@ -127,7 +127,7 @@ public class ComputationExceptionBuilder {
             byte[] bytes = Files.readAllBytes(path);
             bytesByFileName.put(path.getFileName().toString(), bytes);
         } catch (IOException e) {
-            LOGGER.warn("Can not read zip file '{}'", path);
+            LOGGER.warn("Cannot read zip file '{}'", path);
         }
         return this;
     }
@@ -155,7 +155,7 @@ public class ComputationExceptionBuilder {
             byte[] bytes = Files.readAllBytes(path);
             map.put(path.getFileName().toString(), new String(bytes, StandardCharsets.UTF_8));
         } catch (IOException e) {
-            LOGGER.warn("Can not read log file '{}'", path);
+            LOGGER.warn("Cannot read log file '{}'", path);
         }
         return this;
     }

--- a/computation/src/main/java/com/powsybl/computation/ThreadInterruptedCompletableFuture.java
+++ b/computation/src/main/java/com/powsybl/computation/ThreadInterruptedCompletableFuture.java
@@ -29,7 +29,7 @@ public class ThreadInterruptedCompletableFuture<R> extends CompletableFuture<R> 
         cancel = true;
 
         if (this.isDone() || this.isCompletedExceptionally()) {
-            LOGGER.warn("Can not be canceled because the caller future isDone or isCompletedExceptionally");
+            LOGGER.warn("Cannot be canceled because the caller future isDone or isCompletedExceptionally");
             return false;
         }
 

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingencyElementFactory.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/ContingencyElementFactory.java
@@ -47,6 +47,6 @@ public final class ContingencyElementFactory {
             .filter(entry -> entry.getKey().isInstance(identifiable))
             .findFirst()
             .map(entry -> entry.getValue().apply(identifiable))
-            .orElseThrow(() -> new PowsyblException(identifiable.getId() + " can not be a ContingencyElement"));
+            .orElseThrow(() -> new PowsyblException(identifiable.getId() + " cannot be a ContingencyElement"));
     }
 }

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/CriterionContingencyListTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/CriterionContingencyListTest.java
@@ -285,7 +285,7 @@ class CriterionContingencyListTest {
                 null, Collections.singletonList(propertyCriterion), null);
         var cl = contingencyList;
         Exception e = assertThrows(IllegalArgumentException.class, () -> cl.getContingencies(network));
-        assertTrue(e.getMessage().contains("enum to check side can not be null for threeWindingsTransformer to check their voltage level"));
+        assertTrue(e.getMessage().contains("enum to check side cannot be null for threeWindingsTransformer to check their voltage level"));
 
         assertThreeWindingsTransformerContingencies(false, network, "value0", PropertyCriterion.SideToCheck.ONE);
         assertThreeWindingsTransformerContingencies(true, network, "value1", PropertyCriterion.SideToCheck.ONE);

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/identifiers/json/IdentifierDeserializer.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/identifiers/json/IdentifierDeserializer.java
@@ -77,7 +77,7 @@ public class IdentifierDeserializer extends StdDeserializer<NetworkElementIdenti
             }
         }
         if (type == null) {
-            throw new IllegalArgumentException("type of identifier can not be null");
+            throw new IllegalArgumentException("type of identifier cannot be null");
         }
         return switch (type) {
             case ID_BASED -> new IdBasedNetworkElementIdentifier(identifier, contingencyId);

--- a/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/PropertyCriterion.java
+++ b/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/PropertyCriterion.java
@@ -98,7 +98,7 @@ public class PropertyCriterion implements Criterion {
         VoltageLevel voltageLevel2 = threeWindingsTransformer.getLeg2().getTerminal().getVoltageLevel();
         VoltageLevel voltageLevel3 = threeWindingsTransformer.getLeg3().getTerminal().getVoltageLevel();
         if (sideToCheck == null) {
-            throw new IllegalArgumentException("enum to check side can not be null for threeWindingsTransformer to check their voltage level");
+            throw new IllegalArgumentException("enum to check side cannot be null for threeWindingsTransformer to check their voltage level");
         }
         return switch (sideToCheck) {
             case ONE ->

--- a/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/json/CriterionDeserializer.java
+++ b/iidm/iidm-criteria/src/main/java/com/powsybl/iidm/criteria/json/CriterionDeserializer.java
@@ -92,7 +92,7 @@ public class CriterionDeserializer extends StdDeserializer<Criterion> {
             }
         }
         if (type == null) {
-            throw new IllegalArgumentException("type of criterion can not be null");
+            throw new IllegalArgumentException("type of criterion cannot be null");
         }
         return switch (type) {
             case PROPERTY -> new PropertyCriterion(propertyKey, propertyValues, equipmentToCheck, sideToCheck);

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/DiscreteMeasurement.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/DiscreteMeasurement.java
@@ -113,7 +113,7 @@ public interface DiscreteMeasurement {
 
     /**
      * Set the discrete measured value and set the value type as STRING (see {@link ValueType}).
-     * Can not be null if the measurement is valid.
+     * Cannot be null if the measurement is valid.
      */
     DiscreteMeasurement setValue(String value);
 
@@ -129,13 +129,13 @@ public interface DiscreteMeasurement {
 
     /**
      * Get validity status of the measurement.
-     * If it is true (i.e. the measurement is valid), the discrete measured value can not be null.
+     * If it is true (i.e. the measurement is valid), the discrete measured value cannot be null.
      */
     boolean isValid();
 
     /**
      * Set validity status of the measurement.
-     * If it is true (i.e. the measurement is valid), the discrete measured value can not be null.
+     * If it is true (i.e. the measurement is valid), the discrete measured value cannot be null.
      */
     DiscreteMeasurement setValid(boolean valid);
 

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/Measurement.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/Measurement.java
@@ -65,7 +65,7 @@ public interface Measurement {
 
     /**
      * Set measurement value.
-     * Can not be NaN if the measurement is valid.
+     * Cannot be NaN if the measurement is valid.
      */
     Measurement setValue(double value);
 
@@ -86,13 +86,13 @@ public interface Measurement {
 
     /**
      * Get validity status of the measurement.
-     * If it is true (i.e. the measurement is valid), the measured value can not be NaN.
+     * If it is true (i.e. the measurement is valid), the measured value cannot be NaN.
      */
     boolean isValid();
 
     /**
      * Set validity status of the measurement.
-     * If it is true (i.e. the measurement is valid), the measured value can not be NaN.
+     * If it is true (i.e. the measurement is valid), the measured value cannot be NaN.
      */
     Measurement setValid(boolean valid);
 

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/util/DiscreteMeasurementValidationUtil.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/util/DiscreteMeasurementValidationUtil.java
@@ -78,7 +78,7 @@ public final class DiscreteMeasurementValidationUtil {
 
     public static void checkValue(Object value, boolean valid) {
         if (value == null && valid) {
-            throw new PowsyblException("A valid discrete measurement can not have an undefined value");
+            throw new PowsyblException("A valid discrete measurement cannot have an undefined value");
         }
     }
 

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/util/MeasurementValidationUtil.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/util/MeasurementValidationUtil.java
@@ -45,7 +45,7 @@ public final class MeasurementValidationUtil {
 
     public static void checkValue(double value, boolean valid) {
         if (Double.isNaN(value) && valid) {
-            throw new PowsyblException("Valid measurement can not have an undefined value");
+            throw new PowsyblException("Valid measurement cannot have an undefined value");
         }
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/MeasurementAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/MeasurementAdderImpl.java
@@ -91,7 +91,7 @@ class MeasurementAdderImpl implements MeasurementAdder {
     public Measurement add() {
         id = checkId(id, idUnicity, measurements);
         if (type == null) {
-            throw new PowsyblException("Measurement type can not be null");
+            throw new PowsyblException("Measurement type cannot be null");
         }
         checkValue(value, valid);
         checkSide(type, side, measurements.getExtendable());

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/Replace3TwoWindingsTransformersByThreeWindingsTransformers.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/Replace3TwoWindingsTransformersByThreeWindingsTransformers.java
@@ -56,7 +56,7 @@ import static com.powsybl.iidm.modification.util.TransformerUtils.*;
  *     <li>Extensions:
  *         <ul>
  *             <li>Only IIDM extensions are copied: TransformerFortescueData, PhaseAngleClock, and TransformerToBeEstimated.</li>
- *             <li>CGMES extensions can not be copied, as they cause circular dependencies.</li>
+ *             <li>CGMES extensions cannot be copied, as they cause circular dependencies.</li>
  *             <li>Extensions that are not copied are recorded in the functional log.</li>
  *         </ul>
  *     </li>

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ReplaceThreeWindingsTransformersBy3TwoWindingsTransformers.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/ReplaceThreeWindingsTransformersBy3TwoWindingsTransformers.java
@@ -54,7 +54,7 @@ import static com.powsybl.iidm.modification.util.TransformerUtils.copyAndAddPhas
  *     <li>Extensions:
  *         <ul>
  *             <li>Only IIDM extensions are copied: TransformerFortescueData, PhaseAngleClock, and TransformerToBeEstimated.</li>
- *             <li>CGMES extensions can not be copied, as they cause circular dependencies.</li>
+ *             <li>CGMES extensions cannot be copied, as they cause circular dependencies.</li>
  *             <li>Extensions that are not copied are recorded in the functional log.</li>
  *         </ul>
  *     </li>

--- a/psse/psse-converter/src/main/java/com/powsybl/psse/converter/AbstractConverter.java
+++ b/psse/psse-converter/src/main/java/com/powsybl/psse/converter/AbstractConverter.java
@@ -163,7 +163,7 @@ public abstract class AbstractConverter {
         return "T-" + busI + "-" + busJ + "-" + busK + "-" + ckt;
     }
 
-    // we can not use rectifierIp and inverterIp as it is managed with only one end in substationData
+    // we cannot use rectifierIp and inverterIp as it is managed with only one end in substationData
     // In Psse each two-terminal dc line must have a unique name (up to 12 characters)
     static String getTwoTerminalDcId(String name) {
         return TWO_TERMINAL_DC_TAG + name;

--- a/psse/psse-model/src/main/java/com/powsybl/psse/model/PsseVersioned.java
+++ b/psse/psse-model/src/main/java/com/powsybl/psse/model/PsseVersioned.java
@@ -30,7 +30,7 @@ public class PsseVersioned {
 
     public void checkVersion(String fieldName) {
         // If we do not have a reference back to a model
-        // We can not obtain current version and we can not perform checks
+        // We cannot obtain current version and we cannot perform checks
         if (model == null) {
             return;
         }

--- a/psse/psse-model/src/main/java/com/powsybl/psse/model/io/RecordGroupIOJson.java
+++ b/psse/psse-model/src/main/java/com/powsybl/psse/model/io/RecordGroupIOJson.java
@@ -67,12 +67,12 @@ public class RecordGroupIOJson<T> implements RecordGroupIO<T> {
 
     @Override
     public T readHead(LegacyTextReader reader, Context context) throws IOException {
-        throw new PsseException("Generic record group can not be read as head record");
+        throw new PsseException("Generic record group cannot be read as head record");
     }
 
     @Override
     public void writeHead(T psseObject, Context context, OutputStream outputStream) {
-        throw new PsseException("Generic record group can not be written as head record");
+        throw new PsseException("Generic record group cannot be written as head record");
     }
 
     private JsonNode readJsonNode(JsonParser parser) throws IOException {

--- a/psse/psse-model/src/main/java/com/powsybl/psse/model/io/RecordGroupIOLegacyText.java
+++ b/psse/psse-model/src/main/java/com/powsybl/psse/model/io/RecordGroupIOLegacyText.java
@@ -56,12 +56,12 @@ public class RecordGroupIOLegacyText<T> implements RecordGroupIO<T> {
 
     @Override
     public T readHead(LegacyTextReader reader, Context context) throws IOException {
-        throw new PsseException("Generic record group can not be read as head record");
+        throw new PsseException("Generic record group cannot be read as head record");
     }
 
     @Override
     public void writeHead(T psseObject, Context context, OutputStream outputStream) {
-        throw new PsseException("Generic record group can not be written as head record");
+        throw new PsseException("Generic record group cannot be written as head record");
     }
 
     protected void write(List<T> objects, String[] headers, String[] quotedFields, Context context, OutputStream outputStream) {

--- a/psse/psse-model/src/main/java/com/powsybl/psse/model/pf/io/CaseIdentificationData.java
+++ b/psse/psse-model/src/main/java/com/powsybl/psse/model/pf/io/CaseIdentificationData.java
@@ -84,12 +84,12 @@ class CaseIdentificationData extends AbstractRecordGroup<PsseCaseIdentification>
 
         @Override
         public List<PsseCaseIdentification> read(LegacyTextReader reader, Context context) throws IOException {
-            throw new PsseException("Case Identification can not be read as a record group, it was be read as head record");
+            throw new PsseException("Case Identification cannot be read as a record group, it was be read as head record");
         }
 
         @Override
         public void write(List<PsseCaseIdentification> psseObjects, Context context, OutputStream outputStream) {
-            throw new PsseException("Case Identification can not be written as a record group, it was be written as head record");
+            throw new PsseException("Case Identification cannot be written as a record group, it was be written as head record");
         }
     }
 

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/PhaseTapChangerRegulationActionTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/PhaseTapChangerRegulationActionTest.java
@@ -22,7 +22,7 @@ class PhaseTapChangerRegulationActionTest {
     void test() {
         String message = assertThrows(IllegalArgumentException.class, () -> new PhaseTapChangerRegulationAction("id17", "transformerId5", ThreeSides.ONE,
                 false, PhaseTapChanger.RegulationMode.ACTIVE_POWER_CONTROL, 10.0)).getMessage();
-        assertEquals("PhaseTapChangerRegulationAction can not have a regulation mode " +
+        assertEquals("PhaseTapChangerRegulationAction cannot have a regulation mode " +
                 "if it is not regulating", message);
         PhaseTapChangerRegulationAction action = PhaseTapChangerRegulationAction.deactivateRegulation("id17", "transformerId5",
                 ThreeSides.ONE);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
There was a recurring typo throughout the repository, with 'can not' being written instead of 'cannot'. This was fixed.


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
