### PR TITLE
Ensure unicity on new busbarSection id for CreateVoltageLevelSections

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateVoltageLevelSections.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/CreateVoltageLevelSections.java
@@ -350,6 +350,7 @@ public class CreateVoltageLevelSections extends AbstractNetworkModification {
             .setId(namingStrategy.getBusbarId(busbarSectionPrefixId, busbarNum, sectionNum))
             .setName(Integer.toString(busbarSectionNode))
             .setNode(busbarSectionNode)
+            .setEnsureIdUnicity(true)
             .add();
         busbarSection.newExtension(BusbarSectionPositionAdder.class)
             .withBusbarIndex(busbarNum)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
fix



**What is the current behavior?**
when creating a new busbar with CreateVoltageLevelSections the unicty of the id is not ensured and it can crash when adding the bar after a existing bar



**What is the new behavior (if this is a feature change)?**
ensure unicity on the new id bar created


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No