### PR TITLE
Implementation de https://github.com/powsybl/powsybl-core/issues/3427

### DIFF
--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractOptions.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractOptions.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.iidm.serde;
 
+import com.google.common.collect.Sets;
 import com.powsybl.commons.io.TreeDataFormat;
 
 import java.util.Objects;
@@ -19,15 +20,27 @@ import java.util.Set;
 public abstract class AbstractOptions<T> {
 
     protected Set<String> extensions;
+    /**
+     * Extensions to be loaded must be in the extensions set but must not belong to the filteredExtension Set
+     */
+    protected Set<String> filteredExtension = Sets.newHashSet();
 
     protected TreeDataFormat format = TreeDataFormat.XML;
 
     public abstract T setExtensions(Set<String> extensions);
 
+    public abstract T setFilteredExtensions(Set<String> extensions);
+
     public abstract T addExtension(String extension);
+
+    public abstract T addFilteredExtension(String extensionToBeFiltered);
 
     public Optional<Set<String>> getExtensions() {
         return Optional.ofNullable(extensions);
+    }
+
+    public Optional<Set<String>> getFilteredExtensions() {
+        return Optional.ofNullable(filteredExtension);
     }
 
     public boolean withNoExtension() {
@@ -54,6 +67,10 @@ public abstract class AbstractOptions<T> {
         return withAllExtensions() || extensions.contains(extensionName);
     }
 
+    public boolean withFilteredExtension(String extensionName) {
+        return filteredExtension != null && filteredExtension.contains(extensionName);
+    }
+
     public abstract boolean isThrowExceptionIfExtensionNotFound();
 
     public TreeDataFormat getFormat() {
@@ -64,4 +81,5 @@ public abstract class AbstractOptions<T> {
         this.format = Objects.requireNonNull(format);
         return (T) this;
     }
+
 }

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTreeDataExporter.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTreeDataExporter.java
@@ -111,6 +111,7 @@ public abstract class AbstractTreeDataExporter implements Exporter {
     public static final String TOPOLOGY_LEVEL = "iidm.export.xml.topology-level";
     public static final String THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND = "iidm.export.xml.throw-exception-if-extension-not-found";
     public static final String EXTENSIONS_LIST = "iidm.export.xml.extensions";
+    public static final String EXTENSIONS_FILTERED_LIST = "iidm.export.xml.filtered-extensions";
     public static final String SORTED = "iidm.export.xml.sorted";
     public static final String VERSION = "iidm.export.xml.version";
     public static final String WITH_AUTOMATION_SYSTEMS = "iidm.export.xml.with-automation-systems";
@@ -126,6 +127,9 @@ public abstract class AbstractTreeDataExporter implements Exporter {
             Arrays.stream(TopologyLevel.values()).map(Enum::name).collect(Collectors.toList()));
     private static final Parameter THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER = new Parameter(THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND, ParameterType.BOOLEAN, "Throw exception if extension not found", Boolean.FALSE);
     private static final Parameter EXTENSIONS_LIST_PARAMETER = new Parameter(EXTENSIONS_LIST, ParameterType.STRING_LIST,
+            "The list of extensions that will be ignored during export", null,
+            EXTENSIONS_SUPPLIER.get().getProviders().stream().map(ExtensionProvider::getExtensionName).collect(Collectors.toList()));
+    private static final Parameter EXTENSIONS_FILTERED_LIST_PARAMETER = new Parameter(EXTENSIONS_FILTERED_LIST, ParameterType.STRING_LIST,
             "The list of exported extensions", null,
             EXTENSIONS_SUPPLIER.get().getProviders().stream().map(ExtensionProvider::getExtensionName).collect(Collectors.toList()));
     private static final Parameter SORTED_PARAMETER = new Parameter(SORTED, ParameterType.BOOLEAN, "Sort export output file", Boolean.FALSE);
@@ -136,7 +140,7 @@ public abstract class AbstractTreeDataExporter implements Exporter {
     private static final List<Parameter> STATIC_PARAMETERS = List.of(INDENT_PARAMETER, WITH_BRANCH_STATE_VARIABLES_PARAMETER,
             ONLY_MAIN_CC_PARAMETER, ANONYMISED_PARAMETER, IIDM_VERSION_INCOMPATIBILITY_BEHAVIOR_PARAMETER,
             TOPOLOGY_LEVEL_PARAMETER, THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER, EXTENSIONS_LIST_PARAMETER,
-            SORTED_PARAMETER, VERSION_PARAMETER, WITH_AUTOMATION_SYSTEMS_PARAMETER);
+            EXTENSIONS_FILTERED_LIST_PARAMETER, SORTED_PARAMETER, VERSION_PARAMETER, WITH_AUTOMATION_SYSTEMS_PARAMETER);
 
     private final ParameterDefaultValueConfig defaultValueConfig;
 
@@ -195,6 +199,7 @@ public abstract class AbstractTreeDataExporter implements Exporter {
                 .setTopologyLevel(TopologyLevel.valueOf(Parameter.readString(getFormat(), parameters, TOPOLOGY_LEVEL_PARAMETER, defaultValueConfig)))
                 .setThrowExceptionIfExtensionNotFound(Parameter.readBoolean(getFormat(), parameters, THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER, defaultValueConfig))
                 .setExtensions(Parameter.readStringList(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig) != null ? new HashSet<>(Parameter.readStringList(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig)) : null)
+                .setFilteredExtensions(Parameter.readStringList(getFormat(), parameters, EXTENSIONS_FILTERED_LIST_PARAMETER, defaultValueConfig) != null ? new HashSet<>(Parameter.readStringList(getFormat(), parameters, EXTENSIONS_FILTERED_LIST_PARAMETER, defaultValueConfig)) : null)
                 .setSorted(Parameter.readBoolean(getFormat(), parameters, SORTED_PARAMETER, defaultValueConfig))
                 .setVersion(Parameter.readString(getFormat(), parameters, VERSION_PARAMETER, defaultValueConfig))
                 .setFormat(getTreeDataFormat())

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTreeDataImporter.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTreeDataImporter.java
@@ -49,6 +49,8 @@ public abstract class AbstractTreeDataImporter implements Importer {
 
     public static final String EXTENSIONS_LIST = "iidm.import.xml.extensions";
 
+    public static final String EXTENSIONS_FILTERED_LIST = "iidm.import.xml.filtered-extensions";
+
     public static final String WITH_AUTOMATION_SYSTEMS = "iidm.import.xml.with-automation-systems";
 
     public static final String MISSING_PERMANENT_LIMIT_PERCENTAGE = "iidm.import.xml.missing-permanent-limit-percentage";
@@ -61,6 +63,10 @@ public abstract class AbstractTreeDataImporter implements Importer {
 
     private static final Parameter EXTENSIONS_LIST_PARAMETER
             = new Parameter(EXTENSIONS_LIST, ParameterType.STRING_LIST, "The list of extension files ", null,
+            EXTENSIONS_SUPPLIER.get().getProviders().stream().map(ExtensionProvider::getExtensionName).collect(Collectors.toList()));
+
+    private static final Parameter EXTENSIONS_FILTERED_LIST_PARAMETER
+            = new Parameter(EXTENSIONS_FILTERED_LIST, ParameterType.STRING_LIST, "The list of extension files that will be ignored and not imported ", null,
             EXTENSIONS_SUPPLIER.get().getProviders().stream().map(ExtensionProvider::getExtensionName).collect(Collectors.toList()));
 
     private static final Parameter WITH_AUTOMATION_SYSTEMS_PARAMETER = new Parameter(WITH_AUTOMATION_SYSTEMS, ParameterType.BOOLEAN,
@@ -89,6 +95,7 @@ public abstract class AbstractTreeDataImporter implements Importer {
     @Override
     public List<Parameter> getParameters() {
         List<Parameter> parameters = List.of(THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER, EXTENSIONS_LIST_PARAMETER,
+                EXTENSIONS_FILTERED_LIST_PARAMETER,
                 WITH_AUTOMATION_SYSTEMS_PARAMETER, MISSING_PERMANENT_LIMIT_PERCENTAGE_PARAMETER,
                 MINIMAL_VALIDATION_LEVEL_PARAMETER);
         return ConfiguredParameter.load(parameters, getFormat(), defaultValueConfig);
@@ -175,6 +182,7 @@ public abstract class AbstractTreeDataImporter implements Importer {
         return new ImportOptions()
                 .setThrowExceptionIfExtensionNotFound(Parameter.readBoolean(getFormat(), parameters, THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER, defaultValueConfig))
                 .setExtensions(Parameter.readStringList(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig) != null ? new HashSet<>(Parameter.readStringList(getFormat(), parameters, EXTENSIONS_LIST_PARAMETER, defaultValueConfig)) : null)
+                .setFilteredExtensions(Parameter.readStringList(getFormat(), parameters, EXTENSIONS_FILTERED_LIST_PARAMETER, defaultValueConfig) != null ? new HashSet<>(Parameter.readStringList(getFormat(), parameters, EXTENSIONS_FILTERED_LIST_PARAMETER, defaultValueConfig)) : null)
                 .setWithAutomationSystems(Parameter.readBoolean(getFormat(), parameters, WITH_AUTOMATION_SYSTEMS_PARAMETER, defaultValueConfig))
                 .setMissingPermanentLimitPercentage(Parameter.readDouble(getFormat(), parameters, MISSING_PERMANENT_LIMIT_PERCENTAGE_PARAMETER, defaultValueConfig))
                 .setMinimalValidationLevel(Parameter.readString(getFormat(), parameters, MINIMAL_VALIDATION_LEVEL_PARAMETER, defaultValueConfig));

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ExportOptions.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ExportOptions.java
@@ -106,6 +106,16 @@ public class ExportOptions extends AbstractOptions<ExportOptions> {
         return this;
     }
 
+    @Override
+    public ExportOptions addFilteredExtension(String extensionToBeFiltered) {
+        if (filteredExtension != null) {
+            filteredExtension.add(extensionToBeFiltered);
+        } else {
+            this.filteredExtension = Sets.newHashSet(extensionToBeFiltered);
+        }
+        return this;
+    }
+
     public boolean isWithBranchSV() {
         return withBranchSV;
     }
@@ -160,6 +170,18 @@ public class ExportOptions extends AbstractOptions<ExportOptions> {
             }
         });
         this.extensions = extensions;
+        return this;
+    }
+
+    @Override
+    public ExportOptions setFilteredExtensions(Set<String> filteredExtension) {
+        // this warning is to prevent people to use setSkipExtensions and setExtensions at the same time
+        Optional.ofNullable(this.filteredExtension).ifPresent(e -> {
+            if (e.isEmpty()) {
+                LOGGER.warn("Extensions have already been set as empty. This call will override it.");
+            }
+        });
+        this.filteredExtension = filteredExtension;
         return this;
     }
 

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ImportOptions.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ImportOptions.java
@@ -40,6 +40,11 @@ public class ImportOptions extends AbstractOptions<ImportOptions> {
         return this;
     }
 
+    public ImportOptions setFilteredExtensions(Set<String> filteredExtensions) {
+        this.filteredExtension = filteredExtensions;
+        return this;
+    }
+
     public ImportOptions setThrowExceptionIfExtensionNotFound(boolean throwExceptionIfExtensionNotFound) {
         this.throwExceptionIfExtensionNotFound = throwExceptionIfExtensionNotFound;
         return this;
@@ -51,6 +56,16 @@ public class ImportOptions extends AbstractOptions<ImportOptions> {
             extensions.add(extension);
         } else {
             this.extensions = Sets.newHashSet(extension);
+        }
+        return this;
+    }
+
+    @Override
+    public ImportOptions addFilteredExtension(String extensionToBeFiltered) {
+        if (filteredExtension != null) {
+            filteredExtension.add(extensionToBeFiltered);
+        } else {
+            this.filteredExtension = Sets.newHashSet(extensionToBeFiltered);
         }
         return this;
     }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/BinaryImporterTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/BinaryImporterTest.java
@@ -25,6 +25,6 @@ class BinaryImporterTest {
         assertEquals("BIIDM", importer.getFormat());
         assertEquals("IIDM binary v " + CURRENT_IIDM_VERSION.toString(".") + " importer", importer.getComment());
         assertEquals(List.of("biidm", "bin"), importer.getSupportedExtensions());
-        assertEquals(5, importer.getParameters().size());
+        assertEquals(6, importer.getParameters().size());
     }
 }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ExportOptionsTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ExportOptionsTest.java
@@ -90,4 +90,18 @@ class ExportOptionsTest {
         assertEquals(StandardCharsets.UTF_8, options.getCharset());
         assertEquals(Boolean.TRUE, options.isWithAutomationSystems());
     }
+
+    @Test
+    void exportOptionsTestFilteredExtensions() {
+        ExportOptions options = new ExportOptions();
+        options.setExtensions(Sets.newHashSet("loadFoo", "loadBar"));
+        options.setFilteredExtensions(Sets.newHashSet("loadBar"));
+        options.addFilteredExtension("test");
+        assertEquals(Boolean.FALSE, options.withNoExtension());
+        assertEquals(Boolean.TRUE, options.withExtension("loadFoo"));
+        assertEquals(Boolean.FALSE, options.withFilteredExtension("loadFoo"));
+        assertEquals(Boolean.TRUE, options.withFilteredExtension("loadBar"));
+        assertEquals(2, (int) options.getExtensions().map(Set::size).orElse(-1));
+        assertEquals(2, (int) options.getFilteredExtensions().map(Set::size).orElse(-1));
+    }
 }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ExtensionDeserIssueTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ExtensionDeserIssueTest.java
@@ -9,6 +9,8 @@ package com.powsybl.iidm.serde;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import com.powsybl.computation.local.LocalComputationManager;
+import com.powsybl.iidm.network.ImportConfig;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.extensions.SlackTerminal;
 import com.powsybl.iidm.network.extensions.SlackTerminalAdder;
@@ -16,8 +18,11 @@ import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Properties;
 
+import static com.powsybl.iidm.serde.AbstractTreeDataExporter.EXTENSIONS_FILTERED_LIST;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -39,6 +44,68 @@ class ExtensionDeserIssueTest {
             var vlload2 = network2.getVoltageLevel("VLLOAD");
             var slackTerminal = vlload2.getExtension(SlackTerminal.class);
             assertNotNull(slackTerminal.getTerminal().getBusView().getBus());
+        }
+    }
+
+    @Test
+    void testIgnoreExtensionExport() throws IOException {
+        Network network = EurostagTutorialExample1Factory.create();
+        var load = network.getLoad("LOAD");
+        var vlload = network.getVoltageLevel("VLLOAD");
+        vlload.newExtension(SlackTerminalAdder.class)
+                .withTerminal(load.getTerminal())
+                .add();
+        try (var fs = Jimfs.newFileSystem(Configuration.unix())) {
+            var file = fs.getPath("/work/test.xiidm");
+            Properties exportParams = new Properties();
+            exportParams.put(EXTENSIONS_FILTERED_LIST, "slackTerminal");
+            network.write("XIIDM", exportParams, file);
+            Network network2 = Network.read(file);
+            var vlload2 = network2.getVoltageLevel("VLLOAD");
+            var slackTerminal = vlload2.getExtension(SlackTerminal.class);
+            assertNull(slackTerminal);
+        }
+    }
+
+    @Test
+    void testIgnoreExtensionImport() throws IOException {
+        Network network = EurostagTutorialExample1Factory.create();
+        var load = network.getLoad("LOAD");
+        var vlload = network.getVoltageLevel("VLLOAD");
+        vlload.newExtension(SlackTerminalAdder.class)
+                .withTerminal(load.getTerminal())
+                .add();
+        try (var fs = Jimfs.newFileSystem(Configuration.unix())) {
+            var file = fs.getPath("/work/test.xiidm");
+            network.write("XIIDM", null, file);
+            Properties importParams = new Properties();
+            importParams.put(AbstractTreeDataImporter.EXTENSIONS_FILTERED_LIST, "slackTerminal");
+            Network network2 = Network.read(file, LocalComputationManager.getDefault(), ImportConfig.CACHE.get(), importParams);
+            var vlload2 = network2.getVoltageLevel("VLLOAD");
+            var slackTerminal = vlload2.getExtension(SlackTerminal.class);
+            assertNull(slackTerminal);
+        }
+    }
+
+    @Test
+    void testIgnoreExtensionImportExtensionAndFiltered() throws IOException {
+        Network network = EurostagTutorialExample1Factory.create();
+        var load = network.getLoad("LOAD");
+        var vlload = network.getVoltageLevel("VLLOAD");
+        vlload.newExtension(SlackTerminalAdder.class)
+                .withTerminal(load.getTerminal())
+                .add();
+        try (var fs = Jimfs.newFileSystem(Configuration.unix())) {
+            var file = fs.getPath("/work/test.xiidm");
+            network.write("XIIDM", null, file);
+            Properties importParams = new Properties();
+            importParams.put(AbstractTreeDataImporter.EXTENSIONS_LIST, "identifiableShortCircuit,slackTerminal");
+            // Filter has priority over positive import list
+            importParams.put(AbstractTreeDataImporter.EXTENSIONS_FILTERED_LIST, "slackTerminal");
+            Network network2 = Network.read(file, LocalComputationManager.getDefault(), ImportConfig.CACHE.get(), importParams);
+            var vlload2 = network2.getVoltageLevel("VLLOAD");
+            var slackTerminal = vlload2.getExtension(SlackTerminal.class);
+            assertNull(slackTerminal);
         }
     }
 }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ImportOptionsTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ImportOptionsTest.java
@@ -46,6 +46,19 @@ class ImportOptionsTest {
     }
 
     @Test
+    void importOptionsTestFilteredExtensions() {
+        ImportOptions options = new ImportOptions(Boolean.FALSE);
+        options.setExtensions(Sets.newHashSet("loadFoo", "loadBar"));
+        options.setFilteredExtensions(Sets.newHashSet("loadBar"));
+        assertEquals(Boolean.FALSE, options.withNoExtension());
+        assertEquals(Boolean.TRUE, options.withExtension("loadFoo"));
+        assertEquals(Boolean.FALSE, options.withFilteredExtension("loadFoo"));
+        assertEquals(Boolean.TRUE, options.withFilteredExtension("loadBar"));
+        assertEquals(2, (int) options.getExtensions().map(Set::size).orElse(-1));
+        assertEquals(1, (int) options.getFilteredExtensions().map(Set::size).orElse(-1));
+    }
+
+    @Test
     void importOptionsDefaultValues() {
         ImportOptions options = new ImportOptions(Boolean.FALSE);
 

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/JsonImporterTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/JsonImporterTest.java
@@ -25,6 +25,6 @@ class JsonImporterTest {
         assertEquals("JIIDM", importer.getFormat());
         assertEquals("IIDM JSON v " + CURRENT_IIDM_VERSION.toString(".") + " importer", importer.getComment());
         assertEquals(List.of("jiidm", "json"), importer.getSupportedExtensions());
-        assertEquals(5, importer.getParameters().size());
+        assertEquals(6, importer.getParameters().size());
     }
 }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/XMLExporterTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/XMLExporterTest.java
@@ -80,7 +80,7 @@ class XMLExporterTest extends AbstractIidmSerDeTest {
     @Test
     void paramsTest() {
         var xmlExporter = new XMLExporter();
-        assertEquals(11, xmlExporter.getParameters().size());
+        assertEquals(12, xmlExporter.getParameters().size());
         assertEquals("IIDM XML v" + CURRENT_IIDM_VERSION.toString(".") + " exporter", xmlExporter.getComment());
     }
 

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/XMLImporterTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/XMLImporterTest.java
@@ -139,7 +139,7 @@ class XMLImporterTest extends AbstractIidmSerDeTest {
         assertEquals("XIIDM", importer.getFormat());
         assertEquals("IIDM XML v " + CURRENT_IIDM_VERSION.toString(".") + " importer", importer.getComment());
         assertEquals(List.of("xiidm", "iidm", "xml"), importer.getSupportedExtensions());
-        assertEquals(5, importer.getParameters().size());
+        assertEquals(6, importer.getParameters().size());
         assertEquals("iidm.import.xml.throw-exception-if-extension-not-found", importer.getParameters().get(0).getName());
         assertEquals(Arrays.asList("iidm.import.xml.throw-exception-if-extension-not-found", "throwExceptionIfExtensionNotFound"), importer.getParameters().get(0).getNames());
     }


### PR DESCRIPTION
Describe the motivation

Sometimes we want to import all the extensions except some of them, for that it is easier to propose a blacklist of extensions than having to list all the extensions to import except some of them.

New Parameters :

For Import :
iidm.import.xml.filtered-extensions (string list of extensions that will not be imported)

For export
iidm.export.xml.filtered-extensions (string list of extensions that will not be exported

To avoid incoherence, the rule can be that :

if both iidm.import.xml.extensions and iidm.import.xml.filtered-extensions are used, 

then ignore the iidm.import.xml.filtered-extensions has priority hence the extension will not be imported

Same behavior for export filter list.

Signed-off-by: Fabrice Buscaylet <fabrice.buscaylet@artelys.com>