### PR TITLE
Fix typo in Battery javadoc

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Battery.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Battery.java
@@ -141,7 +141,7 @@ public interface Battery extends Injection<Battery>, ReactiveLimitsHolder {
     double getTargetQ();
 
     /**
-     * @deprecated Use {@link #setTargetP(double)} instead.
+     * @deprecated Use {@link #setTargetQ(double)} instead.
      */
     @Deprecated(since = "4.9.0")
     default Battery setQ0(double q0) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Documentation fix.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
There is a typo in setQ0 method of  Battery interface.


**What is the new behavior (if this is a feature change)?**
<!-- -->
The typo has been fixed.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
