### PR TITLE
Add missing hvdcAcEmulation parameter in documentation for LoadFlowParameters

### DIFF
--- a/docs/simulation/loadflow/configuration.md
+++ b/docs/simulation/loadflow/configuration.md
@@ -35,6 +35,7 @@ load-flow-default-parameters:
     twtSplitShuntAdmittance: false
     dcUseTransformerRatio: true
     dcPowerFactor: 1.0
+    hvdcAcEmulation: true
 ```
 
 The parameters may also be overridden with a JSON file, in which case the configuration will look like:
@@ -55,7 +56,8 @@ The parameters may also be overridden with a JSON file, in which case the config
   "connectedComponentMode": "MAIN",
   "twtSplitShuntAdmittance": false,
   "dcUseTransformerRatio": true,
-  "dcPowerFactor": 1.0
+  "dcPowerFactor": 1.0,
+  "hvdcAcEmulation": true
 }
 ```
 
@@ -134,6 +136,10 @@ The default value of this parameter is `true`.
 **dcPowerFactor**  
 The `dcPowerFactor` property is an optional property that defines the power factor used to convert current limits into active power limits in DC calculations.  
 The default value is `1.0`.
+
+**hvdcAcEmulation**
+The `hvdcAcEmulation` property is an optional property that defines whether AC emulation for HVDC should be simulated in the load flow or not (HVDC that are in AC emulation mode should have the hvdc-angle-droop-active-power-control extension).
+The default value is `true`.
 
 ### Specific parameters
 Some implementations use specific parameters that can be defined in the configuration file or in the JSON parameters file:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
hvdcAcEmulation parameter was not mentioned in the documentation



**What is the current behavior?**
hvdcAcEmulation is missing in the doc



**What is the new behavior (if this is a feature change)?**
hvdcAcEmulation is in the doc


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

