### PR TITLE
Enable AutoService Discovery for CGMES Naming Strategy

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesExport.java
@@ -644,8 +644,7 @@ public class CgmesExport implements Exporter {
             NAMING_STRATEGY,
             ParameterType.STRING,
             "Configure what type of naming strategy you want",
-            NamingStrategyFactory.IDENTITY,
-            new ArrayList<>(NamingStrategyFactory.LIST));
+            NamingStrategyFactory.IDENTITY);
     private static final Parameter PROFILES_PARAMETER = new Parameter(
             PROFILES,
             ParameterType.STRING_LIST,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/AbstractCgmesAliasNamingStrategy.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/AbstractCgmesAliasNamingStrategy.java
@@ -32,9 +32,9 @@ import static com.powsybl.cgmes.conversion.naming.CgmesObjectReference.ref;
  */
 public abstract class AbstractCgmesAliasNamingStrategy implements NamingStrategy {
 
-    public final BiMap<String, String> idByUuid = HashBiMap.create();
-    public final Map<String, String> uuidSeed = new HashMap<>();
-    public final NameBasedGenerator nameBasedGenerator;
+    protected final BiMap<String, String> idByUuid = HashBiMap.create();
+    protected final Map<String, String> uuidSeed = new HashMap<>();
+    protected final NameBasedGenerator nameBasedGenerator;
 
     protected AbstractCgmesAliasNamingStrategy(UUID uuidNamespace) {
         // The namespace for generating stable name-based UUIDs is also a UUID

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/AbstractCgmesAliasNamingStrategy.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/AbstractCgmesAliasNamingStrategy.java
@@ -32,9 +32,9 @@ import static com.powsybl.cgmes.conversion.naming.CgmesObjectReference.ref;
  */
 public abstract class AbstractCgmesAliasNamingStrategy implements NamingStrategy {
 
-    private final BiMap<String, String> idByUuid = HashBiMap.create();
-    private final Map<String, String> uuidSeed = new HashMap<>();
-    private final NameBasedGenerator nameBasedGenerator;
+    public final BiMap<String, String> idByUuid = HashBiMap.create();
+    public final Map<String, String> uuidSeed = new HashMap<>();
+    public final NameBasedGenerator nameBasedGenerator;
 
     protected AbstractCgmesAliasNamingStrategy(UUID uuidNamespace) {
         // The namespace for generating stable name-based UUIDs is also a UUID

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/NamingStrategiesServiceLoader.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/NamingStrategiesServiceLoader.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.naming;
+
+import com.powsybl.commons.util.ServiceLoaderCache;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Service loader to discover all CGMES NamingStrategy providers
+ * @author Coline Piloquet {@literal <coline.piloquet at rte-france.com>}
+ */
+public class NamingStrategiesServiceLoader {
+
+    private static final ServiceLoaderCache<NamingStrategyProvider> NAMING_STRATEGY_PROVIDERS = new ServiceLoaderCache<>(NamingStrategyProvider.class);
+
+    public List<NamingStrategyProvider> findAllProviders() {
+        return NAMING_STRATEGY_PROVIDERS.getServices();
+    }
+
+    public Optional<NamingStrategyProvider> findProviderByName(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return Optional.empty();
+        }
+        return findAllProviders().stream()
+                .filter(provider -> name.equals(provider.getName()))
+                .findFirst();
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/NamingStrategyFactory.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/NamingStrategyFactory.java
@@ -26,6 +26,15 @@ public final class NamingStrategyFactory {
 
     public static NamingStrategy create(String impl, UUID uuidNamespace) {
         Objects.requireNonNull(impl);
+
+        // First, try to find a provider via ServiceLoader
+        NamingStrategiesServiceLoader serviceLoader = new NamingStrategiesServiceLoader();
+        var providerOpt = serviceLoader.findProviderByName(impl);
+        if (providerOpt.isPresent()) {
+            return providerOpt.get().create(uuidNamespace);
+        }
+
+        // Fallback to built-in implementations for backward compatibility
         return switch (impl) {
             case IDENTITY -> new NamingStrategy.Identity();
             case CGMES -> new SimpleCgmesAliasNamingStrategy(uuidNamespace);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/NamingStrategyProvider.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/NamingStrategyProvider.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.naming;
+
+import java.util.UUID;
+
+/**
+ * @author Coline Piloquet {@literal <coline.piloquet at rte-france.com>}
+ */
+public interface NamingStrategyProvider {
+    /**
+     * The public name used to select this naming strategy (e.g., "identity", "cgmes").
+     */
+    String getName();
+
+    /**
+     * Create a new NamingStrategy instance. Implementations may use the provided UUID namespace
+     * to generate stable identifiers.
+     */
+    NamingStrategy create(UUID uuidNamespace);
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/providers/FixedCgmesNamingStrategyProvider.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/providers/FixedCgmesNamingStrategyProvider.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.naming.providers;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.cgmes.conversion.naming.FixedCgmesAliasNamingStrategy;
+import com.powsybl.cgmes.conversion.naming.NamingStrategy;
+import com.powsybl.cgmes.conversion.naming.NamingStrategyFactory;
+import com.powsybl.cgmes.conversion.naming.NamingStrategyProvider;
+
+import java.util.UUID;
+
+/**
+ * @author Coline Piloquet {@literal <coline.piloquet at rte-france.com>}
+ */
+@AutoService(NamingStrategyProvider.class)
+public class FixedCgmesNamingStrategyProvider implements NamingStrategyProvider {
+
+    @Override
+    public String getName() {
+        return NamingStrategyFactory.CGMES_FIX_ALL_INVALID_IDS;
+    }
+
+    @Override
+    public NamingStrategy create(UUID uuidNamespace) {
+        return new FixedCgmesAliasNamingStrategy(uuidNamespace);
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/providers/IdentityNamingStrategyProvider.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/providers/IdentityNamingStrategyProvider.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.naming.providers;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.cgmes.conversion.naming.NamingStrategy;
+import com.powsybl.cgmes.conversion.naming.NamingStrategyFactory;
+import com.powsybl.cgmes.conversion.naming.NamingStrategyProvider;
+
+import java.util.UUID;
+
+/**
+ * @author Coline Piloquet {@literal <coline.piloquet at rte-france.com>}
+ */
+@AutoService(NamingStrategyProvider.class)
+public class IdentityNamingStrategyProvider implements NamingStrategyProvider {
+
+    @Override
+    public String getName() {
+        return NamingStrategyFactory.IDENTITY;
+    }
+
+    @Override
+    public NamingStrategy create(UUID uuidNamespace) {
+        return new NamingStrategy.Identity();
+    }
+}

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/providers/SimpleCgmesNamingStrategyProvider.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/naming/providers/SimpleCgmesNamingStrategyProvider.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.naming.providers;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.cgmes.conversion.naming.NamingStrategy;
+import com.powsybl.cgmes.conversion.naming.NamingStrategyFactory;
+import com.powsybl.cgmes.conversion.naming.NamingStrategyProvider;
+import com.powsybl.cgmes.conversion.naming.SimpleCgmesAliasNamingStrategy;
+
+import java.util.UUID;
+
+/**
+ * @author Coline Piloquet {@literal <coline.piloquet at rte-france.com>}
+ */
+@AutoService(NamingStrategyProvider.class)
+public class SimpleCgmesNamingStrategyProvider implements NamingStrategyProvider {
+
+    @Override
+    public String getName() {
+        return NamingStrategyFactory.CGMES;
+    }
+
+    @Override
+    public NamingStrategy create(UUID uuidNamespace) {
+        return new SimpleCgmesAliasNamingStrategy(uuidNamespace);
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/naming/MockNamingStrategyTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/naming/MockNamingStrategyTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.naming;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.powsybl.cgmes.conversion.CgmesExport;
+import com.powsybl.cgmes.conversion.naming.mock.MockNamingStrategy;
+import com.powsybl.commons.datasource.DirectoryDataSource;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Coline Piloquet {@literal <coline.piloquet at rte-france.com>}
+ */
+class MockNamingStrategyTest {
+
+    @Test
+    void testServiceLoaderAndFactoryWithMock() {
+        NamingStrategiesServiceLoader loader = new NamingStrategiesServiceLoader();
+        Optional<NamingStrategyProvider> found = loader.findProviderByName("mock");
+        assertTrue(found.isPresent(), "Mock naming strategy provider should be discovered");
+
+        UUID ns = UUID.nameUUIDFromBytes("powsybl.org".getBytes());
+        NamingStrategy strategy = NamingStrategyFactory.create("mock", ns);
+        assertEquals("mock", strategy.getName());
+        assertInstanceOf(MockNamingStrategy.class, strategy);
+    }
+
+    @Test
+    void testExportUsesMockNamingStrategy() throws IOException {
+        Network network = EurostagTutorialExample1Factory.create();
+
+        try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
+            Path tmpDir = Files.createDirectory(fs.getPath("/mock-ns-test"));
+            Properties exportParams = new Properties();
+            exportParams.put(CgmesExport.PROFILES, "EQ");
+            exportParams.put(CgmesExport.NAMING_STRATEGY, "mock");
+
+            String baseName = "mockNaming";
+            new CgmesExport().export(network, exportParams, new DirectoryDataSource(tmpDir, baseName));
+            String eq = Files.readString(tmpDir.resolve(baseName + "_EQ.xml"));
+            assertTrue(eq.contains("MOCK_"), "EQ export should contain IDs prefixed with 'MOCK_' when mock naming strategy is used");
+        }
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/naming/NamingStrategiesServiceLoaderTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/naming/NamingStrategiesServiceLoaderTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.naming;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.powsybl.cgmes.conversion.export.CgmesExportContext.DEFAULT_UUID_NAMESPACE;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Coline Piloquet {@literal <coline.piloquet at rte-france.com>}
+ */
+class NamingStrategiesServiceLoaderTest {
+
+    private NamingStrategiesServiceLoader loader;
+
+    @BeforeEach
+    void setUp() {
+        loader = new NamingStrategiesServiceLoader();
+    }
+
+    @Test
+    void testFindAllProviders() {
+        List<NamingStrategyProvider> providers = loader.findAllProviders();
+        assertNotNull(providers);
+        assertFalse(providers.isEmpty());
+        assertTrue(providers.stream().anyMatch(p -> NamingStrategyFactory.IDENTITY.equals(p.getName())));
+        assertTrue(providers.stream().anyMatch(p -> NamingStrategyFactory.CGMES.equals(p.getName())));
+        assertTrue(providers.stream().anyMatch(p -> NamingStrategyFactory.CGMES_FIX_ALL_INVALID_IDS.equals(p.getName())));
+    }
+
+    @Test
+    void testFindProviderByNameAndFactory() {
+        Optional<NamingStrategyProvider> identityProv = loader.findProviderByName(NamingStrategyFactory.IDENTITY);
+        assertTrue(identityProv.isPresent());
+
+        // Test factory creation via provider
+        NamingStrategy s1 = NamingStrategyFactory.create(NamingStrategyFactory.IDENTITY, DEFAULT_UUID_NAMESPACE);
+        assertEquals(NamingStrategyFactory.IDENTITY, s1.getName());
+
+        NamingStrategy s2 = NamingStrategyFactory.create(NamingStrategyFactory.CGMES, DEFAULT_UUID_NAMESPACE);
+        assertEquals(NamingStrategyFactory.CGMES, s2.getName());
+
+        NamingStrategy s3 = NamingStrategyFactory.create(NamingStrategyFactory.CGMES_FIX_ALL_INVALID_IDS, DEFAULT_UUID_NAMESPACE);
+        assertEquals(NamingStrategyFactory.CGMES_FIX_ALL_INVALID_IDS, s3.getName());
+
+        assertFalse(loader.findProviderByName("NotFound").isPresent());
+        assertFalse(loader.findProviderByName(null).isPresent());
+        assertFalse(loader.findProviderByName(" ").isPresent());
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/naming/mock/MockNamingStrategy.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/naming/mock/MockNamingStrategy.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.naming.mock;
+
+import com.powsybl.cgmes.conversion.naming.CgmesObjectReference;
+import com.powsybl.cgmes.conversion.naming.NamingStrategy;
+import com.powsybl.commons.datasource.DataSource;
+import com.powsybl.iidm.network.Identifiable;
+
+/**
+ * Simple mock naming strategy used for tests. It prefixes all generated CGMES composite ids with "MOCK_".
+ * @author Coline Piloquet {@literal <coline.piloquet at rte-france.com>}
+ */
+public class MockNamingStrategy implements NamingStrategy {
+
+    private final NamingStrategy delegate = new NamingStrategy.Identity();
+
+    @Override
+    public String getName() {
+        return "mock";
+    }
+
+    @Override
+    public String getIidmId(String type, String id) {
+        return delegate.getIidmId(type, id);
+    }
+
+    @Override
+    public String getIidmName(String type, String name) {
+        return delegate.getIidmName(type, name);
+    }
+
+    @Override
+    public String getCgmesId(Identifiable<?> identifiable) {
+        // Keep identifiable direct id as identity to avoid over-constraining test; focus on composite ids
+        return delegate.getCgmesId(identifiable);
+    }
+
+    @Override
+    public void debug(String baseName, DataSource ds) {
+        // no-op
+    }
+
+    @Override
+    public String getCgmesId(CgmesObjectReference... refs) {
+        return "MOCK_" + CgmesObjectReference.combine(refs);
+    }
+}

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/naming/mock/MockNamingStrategyProvider.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/naming/mock/MockNamingStrategyProvider.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.naming.mock;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.cgmes.conversion.naming.NamingStrategy;
+import com.powsybl.cgmes.conversion.naming.NamingStrategyProvider;
+
+import java.util.UUID;
+
+/**
+ * Provider for the mock strategy (test scope only).
+ * @author Coline Piloquet {@literal <coline.piloquet at rte-france.com>}
+ */
+@AutoService(NamingStrategyProvider.class)
+public class MockNamingStrategyProvider implements NamingStrategyProvider {
+
+    @Override
+    public String getName() {
+        return "mock";
+    }
+
+    @Override
+    public NamingStrategy create(UUID uuidNamespace) {
+        return new MockNamingStrategy();
+    }
+}

--- a/computation-local/src/test/java/com/powsybl/computation/local/LocalComputationManagerTest.java
+++ b/computation-local/src/test/java/com/powsybl/computation/local/LocalComputationManagerTest.java
@@ -118,6 +118,7 @@ class LocalComputationManagerTest {
                                     .id("prog1_cmd")
                                     .program("prog1")
                                     .args("file1", "file2", "file3")
+                                    .timeout(60)
                                     .inputFiles(new InputFile("file1"),
                                                 new InputFile("file2.gz", FilePreProcessor.FILE_GUNZIP),
                                                 new InputFile("file3.zip", FilePreProcessor.ARCHIVE_UNZIP))

--- a/computation-local/src/test/java/com/powsybl/computation/local/LocalComputationManagerTest.java
+++ b/computation-local/src/test/java/com/powsybl/computation/local/LocalComputationManagerTest.java
@@ -118,7 +118,6 @@ class LocalComputationManagerTest {
                                     .id("prog1_cmd")
                                     .program("prog1")
                                     .args("file1", "file2", "file3")
-                                    .timeout(60)
                                     .inputFiles(new InputFile("file1"),
                                                 new InputFile("file2.gz", FilePreProcessor.FILE_GUNZIP),
                                                 new InputFile("file3.zip", FilePreProcessor.ARCHIVE_UNZIP))

--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -439,12 +439,14 @@ Optional property that defines if power flows of switches are exported in the SV
 
 **iidm.export.cgmes.naming-strategy**  
 Optional property that defines which naming strategy is used to transform IIDM identifiers to CGMES identifiers.
-It can be:
+Available naming strategies are:
 - `identity`: CGMES IDs are the same as IIDM IDs.
 - `cgmes`: new CGMES IDs (new master resource identifiers, cim:mRID) are created for IIDM `Identifiables` if the IIDM IDs are not compliant with CGMES requirements.
 - `cgmes-fix-all-invalid-ids`: ensures that all CGMES IDs in the export will comply with CGMES requirements, for IIDM `Identifiables`and also for its related objects (tap changers, operational limits, regulating controls, reactive capability outputVariables, ...).  
 
 Its default value is `identity`.
+You can also define a custom naming strategy by implementing the `NamingStrategy` interface on your own project and declare
+a `NamingStrategyProvider` that can be automatically discovered. Then in this parameter, you can specify the name of the provider.
 
 **iidm.export.cgmes.uuid-namespace**  
 Optional property related to the naming strategy specified in `iidm.export.cgmes.naming-strategy`. When new CGMES IDs have to be generated, a mechanism that ensures creation of new, stable identifiers based on IIDM IDs is used (see [RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122)). These new IDs are guaranteed to be unique inside a namespace given by this UUID. By default, it is the name-based UUID fo the text "powsybl.org" in the empty namespace.

--- a/docs/grid_exchange_formats/cgmes/import.md
+++ b/docs/grid_exchange_formats/cgmes/import.md
@@ -631,6 +631,8 @@ Optional property that defines if control areas must be imported or not. `true` 
 
 **iidm.import.cgmes.naming-strategy**  
 Optional property that defines which naming strategy is used to transform CGMES identifiers to IIDM identifiers. Currently, all naming strategies assign CGMES Ids directly to IIDM Ids during import, without any transformation. The default value is `identity`.
+You can also define a custom naming strategy by implementing the `NamingStrategy` interface on your own project and declare
+a `NamingStrategyProvider` that can be automatically discovered. Then in this parameter, you can specify the name of the provider.
 
 **iidm.import.cgmes.post-processors**  
 Optional property that defines all the CGMES post-processors which will be activated after import.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Naming strategy for CGMES import and export must be defined in powsybl-core.


**What is the new behavior (if this is a feature change)?**
This PR allows automatic discovery of Naming Strategies, allowing thus to define one outside powsybl-core.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
