### PR TITLE
Check if r is a positive or null double (for lines and 2w-transfos)

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
@@ -299,6 +299,15 @@ public final class ValidationUtil {
         }
     }
 
+    public static void checkPositiveR(Validable validable, double r) {
+        if (Double.isNaN(r)) {
+            throw new ValidationException(validable, "r is invalid");
+        }
+        if (r < 0) {
+            throw new ValidationException(validable, "r must be positive");
+        }
+    }
+
     public static void checkX(Validable validable, double x) {
         if (Double.isNaN(x)) {
             throw new ValidationException(validable, "x is invalid");

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LineAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LineAdderImpl.java
@@ -106,7 +106,7 @@ class LineAdderImpl extends AbstractBranchAdder<LineAdderImpl> implements LineAd
         TerminalExt terminal1 = checkAndGetTerminal1();
         TerminalExt terminal2 = checkAndGetTerminal2();
 
-        ValidationUtil.checkR(this, r);
+        ValidationUtil.checkPositiveR(this, r);
         ValidationUtil.checkX(this, x);
         ValidationUtil.checkG1(this, g1);
         ValidationUtil.checkG2(this, g2);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/TwoWindingsTransformerAdderImpl.java
@@ -118,7 +118,7 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
         TerminalExt terminal1 = checkAndGetTerminal1();
         TerminalExt terminal2 = checkAndGetTerminal2();
 
-        ValidationUtil.checkR(this, r);
+        ValidationUtil.checkPositiveR(this, r);
         ValidationUtil.checkX(this, x);
         ValidationUtil.checkG(this, g);
         ValidationUtil.checkB(this, b);

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractLineTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractLineTest.java
@@ -493,8 +493,17 @@ public abstract class AbstractLineTest {
 
     @Test
     public void invalidR() {
-        ValidationException e = assertThrows(ValidationException.class, () -> createLineBetweenVoltageAB(INVALID, INVALID, Double.NaN, 2.0, 3.0, 3.5, 4.0, 4.5));
-        assertTrue(e.getMessage().contains("r is invalid"));
+        ValidationException e1 = assertThrows(ValidationException.class, () -> createLineBetweenVoltageAB(INVALID, INVALID, Double.NaN, 2.0, 3.0, 3.5, 4.0, 4.5));
+        assertTrue(e1.getMessage().contains("r is invalid"));
+
+        ValidationException e2 = assertThrows(ValidationException.class, () -> createLineBetweenVoltageAB(INVALID, INVALID, -1.0, 2.0, 3.0, 3.5, 4.0, 4.5));
+        assertTrue(e2.getMessage().contains("r must be positive"));
+    }
+
+    @Test
+    public void negativeR() {
+        ValidationException e = assertThrows(ValidationException.class, () -> createLineBetweenVoltageAB(INVALID, INVALID, -1.0, 2.0, 3.0, 3.5, 4.0, 4.5));
+        assertTrue(e.getMessage().contains("r must be positive"));
     }
 
     @Test

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractTwoWindingsTransformerTest.java
@@ -169,8 +169,11 @@ public abstract class AbstractTwoWindingsTransformerTest extends AbstractTransfo
 
     @Test
     public void testInvalidR() {
-        ValidationException e = assertThrows(ValidationException.class, () -> createTwoWindingTransformer(INVALID, INVALID, Double.NaN, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0));
-        assertTrue(e.getMessage().contains("r is invalid"));
+        ValidationException e1 = assertThrows(ValidationException.class, () -> createTwoWindingTransformer(INVALID, INVALID, Double.NaN, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0));
+        assertTrue(e1.getMessage().contains("r is invalid"));
+
+        ValidationException e2 = assertThrows(ValidationException.class, () -> createTwoWindingTransformer(INVALID, INVALID, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0));
+        assertTrue(e2.getMessage().contains("r must be positive"));
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
https://github.com/powsybl/powsybl-core/issues/3527


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->
In LineAdderImpl, HvdcLineAdder and TwoWindingsTransformerAdderImpl classes : the method add() checks if r values are invalid (NaN).


**What is the new behavior (if this is a feature change)?**
In these cases, the method add() now also checks if r values are negative.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
