### PR TITLE
Fix LoadFlow API to introduce `LoadFlowRunParameters` to keep a stateless runner

### DIFF
--- a/action-ial/action-ial-simulator/src/test/java/com/powsybl/action/ial/simulator/LoadFlowProviderMock.java
+++ b/action-ial/action-ial-simulator/src/test/java/com/powsybl/action/ial/simulator/LoadFlowProviderMock.java
@@ -38,6 +38,14 @@ public class LoadFlowProviderMock extends AbstractNoSpecificParametersLoadFlowPr
 
     @Override
     public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingStateId, LoadFlowParameters parameters, ReportNode reportNode) {
+        return run(network, workingStateId, LoadFlowRunParameters.getDefault()
+            .setParameters(parameters)
+            .setComputationManager(computationManager)
+            .setReportNode(reportNode));
+    }
+
+    @Override
+    public CompletableFuture<LoadFlowResult> run(Network network, String workingStateId, LoadFlowRunParameters runParameters) {
         LOGGER.warn("Running loadflow mock");
         return CompletableFuture.completedFuture(new LoadFlowResultImpl(true, Collections.emptyMap(), ""));
     }

--- a/action-ial/action-ial-simulator/src/test/java/com/powsybl/action/ial/simulator/LoadFlowProviderMock.java
+++ b/action-ial/action-ial-simulator/src/test/java/com/powsybl/action/ial/simulator/LoadFlowProviderMock.java
@@ -8,10 +8,12 @@
 package com.powsybl.action.ial.simulator;
 
 import com.google.auto.service.AutoService;
-import com.powsybl.commons.report.ReportNode;
-import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.loadflow.*;
+import com.powsybl.loadflow.AbstractNoSpecificParametersLoadFlowProvider;
+import com.powsybl.loadflow.LoadFlowProvider;
+import com.powsybl.loadflow.LoadFlowResult;
+import com.powsybl.loadflow.LoadFlowResultImpl;
+import com.powsybl.loadflow.LoadFlowRunParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,14 +36,6 @@ public class LoadFlowProviderMock extends AbstractNoSpecificParametersLoadFlowPr
     @Override
     public String getVersion() {
         return "1.0";
-    }
-
-    @Override
-    public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingStateId, LoadFlowParameters parameters, ReportNode reportNode) {
-        return run(network, workingStateId, LoadFlowRunParameters.getDefault()
-            .setParameters(parameters)
-            .setComputationManager(computationManager)
-            .setReportNode(reportNode));
     }
 
     @Override

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlow.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlow.java
@@ -13,7 +13,6 @@ import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.config.PlatformConfigNamedProvider;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.computation.ComputationManager;
-import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.network.Network;
 
 import java.util.Objects;
@@ -37,98 +36,120 @@ public final class LoadFlow {
     public static class Runner implements Versionable {
 
         private final LoadFlowProvider provider;
-        private Network network = null;
-        private LoadFlowParameters parameters = LoadFlowParameters.load();
-        private ComputationManager computationManager = LocalComputationManager.getDefault();
-        private ReportNode reportNode = ReportNode.NO_OP;
-        private String variantId = null;
 
         public Runner(LoadFlowProvider provider) {
             this.provider = Objects.requireNonNull(provider);
         }
 
-        public Runner setNetwork(Network network) {
-            this.network = Objects.requireNonNull(network);
-            this.variantId = getVariantId(network);
-            return this;
-        }
-
-        public Runner setParameters(LoadFlowParameters parameters) {
-            this.parameters = parameters;
-            return this;
-        }
-
-        public Runner setComputationManager(ComputationManager computationManager) {
-            this.computationManager = computationManager;
-            return this;
-        }
-
-        public Runner setReportNode(ReportNode reportNode) {
-            this.reportNode = reportNode;
-            return this;
-        }
-
-        public Runner setVariantId(String variantId) {
-            this.variantId = variantId;
-            return this;
-        }
-
-        private String getVariantId(Network network) {
-            return this.variantId == null ? network.getVariantManager().getWorkingVariantId() : this.variantId;
-        }
-
+        /**
+         * @deprecated use {@link #runAsync(Network, String, LoadFlowRunParameters)} instead
+         */
+        @Deprecated(since = "6.9.0", forRemoval = true)
         public CompletableFuture<LoadFlowResult> runAsync(Network network, String workingStateId, ComputationManager computationManager, LoadFlowParameters parameters, ReportNode reportNode) {
-            Objects.requireNonNull(workingStateId);
-            Objects.requireNonNull(parameters);
-            Objects.requireNonNull(reportNode);
-            return provider.run(network, computationManager, workingStateId, parameters, reportNode);
+            return runAsync(network,
+                workingStateId,
+                new LoadFlowRunParameters()
+                    .setComputationManager(computationManager)
+                    .setParameters(parameters)
+                    .setReportNode(reportNode));
         }
 
+        /**
+         * @deprecated use {@link #runAsync(Network, String, LoadFlowRunParameters)} instead
+         */
+        @Deprecated(since = "6.9.0", forRemoval = true)
         public CompletableFuture<LoadFlowResult> runAsync(Network network, String workingStateId, ComputationManager computationManager, LoadFlowParameters parameters) {
-            return runAsync(network, workingStateId, computationManager, parameters, reportNode);
+            return runAsync(network,
+                workingStateId,
+                new LoadFlowRunParameters()
+                    .setComputationManager(computationManager)
+                    .setParameters(parameters));
         }
 
+        /**
+         * @deprecated use {@link #runAsync(Network, String, LoadFlowRunParameters)} instead
+         */
+        @Deprecated(since = "6.9.0", forRemoval = true)
         public CompletableFuture<LoadFlowResult> runAsync(Network network, ComputationManager computationManager, LoadFlowParameters parameters) {
-            return runAsync(network, getVariantId(network), computationManager, parameters);
+            return runAsync(network,
+                network.getVariantManager().getWorkingVariantId(),
+                new LoadFlowRunParameters()
+                    .setComputationManager(computationManager)
+                    .setParameters(parameters));
+        }
+
+        public CompletableFuture<LoadFlowResult> runAsync(Network network,
+                                                          String workingStateId,
+                                                          LoadFlowRunParameters runParameters) {
+            Objects.requireNonNull(network, "Network should not be null");
+            Objects.requireNonNull(workingStateId, "WorkingVariantId should not be null");
+            Objects.requireNonNull(runParameters, "LoadFlowRunParameters should not be null");
+            return provider.run(network, workingStateId, runParameters);
+        }
+
+        public CompletableFuture<LoadFlowResult> runAsync(Network network, LoadFlowRunParameters runParameters) {
+            return runAsync(network, network.getVariantManager().getWorkingVariantId(), runParameters);
         }
 
         public CompletableFuture<LoadFlowResult> runAsync(Network network, LoadFlowParameters parameters) {
-            return runAsync(network, computationManager, parameters);
+            return runAsync(network, network.getVariantManager().getWorkingVariantId(), new LoadFlowRunParameters().setParameters(parameters));
         }
 
         public CompletableFuture<LoadFlowResult> runAsync(Network network) {
-            return runAsync(network, parameters);
+            return runAsync(network, LoadFlowRunParameters.getDefault());
         }
 
-        public CompletableFuture<LoadFlowResult> runAsync() {
-            return runAsync(network);
-        }
-
+        /**
+         * @deprecated use {@link #run(Network, String, LoadFlowRunParameters)} instead
+         */
+        @Deprecated(since = "6.9.0", forRemoval = true)
         public LoadFlowResult run(Network network, String workingStateId, ComputationManager computationManager, LoadFlowParameters parameters, ReportNode reportNode) {
-            Objects.requireNonNull(workingStateId);
-            Objects.requireNonNull(parameters);
-            Objects.requireNonNull(reportNode);
-            return provider.run(network, computationManager, workingStateId, parameters, reportNode).join();
+            return run(network,
+                workingStateId,
+                new LoadFlowRunParameters()
+                    .setComputationManager(computationManager)
+                    .setParameters(parameters)
+                    .setReportNode(reportNode));
         }
 
+        /**
+         * @deprecated use {@link #run(Network, String, LoadFlowRunParameters)} instead
+         */
+        @Deprecated(since = "6.9.0", forRemoval = true)
         public LoadFlowResult run(Network network, String workingStateId, ComputationManager computationManager, LoadFlowParameters parameters) {
-            return run(network, workingStateId, computationManager, parameters, reportNode);
+            return run(network,
+                workingStateId,
+                new LoadFlowRunParameters()
+                    .setComputationManager(computationManager)
+                    .setParameters(parameters));
         }
 
+        /**
+         * @deprecated use {@link #run(Network, LoadFlowRunParameters)} instead
+         */
+        @Deprecated(since = "6.9.0", forRemoval = true)
         public LoadFlowResult run(Network network, ComputationManager computationManager, LoadFlowParameters parameters) {
-            return run(network, getVariantId(network), computationManager, parameters);
+            return run(network,
+                network.getVariantManager().getWorkingVariantId(),
+                new LoadFlowRunParameters()
+                    .setComputationManager(computationManager)
+                    .setParameters(parameters));
+        }
+
+        public LoadFlowResult run(Network network, String workingStateId, LoadFlowRunParameters runParameters) {
+            return runAsync(network, workingStateId, runParameters).join();
+        }
+
+        public LoadFlowResult run(Network network, LoadFlowRunParameters runParameters) {
+            return run(network, network.getVariantManager().getWorkingVariantId(), runParameters);
         }
 
         public LoadFlowResult run(Network network, LoadFlowParameters parameters) {
-            return run(network, computationManager, parameters);
+            return run(network, network.getVariantManager().getWorkingVariantId(), new LoadFlowRunParameters().setParameters(parameters));
         }
 
         public LoadFlowResult run(Network network) {
-            return run(network, parameters);
-        }
-
-        public LoadFlowResult run() {
-            return run(network);
+            return run(network, LoadFlowRunParameters.getDefault());
         }
 
         @Override
@@ -165,16 +186,38 @@ public final class LoadFlow {
         return find(null);
     }
 
+    /**
+     * @deprecated use {@link #runAsync(Network, String, LoadFlowRunParameters)} instead
+     */
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public static CompletableFuture<LoadFlowResult> runAsync(Network network, String workingStateId, ComputationManager computationManager, LoadFlowParameters parameters, ReportNode reportNode) {
         return find().runAsync(network, workingStateId, computationManager, parameters, reportNode);
     }
 
+    /**
+     * @deprecated use {@link #runAsync(Network, String, LoadFlowRunParameters)} instead
+     */
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public static CompletableFuture<LoadFlowResult> runAsync(Network network, String workingStateId, ComputationManager computationManager, LoadFlowParameters parameters) {
         return find().runAsync(network, workingStateId, computationManager, parameters);
     }
 
+    /**
+     * @deprecated use {@link #runAsync(Network, LoadFlowRunParameters)} instead
+     */
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public static CompletableFuture<LoadFlowResult> runAsync(Network network, ComputationManager computationManager, LoadFlowParameters parameters) {
         return find().runAsync(network, computationManager, parameters);
+    }
+
+    public static CompletableFuture<LoadFlowResult> runAsync(Network network,
+                                                             String workingStateId,
+                                                             LoadFlowRunParameters runParameters) {
+        return find().runAsync(network, workingStateId, runParameters);
+    }
+
+    public static CompletableFuture<LoadFlowResult> runAsync(Network network, LoadFlowRunParameters runParameters) {
+        return find().runAsync(network, runParameters);
     }
 
     public static CompletableFuture<LoadFlowResult> runAsync(Network network, LoadFlowParameters parameters) {
@@ -185,16 +228,41 @@ public final class LoadFlow {
         return find().runAsync(network);
     }
 
+
+    /**
+     * @deprecated use {@link #run(Network, String, LoadFlowRunParameters)} instead
+     */
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public static LoadFlowResult run(Network network, String workingStateId, ComputationManager computationManager, LoadFlowParameters parameters, ReportNode reportNode) {
         return find().run(network, workingStateId, computationManager, parameters, reportNode);
     }
 
+
+    /**
+     * @deprecated use {@link #run(Network, String, LoadFlowRunParameters)} instead
+     */
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public static LoadFlowResult run(Network network, String workingStateId, ComputationManager computationManager, LoadFlowParameters parameters) {
         return find().run(network, workingStateId, computationManager, parameters);
     }
 
+
+    /**
+     * @deprecated use {@link #runAsync(Network, LoadFlowRunParameters)} instead
+     */
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public static LoadFlowResult run(Network network, ComputationManager computationManager, LoadFlowParameters parameters) {
         return find().run(network, computationManager, parameters);
+    }
+
+    public static LoadFlowResult run(Network network,
+                                     String workingStateId,
+                                     LoadFlowRunParameters runParameters) {
+        return find().run(network, workingStateId, runParameters);
+    }
+
+    public static LoadFlowResult run(Network network, LoadFlowRunParameters runParameters) {
+        return find().run(network, runParameters);
     }
 
     public static LoadFlowResult run(Network network, LoadFlowParameters parameters) {

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlow.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlow.java
@@ -67,7 +67,7 @@ public final class LoadFlow {
         }
 
         /**
-         * @deprecated use {@link #runAsync(Network, String, LoadFlowRunParameters)} instead
+         * @deprecated use {@link #runAsync(Network, LoadFlowRunParameters)} instead
          */
         @Deprecated(since = "6.9.0", forRemoval = true)
         public CompletableFuture<LoadFlowResult> runAsync(Network network, ComputationManager computationManager, LoadFlowParameters parameters) {

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
@@ -62,7 +62,12 @@ public interface LoadFlowProvider extends Versionable, PlatformConfigNamedProvid
      * @return a {@link CompletableFuture} on {@link LoadFlowResult]
      */
     @Deprecated(since = "6.9.0", forRemoval = true)
-    CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, ReportNode reportNode);
+    default CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, ReportNode reportNode) {
+        return run(network, workingVariantId, new LoadFlowRunParameters()
+            .setComputationManager(computationManager)
+            .setParameters(parameters)
+            .setReportNode(reportNode));
+    }
 
     /**
      * Run a loadflow on variant {@code workingVariantId} of {@code network} delegating external program execution to

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowProvider.java
@@ -52,6 +52,7 @@ public interface LoadFlowProvider extends Versionable, PlatformConfigNamedProvid
      * {@code computationManager} if necessary and using loadflow execution {@code parameters}. This method is expected
      * to be stateless so that it can be call simultaneously with different arguments (a different network for instance)
      * without any concurrency issue.
+     * @deprecated use {@link #run(Network, String, LoadFlowRunParameters)} instead
      *
      * @param network            the network
      * @param computationManager a computation manager to external program execution
@@ -60,7 +61,22 @@ public interface LoadFlowProvider extends Versionable, PlatformConfigNamedProvid
      * @param reportNode           the reportNode used for functional logs
      * @return a {@link CompletableFuture} on {@link LoadFlowResult]
      */
+    @Deprecated(since = "6.9.0", forRemoval = true)
     CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, ReportNode reportNode);
+
+    /**
+     * Run a loadflow on variant {@code workingVariantId} of {@code network} delegating external program execution to
+     * {@code computationManager} if necessary and using loadflow execution {@code parameters}, with
+     * {@code computationManager} and {@code parameters} both defined in the load flow {@code runParameters}. This
+     * method is expected to be stateless so that it can be called simultaneously with different arguments (different
+     * networks, for instance) without any concurrency issue.
+     *
+     * @param network            the network
+     * @param workingVariantId   variant id of the network
+     * @param runParameters         load flow run parameters
+     * @return a {@link CompletableFuture} on {@link LoadFlowResult]
+     */
+    CompletableFuture<LoadFlowResult> run(Network network, String workingVariantId, LoadFlowRunParameters runParameters);
 
     /**
      * Get specific parameters class.

--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowRunParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowRunParameters.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.loadflow;
+
+import com.powsybl.commons.report.ReportNode;
+import com.powsybl.computation.ComputationManager;
+import com.powsybl.computation.local.LocalComputationManager;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Parameters used in {@link LoadFlow#run} called in {@link LoadFlow} API
+ * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
+ */
+public class LoadFlowRunParameters {
+
+    private static final Supplier<ComputationManager> DEFAULT_COMPUTATION_MANAGER_SUPPLIER = LocalComputationManager::getDefault;
+    private static final Supplier<LoadFlowParameters> DEFAULT_LOAD_FLOW_PARAMETERS_SUPPLIER = LoadFlowParameters::load;
+
+    private LoadFlowParameters parameters;
+    private ComputationManager computationManager;
+    private ReportNode reportNode = ReportNode.NO_OP;
+
+    /**
+     * Returns a {@link LoadFlowRunParameters} instance with default value on each field.
+     * @return the LoadFlowRunParameters instance.
+     */
+    public static LoadFlowRunParameters getDefault() {
+        return new LoadFlowRunParameters()
+            .setParameters(DEFAULT_LOAD_FLOW_PARAMETERS_SUPPLIER.get())
+            .setComputationManager(DEFAULT_COMPUTATION_MANAGER_SUPPLIER.get());
+    }
+
+    /**
+     * {@link LoadFlowParameters} getter<br>
+     * If null, sets the field to its default value with {@link #DEFAULT_LOAD_FLOW_PARAMETERS_SUPPLIER} before returning it.
+     */
+    public LoadFlowParameters getLoadFlowParameters() {
+        if (parameters == null) {
+            setParameters(DEFAULT_LOAD_FLOW_PARAMETERS_SUPPLIER.get());
+        }
+        return parameters;
+    }
+
+    /**
+     * {@link ComputationManager} getter<br>
+     * If null, sets the field to its default value with {@link #DEFAULT_COMPUTATION_MANAGER_SUPPLIER} before returning it.
+     */
+    public ComputationManager getComputationManager() {
+        if (computationManager == null) {
+            setComputationManager(DEFAULT_COMPUTATION_MANAGER_SUPPLIER.get());
+        }
+        return computationManager;
+    }
+
+    public ReportNode getReportNode() {
+        return reportNode;
+    }
+
+    public LoadFlowRunParameters setParameters(LoadFlowParameters parameters) {
+        Objects.requireNonNull(parameters, "LoadFlowRunParameters should not be null");
+        this.parameters = parameters;
+        return this;
+    }
+
+    /**
+     * Sets the computationManager handling command execution.
+     */
+    public LoadFlowRunParameters setComputationManager(ComputationManager computationManager) {
+        Objects.requireNonNull(computationManager, "ComputationManager should not be null");
+        this.computationManager = computationManager;
+        return this;
+    }
+
+    public LoadFlowRunParameters setReportNode(ReportNode reportNode) {
+        Objects.requireNonNull(reportNode, "ReportNode should not be null");
+        this.reportNode = reportNode;
+        return this;
+    }
+}

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderMock.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderMock.java
@@ -15,7 +15,6 @@ import com.powsybl.commons.extensions.ExtensionJsonSerializer;
 import com.powsybl.commons.parameters.Parameter;
 import com.powsybl.commons.parameters.ParameterType;
 import com.powsybl.commons.report.ReportNode;
-import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.json.JsonLoadFlowParametersTest.DummyExtension;
 import com.powsybl.loadflow.json.JsonLoadFlowParametersTest.DummySerializer;

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderMock.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderMock.java
@@ -43,7 +43,15 @@ public class LoadFlowProviderMock implements LoadFlowProvider {
 
     @Override
     public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingStateId, LoadFlowParameters parameters, ReportNode reportNode) {
-        Executor executor = computationManager.getExecutor();
+        return run(network, workingStateId, LoadFlowRunParameters.getDefault()
+            .setParameters(parameters)
+            .setComputationManager(computationManager)
+            .setReportNode(reportNode));
+    }
+
+    @Override
+    public CompletableFuture<LoadFlowResult> run(Network network, String workingStateId, LoadFlowRunParameters runParameters) {
+        Executor executor = runParameters.getComputationManager().getExecutor();
         if (executor != null) {
             executor.execute(new Runnable() {
                 @Override
@@ -52,15 +60,17 @@ public class LoadFlowProviderMock implements LoadFlowProvider {
                 }
             });
         }
+        ReportNode reportNode = runParameters.getReportNode();
         if (reportNode != null) {
             reportNode.newReportNode()
-                    .withMessageTemplate("testLoadflow")
-                    .withUntypedValue("variantId", workingStateId)
-                    .add();
+                .withMessageTemplate("testLoadflow")
+                .withUntypedValue("variantId", workingStateId)
+                .add();
         }
         String logs = "";
+        LoadFlowParameters parameters = runParameters.getLoadFlowParameters();
         if (parameters != null) {
-            logs = "Loadflow parameters: " + parameters.toString();
+            logs = "Loadflow parameters: " + parameters;
         }
         return CompletableFuture.completedFuture(new LoadFlowResultImpl(true, Collections.emptyMap(), logs));
     }

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderMock.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderMock.java
@@ -42,14 +42,6 @@ public class LoadFlowProviderMock implements LoadFlowProvider {
                                                              new Parameter(STRING_PARAMETER_NAME, ParameterType.STRING, "a string parameter", "yes", List.of("yes", "no")));
 
     @Override
-    public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingStateId, LoadFlowParameters parameters, ReportNode reportNode) {
-        return run(network, workingStateId, LoadFlowRunParameters.getDefault()
-            .setParameters(parameters)
-            .setComputationManager(computationManager)
-            .setReportNode(reportNode));
-    }
-
-    @Override
     public CompletableFuture<LoadFlowResult> run(Network network, String workingStateId, LoadFlowRunParameters runParameters) {
         Executor executor = runParameters.getComputationManager().getExecutor();
         if (executor != null) {

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderTest.java
@@ -65,13 +65,6 @@ class LoadFlowProviderTest {
     @Test
     void abstractLoadFlowProviderTest() throws IOException {
         var provider = new AbstractNoSpecificParametersLoadFlowProvider() {
-            @Override
-            public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, ReportNode reportNode) {
-                return run(network, workingVariantId, LoadFlowRunParameters.getDefault()
-                    .setParameters(parameters)
-                    .setComputationManager(computationManager)
-                    .setReportNode(reportNode));
-            }
 
             @Override
             public CompletableFuture<LoadFlowResult> run(Network network, String workingStateId, LoadFlowRunParameters runParameters) {

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderTest.java
@@ -67,6 +67,14 @@ class LoadFlowProviderTest {
         var provider = new AbstractNoSpecificParametersLoadFlowProvider() {
             @Override
             public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, ReportNode reportNode) {
+                return run(network, workingVariantId, LoadFlowRunParameters.getDefault()
+                    .setParameters(parameters)
+                    .setComputationManager(computationManager)
+                    .setReportNode(reportNode));
+            }
+
+            @Override
+            public CompletableFuture<LoadFlowResult> run(Network network, String workingStateId, LoadFlowRunParameters runParameters) {
                 return null;
             }
 

--- a/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderTest.java
+++ b/loadflow/loadflow-api/src/test/java/com/powsybl/loadflow/LoadFlowProviderTest.java
@@ -12,8 +12,6 @@ import com.google.common.jimfs.Jimfs;
 import com.powsybl.commons.config.InMemoryPlatformConfig;
 import com.powsybl.commons.config.MapModuleConfig;
 import com.powsybl.commons.parameters.Parameter;
-import com.powsybl.commons.report.ReportNode;
-import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.json.JsonLoadFlowParametersTest;
 import com.powsybl.loadflow.json.JsonLoadFlowParametersTest.DummyExtension;
@@ -26,7 +24,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}

--- a/loadflow/loadflow-scripting/src/test/java/com/powsybl/loadflow/scripting/LFMock.java
+++ b/loadflow/loadflow-scripting/src/test/java/com/powsybl/loadflow/scripting/LFMock.java
@@ -25,6 +25,14 @@ public class LFMock extends AbstractNoSpecificParametersLoadFlowProvider {
 
     @Override
     public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingStateId, LoadFlowParameters parameters, ReportNode reportNode) {
+        return run(network, workingStateId, LoadFlowRunParameters.getDefault()
+            .setParameters(parameters)
+            .setComputationManager(computationManager)
+            .setReportNode(reportNode));
+    }
+
+    @Override
+    public CompletableFuture<LoadFlowResult> run(Network network, String workingStateId, LoadFlowRunParameters runParameters) {
         return CompletableFuture.completedFuture(new LoadFlowResultImpl(true, Collections.emptyMap(), ""));
     }
 

--- a/loadflow/loadflow-scripting/src/test/java/com/powsybl/loadflow/scripting/LFMock.java
+++ b/loadflow/loadflow-scripting/src/test/java/com/powsybl/loadflow/scripting/LFMock.java
@@ -24,14 +24,6 @@ import java.util.concurrent.CompletableFuture;
 public class LFMock extends AbstractNoSpecificParametersLoadFlowProvider {
 
     @Override
-    public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingStateId, LoadFlowParameters parameters, ReportNode reportNode) {
-        return run(network, workingStateId, LoadFlowRunParameters.getDefault()
-            .setParameters(parameters)
-            .setComputationManager(computationManager)
-            .setReportNode(reportNode));
-    }
-
-    @Override
     public CompletableFuture<LoadFlowResult> run(Network network, String workingStateId, LoadFlowRunParameters runParameters) {
         return CompletableFuture.completedFuture(new LoadFlowResultImpl(true, Collections.emptyMap(), ""));
     }

--- a/loadflow/loadflow-scripting/src/test/java/com/powsybl/loadflow/scripting/LFMock.java
+++ b/loadflow/loadflow-scripting/src/test/java/com/powsybl/loadflow/scripting/LFMock.java
@@ -9,10 +9,12 @@
 package com.powsybl.loadflow.scripting;
 
 import com.google.auto.service.AutoService;
-import com.powsybl.commons.report.ReportNode;
-import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.loadflow.*;
+import com.powsybl.loadflow.AbstractNoSpecificParametersLoadFlowProvider;
+import com.powsybl.loadflow.LoadFlowProvider;
+import com.powsybl.loadflow.LoadFlowResult;
+import com.powsybl.loadflow.LoadFlowResultImpl;
+import com.powsybl.loadflow.LoadFlowRunParameters;
 
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;

--- a/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/LoadFlowProviderMock.java
+++ b/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/LoadFlowProviderMock.java
@@ -8,10 +8,12 @@
 package com.powsybl.loadflow.validation;
 
 import com.google.auto.service.AutoService;
-import com.powsybl.commons.report.ReportNode;
-import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.loadflow.*;
+import com.powsybl.loadflow.AbstractNoSpecificParametersLoadFlowProvider;
+import com.powsybl.loadflow.LoadFlowProvider;
+import com.powsybl.loadflow.LoadFlowResult;
+import com.powsybl.loadflow.LoadFlowResultImpl;
+import com.powsybl.loadflow.LoadFlowRunParameters;
 
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
@@ -30,14 +32,6 @@ public class LoadFlowProviderMock extends AbstractNoSpecificParametersLoadFlowPr
     @Override
     public String getVersion() {
         return "1.0";
-    }
-
-    @Override
-    public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingStateId, LoadFlowParameters parameters, ReportNode reportNode) {
-        return run(network, workingStateId, LoadFlowRunParameters.getDefault()
-            .setParameters(parameters)
-            .setComputationManager(computationManager)
-            .setReportNode(reportNode));
     }
 
     @Override

--- a/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/LoadFlowProviderMock.java
+++ b/loadflow/loadflow-validation/src/test/java/com/powsybl/loadflow/validation/LoadFlowProviderMock.java
@@ -34,6 +34,14 @@ public class LoadFlowProviderMock extends AbstractNoSpecificParametersLoadFlowPr
 
     @Override
     public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingStateId, LoadFlowParameters parameters, ReportNode reportNode) {
+        return run(network, workingStateId, LoadFlowRunParameters.getDefault()
+            .setParameters(parameters)
+            .setComputationManager(computationManager)
+            .setReportNode(reportNode));
+    }
+
+    @Override
+    public CompletableFuture<LoadFlowResult> run(Network network, String workingStateId, LoadFlowRunParameters runParameters) {
         network.getGenerator("GEN").getTerminal().setP(92f);
         return CompletableFuture.completedFuture(new LoadFlowResultImpl(true, Collections.emptyMap(), ""));
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
Changes introduced in #3538 rendered the loadflow runner not stateless.

**What is the new behavior (if this is a feature change)?**
The loadflow runner is stateless again and a new class LoadFlowRunParameters has been introduced to define the different parameters with possible default values.

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
A new methods has been added to the loadflow provider API: `LoadFlowProvider.run(Network, String, LoadFlowRunParameters)`.

Some methods have been deprecated in the loadflow API. Users should switch to the new API:
| Deprecated method | New method |
|----------------------------|------------------|
|`runAsync(Network, String, ComputationManager, LoadFlowParameters, ReportNode)`|`runAsync(Network, String, LoadFlowRunParameters)`|
|`runAsync(Network, String, ComputationManager, LoadFlowParameters)`|`runAsync(Network, String, LoadFlowRunParameters)`|
|`runAsync(Network, ComputationManager, LoadFlowParameters)`|`runAsync(Network, LoadFlowRunParameters)`|
|`run(Network, String, ComputationManager, LoadFlowParameters, ReportNode)`|`run(Network, String, LoadFlowRunParameters)`|
|`run(Network, String, ComputationManager, LoadFlowParameters)`|`run(Network, String, LoadFlowRunParameters)`|
|`run(Network, ComputationManager, LoadFlowParameters)`|`run(Network, LoadFlowRunParameters)`|

*Nota: this change has to be done for the `LoadFlow.Runner` methods and for the `LoadFlow` static methods.*

The `run` method of the the `LoadFlowProvider` has also been modified. The method `run(Network, ComputationManager, String, LoadFlowParameters, ReportNode)` has been deprecated in favor of `run(Network, String, LoadFlowRunParameters)`.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
