### PR TITLE
Refactor to use try-with-resources for proper ExecutorService management in LocalComputationManager and Importers

### DIFF
--- a/computation-local/src/test/java/com/powsybl/computation/local/LocalComputationManagerTest.java
+++ b/computation-local/src/test/java/com/powsybl/computation/local/LocalComputationManagerTest.java
@@ -333,7 +333,12 @@ class LocalComputationManagerTest {
             }
         };
 
-        try (ComputationManager computationManager = new LocalComputationManager(config, localCommandExecutor, ForkJoinPool.commonPool())) {
+        try (ComputationManager computationManager = new LocalComputationManager(config, localCommandExecutor, ForkJoinPool.commonPool()) {
+            @Override
+            protected long getTimeout() {
+                return 2L;
+            }
+        }) {
 
             CompletableFuture<Object> result = computationManager.execute(ExecutionEnvironment.createDefault(), new AbstractExecutionHandler<Object>() {
                 @Override

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Importers.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Importers.java
@@ -148,8 +148,7 @@ public final class Importers {
         List<ReadOnlyDataSource> dataSources = new ArrayList<>();
         importAll(dir, importer, dataSources);
         if (parallel) {
-            ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
-            try {
+            try (ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors())) {
                 List<Future<?>> futures = dataSources.stream()
                         .map(ds -> {
                             ReportNode child = NetworkReports.createChildReportNode(reportNode, ds);
@@ -159,8 +158,6 @@ public final class Importers {
                 for (Future<?> future : futures) {
                     future.get();
                 }
-            } finally {
-                executor.shutdownNow();
             }
         } else {
             for (ReadOnlyDataSource dataSource : dataSources) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bugfix

**What is the current behavior?**
Executors are not closed properly in `LocalComputationManager` and `Importers`

**What is the new behavior (if this is a feature change)?**
A try-with-resources block is now used to properly close executors in `LocalComputationManager` and `Importers`.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
