### PR TITLE
Fix one test not being public in TCK

### DIFF
--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -693,7 +693,7 @@ public abstract class AbstractNetworkTest {
     }
 
     @Test
-    void testSetMinimumAcceptableValidationLevelOnInvalidatedNetwork() {
+    public void testSetMinimumAcceptableValidationLevelOnInvalidatedNetwork() {
         Network network = Network.create("test", "iidm");
         network.setMinimumAcceptableValidationLevel(ValidationLevel.EQUIPMENT);
         VoltageLevel vl = network.newSubstation().setId("s1").add()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
Unit test `AbstractNetworkTest.testSetMinimumAcceptableValidationLevelOnInvalidatedNetwork()` is not public in the TCK, preventing other implementations from overriding it.



**What is the new behavior (if this is a feature change)?**
The test is now public.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
