### PR TITLE
Fix switch flow computation for SV export

### DIFF
--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/util/SwitchesFlowTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/util/SwitchesFlowTest.java
@@ -41,16 +41,16 @@ class SwitchesFlowTest {
         VoltageLevel voltageLevel11 = network.getVoltageLevel("S1VL1");
         SwitchesFlow switchesFlow11 = new SwitchesFlow(voltageLevel11);
 
-        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-0B-1B", -180.0, -19.0));
-        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-0A-1A", 10.0, -1.0));
-        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-1B-2B", 70.0, 10.0));
+        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-0B-1B", -107.5, -12.0));
+        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-0A-1A", -62.5, -8.0));
+        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-1B-2B", 35.0, 5.0));
         assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-0B-10", 100.0, 10.0));
         assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-1A-8", -80.0, -10.0));
-        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-0A-0B", -80.0, -9.0));
-        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-2A-2B", 0.0, 0.0));
-        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-1A-1B", 0.0, 0.0));
+        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-0A-0B", -7.5, -2.0));
+        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-2A-2B", 35.0, 5.0));
+        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-1A-1B", -107.5, -12.0));
         assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-2B-12", 70.0, 10.0));
-        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-1A-2A", 90.0, 9.0));
+        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-1A-2A", 125.0, 14.0));
 
         VoltageLevel voltageLevel12 = network.getVoltageLevel("S1VL2");
         SwitchesFlow switchesFlow12 = new SwitchesFlow(voltageLevel12);
@@ -313,9 +313,9 @@ class SwitchesFlowTest {
         VoltageLevel voltageLevel11 = network.getVoltageLevel("S1VL1");
         SwitchesFlow switchesFlow11 = new SwitchesFlow(voltageLevel11);
 
-        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-BUS0-BUS1", -25.0, -10.5));
-        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-BUS1-BUS2", -25.0, -10.5));
-        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-BUS0-BUS2", 0.0, 0.0));
+        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-BUS0-BUS1", -12.5, -5.25));
+        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-BUS1-BUS2", -12.5, -5.25));
+        assertTrue(compareSwitchFlow(switchesFlow11, "S1VL1-SW-BUS0-BUS2", -12.5, -5.25));
 
         VoltageLevel voltageLevel12 = network.getVoltageLevel("S1VL2");
         SwitchesFlow switchesFlow12 = new SwitchesFlow(voltageLevel12);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
During switch flow computation, the graph is transformed to a tree, which induce a loss of information: some switches and/or internal connections are missing from the results. Also, the results depends on how the tree is built, which can be dependent on the order of the edges in the subgraph.

**What is the new behavior (if this is a feature change)?**
Switch flow computation is done on the graph directly.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
