### PR TITLE
Fix node/breaker to bus/breaker topology conversion

### DIFF
--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractConvertTopologyTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractConvertTopologyTest.java
@@ -220,4 +220,59 @@ public abstract class AbstractConvertTopologyTest {
         vl.convertToTopology(TopologyKind.BUS_BREAKER);
         assertEquals(gh2.getTerminal(), slackTerminal.getTerminal());
     }
+
+    @Test
+    public void testNodeBreakerToBusBreakerIssue() {
+        var vl = network.newVoltageLevel()
+                .setId("vl_issue")
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .setNominalV(400)
+                .add();
+        vl.getNodeBreakerView().newBusbarSection()
+                .setId("bbs")
+                .setNode(0)
+                .add();
+        var line = network.newLine()
+                .setId("line")
+                .setVoltageLevel1("S1VL2")
+                .setNode1(999)
+                .setVoltageLevel2("vl_issue")
+                .setNode2(1)
+                .setR(0.1)
+                .setX(1.0)
+                .setG1(0.0)
+                .setG2(0.0)
+                .setB1(0.0)
+                .setB2(0.0)
+                .add();
+        network.getVoltageLevel("S1VL2").getNodeBreakerView().newDisconnector()
+                .setId("disconnector")
+                .setNode1(0)
+                .setNode2(999)
+                .setOpen(false)
+                .add();
+        vl.getNodeBreakerView().newDisconnector()
+                .setId("disconnector2")
+                .setNode1(0)
+                .setNode2(1)
+                .setOpen(false)
+                .add();
+        vl.newLoad()
+                .setId("load")
+                .setNode(2)
+                .setP0(1.0)
+                .setQ0(2.0)
+                .add();
+        vl.getNodeBreakerView().newBreaker()
+                .setId("breaker")
+                .setNode1(0)
+                .setNode2(2)
+                .setOpen(true)
+                .add();
+        assertTrue(line.getTerminal1().isConnected());
+        assertTrue(line.getTerminal2().isConnected());
+        vl.convertToTopology(TopologyKind.BUS_BREAKER);
+        assertTrue(line.getTerminal1().isConnected());
+        assertTrue(line.getTerminal2().isConnected());
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
For some voltage level when converting from node/breaker to bus/breaker and when looking at the resulting bus/view some element are disconnected while they were not in the initial model. So resulting network is corrupted / wrong.


**What is the new behavior (if this is a feature change)?**
Conversion has been fixed.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
