### PR TITLE
Some typo and fix an error with < and > in javadoc

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageLevel.java
@@ -169,7 +169,7 @@ import java.util.stream.Stream;
  * </div>
  * The node/breaker topology model is stored inside the voltage level as a graph
  * where connection nodes are the vertices and switches are the edges.
- * <p>The next diagram shows how to map the subtation topology to a graph.
+ * <p>The next diagram shows how to map the substation topology to a graph.
  * <div>
  *    <object data="doc-files/nodeBreakerTopologyGraph.svg" type="image/svg+xml"></object>
  * </div>
@@ -179,9 +179,9 @@ import java.util.stream.Stream;
  * connection nodes. Voltage level VL2 has 3 nodes, line LN is connected to
  * node 1, busbar section BBS3 to node 2. Transformer TR is connected
  * to node 8 of voltage level 400Kv and node 3 of voltage level 225Kv. Plain
- * edges represent closed switches. Dashed edges reprensent opened switches.
+ * edges represent closed switches. Dashed edges represent opened switches.
  * Green edges will disappear during the bus/breaker topology computation
- * whereas pink edges (like in this case 3<->4) will be retained whatever their
+ * whereas pink edges (like in this case 3 {@literal <->} 4) will be retained whatever their
  * position are (see {@link Switch#isRetained()}).
  * <p>The following code shows how to create the substation with a node/breaker
  *   topology model.
@@ -273,7 +273,7 @@ import java.util.stream.Stream;
  * </pre>
  *
  * <p>The following diagram shows computed bus/breaker topology. Compared to
- * node/breaker topology, only remains equipements (GN, LD, TR, LN), and switches
+ * node/breaker topology, only remains equipments (GN, LD, TR, LN), and switches
  * flagged as retained (BR3). Equipments are now connected through buses
  * (B1 and B2).
  * <div>
@@ -306,7 +306,7 @@ import java.util.stream.Stream;
  * </pre>
  *
  * <p>The following diagram shows computed bus topology. Compared to bus/breaker
- * topology, there is no switches anymore. Only remains equipements (GN, LD, TR, LN)
+ * topology, there is no switches anymore. Only remains equipments (GN, LD, TR, LN)
  * connected through buses.
  * <div>
  *    <object data="doc-files/busTopology.svg" type="image/svg+xml"></object>
@@ -318,7 +318,7 @@ import java.util.stream.Stream;
  *    // VL1 contains 1 buses in the bus view
  *    Iterator&lt;Bus&gt; itB = vl1.getBusView().getBuses();
  *
- *    // the bus connects all the equipements of voltage level VL1
+ *    // the bus connects all the equipments of voltage level VL1
  *    Bus b1 = itB.next();
  * </pre>
  * <h3>Creating a substation with a bus/breaker topology model:</h3>
@@ -1431,7 +1431,7 @@ public interface VoltageLevel extends Container<VoltageLevel> {
     void convertToTopology(TopologyKind newTopologyKind);
 
     /**
-     * Print an ASCII representation of the topology on the standard ouput.
+     * Print an ASCII representation of the topology on the standard output.
      */
     void printTopology();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Doc fix

**What is the current behavior?**
<!-- You can also link to an open issue here -->

Update javadoc to correct some typo and an `invalid input: "<"` error in the generated javadoc.

<img width="339" height="57" alt="image" src="https://github.com/user-attachments/assets/4db60f13-c97c-4c86-9553-3c92af285de4" />


**What is the new behavior (if this is a feature change)?**
Escape this code part in the Javadoc + fix some typos.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
