### PR TITLE
NetworkTest tck: improve test on fictitiousP0-Q0 by always asserting and not only in an if

### DIFF
--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -97,8 +97,8 @@ public abstract class AbstractNetworkTest {
         topology1.setFictitiousP0(0, 1.0).setFictitiousQ0(0, 2.0);
         assertEquals(1.0, topology1.getFictitiousP0(0), 0.0);
         assertEquals(2.0, topology1.getFictitiousQ0(0), 0.0);
-        assertEquals(1.0, voltageLevel1.getNodeBreakerView().getTerminal(0).getBusView().getBus().getFictitiousP0(), 0.0);
-        assertEquals(2.0, voltageLevel1.getNodeBreakerView().getTerminal(0).getBusView().getBus().getFictitiousQ0(), 0.0);
+        assertEquals(1.0, topology1.getTerminal(0).getBusView().getBus().getFictitiousP0(), 0.0);
+        assertEquals(2.0, topology1.getTerminal(0).getBusView().getBus().getFictitiousQ0(), 0.0);
 
         assertEquals(6, topology1.getMaximumNodeIndex());
         assertEquals(2, Iterables.size(topology1.getBusbarSections()));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
potential bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
dangerous to run an assert conditionally. Actually previously this test had a bug in the test code (wrong node) so it didn't run the assert and it still passed

**What is the new behavior (if this is a feature change)?**
always run the assert


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
    
    If the standard test network doesn't have a terminal at node 0, it's
    ok the test will be Error (different than Failure) but still noticeable
