### PR TITLE
NetworkTest tck add test for calculatedBus setFictitiousP0/Q0

### DIFF
--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -88,13 +88,8 @@ public abstract class AbstractNetworkTest {
         topology1.setFictitiousP0(0, 1.0).setFictitiousQ0(0, 2.0);
         assertEquals(1.0, topology1.getFictitiousP0(0), 0.0);
         assertEquals(2.0, topology1.getFictitiousQ0(0), 0.0);
-        Map<String, Set<Integer>> nodesByBus = Networks.getNodesByBus(voltageLevel1);
-        nodesByBus.forEach((busId, nodes) -> {
-            if (nodes.contains(0)) {
-                assertEquals(1.0, voltageLevel1.getBusView().getBus(busId).getFictitiousP0(), 0.0);
-                assertEquals(2.0, voltageLevel1.getBusView().getBus(busId).getFictitiousQ0(), 0.0);
-            }
-        });
+        assertEquals(1.0, voltageLevel1.getNodeBreakerView().getTerminal(0).getBusView().getBus().getFictitiousP0(), 0.0);
+        assertEquals(2.0, voltageLevel1.getNodeBreakerView().getTerminal(0).getBusView().getBus().getFictitiousQ0(), 0.0);
 
         assertEquals(6, topology1.getMaximumNodeIndex());
         assertEquals(2, Iterables.size(topology1.getBusbarSections()));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
no tests for setFictitiousP0/Q0 on a calculated bus


**What is the new behavior (if this is a feature change)?**
added tests for setFictitiousP0/Q0 on a calculated bus


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
