### PR TITLE
NetworkTest tck: add test for calculatedBus setFictitiousP0/Q0

### DIFF
--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworkTest.java
@@ -101,9 +101,9 @@ public abstract class AbstractNetworkTest {
         assertEquals(2.0, topology1.getTerminal(0).getBusView().getBus().getFictitiousQ0(), 0.0);
         topology1.getTerminal(0).getBusView().getBus().setFictitiousP0(3.0);
         topology1.getTerminal(0).getBusView().getBus().setFictitiousQ0(4.0);
-        // here we only test that the bus has the correct fictitious.
-        // Do we want to enforce the current behavior of the in memory implementation
-        // on how to distribute it on the different nodes of the bus ?
+        // here we only test that the bus has the correct total fictitious. We
+        // decided not to enforce how it is distributed on the different nodes
+        // of the bus to allow different behaviors.
         assertEquals(3.0, topology1.getTerminal(0).getBusView().getBus().getFictitiousP0(), 0.0);
         assertEquals(4.0, topology1.getTerminal(0).getBusView().getBus().getFictitiousQ0(), 0.0);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
no tests for setFictitiousP0/Q0 on a calculated bus


**What is the new behavior (if this is a feature change)?**
added tests for setFictitiousP0/Q0 on a calculated bus


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
