### PR TITLE
Cleanup started in #3524: add TCK abstract tests for GeneratorEntsoeCategory and BusbarSectionPosition

### DIFF
--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/extensions/BusbarSectionPositionImplTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/extensions/BusbarSectionPositionImplTest.java
@@ -8,53 +8,10 @@
 
 package com.powsybl.iidm.network.impl.tck.extensions;
 
-import com.powsybl.iidm.network.*;
-import com.powsybl.iidm.network.extensions.BusbarSectionPosition;
-import com.powsybl.iidm.network.extensions.BusbarSectionPositionAdder;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.powsybl.iidm.network.tck.extensions.AbstractBusbarSectionPositionTest;
 
 /**
  * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
+ * @author Samir Romdhani {@literal <samir.romdhani at rte-france.com>}
  */
-class BusbarSectionPositionImplTest {
-
-    @Test
-    void testExtension() {
-        IllegalArgumentException e0;
-        Network network = Network.create("test", "test");
-        Substation s = network.newSubstation()
-            .setId("S")
-            .setCountry(Country.FR)
-            .add();
-        VoltageLevel vl = s.newVoltageLevel()
-            .setId("VL")
-            .setNominalV(400.0)
-            .setTopologyKind(TopologyKind.NODE_BREAKER)
-            .add();
-        BusbarSection bbs = vl.getNodeBreakerView().newBusbarSection()
-            .setId("BBS")
-            .setNode(0)
-            .add();
-
-        BusbarSectionPosition busbarSectionPosition = bbs.newExtension(BusbarSectionPositionAdder.class)
-            .withBusbarIndex(1)
-            .withSectionIndex(2)
-            .add();
-        assertEquals(1, busbarSectionPosition.getBusbarIndex());
-        assertEquals(2, busbarSectionPosition.getSectionIndex());
-
-        // Wrong Busbar index
-        e0 = assertThrows(IllegalArgumentException.class, () -> busbarSectionPosition.setBusbarIndex(-1));
-        assertEquals("Busbar index (-1) has to be greater or equals to zero for busbar section BBS",
-            e0.getMessage());
-
-        // RIght busbar index
-        busbarSectionPosition.setBusbarIndex(10);
-        busbarSectionPosition.setSectionIndex(5);
-        assertEquals(10, busbarSectionPosition.getBusbarIndex());
-        assertEquals(5, busbarSectionPosition.getSectionIndex());
-    }
-}
+class BusbarSectionPositionImplTest extends AbstractBusbarSectionPositionTest { }

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/extensions/GeneratorEntsoeCategoryTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/tck/extensions/GeneratorEntsoeCategoryTest.java
@@ -8,56 +8,10 @@
 
 package com.powsybl.iidm.network.impl.tck.extensions;
 
-import com.powsybl.iidm.network.*;
-import com.powsybl.iidm.network.extensions.GeneratorEntsoeCategory;
-import com.powsybl.iidm.network.extensions.GeneratorEntsoeCategoryAdder;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.powsybl.iidm.network.tck.extensions.AbstractGeneratorEntsoeCategoryTest;
 
 /**
  * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
+ * @author Samir Romdhani {@literal <samir.romdhani at rte-france.com>}
  */
-class GeneratorEntsoeCategoryTest {
-
-    @Test
-    void testExtension() {
-        Network network = Network.create("test", "test");
-        Substation s = network.newSubstation()
-            .setId("S")
-            .setCountry(Country.FR)
-            .add();
-        VoltageLevel vl = s.newVoltageLevel()
-            .setId("VL")
-            .setNominalV(400)
-            .setTopologyKind(TopologyKind.BUS_BREAKER)
-            .add();
-        vl.getBusBreakerView().newBus()
-            .setId("B")
-            .add();
-        Generator generator = vl.newGenerator()
-            .setId("G1")
-            .setBus("B")
-            .setMaxP(100)
-            .setMinP(50)
-            .setTargetP(100)
-            .setTargetV(400)
-            .setVoltageRegulatorOn(true)
-            .add();
-
-        GeneratorEntsoeCategory generatorEntsoeCategory = generator.newExtension(GeneratorEntsoeCategoryAdder.class)
-            .withCode(10)
-            .add();
-        assertEquals(10, generatorEntsoeCategory.getCode());
-
-        // Wrong code
-        IllegalArgumentException e0 = assertThrows(IllegalArgumentException.class, () -> generatorEntsoeCategory.setCode(-1));
-        assertEquals("Bad generator ENTSO-E code -1 for generator G1",
-            e0.getMessage());
-
-        // Right code
-        generatorEntsoeCategory.setCode(5);
-        assertEquals(5, generatorEntsoeCategory.getCode());
-    }
-}
+class GeneratorEntsoeCategoryTest extends AbstractGeneratorEntsoeCategoryTest { }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractBusbarSectionPositionTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractBusbarSectionPositionTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network.tck.extensions;
+
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.extensions.BusbarSectionPosition;
+import com.powsybl.iidm.network.extensions.BusbarSectionPositionAdder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author Samir Romdhani {@literal <samir.romdhani at rte-france.com>}
+ */
+public abstract class AbstractBusbarSectionPositionTest {
+
+    @Test
+    void testExtension() {
+        BusbarSectionPosition busbarSectionPosition = busbarSection().newExtension(BusbarSectionPositionAdder.class)
+                .withBusbarIndex(1)
+                .withSectionIndex(2)
+                .add();
+        assertEquals(1, busbarSectionPosition.getBusbarIndex());
+        assertEquals(2, busbarSectionPosition.getSectionIndex());
+
+        // Wrong Busbar index
+        IllegalArgumentException e0;
+        e0 = assertThrows(IllegalArgumentException.class, () -> busbarSectionPosition.setBusbarIndex(-1));
+        assertEquals("Busbar index (-1) has to be greater or equals to zero for busbar section BBS",
+                e0.getMessage());
+
+        // Right busbar index
+        busbarSectionPosition.setBusbarIndex(10);
+        busbarSectionPosition.setSectionIndex(5);
+        assertEquals(10, busbarSectionPosition.getBusbarIndex());
+        assertEquals(5, busbarSectionPosition.getSectionIndex());
+    }
+
+    protected BusbarSection busbarSection() {
+        Network network = Network.create("test", "test");
+        Substation s = network.newSubstation()
+                .setId("S")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl = s.newVoltageLevel()
+                .setId("VL")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        return vl.getNodeBreakerView().newBusbarSection()
+                .setId("BBS")
+                .setNode(0)
+                .add();
+    }
+}

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractGeneratorEntsoeCategoryTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractGeneratorEntsoeCategoryTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.iidm.network.tck.extensions;
+
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.extensions.GeneratorEntsoeCategory;
+import com.powsybl.iidm.network.extensions.GeneratorEntsoeCategoryAdder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author Samir Romdhani {@literal <samir.romdhani at rte-france.com>}
+ */
+public abstract class AbstractGeneratorEntsoeCategoryTest {
+
+    @Test
+    void testExtension() {
+        GeneratorEntsoeCategory generatorEntsoeCategory = generator().newExtension(GeneratorEntsoeCategoryAdder.class)
+                .withCode(10)
+                .add();
+        assertEquals(10, generatorEntsoeCategory.getCode());
+
+        // Wrong code
+        IllegalArgumentException e0 = assertThrows(IllegalArgumentException.class, () -> generatorEntsoeCategory.setCode(-1));
+        assertEquals("Bad generator ENTSO-E code -1 for generator G1",
+                e0.getMessage());
+
+        // Right code
+        generatorEntsoeCategory.setCode(5);
+        assertEquals(5, generatorEntsoeCategory.getCode());
+    }
+
+    protected Generator generator() {
+        Network network = Network.create("test", "test");
+        Substation s = network.newSubstation()
+                .setId("S")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl = s.newVoltageLevel()
+                .setId("VL")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl.getBusBreakerView().newBus()
+                .setId("B")
+                .add();
+        return vl.newGenerator()
+                .setId("G1")
+                .setBus("B")
+                .setMaxP(100)
+                .setMinP(50)
+                .setTargetP(100)
+                .setTargetV(400)
+                .setVoltageRegulatorOn(true)
+                .add();
+    }
+
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Contract checks for these extensions ( GeneratorEntsoeCategory and BusbarSectionPosition) should be part of iidm-tck so they can be reused by all IIDM implementations.
