### PR TITLE
Move ProportionalScalable percentage computation to public and static

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/ProportionalScalable.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/ProportionalScalable.java
@@ -102,6 +102,20 @@ public class ProportionalScalable extends AbstractCompoundScalable {
         // Create the scalable for each injection
         List<Scalable> injectionScalables = injections.stream().map(scalableMapping).collect(Collectors.toList());
 
+        List<Double> percentages = computePercentages(injections, distributionMode);
+        checkPercentages(percentages, injectionScalables);
+
+        // Create the list of ScalablePercentage
+        this.scalablePercentageList = new ArrayList<>();
+        for (int i = 0; i < injectionScalables.size(); i++) {
+            this.scalablePercentageList.add(new ScalablePercentage(injectionScalables.get(i), percentages.get(i)));
+        }
+
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+    }
+
+    public static List<Double> computePercentages(List<? extends Injection> injections, DistributionMode distributionMode) {
         // Compute the sum of every individual power
         double totalDistribution = computeTotalDistribution(injections, distributionMode);
 
@@ -125,24 +139,14 @@ public class ProportionalScalable extends AbstractCompoundScalable {
         }
 
         // Compute the percentages for each injection
-        List<Double> percentages = injections.stream().map(injection -> getIndividualDistribution(injection, finalDistributionMode) * 100.0 / finalTotalDistribution).toList();
-        checkPercentages(percentages, injectionScalables);
-
-        // Create the list of ScalablePercentage
-        this.scalablePercentageList = new ArrayList<>();
-        for (int i = 0; i < injectionScalables.size(); i++) {
-            this.scalablePercentageList.add(new ScalablePercentage(injectionScalables.get(i), percentages.get(i)));
-        }
-
-        this.minValue = minValue;
-        this.maxValue = maxValue;
+        return injections.stream().map(injection -> getIndividualDistribution(injection, finalDistributionMode) * 100.0 / finalTotalDistribution).toList();
     }
 
-    private double computeTotalDistribution(List<? extends Injection> injections, DistributionMode distributionMode) {
+    private static double computeTotalDistribution(List<? extends Injection> injections, DistributionMode distributionMode) {
         return injections.stream().mapToDouble(injection -> getIndividualDistribution(injection, distributionMode)).sum();
     }
 
-    private double getIndividualDistribution(Injection<?> injection, DistributionMode distributionMode) {
+    private static double getIndividualDistribution(Injection<?> injection, DistributionMode distributionMode) {
         // Check the injection type
         checkInjectionClass(injection);
 
@@ -157,7 +161,7 @@ public class ProportionalScalable extends AbstractCompoundScalable {
         };
     }
 
-    private void checkInjectionClass(Injection<?> injection) {
+    private static void checkInjectionClass(Injection<?> injection) {
         if (!(injection instanceof Generator
             || injection instanceof Load
             || injection instanceof DanglingLine)) {
@@ -165,7 +169,7 @@ public class ProportionalScalable extends AbstractCompoundScalable {
         }
     }
 
-    private double getTargetP(Injection<?> injection) {
+    private static double getTargetP(Injection<?> injection) {
         if (injection instanceof Generator generator) {
             return generator.getTargetP();
         } else {
@@ -174,7 +178,7 @@ public class ProportionalScalable extends AbstractCompoundScalable {
         }
     }
 
-    private double getP0(Injection<?> injection) {
+    private static double getP0(Injection<?> injection) {
         if (injection instanceof Load load) {
             return load.getP0();
         } else if (injection instanceof DanglingLine danglingLine) {
@@ -185,7 +189,7 @@ public class ProportionalScalable extends AbstractCompoundScalable {
         }
     }
 
-    private double getMaxP(Injection<?> injection) {
+    private static double getMaxP(Injection<?> injection) {
         if (injection instanceof Generator generator) {
             return generator.getMaxP();
         } else {
@@ -194,7 +198,7 @@ public class ProportionalScalable extends AbstractCompoundScalable {
         }
     }
 
-    private double getMinP(Injection<?> injection) {
+    private static double getMinP(Injection<?> injection) {
         if (injection instanceof Generator generator) {
             return generator.getMinP();
         } else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->
The computation of percentages in ProportionalScalable based on DistributionMode is not reproducible outside of the constructor, and the obtained percentages also do not have a associated getter.


**What is the new behavior (if this is a feature change)?**
One can use the new static method (also now used in the constructor) to reproduce the percentage computation outside of a ProportionalScalable.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No