### PR TITLE
CGMES import option: Default to not store CgmesModelExtension (in case #3819 breaking change is unacceptable)

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -764,7 +764,7 @@ public class CgmesImport implements Importer {
             STORE_CGMES_MODEL_AS_NETWORK_EXTENSION,
             ParameterType.BOOLEAN,
             "Store the initial CGMES model as a network extension",
-            Boolean.TRUE)
+            Boolean.FALSE)
             .addAdditionalNames("storeCgmesModelAsNetworkExtension");
     private static final Parameter SOURCE_FOR_IIDM_ID_PARAMETER = new Parameter(
             SOURCE_FOR_IIDM_ID,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -1104,7 +1104,7 @@ public class Conversion {
 
         private boolean createBusbarSectionForEveryConnectivityNode = false;
         private boolean convertSvInjections = true;
-        private boolean storeCgmesModelAsNetworkExtension = true;
+        private boolean storeCgmesModelAsNetworkExtension = false;
         private boolean storeCgmesConversionContextAsNetworkExtension = false;
         private boolean createActivePowerControlExtension = false;
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/EntsoeCategoryPostProcessor.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/EntsoeCategoryPostProcessor.java
@@ -8,6 +8,7 @@
 package com.powsybl.cgmes.conversion;
 
 import com.google.auto.service.AutoService;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Network;
@@ -46,7 +47,11 @@ public class EntsoeCategoryPostProcessor implements CgmesImportPostProcessor {
     public void process(Network network, TripleStore tripleStore) {
         Objects.requireNonNull(network);
         LOG.info("Execute {} post processor on network {}", getName(), network.getId());
-        for (PropertyBag sm : network.getExtension(CgmesModelExtension.class).getCgmesModel().synchronousMachinesGenerators()) {
+        CgmesModelExtension cgmes = network.getExtension(CgmesModelExtension.class);
+        if (cgmes == null) {
+            throw new PowsyblException("CgmesModelExtension is required by the EntsoeCategoryPostProcessor");
+        }
+        for (PropertyBag sm : cgmes.getCgmesModel().synchronousMachinesGenerators()) {
             String generatingUnitId = sm.getId("GeneratingUnit");
             if (generatingUnitId != null) {
                 processGenerator(network, sm, generatingUnitId);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/PhaseAngleClock.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/PhaseAngleClock.java
@@ -43,14 +43,9 @@ public class PhaseAngleClock implements CgmesImportPostProcessor {
     public void process(Network network, TripleStore tripleStore) {
         CgmesModelExtension cgmesExtension = network.getExtension(CgmesModelExtension.class);
         if (cgmesExtension == null) {
-            LOG.warn("PhaseAngleClock-PostProcessor: Unexpected null cgmesExtension pointer");
-            return;
+            throw new PowsyblException("CgmesModelExtension is required by the PhaseAngleClock PostProcessor");
         }
         CgmesModel cgmes = cgmesExtension.getCgmesModel();
-        if (cgmes == null) {
-            LOG.warn("PhaseAngleClock-PostProcessor: Unexpected null cgmesModel pointer");
-            return;
-        }
         Map<String, PropertyBags> groupedTransformerEnds = new HashMap<>();
         cgmes.transformerEnds()
                 .forEach(p -> groupedTransformerEnds

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
@@ -119,7 +119,7 @@ public class ConversionTester {
     private void testConversion(Network expected, GridModelReference gm, ComparisonConfig config, String impl)
         throws IOException {
         Properties iparams = importParams == null ? new Properties() : importParams;
-        iparams.put("storeCgmesModelAsNetworkExtension", "true");
+        iparams.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, "true");
         iparams.put("powsyblTripleStore", impl);
         // This is to be able to easily compare the topology computed
         // by powsybl against the topology present in the CGMES model
@@ -158,6 +158,7 @@ public class ConversionTester {
         CgmesImport i = new CgmesImport();
         ReadOnlyDataSource ds = gm.dataSource();
         LOG.info("Importer.exists() == {}", i.exists(ds));
+        importParams.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, true);
         Network n = i.importData(ds, new NetworkFactoryImpl(), importParams);
         CgmesModel m = n.getExtension(CgmesModelExtension.class).getCgmesModel();
         new Conversion(m).report(reportConsumer);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TransformerConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/TransformerConversionTest.java
@@ -336,6 +336,7 @@ class TransformerConversionTest {
     @Test
     void miniBusBranchPhaseAngleClock() {
         Conversion.Config config = new Conversion.Config();
+        config.setStoreCgmesModelAsNetworkExtension(true);
         List<CgmesImportPostProcessor> postProcessors = new ArrayList<>();
         postProcessors.add(new PhaseAngleClock());
 
@@ -350,6 +351,7 @@ class TransformerConversionTest {
     @Test
     void miniBusBranchPhaseAngleClockZero() {
         Conversion.Config config = new Conversion.Config();
+        config.setStoreCgmesModelAsNetworkExtension(true);
         List<CgmesImportPostProcessor> postProcessors = new ArrayList<>();
         postProcessors.add(new PhaseAngleClock());
 
@@ -364,6 +366,7 @@ class TransformerConversionTest {
     @Test
     void miniBusBranchT2xPhaseAngleClock1NonZero() {
         Conversion.Config config = new Conversion.Config();
+        config.setStoreCgmesModelAsNetworkExtension(true);
         List<CgmesImportPostProcessor> postProcessors = new ArrayList<>();
         postProcessors.add(new PhaseAngleClock());
 
@@ -376,6 +379,7 @@ class TransformerConversionTest {
     @Test
     void miniBusBranchT3xAllPhaseAngleClockNonZero() {
         Conversion.Config config = new Conversion.Config();
+        config.setStoreCgmesModelAsNetworkExtension(true);
         List<CgmesImportPostProcessor> postProcessors = new ArrayList<>();
         postProcessors.add(new PhaseAngleClock());
 

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/modified/CgmesConformity1ModifiedConversionTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/conformity/modified/CgmesConformity1ModifiedConversionTest.java
@@ -743,6 +743,7 @@ class CgmesConformity1ModifiedConversionTest {
     @Test
     void microGridBaseCaseAssembledEntsoeCategory() {
         importParams.put(CgmesImport.POST_PROCESSORS, "EntsoeCategory");
+        importParams.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, true);
         Network network = Importers.importData("CGMES", CgmesConformity1ModifiedCatalog.microGridBaseCaseAssembledEntsoeCategory().dataSource(), importParams);
         assertEquals(31, network.getGenerator("550ebe0d-f2b2-48c1-991f-cebea43a21aa").getExtension(GeneratorEntsoeCategory.class).getCode());
         assertEquals(42, network.getGenerator("9c3b8f97-7972-477d-9dc8-87365cc0ad0e").getExtension(GeneratorEntsoeCategory.class).getCode());

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesNamingStrategyTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesNamingStrategyTest.java
@@ -69,7 +69,9 @@ class CgmesNamingStrategyTest extends AbstractSerDeTest {
         }
 
         // Load the exported CGMES model and check that all objects have valid CGMES identifiers
-        Network network1 = Network.read(exportedCgmes);
+        Properties importParams = new Properties();
+        importParams.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, true); // needed by the test
+        Network network1 = Network.read(exportedCgmes, importParams);
         checkAllIdentifiersAreValidCimCgmesIdentifiers(network1);
         // Also, all Identifiables that do not have a valid CIM mRID must have a valid UUID alias
         for (Identifiable<?> i : network1.getIdentifiables()) {

--- a/cgmes/cgmes-measurements/src/test/java/com/powsybl/cgmes/measurements/CgmesMeasurementsTest.java
+++ b/cgmes/cgmes-measurements/src/test/java/com/powsybl/cgmes/measurements/CgmesMeasurementsTest.java
@@ -222,6 +222,7 @@ class CgmesMeasurementsTest {
     @Test
     void testDeprecated() {
         Properties properties = new Properties();
+        properties.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, true);
         Network network = new CgmesImport().importData(CgmesConformity1ModifiedCatalog.microGridBaseCaseMeasurements().dataSource(),
                 NetworkFactory.findDefault(), properties);
         assertNotNull(network);

--- a/cgmes/cgmes-shortcircuit/src/test/java/com/powsybl/cgmes/shortcircuit/CgmesImporterTest.java
+++ b/cgmes/cgmes-shortcircuit/src/test/java/com/powsybl/cgmes/shortcircuit/CgmesImporterTest.java
@@ -11,8 +11,6 @@ import com.powsybl.cgmes.conformity.Cgmes3Catalog;
 import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conformity.CgmesConformity1ModifiedCatalog;
 import com.powsybl.cgmes.conversion.CgmesImport;
-import com.powsybl.cgmes.conversion.CgmesModelExtension;
-import com.powsybl.cgmes.model.CgmesModel;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.BusbarSection;
 import com.powsybl.iidm.network.Generator;
@@ -54,16 +52,10 @@ class CgmesImporterTest {
 
     @Test
     void testImportCgmes3GeneratorShortCircuitData() {
+        Properties p = new Properties();
+        p.put(CgmesImport.POST_PROCESSORS, List.of("shortcircuit"));
         Network network = new CgmesImport().importData(Cgmes3Catalog.miniGrid().dataSource(),
-                NetworkFactory.findDefault(), new Properties());
-
-        CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
-        assertNotNull(cgmesModelExtension);
-        CgmesModel cgmesModel = cgmesModelExtension.getCgmesModel();
-        assertNotNull(cgmesModel);
-
-        CgmesShortCircuitModel cgmesScModel = new CgmesShortCircuitModel(cgmesModel.tripleStore());
-        new CgmesShortCircuitImporter(cgmesScModel, network).importShortcircuitData();
+                NetworkFactory.findDefault(), p);
 
         Generator generator = network.getGenerator("ca67be42-750e-4ebf-bfaa-24d446e59a22");
         assertNotNull(generator);
@@ -79,21 +71,15 @@ class CgmesImporterTest {
 
     @Test
     void testImportCgmesBranchModelBusbarSectionShortCircuitData() {
+        Properties p = new Properties();
+        p.put(CgmesImport.POST_PROCESSORS, List.of("shortcircuit"));
         Network network = new CgmesImport().importData(CgmesConformity1ModifiedCatalog.smallGridBusBranchWithBusbarSectionsAndIpMax().dataSource(),
-                NetworkFactory.findDefault(), new Properties());
-
-        CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
-        assertNotNull(cgmesModelExtension);
-        CgmesModel cgmesModel = cgmesModelExtension.getCgmesModel();
-        assertNotNull(cgmesModel);
-
-        CgmesShortCircuitModel cgmesScModel = new CgmesShortCircuitModel(cgmesModel.tripleStore());
-        new CgmesShortCircuitImporter(cgmesScModel, network).importShortcircuitData();
+                NetworkFactory.findDefault(), p);
 
         Bus bus = network.getBusBreakerView().getBus("0472a783-c766-11e1-8775-005056c00008");
         assertNotNull(bus);
 
-        IdentifiableShortCircuit busShortCircuit = bus.getExtension(IdentifiableShortCircuit.class);
+        IdentifiableShortCircuit<Bus> busShortCircuit = bus.getExtension(IdentifiableShortCircuit.class);
         assertNotNull(busShortCircuit);
 
         assertTrue(Double.isNaN(busShortCircuit.getIpMin()));
@@ -102,44 +88,31 @@ class CgmesImporterTest {
 
     @Test
     void testImportCgmesBusbarSectionShortCircuitData() {
+        Properties p = new Properties();
+        p.put(CgmesImport.POST_PROCESSORS, List.of("shortcircuit"));
         Network network = new CgmesImport().importData(CgmesConformity1Catalog.miniNodeBreaker().dataSource(),
-                NetworkFactory.findDefault(), new Properties());
-
-        CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
-        assertNotNull(cgmesModelExtension);
-        CgmesModel cgmesModel = cgmesModelExtension.getCgmesModel();
-        assertNotNull(cgmesModel);
-
-        CgmesShortCircuitModel cgmesScModel = new CgmesShortCircuitModel(cgmesModel.tripleStore());
-        new CgmesShortCircuitImporter(cgmesScModel, network).importShortcircuitData();
+                NetworkFactory.findDefault(), p);
 
         BusbarSection busbarSection = network.getBusbarSection("d9f23c01-d924-4040-ab48-d5c36ccdf1a3");
         assertNotNull(busbarSection);
 
-        IdentifiableShortCircuit busbarSectionShortCircuit = busbarSection.getExtension(IdentifiableShortCircuit.class);
+        IdentifiableShortCircuit<BusbarSection> busbarSectionShortCircuit = busbarSection.getExtension(IdentifiableShortCircuit.class);
         assertNull(busbarSectionShortCircuit);
     }
 
     @Test
     void testImportCgmes3BusbarSectionShortCircuitData() {
         Properties importParams = new Properties();
+        importParams.put(CgmesImport.POST_PROCESSORS, List.of("shortcircuit"));
         // Avoid importing assembled micro grid as subnetworks, to have access to whole CGMES model
         importParams.put(CgmesImport.IMPORT_CGM_WITH_SUBNETWORKS, "false");
         Network network = new CgmesImport().importData(Cgmes3Catalog.microGrid().dataSource(),
                 NetworkFactory.findDefault(), importParams);
 
-        CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
-        assertNotNull(cgmesModelExtension);
-        CgmesModel cgmesModel = cgmesModelExtension.getCgmesModel();
-        assertNotNull(cgmesModel);
-
-        CgmesShortCircuitModel cgmesScModel = new CgmesShortCircuitModel(cgmesModel.tripleStore());
-        new CgmesShortCircuitImporter(cgmesScModel, network).importShortcircuitData();
-
         BusbarSection busbarSection = network.getBusbarSection("364c9ca2-0d1d-4363-8f46-e586f8f66a8c");
         assertNotNull(busbarSection);
 
-        IdentifiableShortCircuit busbarSectionShortCircuit = busbarSection.getExtension(IdentifiableShortCircuit.class);
+        IdentifiableShortCircuit<BusbarSection> busbarSectionShortCircuit = busbarSection.getExtension(IdentifiableShortCircuit.class);
         assertNotNull(busbarSectionShortCircuit);
 
         assertTrue(Double.isNaN(busbarSectionShortCircuit.getIpMin()));


### PR DESCRIPTION
ℹ️ I prefer #3819, this PR is here only if the breaking change introduced by #3819 is unacceptable. The problem here is that PhaseAngleClock and EntsoeCategoryPostProcessor still need the CgmesModelExtension which is in my opinion quite bad.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
See #3561 and #3788


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
By default the CgmesModel is stored as a network extension (option `iidm.import.cgmes.store-cgmes-model-as-network-extension` default value is `true`), for most use cases this consumes RAM unnecessarily.


**What is the new behavior (if this is a feature change)?**
- option `iidm.import.cgmes.store-cgmes-model-as-network-extension` default value is `false`.
- tests using the CgmesModelExtension must explicitly enable the option
- The CGMES PostProcessors `PhaseAngleClock` and `EntsoeCategoryPostProcessor` rely on the CgmesModelExtension being present. Until these are refactored to not rely on the CgmesModelExtension, these post-processors throw an exception in the absence of the CgmesModelExtension.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
