### PR TITLE
CGMES import: Default to not store CgmesModelExtension

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -764,7 +764,7 @@ public class CgmesImport implements Importer {
             STORE_CGMES_MODEL_AS_NETWORK_EXTENSION,
             ParameterType.BOOLEAN,
             "Store the initial CGMES model as a network extension",
-            Boolean.TRUE)
+            Boolean.FALSE)
             .addAdditionalNames("storeCgmesModelAsNetworkExtension");
     private static final Parameter SOURCE_FOR_IIDM_ID_PARAMETER = new Parameter(
             SOURCE_FOR_IIDM_ID,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImportPostProcessor.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImportPostProcessor.java
@@ -7,8 +7,8 @@
  */
 package com.powsybl.cgmes.conversion;
 
+import com.powsybl.cgmes.model.CgmesModel;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.triplestore.api.TripleStore;
 
 /**
  * <p>
@@ -26,7 +26,7 @@ import com.powsybl.triplestore.api.TripleStore;
  *        }
  *
  *       {@literal @}Override
- *        public void process(Network network, TripleStore tripleStore) {
+ *        public void process(Network network, CgmesModel cgmesModel) {
  *            ...
  *        }
  *    }
@@ -47,10 +47,11 @@ public interface CgmesImportPostProcessor {
 
     /**
      * Method called after all base data have been processed. It is called one time per CGMES conversion.
-     * It is expected in this method to query triple store for additional data and to attach IIDM extensions to network.
+     * It is expected in this method to either use the CGMES model and/or query its triple store for additional
+     * data and to attach IIDM extensions to network.
      *
      * @param network the IIDM network model
-     * @param tripleStore the triple store
+     * @param cgmesModel the CGMES model
      */
-    void process(Network network, TripleStore tripleStore);
+    void process(Network network, CgmesModel cgmesModel);
 }

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -259,7 +259,7 @@ public class Conversion {
             // FIXME generic cgmes models may not have an underlying triplestore
             // TODO maybe pass the properties to the post processors
             CgmesReports.applyingProcessorReport(postProcessorsNode, postProcessor.getName());
-            postProcessor.process(network, cgmes.tripleStore());
+            postProcessor.process(network, cgmes);
         }
 
         CgmesReports.importedCgmesNetworkReport(reportNode, network.getId());
@@ -1105,7 +1105,7 @@ public class Conversion {
 
         private boolean createBusbarSectionForEveryConnectivityNode = false;
         private boolean convertSvInjections = true;
-        private boolean storeCgmesModelAsNetworkExtension = true;
+        private boolean storeCgmesModelAsNetworkExtension = false;
         private boolean storeCgmesConversionContextAsNetworkExtension = false;
         private boolean createActivePowerControlExtension = false;
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/EntsoeCategoryPostProcessor.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/EntsoeCategoryPostProcessor.java
@@ -8,12 +8,12 @@
 package com.powsybl.cgmes.conversion;
 
 import com.google.auto.service.AutoService;
+import com.powsybl.cgmes.model.CgmesModel;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.extensions.GeneratorEntsoeCategoryAdder;
 import com.powsybl.triplestore.api.PropertyBag;
-import com.powsybl.triplestore.api.TripleStore;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,10 +43,10 @@ public class EntsoeCategoryPostProcessor implements CgmesImportPostProcessor {
     }
 
     @Override
-    public void process(Network network, TripleStore tripleStore) {
+    public void process(Network network, CgmesModel cgmesModel) {
         Objects.requireNonNull(network);
         LOG.info("Execute {} post processor on network {}", getName(), network.getId());
-        for (PropertyBag sm : network.getExtension(CgmesModelExtension.class).getCgmesModel().synchronousMachinesGenerators()) {
+        for (PropertyBag sm : cgmesModel.synchronousMachinesGenerators()) {
             String generatingUnitId = sm.getId("GeneratingUnit");
             if (generatingUnitId != null) {
                 processGenerator(network, sm, generatingUnitId);

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/PhaseAngleClock.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/PhaseAngleClock.java
@@ -22,7 +22,6 @@ import com.powsybl.iidm.network.TwoWindingsTransformer;
 import com.powsybl.iidm.network.extensions.TwoWindingsTransformerPhaseAngleClockAdder;
 import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
-import com.powsybl.triplestore.api.TripleStore;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,19 +39,9 @@ public class PhaseAngleClock implements CgmesImportPostProcessor {
     }
 
     @Override
-    public void process(Network network, TripleStore tripleStore) {
-        CgmesModelExtension cgmesExtension = network.getExtension(CgmesModelExtension.class);
-        if (cgmesExtension == null) {
-            LOG.warn("PhaseAngleClock-PostProcessor: Unexpected null cgmesExtension pointer");
-            return;
-        }
-        CgmesModel cgmes = cgmesExtension.getCgmesModel();
-        if (cgmes == null) {
-            LOG.warn("PhaseAngleClock-PostProcessor: Unexpected null cgmesModel pointer");
-            return;
-        }
+    public void process(Network network, CgmesModel cgmesModel) {
         Map<String, PropertyBags> groupedTransformerEnds = new HashMap<>();
-        cgmes.transformerEnds()
+        cgmesModel.transformerEnds()
                 .forEach(p -> groupedTransformerEnds
                         .computeIfAbsent(p.getId("PowerTransformer"), b -> new PropertyBags())
                         .add(p));

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RemoveGroundsPostProcessor.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/RemoveGroundsPostProcessor.java
@@ -8,11 +8,11 @@
 package com.powsybl.cgmes.conversion;
 
 import com.google.auto.service.AutoService;
+import com.powsybl.cgmes.model.CgmesModel;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.iidm.modification.topology.RemoveFeederBay;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.triplestore.api.TripleStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +42,7 @@ public class RemoveGroundsPostProcessor implements CgmesImportPostProcessor {
     }
 
     @Override
-    public void process(Network network, TripleStore tripleStore) {
+    public void process(Network network, CgmesModel cgmesModel) {
         Objects.requireNonNull(network);
         LOG.info("Execute {} post processor on network {}", getName(), network.getId());
         List<String> grounds = network.getGroundStream().map(Identifiable::getId).toList();

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/CgmesImportPreAndPostProcessorsTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/CgmesImportPreAndPostProcessorsTest.java
@@ -15,7 +15,6 @@ import com.powsybl.cgmes.model.GridModelReferenceResources;
 import com.powsybl.commons.parameters.Parameter;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.NetworkFactory;
-import com.powsybl.triplestore.api.TripleStore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,7 +45,7 @@ class CgmesImportPreAndPostProcessorsTest {
         }
 
         @Override
-        public void process(Network network, TripleStore tripleStore) {
+        public void process(Network network, CgmesModel cgmesModel) {
             activatedPostProcessorNames.add(getName());
         }
     }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/ConversionTester.java
@@ -158,6 +158,7 @@ public class ConversionTester {
         CgmesImport i = new CgmesImport();
         ReadOnlyDataSource ds = gm.dataSource();
         LOG.info("Importer.exists() == {}", i.exists(ds));
+        importParams.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, "true");
         Network n = i.importData(ds, new NetworkFactoryImpl(), importParams);
         CgmesModel m = n.getExtension(CgmesModelExtension.class).getCgmesModel();
         new Conversion(m).report(reportConsumer);

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesNamingStrategyTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/CgmesNamingStrategyTest.java
@@ -59,7 +59,9 @@ class CgmesNamingStrategyTest extends AbstractSerDeTest {
         }
 
         // Load the exported CGMES model and check that all objects have valid CGMES identifiers
-        Network network1 = Network.read(exportedCgmes);
+        Properties importParams = new Properties();
+        importParams.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, "true");
+        Network network1 = Network.read(exportedCgmes, importParams);
         checkAllIdentifiersAreValidCimCgmesIdentifiers(network1);
 
         // Now that we have valid identifiers stored as aliases, we should be able to re-export to CGMES

--- a/cgmes/cgmes-gl/src/main/java/com/powsybl/cgmes/gl/CgmesGLImportPostProcessor.java
+++ b/cgmes/cgmes-gl/src/main/java/com/powsybl/cgmes/gl/CgmesGLImportPostProcessor.java
@@ -9,9 +9,9 @@ package com.powsybl.cgmes.gl;
 
 import com.google.auto.service.AutoService;
 import com.powsybl.cgmes.conversion.CgmesImportPostProcessor;
+import com.powsybl.cgmes.model.CgmesModel;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.triplestore.api.QueryCatalog;
-import com.powsybl.triplestore.api.TripleStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,9 +43,9 @@ public class CgmesGLImportPostProcessor implements CgmesImportPostProcessor {
     }
 
     @Override
-    public void process(Network network, TripleStore tripleStore) {
+    public void process(Network network, CgmesModel cgmesModel) {
         LOG.info("Execute {} CGMES import post processor on network {}", getName(), network.getId());
-        CgmesGLModel cgmesGLModel = new CgmesGLModel(tripleStore, queryCatalog);
+        CgmesGLModel cgmesGLModel = new CgmesGLModel(cgmesModel.tripleStore(), queryCatalog);
         new CgmesGLImporter(network, cgmesGLModel).importGLData();
     }
 

--- a/cgmes/cgmes-measurements/src/main/java/com/powsybl/cgmes/measurements/CgmesMeasurementsPostProcessor.java
+++ b/cgmes/cgmes-measurements/src/main/java/com/powsybl/cgmes/measurements/CgmesMeasurementsPostProcessor.java
@@ -9,6 +9,7 @@ package com.powsybl.cgmes.measurements;
 
 import com.google.auto.service.AutoService;
 import com.powsybl.cgmes.conversion.CgmesImportPostProcessor;
+import com.powsybl.cgmes.model.CgmesModel;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.commons.parameters.Parameter;
@@ -16,7 +17,6 @@ import com.powsybl.commons.parameters.ParameterDefaultValueConfig;
 import com.powsybl.commons.parameters.ParameterType;
 import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
-import com.powsybl.triplestore.api.TripleStore;
 
 import java.util.Collections;
 import java.util.List;
@@ -59,8 +59,8 @@ public class CgmesMeasurementsPostProcessor implements CgmesImportPostProcessor 
     }
 
     @Override
-    public void process(Network network, TripleStore tripleStore) {
-        CgmesMeasurementsModel model = new CgmesMeasurementsModel(tripleStore);
+    public void process(Network network, CgmesModel cgmesModel) {
+        CgmesMeasurementsModel model = new CgmesMeasurementsModel(cgmesModel.tripleStore());
         PropertyBags bays = model.bays();
         Map<String, PropertyBag> idToBayBag = bays.stream().collect(Collectors.toMap(b -> b.getId("Bay"), b -> b));
         Map<String, String> analogTypesMapping = createTypesMapping(

--- a/cgmes/cgmes-measurements/src/test/java/com/powsybl/cgmes/measurements/CgmesMeasurementsTest.java
+++ b/cgmes/cgmes-measurements/src/test/java/com/powsybl/cgmes/measurements/CgmesMeasurementsTest.java
@@ -222,6 +222,7 @@ class CgmesMeasurementsTest {
     @Test
     void testDeprecated() {
         Properties properties = new Properties();
+        properties.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, "true");
         Network network = new CgmesImport().importData(CgmesConformity1ModifiedCatalog.microGridBaseCaseMeasurements().dataSource(),
                 NetworkFactory.findDefault(), properties);
         assertNotNull(network);

--- a/cgmes/cgmes-shortcircuit/src/main/java/com/powsybl/cgmes/shortcircuit/CgmesShortCircuitPostProcessor.java
+++ b/cgmes/cgmes-shortcircuit/src/main/java/com/powsybl/cgmes/shortcircuit/CgmesShortCircuitPostProcessor.java
@@ -9,8 +9,8 @@ package com.powsybl.cgmes.shortcircuit;
 
 import com.google.auto.service.AutoService;
 import com.powsybl.cgmes.conversion.CgmesImportPostProcessor;
+import com.powsybl.cgmes.model.CgmesModel;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.triplestore.api.TripleStore;
 
 /**
  * @author Miora Vedelago {@literal <miora.ralambotiana at rte-france.com>}
@@ -24,7 +24,7 @@ public class CgmesShortCircuitPostProcessor implements CgmesImportPostProcessor 
     }
 
     @Override
-    public void process(Network network, TripleStore tripleStore) {
-        new CgmesShortCircuitImporter(new CgmesShortCircuitModel(tripleStore), network).importShortcircuitData();
+    public void process(Network network, CgmesModel cgmesModel) {
+        new CgmesShortCircuitImporter(new CgmesShortCircuitModel(cgmesModel.tripleStore()), network).importShortcircuitData();
     }
 }

--- a/cgmes/cgmes-shortcircuit/src/test/java/com/powsybl/cgmes/shortcircuit/CgmesImporterTest.java
+++ b/cgmes/cgmes-shortcircuit/src/test/java/com/powsybl/cgmes/shortcircuit/CgmesImporterTest.java
@@ -54,8 +54,10 @@ class CgmesImporterTest {
 
     @Test
     void testImportCgmes3GeneratorShortCircuitData() {
+        Properties importParams = new Properties();
+        importParams.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, "true");
         Network network = new CgmesImport().importData(Cgmes3Catalog.miniGrid().dataSource(),
-                NetworkFactory.findDefault(), new Properties());
+                NetworkFactory.findDefault(), importParams);
 
         CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
         assertNotNull(cgmesModelExtension);
@@ -79,8 +81,10 @@ class CgmesImporterTest {
 
     @Test
     void testImportCgmesBranchModelBusbarSectionShortCircuitData() {
+        Properties importParams = new Properties();
+        importParams.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, "true");
         Network network = new CgmesImport().importData(CgmesConformity1ModifiedCatalog.smallGridBusBranchWithBusbarSectionsAndIpMax().dataSource(),
-                NetworkFactory.findDefault(), new Properties());
+                NetworkFactory.findDefault(), importParams);
 
         CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
         assertNotNull(cgmesModelExtension);
@@ -102,8 +106,10 @@ class CgmesImporterTest {
 
     @Test
     void testImportCgmesBusbarSectionShortCircuitData() {
+        Properties importParams = new Properties();
+        importParams.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, "true");
         Network network = new CgmesImport().importData(CgmesConformity1Catalog.miniNodeBreaker().dataSource(),
-                NetworkFactory.findDefault(), new Properties());
+                NetworkFactory.findDefault(), importParams);
 
         CgmesModelExtension cgmesModelExtension = network.getExtension(CgmesModelExtension.class);
         assertNotNull(cgmesModelExtension);
@@ -123,6 +129,7 @@ class CgmesImporterTest {
     @Test
     void testImportCgmes3BusbarSectionShortCircuitData() {
         Properties importParams = new Properties();
+        importParams.put(CgmesImport.STORE_CGMES_MODEL_AS_NETWORK_EXTENSION, "true");
         // Avoid importing assembled micro grid as subnetworks, to have access to whole CGMES model
         importParams.put(CgmesImport.IMPORT_CGM_WITH_SUBNETWORKS, "false");
         Network network = new CgmesImport().importData(Cgmes3Catalog.microGrid().dataSource(),

--- a/docs/grid_exchange_formats/cgmes/import.md
+++ b/docs/grid_exchange_formats/cgmes/import.md
@@ -840,7 +840,7 @@ Optional property that defines if IIDM IDs must be obtained from the CGMES `mRID
 
 **iidm.import.cgmes.store-cgmes-model-as-network-extension**<br>
 Optional property that defines if the whole CGMES model is stored in the imported IIDM network as an [extension](import.md#cgmes-model) of the IIDM output network.
-The default value is `true`.
+The default value is `false`.
 
 The CGMES model triplestore is not closed after CGMES import when this option is enabled.
 To reclaim memory, manually close the triplestore via the extension.


### PR DESCRIPTION
ℹ️ An alternative implementation without breaking change is in #3818 

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
See #3561 and #3788


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature
This is an alternative (and in my opinion better) implementation of #3818

**What is the current behavior?**
<!-- You can also link to an open issue here -->
- By default the CgmesModel is stored as a network extension (option `iidm.import.cgmes.store-cgmes-model-as-network-extension` default value is `true`), for most use cases this consumes RAM unnecessarily.
- CgmesImportPostProcessor-s plugins have access to only the triple store, not the complete CgmesModel


**What is the new behavior (if this is a feature change)?**
- option `iidm.import.cgmes.store-cgmes-model-as-network-extension` default value is `false`.
- tests using the CgmesModelExtension must explicitly enable the option
- `CgmesImportPostProcessor`-s plugins have access the complete CgmesModel (and its underlying triplestore)


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

In your `CgmesImportPostProcessor`-s implementation, the `process` method signature is changed from

```java
    @Override
    public void process(Network network, TripleStore tripleStore) {
         /* your implementation */
    }
```

to

```java
    @Override
    public void process(Network network, CgmesModel cgmesModel) {
        // the triplestore can still be accessed with
        TripleStore tripleStore = cgmesModel.tripleStore();
         /* your implementation */
    }
```

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
