### PR TITLE
Make TCK method public in AbstractOperationalLimitsGroupsTest

### DIFF
--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractOperationalLimitsGroupsTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractOperationalLimitsGroupsTest.java
@@ -935,7 +935,7 @@ public abstract class AbstractOperationalLimitsGroupsTest {
 
     @ParameterizedTest
     @MethodSource("provideReductionValueSelectionArguments")
-    void operationalLimitsGroupLimitReductionValueSelection(Identifiable<?> identifiable, ThreeSides side, double limitReductionValue, Collection<String> groupsToApplyLimitReduction, LimitType type, double value, Collection<ExpectedOverload> expected) {
+    public void operationalLimitsGroupLimitReductionValueSelection(Identifiable<?> identifiable, ThreeSides side, double limitReductionValue, Collection<String> groupsToApplyLimitReduction, LimitType type, double value, Collection<ExpectedOverload> expected) {
         Collection<Overload> overloads = switch (identifiable) {
             case Branch<?> b -> LimitViolationUtils.checkAllTemporaryLimits(b, side.toTwoSides(), limitReductionValue, groupsToApplyLimitReduction, value, type);
             case ThreeWindingsTransformer t -> LimitViolationUtils.checkAllTemporaryLimits(t, side, limitReductionValue, groupsToApplyLimitReduction, value, type);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
TCK test method is protected

**What is the new behavior (if this is a feature change)?**
TCK test method is public

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
