### PR TITLE
Add getSeverity() to ReportNode

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/report/ReportNode.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNode.java
@@ -199,7 +199,7 @@ public interface ReportNode {
     /** Add the {@link String} value for the {@link TypedValue#SEVERITY} type associated to {@link ReportConstants#SEVERITY_KEY} key */
     ReportNode addSeverity(String severity);
 
-    /** Get Severity value **/
+    /** Get the {@link String} value for the {@link TypedValue#SEVERITY} type associated to {@link ReportConstants#SEVERITY_KEY} key */
     default String getSeverity() {
         Optional<TypedValue> typedValue = getValue(ReportConstants.SEVERITY_KEY);
         return typedValue.map(TypedValue::toString).orElse(null);

--- a/commons/src/main/java/com/powsybl/commons/report/ReportNode.java
+++ b/commons/src/main/java/com/powsybl/commons/report/ReportNode.java
@@ -199,6 +199,12 @@ public interface ReportNode {
     /** Add the {@link String} value for the {@link TypedValue#SEVERITY} type associated to {@link ReportConstants#SEVERITY_KEY} key */
     ReportNode addSeverity(String severity);
 
+    /** Get Severity value **/
+    default String getSeverity() {
+        Optional<TypedValue> typedValue = getValue(ReportConstants.SEVERITY_KEY);
+        return typedValue.map(TypedValue::toString).orElse(null);
+    }
+
     /**
      * Print to given path the current report node and its descendants
      * @param path the path to write to

--- a/commons/src/test/java/com/powsybl/commons/report/ReportNodeTest.java
+++ b/commons/src/test/java/com/powsybl/commons/report/ReportNodeTest.java
@@ -11,6 +11,10 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.test.AbstractSerDeTest;
 import com.powsybl.commons.test.ComparisonUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,6 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.powsybl.commons.test.PowsyblTestReportResourceBundle.TEST_BASE_NAME;
 import static org.junit.jupiter.api.Assertions.*;
@@ -452,6 +457,33 @@ class ReportNodeTest extends AbstractSerDeTest {
         ReportNodeBuilder reportNodeBuilder = ReportNode.newRootReportNode();
         PowsyblException e = assertThrows(PowsyblException.class, reportNodeBuilder::withResourceBundles);
         assertEquals("bundleBaseNames must not be empty", e.getMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("severityProvider")
+    void testSeverityGetter(TypedValue typedSeverity, String expectedSeverity) {
+        ReportNode root = ReportNode.newRootReportNode()
+                .withResourceBundles(TEST_BASE_NAME)
+                .withMessageTemplate("root")
+                .build();
+
+        ReportNode child = root.newReportNode()
+                .withMessageTemplate("child")
+                .withSeverity(typedSeverity)
+                .add();
+
+        assertEquals(expectedSeverity, child.getSeverity());
+        assertNull(root.getSeverity());
+    }
+
+    static Stream<Arguments> severityProvider() {
+        return Stream.of(
+                Arguments.of(TypedValue.TRACE_SEVERITY, "TRACE"),
+                Arguments.of(TypedValue.DEBUG_SEVERITY, "DEBUG"),
+                Arguments.of(TypedValue.INFO_SEVERITY, "INFO"),
+                Arguments.of(TypedValue.WARN_SEVERITY, "WARN"),
+                Arguments.of(TypedValue.ERROR_SEVERITY, "ERROR")
+        );
     }
 
     private static void assertHasNoTimeStamp(ReportNode root1) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
https://github.com/powsybl/powsybl-core/issues/3845



**What kind of change does this PR introduce?**
This PR introduces a default String getSeverity() method in ReportNode.



**What is the current behavior?**
ReportNode has no official way to retrieve its severity, which has been set with .withSeverity(…).



**What is the new behavior (if this is a feature change)?**
This PR introduces a default String getSeverity() method in ReportNode, providing a way to retrieve the severity of a reportNode.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No