### PR TITLE
Deprecate `LimitViolation` constructors and use `LimitViolationBuilder` instead

### DIFF
--- a/action-ial/action-ial-simulator/src/test/java/com/powsybl/action/ial/simulator/tools/SecurityAnalysisResultBuilderTest.java
+++ b/action-ial/action-ial-simulator/src/test/java/com/powsybl/action/ial/simulator/tools/SecurityAnalysisResultBuilderTest.java
@@ -34,11 +34,27 @@ class SecurityAnalysisResultBuilderTest {
     }
 
     private List<LimitViolation> createPreContingencyViolations() {
-        return Collections.singletonList(new LimitViolation("line1", LimitViolationType.CURRENT, "IST", Integer.MAX_VALUE, 0.0, 100f, 101, TwoSides.ONE));
+        return Collections.singletonList(LimitViolation.builder()
+            .subject("line1")
+            .type(LimitViolationType.CURRENT)
+            .limitName("IST")
+            .limit(0.0)
+            .reduction(100f)
+            .value(101)
+            .side(TwoSides.ONE)
+            .build());
     }
 
     private List<LimitViolation> createPostContingencyViolations() {
-        return Collections.singletonList(new LimitViolation("line2", LimitViolationType.CURRENT, "IST", Integer.MAX_VALUE, 0.0, 100f, 110, TwoSides.ONE));
+        return Collections.singletonList(LimitViolation.builder()
+            .subject("line2")
+            .type(LimitViolationType.CURRENT)
+            .limitName("IST")
+            .limit(0.0)
+            .reduction(100f)
+            .value(110)
+            .side(TwoSides.ONE)
+            .build());
     }
 
     private void testLimitViolation(LimitViolationsResult result, boolean convergent, List<String> equipmentsId, List<String> actionsId) {

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolation.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolation.java
@@ -77,10 +77,6 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
         this.voltageLocation = voltageLocation;
     }
 
-    public static LimitViolationBuilder builder() {
-        return new LimitViolationBuilder();
-    }
-
     /**
      * Create a new LimitViolation.
      *
@@ -278,6 +274,10 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, LimitViolationType limitType, double limit, double limitReduction, double value) {
         this(subjectId, null, limitType, null, Integer.MAX_VALUE, limit, limitReduction, value, null, null);
+    }
+
+    public static LimitViolationBuilder builder() {
+        return new LimitViolationBuilder();
     }
 
     /**

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolation.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolation.java
@@ -76,7 +76,12 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
         this.voltageLocation = voltageLocation;
     }
 
+    public static LimitViolationBuilder builder() {
+        return new LimitViolationBuilder();
+    }
+
     /**
+     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -91,12 +96,14 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
      */
+    @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
                           double limit, double limitReduction, double value, @Nullable ThreeSides side, @Nullable ViolationLocation voltageLocation) {
         this(subjectId, subjectName, "", limitType, limitName, acceptableDuration, limit, limitReduction, value, side, voltageLocation);
     }
 
     /**
+     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -111,12 +118,14 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
      */
+    @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
                           double limit, double limitReduction, double value, @Nullable ThreeSides side) {
         this(subjectId, subjectName, limitType, limitName, acceptableDuration, limit, limitReduction, value, side, null);
     }
 
     /**
+     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation without side.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -130,6 +139,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction     The limit reduction factor used for violation detection.
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      */
+    @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
                           double limit, double limitReduction, double value) {
         this(subjectId, subjectName, limitType, limitName, acceptableDuration, limit, limitReduction, value, (ThreeSides) null);
@@ -137,6 +147,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     }
 
     /**
+     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -151,12 +162,14 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
      */
+    @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
                           double limit, double limitReduction, double value, TwoSides side) {
         this(subjectId, subjectName, limitType, limitName, acceptableDuration, limit, limitReduction, value, Objects.requireNonNull(side).toThreeSides());
     }
 
     /**
+     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -170,12 +183,14 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
      */
+    @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, LimitViolationType limitType, String limitName, int acceptableDuration,
                           double limit, double limitReduction, double value, TwoSides side) {
         this(subjectId, null, limitType, limitName, acceptableDuration, limit, limitReduction, value, Objects.requireNonNull(side).toThreeSides());
     }
 
     /**
+     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation without side.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -188,6 +203,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction     The limit reduction factor used for violation detection.
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      */
+    @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, LimitViolationType limitType, String limitName, int acceptableDuration,
                           double limit, double limitReduction, double value) {
         this(subjectId, null, limitType, limitName, acceptableDuration, limit, limitReduction, value, (ThreeSides) null);
@@ -206,10 +222,11 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param voltageLocation    Detailed information about the location of the violation.
      */
     public LimitViolation(String subjectId, LimitViolationType limitType, double limit, double limitReduction, double value, ViolationLocation voltageLocation) {
-        this(subjectId, null, limitType, null, Integer.MAX_VALUE, limit, limitReduction, value, null, voltageLocation);
+        this(subjectId, null, null, limitType, null, Integer.MAX_VALUE, limit, limitReduction, value, null, voltageLocation);
     }
 
     /**
+     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation, for types other than current limits.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -221,11 +238,13 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction The limit reduction factor used for violation detection.
      * @param value          The actual value of the physical value which triggered the detection of a violation.
      */
+    @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, String subjectName, LimitViolationType limitType, double limit, double limitReduction, double value) {
         this(subjectId, subjectName, limitType, null, Integer.MAX_VALUE, limit, limitReduction, value, null, null);
     }
 
     /**
+     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation, for types other than current limits.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -238,11 +257,13 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param value          The actual value of the physical value which triggered the detection of a violation.
      * @param voltageLocation    Detailed information about the location of the violation.
      */
+    @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, String subjectName, LimitViolationType limitType, double limit, double limitReduction, double value, ViolationLocation voltageLocation) {
         this(subjectId, subjectName, limitType, null, Integer.MAX_VALUE, limit, limitReduction, value, null, voltageLocation);
     }
 
     /**
+     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation, for voltage angle limit.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -253,6 +274,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction The limit reduction factor used for violation detection.
      * @param value          The actual value of the physical value which triggered the detection of a violation.
      */
+    @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, LimitViolationType limitType, double limit, double limitReduction, double value) {
         this(subjectId, null, limitType, null, Integer.MAX_VALUE, limit, limitReduction, value, null, null);
     }

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolation.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolation.java
@@ -82,7 +82,6 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     }
 
     /**
-     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -96,6 +95,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction     The limit reduction factor used for violation detection.
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
+     * @deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}
      */
     @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
@@ -104,7 +104,6 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     }
 
     /**
-     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -118,6 +117,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction     The limit reduction factor used for violation detection.
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
+     * @deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}
      */
     @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
@@ -126,7 +126,6 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     }
 
     /**
-     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation without side.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -139,6 +138,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limit              The value of the limit which has been violated.
      * @param limitReduction     The limit reduction factor used for violation detection.
      * @param value              The actual value of the physical value which triggered the detection of a violation.
+     * @deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}
      */
     @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
@@ -148,7 +148,6 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     }
 
     /**
-     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -162,6 +161,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction     The limit reduction factor used for violation detection.
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
+     * @deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}
      */
     @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, @Nullable String subjectName, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
@@ -170,7 +170,6 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     }
 
     /**
-     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -183,6 +182,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction     The limit reduction factor used for violation detection.
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
+     * @deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}
      */
     @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, LimitViolationType limitType, String limitName, int acceptableDuration,
@@ -191,7 +191,6 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     }
 
     /**
-     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation without side.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -203,6 +202,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limit              The value of the limit which has been violated.
      * @param limitReduction     The limit reduction factor used for violation detection.
      * @param value              The actual value of the physical value which triggered the detection of a violation.
+     * @deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}
      */
     @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, LimitViolationType limitType, String limitName, int acceptableDuration,
@@ -227,7 +227,6 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     }
 
     /**
-     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation, for types other than current limits.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -238,6 +237,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limit          The value of the limit which has been violated.
      * @param limitReduction The limit reduction factor used for violation detection.
      * @param value          The actual value of the physical value which triggered the detection of a violation.
+     * @deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}
      */
     @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, String subjectName, LimitViolationType limitType, double limit, double limitReduction, double value) {
@@ -245,7 +245,6 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     }
 
     /**
-     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation, for types other than current limits.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -257,6 +256,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction The limit reduction factor used for violation detection.
      * @param value          The actual value of the physical value which triggered the detection of a violation.
      * @param voltageLocation    Detailed information about the location of the violation.
+     * @deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}
      */
     @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, String subjectName, LimitViolationType limitType, double limit, double limitReduction, double value, ViolationLocation voltageLocation) {
@@ -264,7 +264,6 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
     }
 
     /**
-     * <p>@deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}</p>
      * Create a new LimitViolation, for voltage angle limit.
      *
      * <p>According to the violation type, all parameters may not be mandatory. See constructor overloads for particular types.
@@ -274,6 +273,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limit          The value of the limit which has been violated.
      * @param limitReduction The limit reduction factor used for violation detection.
      * @param value          The actual value of the physical value which triggered the detection of a violation.
+     * @deprecated use {@link LimitViolationBuilder} or {@link LimitViolation#LimitViolation(String, String, String, LimitViolationType, String, int, double, double, double, ThreeSides, ViolationLocation)}
      */
     @Deprecated(since = "7.3.0", forRemoval = true)
     public LimitViolation(String subjectId, LimitViolationType limitType, double limit, double limitReduction, double value) {

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolation.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolation.java
@@ -60,6 +60,7 @@ public class LimitViolation extends AbstractExtendable<LimitViolation> {
      * @param limitReduction     The limit reduction factor used for violation detection.
      * @param value              The actual value of the physical value which triggered the detection of a violation.
      * @param side               The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
+     * @param voltageLocation    Detailed information about the location of the violation.
      */
     public LimitViolation(String subjectId, @Nullable String subjectName, String operationalLimitsGroupId, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration,
                           double limit, double limitReduction, double value, @Nullable ThreeSides side, @Nullable ViolationLocation voltageLocation) {

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolationBuilder.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolationBuilder.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.contingency.violations;
 
+import com.powsybl.iidm.network.OperationalLimitsGroup;
 import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.iidm.network.TwoSides;
 
@@ -33,78 +34,153 @@ public class LimitViolationBuilder {
     private ThreeSides side;
     private ViolationLocation violationLocation;
 
+    /**
+     * @param type The type of limit which has been violated.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder type(LimitViolationType type) {
         this.type = requireNonNull(type);
         return this;
     }
 
+    /**
+     * @param subjectId The identifier of the network equipment on which the violation occurred.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder subject(String subjectId) {
         this.subjectId = requireNonNull(subjectId);
         return this;
     }
 
+    /**
+     * @param subjectName An optional name of the network equipment on which the violation occurred.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder subjectName(String subjectName) {
         this.subjectName = subjectName;
         return this;
     }
 
+    /**
+     * @param id The {@link OperationalLimitsGroup} due to which this violation occurred.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder operationalLimitsGroupId(String id) {
         this.operationalLimitsGroupId = id;
         return this;
     }
 
+    /**
+     * @param location Detailed information about the location of the violation.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder violationLocation(ViolationLocation location) {
         this.violationLocation = location;
         return this;
     }
 
+    /**
+     * @param name An optional name for the limit which has been violated.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder limitName(String name) {
         this.limitName = name;
         return this;
     }
 
+    /**
+     * @param duration The acceptable duration, in seconds, associated to the violation value.
+     *                 Default is {@link Integer#MAX_VALUE}.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder duration(int duration) {
         this.duration = duration;
         return this;
     }
 
+    /**
+     * @param duration The acceptable duration, in <code>unit</code> of time, associated to the violation value.
+     * @param unit the time unit to be used.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder duration(int duration, TimeUnit unit) {
         this.duration = (int) unit.toSeconds(duration);
         return this;
     }
 
+    /**
+     * @param limit The value of the limit which has been violated.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder limit(double limit) {
         this.limit = limit;
         return this;
     }
 
+    /**
+     * @param value The actual value of the physical value which triggered the detection of a violation.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder value(double value) {
         this.value = value;
         return this;
     }
 
+    /**
+     * @param reduction The limit reduction factor used for violation detection.
+     *                  Default is 1.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder reduction(double reduction) {
         this.reduction = reduction;
         return this;
     }
 
+    /**
+     * @param side The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder side(ThreeSides side) {
         this.side = requireNonNull(side);
         return this;
     }
 
+    /**
+     * @param side side The side of the equipment where the violation occurred. May be {@code null} for non-branch, non-three windings transformer equipments.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder side(TwoSides side) {
         return side(requireNonNull(side).toThreeSides());
     }
 
+    /**
+     * Sets the side as {@link ThreeSides#ONE}.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder side1() {
         return side(TwoSides.ONE);
     }
 
+    /**
+     * Sets the side as {@link ThreeSides#TWO}.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder side2() {
         return side(TwoSides.TWO);
     }
 
+    /**
+     * Sets the side as {@link ThreeSides#THREE}.
+     * @return this {@link LimitViolationBuilder}
+     */
+    public LimitViolationBuilder side3() {
+        return side(ThreeSides.THREE);
+    }
+
+    /**
+     * Sets the violation type as {@link LimitViolationType#CURRENT}.
+     * @return this {@link LimitViolationBuilder}
+     */
     public LimitViolationBuilder current() {
         return type(LimitViolationType.CURRENT);
     }

--- a/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolationBuilder.java
+++ b/contingency/contingency-api/src/main/java/com/powsybl/contingency/violations/LimitViolationBuilder.java
@@ -27,7 +27,7 @@ public class LimitViolationBuilder {
     private LimitViolationType type;
     private Double limit;
     private String limitName;
-    private Integer duration;
+    private Integer duration = Integer.MAX_VALUE;
     private double reduction = 1.0;
     private Double value;
     private ThreeSides side;

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/violations/LimitViolationFilterTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/violations/LimitViolationFilterTest.java
@@ -88,12 +88,53 @@ class LimitViolationFilterTest {
                 .to(network.getLine("LINE1").getTerminal2())
                 .add();
 
-        LimitViolation line1Violation = new LimitViolation("LINE1", LimitViolationType.CURRENT, "", Integer.MAX_VALUE, 1000.0, 1, 1100.0, TwoSides.ONE);
-        LimitViolation line2Violation = new LimitViolation("LINE2", LimitViolationType.CURRENT, "", Integer.MAX_VALUE, 900.0, 1, 950.0, TwoSides.TWO);
-        LimitViolation vl1Violation = new LimitViolation("VL1", LimitViolationType.HIGH_VOLTAGE, 200.0, 1, 250.0);
-        LimitViolation line1ViolationAcP = new LimitViolation("VL1", LimitViolationType.ACTIVE_POWER, "", Integer.MAX_VALUE, 200.0, 1, 250.0, TwoSides.ONE);
-        LimitViolation line1ViolationApP = new LimitViolation("VL1", LimitViolationType.APPARENT_POWER, "", Integer.MAX_VALUE, 200.0, 1, 250.0, TwoSides.TWO);
-        LimitViolation voltageAngleLimit = new LimitViolation("val", LimitViolationType.HIGH_VOLTAGE_ANGLE, "", Integer.MAX_VALUE, 0.25, 1, 0.26);
+        LimitViolation line1Violation = new LimitViolationBuilder()
+            .subject("LINE1")
+            .type(LimitViolationType.CURRENT)
+            .limitName("")
+            .limit(1000.0)
+            .value(1100.0)
+            .side(TwoSides.ONE)
+            .build();
+        LimitViolation line2Violation = LimitViolation.builder()
+            .subject("LINE2")
+            .type(LimitViolationType.CURRENT)
+            .limitName("")
+            .duration(Integer.MAX_VALUE)
+            .limit(900.0)
+            .value(950.0)
+            .side(TwoSides.TWO)
+            .build();
+        LimitViolation vl1Violation = LimitViolation.builder()
+            .subject("VL1")
+            .type(LimitViolationType.HIGH_VOLTAGE)
+            .limit(200.0)
+            .value(250.0)
+            .build();
+        LimitViolation line1ViolationAcP = LimitViolation.builder()
+            .subject("VL1")
+            .type(LimitViolationType.ACTIVE_POWER)
+            .limitName("")
+            .limit(200.0)
+            .value(250.0)
+            .side(TwoSides.ONE)
+            .build();
+        LimitViolation line1ViolationApP = LimitViolation.builder()
+            .subject("VL1")
+            .type(LimitViolationType.APPARENT_POWER)
+            .limitName("")
+            .limit(200.0)
+            .reduction(1)
+            .value(250.0)
+            .side(TwoSides.TWO)
+            .build();
+        LimitViolation voltageAngleLimit = LimitViolation.builder()
+            .subject("val")
+            .type(LimitViolationType.HIGH_VOLTAGE_ANGLE)
+            .limitName("")
+            .limit(0.25)
+            .value(0.26)
+            .build();
 
         LimitViolationFilter filter = new LimitViolationFilter();
         List<LimitViolation> filteredViolations = filter.apply(Arrays.asList(line1Violation, line2Violation, vl1Violation, line1ViolationAcP, line1ViolationApP, voltageAngleLimit), network);

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/violations/LimitViolationTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/violations/LimitViolationTest.java
@@ -43,7 +43,7 @@ class LimitViolationTest {
             .duration(6300)
             .limit(1000)
             .value(1100)
-            .side(ThreeSides.THREE)
+            .side3()
             .build();
         LimitViolation limitViolation4 = LimitViolation.builder()
             .subject("testId")

--- a/contingency/contingency-api/src/test/java/com/powsybl/contingency/violations/LimitViolationTest.java
+++ b/contingency/contingency-api/src/test/java/com/powsybl/contingency/violations/LimitViolationTest.java
@@ -21,14 +21,38 @@ class LimitViolationTest {
 
     @Test
     void testToString() {
-        LimitViolation limitViolation1 = new LimitViolation("testId", null, LimitViolationType.HIGH_VOLTAGE, "high", Integer.MAX_VALUE,
-                420, 1, 500);
-        LimitViolation limitViolation2 = new LimitViolation("testId", null, LimitViolationType.CURRENT, null, 6300,
-                1000, 1, 1100, TwoSides.ONE);
-        LimitViolation limitViolation3 = new LimitViolation("testId", null, LimitViolationType.APPARENT_POWER, null, 6300,
-                1000, 1, 1100, ThreeSides.THREE);
-        LimitViolation limitViolation4 = new LimitViolation("testId", null, LimitViolationType.LOW_VOLTAGE,
-            1000, 1, 1100, new BusBreakerViolationLocation(List.of("busId1", "busId2")));
+        LimitViolation limitViolation1 = new LimitViolationBuilder()
+            .subject("testId")
+            .type(LimitViolationType.HIGH_VOLTAGE)
+            .limitName("high")
+            .duration(Integer.MAX_VALUE)
+            .limit(420)
+            .value(500)
+            .build();
+        LimitViolation limitViolation2 = LimitViolation.builder()
+            .subject("testId")
+            .type(LimitViolationType.CURRENT)
+            .duration(6300)
+            .limit(1000)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
+        LimitViolation limitViolation3 = LimitViolation.builder()
+            .subject("testId")
+            .type(LimitViolationType.APPARENT_POWER)
+            .duration(6300)
+            .limit(1000)
+            .value(1100)
+            .side(ThreeSides.THREE)
+            .build();
+        LimitViolation limitViolation4 = LimitViolation.builder()
+            .subject("testId")
+            .type(LimitViolationType.LOW_VOLTAGE)
+            .limit(1000)
+            .reduction(1)
+            .value(1100)
+            .violationLocation(new BusBreakerViolationLocation(List.of("busId1", "busId2")))
+            .build();
         String expected1 = "Subject id: testId, Subject name: null, limitType: HIGH_VOLTAGE, limit: 420.0, limitName: high, acceptableDuration: 2147483647, limitReduction: 1.0, value: 500.0, side: null, voltageLocation: null";
         String expected2 = "Subject id: testId, Subject name: null, limitType: CURRENT, limit: 1000.0, limitName: null, acceptableDuration: 6300, limitReduction: 1.0, value: 1100.0, side: ONE, voltageLocation: null";
         String expected3 = "Subject id: testId, Subject name: null, limitType: APPARENT_POWER, limit: 1000.0, limitName: null, acceptableDuration: 6300, limitReduction: 1.0, value: 1100.0, side: THREE, voltageLocation: null";

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationDetection.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationDetection.java
@@ -267,13 +267,29 @@ public final class LimitViolationDetection {
     static void checkVoltage(Bus bus, double value, Consumer<LimitViolation> consumer) {
         VoltageLevel vl = bus.getVoltageLevel();
         if (!Double.isNaN(vl.getLowVoltageLimit()) && value <= vl.getLowVoltageLimit()) {
-            consumer.accept(new LimitViolation(vl.getId(), vl.getOptionalName().orElse(null), LimitViolationType.LOW_VOLTAGE,
-                    vl.getLowVoltageLimit(), 1., value, createViolationLocation(bus)));
+            consumer.accept(
+                LimitViolation.builder()
+                .subject(vl.getId())
+                .subjectName(vl.getOptionalName().orElse(null))
+                .type(LimitViolationType.LOW_VOLTAGE)
+                .limit(vl.getLowVoltageLimit())
+                .value(value)
+                .violationLocation(createViolationLocation(bus))
+                .build()
+            );
         }
 
         if (!Double.isNaN(vl.getHighVoltageLimit()) && value >= vl.getHighVoltageLimit()) {
-            consumer.accept(new LimitViolation(vl.getId(), vl.getOptionalName().orElse(null), LimitViolationType.HIGH_VOLTAGE,
-                    vl.getHighVoltageLimit(), 1., value, createViolationLocation(bus)));
+            consumer.accept(
+                LimitViolation.builder()
+                    .subject(vl.getId())
+                    .subjectName(vl.getOptionalName().orElse(null))
+                    .type(LimitViolationType.HIGH_VOLTAGE)
+                    .limit(vl.getHighVoltageLimit())
+                    .value(value)
+                    .violationLocation(createViolationLocation(bus))
+                    .build()
+            );
         }
     }
 
@@ -311,15 +327,27 @@ public final class LimitViolationDetection {
         voltageAngleLimit.getLowLimit().ifPresent(
                 lowLimit -> {
                     if (value <= lowLimit) {
-                        consumer.accept(new LimitViolation(voltageAngleLimit.getId(), LimitViolationType.LOW_VOLTAGE_ANGLE, lowLimit,
-                                1., value));
+                        consumer.accept(
+                            LimitViolation.builder()
+                                .subject(voltageAngleLimit.getId())
+                                .type(LimitViolationType.LOW_VOLTAGE_ANGLE)
+                                .limit(lowLimit)
+                                .value(value)
+                                .build()
+                        );
                     }
                 });
         voltageAngleLimit.getHighLimit().ifPresent(
                 highLimit -> {
                     if (value >= highLimit) {
-                        consumer.accept(new LimitViolation(voltageAngleLimit.getId(), LimitViolationType.HIGH_VOLTAGE_ANGLE, highLimit,
-                                1., value));
+                        consumer.accept(
+                            LimitViolation.builder()
+                                .subject(voltageAngleLimit.getId())
+                                .type(LimitViolationType.HIGH_VOLTAGE_ANGLE)
+                                .limit(highLimit)
+                                .value(value)
+                                .build()
+                        );
                     }
                 });
     }

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/detectors/DefaultLimitViolationDetector.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/detectors/DefaultLimitViolationDetector.java
@@ -86,13 +86,31 @@ public class DefaultLimitViolationDetector extends AbstractContingencyBlindDetec
     public void checkVoltage(Bus bus, double value, Consumer<LimitViolation> consumer) {
         VoltageLevel vl = bus.getVoltageLevel();
         if (!Double.isNaN(vl.getLowVoltageLimit()) && value <= vl.getLowVoltageLimit()) {
-            consumer.accept(new LimitViolation(vl.getId(), vl.getOptionalName().orElse(null), LimitViolationType.LOW_VOLTAGE,
-                    vl.getLowVoltageLimit(), limitReductionValue, value, createViolationLocation(bus)));
+            consumer.accept(
+                LimitViolation.builder()
+                    .subject(vl.getId())
+                    .subjectName(vl.getOptionalName().orElse(null))
+                    .type(LimitViolationType.LOW_VOLTAGE)
+                    .limit(vl.getLowVoltageLimit())
+                    .reduction(limitReductionValue)
+                    .value(value)
+                    .violationLocation(createViolationLocation(bus))
+                    .build()
+            );
         }
 
         if (!Double.isNaN(vl.getHighVoltageLimit()) && value >= vl.getHighVoltageLimit()) {
-            consumer.accept(new LimitViolation(vl.getId(), vl.getOptionalName().orElse(null), LimitViolationType.HIGH_VOLTAGE,
-                    vl.getHighVoltageLimit(), limitReductionValue, value, createViolationLocation(bus)));
+            consumer.accept(
+                LimitViolation.builder()
+                    .subject(vl.getId())
+                    .subjectName(vl.getOptionalName().orElse(null))
+                    .type(LimitViolationType.HIGH_VOLTAGE)
+                    .limit(vl.getHighVoltageLimit())
+                    .reduction(limitReductionValue)
+                    .value(value)
+                    .violationLocation(createViolationLocation(bus))
+                    .build()
+            );
         }
     }
 
@@ -104,15 +122,29 @@ public class DefaultLimitViolationDetector extends AbstractContingencyBlindDetec
         voltageAngleLimit.getLowLimit().ifPresent(
             lowLimit -> {
                 if (value <= lowLimit) {
-                    consumer.accept(new LimitViolation(voltageAngleLimit.getId(), LimitViolationType.LOW_VOLTAGE_ANGLE, lowLimit,
-                            limitReductionValue, value));
+                    consumer.accept(
+                        LimitViolation.builder()
+                            .subject(voltageAngleLimit.getId())
+                            .type(LimitViolationType.LOW_VOLTAGE_ANGLE)
+                            .limit(lowLimit)
+                            .reduction(limitReductionValue)
+                            .value(value)
+                            .build()
+                    );
                 }
             });
         voltageAngleLimit.getHighLimit().ifPresent(
             highLimit -> {
                 if (value >= highLimit) {
-                    consumer.accept(new LimitViolation(voltageAngleLimit.getId(), LimitViolationType.HIGH_VOLTAGE_ANGLE, highLimit,
-                            limitReductionValue, value));
+                    consumer.accept(
+                        LimitViolation.builder()
+                            .subject(voltageAngleLimit.getId())
+                            .type(LimitViolationType.HIGH_VOLTAGE_ANGLE)
+                            .limit(highLimit)
+                            .reduction(limitReductionValue)
+                            .value(value)
+                            .build()
+                    );
                 }
             });
     }

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisResultMergerTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityAnalysisResultMergerTest.java
@@ -41,13 +41,27 @@ class SecurityAnalysisResultMergerTest {
     @BeforeEach
     void setup() {
         // create pre-contingency results, just one violation on line1
-        LimitViolation line1Violation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000f, 0.95f, 1100, TwoSides.ONE);
+        LimitViolation line1Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000f)
+            .reduction(0.95f)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
         preContingencyResult = new LimitViolationsResult(Collections.singletonList(line1Violation), Collections.singletonList("action1"));
 
         // create post-contingency results, still the line1 violation plus line2 violation
         Contingency contingency1 = Mockito.mock(Contingency.class);
         Mockito.when(contingency1.getId()).thenReturn("contingency1");
-        LimitViolation line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900f, 0.95f, 950, TwoSides.ONE);
+        LimitViolation line2Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.CURRENT)
+            .limit(900f)
+            .reduction(0.95f)
+            .value(950)
+            .side(TwoSides.ONE)
+            .build();
         postContingencyResult = new PostContingencyResult(contingency1, PostContingencyComputationStatus.CONVERGED, new LimitViolationsResult(Arrays.asList(line1Violation, line2Violation), Collections.singletonList("action2")), NetworkResult.empty(), ConnectivityResult.empty(), Double.NaN);
 
         Contingency contingency2 = Mockito.mock(Contingency.class);

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/SecurityTest.java
@@ -52,13 +52,27 @@ class SecurityTest {
         network = EurostagTutorialExample1Factory.createWithFixedCurrentLimits();
 
         // create pre-contingency results, just one violation on line1
-        line1Violation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
+        line1Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100.0)
+            .side(TwoSides.ONE)
+            .build();
         LimitViolationsResult preContingencyResult = new LimitViolationsResult(Collections.singletonList(line1Violation), Collections.singletonList("action1"));
 
         // create post-contingency results, still the line1 violation plus line2 violation
         Contingency contingency1 = Mockito.mock(Contingency.class);
         Mockito.when(contingency1.getId()).thenReturn("contingency1");
-        line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, TwoSides.ONE);
+        line2Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.CURRENT)
+            .limit(900.0)
+            .reduction(0.95f)
+            .value(950.0)
+            .side(TwoSides.ONE)
+            .build();
         PostContingencyResult postContingencyResult = new PostContingencyResult(contingency1, PostContingencyComputationStatus.CONVERGED, new LimitViolationsResult(Arrays.asList(line1Violation, line2Violation), Collections.singletonList("action2")), NetworkResult.empty(), ConnectivityResult.empty(), Double.NaN);
 
         result = new SecurityAnalysisResult(preContingencyResult, LoadFlowResult.ComponentResult.Status.CONVERGED, Collections.singletonList(postContingencyResult));

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationComparatorTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationComparatorTest.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.iidm.network.TwoSides;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.jupiter.api.Test;
@@ -29,15 +28,76 @@ class LimitViolationComparatorTest {
 
     @Test
     void compare() {
-        LimitViolation line1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
-        LimitViolation line1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.TWO);
-        LimitViolation line2Violation1 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, TwoSides.ONE);
-        LimitViolation line2Violation2 = new LimitViolation(EurostagTutorialExample1Factory.NHV1_NHV2_2, null, "group_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, ThreeSides.ONE, null);
-        LimitViolation line2Violation3 = new LimitViolation(EurostagTutorialExample1Factory.NHV1_NHV2_2, null, "group_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, ThreeSides.ONE, null);
-        LimitViolation vl1Violation1 = new LimitViolation("VL1", LimitViolationType.HIGH_VOLTAGE, 200.0, 1, 250.0);
-        LimitViolation vl1Violation2 = new LimitViolation("VL1", LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT, 200.0, 1, 250.0);
-        LimitViolation line1AcPViolation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.ACTIVE_POWER, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
-        LimitViolation line2AppViolation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.APPARENT_POWER, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, TwoSides.ONE);
+        LimitViolation line1Violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100.0)
+            .side(TwoSides.ONE)
+            .build();
+        LimitViolation line1Violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100.0)
+            .side(TwoSides.TWO)
+            .build();
+        LimitViolation line2Violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.CURRENT)
+            .limit(900.0)
+            .reduction(0.95f)
+            .value(950.0)
+            .side(TwoSides.ONE)
+            .build();
+        LimitViolation line2Violation2 = LimitViolation.builder()
+            .subject(EurostagTutorialExample1Factory.NHV1_NHV2_2)
+            .type(LimitViolationType.CURRENT)
+            .operationalLimitsGroupId("group_2")
+            .limit(900.0)
+            .reduction(0.95f)
+            .value(950.0)
+            .side(TwoSides.ONE)
+            .build();
+        LimitViolation line2Violation3 = LimitViolation.builder()
+            .subject(EurostagTutorialExample1Factory.NHV1_NHV2_2)
+            .type(LimitViolationType.CURRENT)
+            .operationalLimitsGroupId("group_1")
+            .limit(900.0)
+            .reduction(0.95f)
+            .value(950.0)
+            .side(TwoSides.ONE)
+            .build();
+        LimitViolation vl1Violation1 = LimitViolation.builder()
+            .subject("VL1")
+            .type(LimitViolationType.HIGH_VOLTAGE)
+            .limit(200.0)
+            .value(250.0)
+            .build();
+        LimitViolation vl1Violation2 = LimitViolation.builder()
+            .subject("VL1")
+            .type(LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT)
+            .limit(200.0)
+            .value(250.0)
+            .build();
+        LimitViolation line1AcPViolation = LimitViolation.builder()
+            .subject(EurostagTutorialExample1Factory.NHV1_NHV2_1)
+            .type(LimitViolationType.ACTIVE_POWER)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100.0)
+            .side(TwoSides.ONE)
+            .build();
+        LimitViolation line2AppViolation = LimitViolation.builder()
+            .subject(EurostagTutorialExample1Factory.NHV1_NHV2_2)
+            .type(LimitViolationType.APPARENT_POWER)
+            .limit(900.0)
+            .reduction(0.95f)
+            .value(950.0)
+            .side(TwoSides.ONE)
+            .build();
 
         List<LimitViolation> violations = Arrays.asList(line1Violation2, vl1Violation1, line2Violation2, line2Violation3, line2Violation1, line1Violation1, vl1Violation2, line1AcPViolation, line2AppViolation);
         Collections.sort(violations, new LimitViolationComparator());

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationEquivalenceTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationEquivalenceTest.java
@@ -10,7 +10,6 @@ package com.powsybl.security.comparator;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.iidm.network.TwoSides;
 import org.junit.jupiter.api.Test;
 
@@ -27,44 +26,158 @@ class LimitViolationEquivalenceTest {
     void equivalent() {
         LimitViolationEquivalence violationEquivalence = new LimitViolationEquivalence(0.1);
 
-        LimitViolation violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
+        LimitViolation violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
 
-        LimitViolation violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
+        LimitViolation violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
+
         assertTrue(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, TwoSides.ONE);
+        violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100.09)
+            .side(TwoSides.ONE)
+            .build();
         assertTrue(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, TwoSides.ONE);
+        violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1101)
+            .side(TwoSides.ONE)
+            .build();
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.TWO);
+        violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100)
+            .side(TwoSides.TWO)
+            .build();
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
+        violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
+        violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.ACTIVE_POWER, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
+        violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.ACTIVE_POWER)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.APPARENT_POWER, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.TWO);
+        violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.APPARENT_POWER)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100)
+            .side(TwoSides.TWO)
+            .build();
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation1 = new LimitViolation("NHV1_NHV2_1", null, "group_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, ThreeSides.ONE, null);
-        violation2 = new LimitViolation("NHV1_NHV2_1", null, "group_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, ThreeSides.ONE, null);
+        violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .operationalLimitsGroupId("group_1")
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
+
+        violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .operationalLimitsGroupId("group_1")
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
         assertTrue(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_1", null, "group_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, ThreeSides.ONE, null);
+        violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .operationalLimitsGroupId("group_1")
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100.09)
+            .side(TwoSides.ONE)
+            .build();
         assertTrue(violationEquivalence.equivalent(violation1, violation2));
 
-        violation2 = new LimitViolation("NHV1_NHV2_1", null, "group_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, ThreeSides.ONE, null);
+        violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .operationalLimitsGroupId("group_2")
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
 
-        violation1 = new LimitViolation("NHV1_NHV2_1", null, null, LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, ThreeSides.ONE, null);
-        violation2 = new LimitViolation("NHV1_NHV2_1", null, "group_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, ThreeSides.ONE, null);
+        violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .operationalLimitsGroupId(null)
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100.09)
+            .side(TwoSides.ONE)
+            .build();
+
+        violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .operationalLimitsGroupId("group_1")
+            .limit(1000.0)
+            .reduction(0.95f)
+            .value(1100.09)
+            .side(TwoSides.ONE)
+            .build();
         assertFalse(violationEquivalence.equivalent(violation1, violation2));
     }
 

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationsResultEquivalenceTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/LimitViolationsResultEquivalenceTest.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.Collections;
 
-import com.powsybl.iidm.network.TwoSides;
 import org.apache.commons.io.output.NullWriter;
 import org.junit.jupiter.api.Test;
 
@@ -31,20 +30,107 @@ class LimitViolationsResultEquivalenceTest {
     void equivalent() {
         LimitViolationsResultEquivalence resultEquivalence = new LimitViolationsResultEquivalence(0.1, NullWriter.INSTANCE);
 
-        LimitViolation line1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
-        LimitViolation sameLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
-        LimitViolation line1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.TWO);
-        LimitViolation sameLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.TWO);
-        LimitViolation similarLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, TwoSides.TWO);
-        LimitViolation differentLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, TwoSides.TWO);
-        LimitViolation line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, TwoSides.ONE);
-        LimitViolation sameLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 0.95f, 950.0, TwoSides.ONE);
-        LimitViolation smallLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 900.0, 1, 900.09, TwoSides.TWO);
-        LimitViolation vl1Violation1 = new LimitViolation("VL1", LimitViolationType.HIGH_VOLTAGE, 200.0, 1, 250.0);
-        LimitViolation sameVl1Violation1 = new LimitViolation("VL1", LimitViolationType.HIGH_VOLTAGE, 200.0, 1, 250.0);
-        LimitViolation vl1Violation2 = new LimitViolation("VL1", LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT, 200.0, 1, 250.0);
-        LimitViolation sameVl1Violation2 = new LimitViolation("VL1", LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT, 200.0, 1, 250.0);
-        LimitViolation smallVl2Violation = new LimitViolation("VL2", LimitViolationType.HIGH_VOLTAGE, 200.0, 1, 200.09);
+        LimitViolation line1Violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95)
+            .value(1100)
+            .side1()
+            .build();
+        LimitViolation sameLine1Violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95)
+            .value(1100)
+            .side1()
+            .build();
+        LimitViolation line1Violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95)
+            .value(1100)
+            .side2()
+            .build();
+        LimitViolation sameLine1Violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95)
+            .value(1100)
+            .side2()
+            .build();
+        LimitViolation similarLine1Violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95)
+            .value(1100.09)
+            .side2()
+            .build();
+        LimitViolation differentLine1Violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000.0)
+            .reduction(0.95)
+            .value(1101)
+            .side2()
+            .build();
+        LimitViolation line2Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.CURRENT)
+            .limit(900.0)
+            .reduction(0.95)
+            .value(950)
+            .side1()
+            .build();
+        LimitViolation sameLine2Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.CURRENT)
+            .limit(900.0)
+            .reduction(0.95)
+            .value(950)
+            .side1()
+            .build();
+        LimitViolation smallLine2Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.CURRENT)
+            .limit(900.0)
+            .value(900.09)
+            .side2()
+            .build();
+        LimitViolation vl1Violation1 = LimitViolation.builder()
+            .subject("VL1")
+            .type(LimitViolationType.HIGH_VOLTAGE)
+            .limit(200.0)
+            .value(250)
+            .build();
+        LimitViolation sameVl1Violation1 = LimitViolation.builder()
+            .subject("VL1")
+            .type(LimitViolationType.HIGH_VOLTAGE)
+            .limit(200.0)
+            .value(250)
+            .build();
+        LimitViolation vl1Violation2 = LimitViolation.builder()
+            .subject("VL1")
+            .type(LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT)
+            .limit(200.0)
+            .value(250)
+            .build();
+        LimitViolation sameVl1Violation2 = LimitViolation.builder()
+            .subject("VL1")
+            .type(LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT)
+            .limit(200.0)
+            .value(250)
+            .build();
+        LimitViolation smallVl2Violation = LimitViolation.builder()
+            .subject("VL2")
+            .type(LimitViolationType.HIGH_VOLTAGE)
+            .limit(200.0)
+            .value(200.09)
+            .build();
 
         // computation ko in both results
         LimitViolationsResult result1 = new LimitViolationsResult(Collections.emptyList(),

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/SecurityAnalysisResultComparisonWriterTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/SecurityAnalysisResultComparisonWriterTest.java
@@ -41,9 +41,28 @@ class SecurityAnalysisResultComparisonWriterTest {
 
     @BeforeEach
     void setUp() {
-        vlViolation = new LimitViolation("VL1", LimitViolationType.HIGH_VOLTAGE, 200.0, 1, 250.0);
-        lineViolation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, "PermanentLimit", Integer.MAX_VALUE, 1000.0, 1, 1100.0, TwoSides.ONE);
-        similarLineViolation = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, "PermanentLimit", Integer.MAX_VALUE, 1000.0, 1, 1100.09, TwoSides.ONE);
+        vlViolation = LimitViolation.builder()
+            .subject("VL1")
+            .type(LimitViolationType.HIGH_VOLTAGE)
+            .limit(200.0)
+            .value(250)
+            .build();
+        lineViolation = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limitName("PermanentLimit")
+            .limit(1000.0)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
+        similarLineViolation = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limitName("PermanentLimit")
+            .limit(1000.0)
+            .value(1100.09)
+            .side1()
+            .build();
         actions = Arrays.asList("action1", "action2");
         writer = new StringWriter();
         comparisonWriter = new SecurityAnalysisResultComparisonWriter(writer);

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/SecurityAnalysisResultEquivalenceTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/comparator/SecurityAnalysisResultEquivalenceTest.java
@@ -36,20 +36,104 @@ class SecurityAnalysisResultEquivalenceTest {
     void equivalent() {
         SecurityAnalysisResultEquivalence resultEquivalence = new SecurityAnalysisResultEquivalence(0.1, NullWriter.INSTANCE);
 
-        LimitViolation line1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
-        LimitViolation similarLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, TwoSides.ONE);
-        LimitViolation differentLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, TwoSides.ONE);
-        LimitViolation smallLine1Violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 950.09, TwoSides.ONE);
+        LimitViolation line1Violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(1100)
+            .side1()
+            .build();
+        LimitViolation similarLine1Violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(1100.09)
+            .side(TwoSides.ONE)
+            .build();
+        LimitViolation differentLine1Violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(1101)
+            .side(TwoSides.ONE)
+            .build();
+        LimitViolation smallLine1Violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(950.09)
+            .side1()
+            .build();
 
-        LimitViolation line1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.TWO);
-        LimitViolation similarLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, TwoSides.TWO);
-        LimitViolation differentLine1Violation2 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1101.0, TwoSides.TWO);
+        LimitViolation line1Violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(1100)
+            .side2()
+            .build();
+        LimitViolation similarLine1Violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(1100.09)
+            .side(TwoSides.TWO)
+            .build();
+        LimitViolation differentLine1Violation2 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(1101)
+            .side(TwoSides.TWO)
+            .build();
 
-        LimitViolation line2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
-        LimitViolation similarLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, TwoSides.ONE);
-        LimitViolation smallLine2Violation = new LimitViolation("NHV1_NHV2_2", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 950.09, TwoSides.ONE);
-        LimitViolation line3Violation = new LimitViolation("NHV1_NHV2_3", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.0, TwoSides.ONE);
-        LimitViolation similarLine3Violation = new LimitViolation("NHV1_NHV2_3", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 1000.0, 0.95f, 1100.09, TwoSides.ONE);
+        LimitViolation line2Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(1100)
+            .side(TwoSides.ONE)
+            .build();
+        LimitViolation similarLine2Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(1100.09)
+            .side1()
+            .build();
+        LimitViolation smallLine2Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(950.09)
+            .side1()
+            .build();
+        LimitViolation line3Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_3")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(1100)
+            .side1()
+            .build();
+        LimitViolation similarLine3Violation = LimitViolation.builder()
+            .subject("NHV1_NHV2_3")
+            .type(LimitViolationType.CURRENT)
+            .limit(1000)
+            .reduction(0.95)
+            .value(1100.09)
+            .side1()
+            .build();
 
         Contingency contingency1 = Mockito.mock(Contingency.class);
         Mockito.when(contingency1.getId()).thenReturn("contingency1");

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/converter/ExporterTest.java
@@ -62,8 +62,24 @@ class ExporterTest extends AbstractSerDeTest {
         LimitViolation violation4 = new LimitViolation("GEN2", LimitViolationType.LOW_VOLTAGE, 100, 0.7f, 115, new NodeBreakerViolationLocation("VL", Arrays.asList(0, 1)));
         violation4.addExtension(VoltageExtension.class, new VoltageExtension(400.0));
 
-        LimitViolation violation5 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.ACTIVE_POWER, "20'", 1200, 100, 1.0f, 110.0, TwoSides.ONE);
-        LimitViolation violation6 = new LimitViolation("NHV1_NHV2_2", LimitViolationType.APPARENT_POWER, "20'", 1200, 100, 1.0f, 110.0, TwoSides.TWO);
+        LimitViolation violation5 = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.ACTIVE_POWER)
+            .limitName("20'")
+            .duration(1200)
+            .limit(100)
+            .value(110)
+            .side1()
+            .build();
+        LimitViolation violation6 = LimitViolation.builder()
+            .subject("NHV1_NHV2_2")
+            .type(LimitViolationType.APPARENT_POWER)
+            .limitName("20'")
+            .duration(1200)
+            .limit(100)
+            .value(110)
+            .side2()
+            .build();
 
         Contingency contingency = Contingency.builder("contingency")
                 .addBranch("NHV1_NHV2_2", "VLNHV1")
@@ -123,7 +139,14 @@ class ExporterTest extends AbstractSerDeTest {
 
     @Test
     void testCompatibilityV1Deserialization() {
-        LimitViolation violation1 = new LimitViolation("NHV1_NHV2_1", LimitViolationType.CURRENT, null, Integer.MAX_VALUE, 100, 0.95f, 110.0, TwoSides.ONE);
+        LimitViolation violation1 = LimitViolation.builder()
+            .subject("NHV1_NHV2_1")
+            .type(LimitViolationType.CURRENT)
+            .limit(100)
+            .reduction(0.95f)
+            .value(110.0)
+            .side1()
+            .build();
         violation1.addExtension(ActivePowerExtension.class, new ActivePowerExtension(220.0));
         SecurityAnalysisResult result = SecurityAnalysisResultDeserializer.read(getClass().getResourceAsStream("/SecurityAnalysisResultV1.json"));
         Assertions.assertThat(result.getPreContingencyLimitViolationsResult().getLimitViolations()).hasSize(1);

--- a/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/PostContingencyResultTest.java
+++ b/security-analysis/security-analysis-api/src/test/java/com/powsybl/security/json/PostContingencyResultTest.java
@@ -36,7 +36,13 @@ class PostContingencyResultTest extends AbstractSerDeTest {
     @Test
     void testGetters() {
         Contingency contingency = new Contingency("contingency");
-        LimitViolation violation = new LimitViolation("violation", LimitViolationType.HIGH_VOLTAGE, 420, (float) 0.1, 500);
+        LimitViolation violation = LimitViolation.builder()
+            .subject("violation")
+            .type(LimitViolationType.HIGH_VOLTAGE)
+            .limit(420)
+            .reduction(0.1)
+            .value(500)
+            .build();
         LimitViolationsResult result = new LimitViolationsResult(Collections.singletonList(violation));
         List<ThreeWindingsTransformerResult> threeWindingsTransformerResults = new ArrayList<>();
         threeWindingsTransformerResults.add(new ThreeWindingsTransformerResult("threeWindingsTransformerId",
@@ -61,7 +67,13 @@ class PostContingencyResultTest extends AbstractSerDeTest {
     @Test
     void roundTrip() throws IOException {
         Contingency contingency = new Contingency("contingency");
-        LimitViolation violation = new LimitViolation("violation", LimitViolationType.HIGH_VOLTAGE, 420, (float) 0.1, 500);
+        LimitViolation violation = LimitViolation.builder()
+            .subject("violation")
+            .type(LimitViolationType.HIGH_VOLTAGE)
+            .limit(420)
+            .reduction(0.1f)
+            .value(500)
+            .build();
         LimitViolation violation2 = new LimitViolation("subject_id", LimitViolationType.HIGH_VOLTAGE, 420,
             (float) 0.1, 500, new BusBreakerViolationLocation(List.of("bus_id")));
         LimitViolation violation3 = new LimitViolation("subject_id", LimitViolationType.LOW_VOLTAGE, 200,

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisMock.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisMock.java
@@ -76,7 +76,13 @@ public class ShortCircuitAnalysisMock implements ShortCircuitAnalysisProvider {
     public static ShortCircuitAnalysisResult runWithNonEmptyResult() {
         Fault fault = new BusFault("F1", "VLGEN", 0.0, 0.0, Fault.ConnectionType.SERIES, Fault.FaultType.THREE_PHASE);
         MagnitudeFeederResult feederResult = new MagnitudeFeederResult("GEN", 5);
-        LimitViolation limitViolation = new LimitViolation("VLGEN", LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT, 0, 0, 0);
+        LimitViolation limitViolation = LimitViolation.builder()
+            .subject("VLGEN")
+            .type(LimitViolationType.HIGH_SHORT_CIRCUIT_CURRENT)
+            .limit(0)
+            .reduction(0)
+            .value(0)
+            .build();
         FortescueFaultResult faultResult = new FortescueFaultResult(fault, 10.0, Collections.singletonList(feederResult), Collections.singletonList(limitViolation),
                 new FortescueValue(10.0), null, Collections.emptyList(), Duration.ofSeconds(1), FortescueFaultResult.Status.SUCCESS);
         return new ShortCircuitAnalysisResult(Collections.singletonList(faultResult));

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/TestingResultFactory.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/TestingResultFactory.java
@@ -46,9 +46,9 @@ public final class TestingResultFactory {
         Fault fault = new BusFault(faultId, "BusId", 0.0, 0.0);
         List<LimitViolation> limitViolations = new ArrayList<>();
         double limitReductionValue = 1;
-        LimitViolation limitViolation1 = new LimitViolation("VLGEN", limitType, limit, limitReductionValue, value);
+        LimitViolation limitViolation1 = LimitViolation.builder().subject("VLGEN").type(limitType).limit(limit).reduction(limitReductionValue).value(value).build();
         limitViolations.add(limitViolation1);
-        LimitViolation limitViolation2 = new LimitViolation("VLGEN", limitType, limit, limitReductionValue, value);
+        LimitViolation limitViolation2 = LimitViolation.builder().subject("VLGEN").type(limitType).limit(limit).reduction(limitReductionValue).value(value).build();
         limitViolations.add(limitViolation2);
         return new FortescueFaultResult(fault, 1.0, Collections.emptyList(), limitViolations, new FortescueValue(value), FortescueFaultResult.Status.SUCCESS);
     }
@@ -61,7 +61,7 @@ public final class TestingResultFactory {
         float limit = 2000;
         double limitReductionValue = 1;
         float value = 2500;
-        LimitViolation limitViolation = new LimitViolation(subjectId, limitType, limit, limitReductionValue, value);
+        LimitViolation limitViolation = LimitViolation.builder().subject(subjectId).type(limitType).limit(limit).reduction(limitReductionValue).value(value).build();
         limitViolations.add(limitViolation);
         List<FaultResult> faultResults = new ArrayList<>();
         MagnitudeFeederResult feederResult;
@@ -113,7 +113,7 @@ public final class TestingResultFactory {
         float limit = 2000;
         double limitReductionValue = 1;
         float value = 2500;
-        LimitViolation limitViolation = new LimitViolation(subjectId, limitType, limit, limitReductionValue, value);
+        LimitViolation limitViolation = LimitViolation.builder().subject(subjectId).type(limitType).limit(limit).reduction(limitReductionValue).value(value).build();
         limitViolation.addExtension(DummyLimitViolationExtension.class, new DummyLimitViolationExtension());
         limitViolations.add(limitViolation);
         List<ShortCircuitBusResults> busResults = new ArrayList<>();
@@ -136,7 +136,7 @@ public final class TestingResultFactory {
         float limit = 2000;
         double limitReductionValue = 1;
         float value = 2500;
-        LimitViolation limitViolation = new LimitViolation(subjectId, limitType, limit, limitReductionValue, value);
+        LimitViolation limitViolation = LimitViolation.builder().subject(subjectId).type(limitType).limit(limit).reduction(limitReductionValue).value(value).build();
         limitViolation.addExtension(DummyLimitViolationExtension.class, new DummyLimitViolationExtension());
         limitViolations.add(limitViolation);
         List<ShortCircuitBusResults> busResults = new ArrayList<>();
@@ -157,7 +157,7 @@ public final class TestingResultFactory {
         float limit = 2000;
         double limitReductionValue = 1;
         float value = 2500;
-        LimitViolation limitViolation = new LimitViolation(subjectId, limitType, limit, limitReductionValue, value);
+        LimitViolation limitViolation = LimitViolation.builder().subject(subjectId).type(limitType).limit(limit).reduction(limitReductionValue).value(value).build();
         limitViolation.addExtension(DummyLimitViolationExtension.class, new DummyLimitViolationExtension());
         limitViolations.add(limitViolation);
         List<ShortCircuitBusResults> busResults = new ArrayList<>();
@@ -182,7 +182,7 @@ public final class TestingResultFactory {
         float limit = 2000;
         double limitReductionValue = 1;
         float value = 2500;
-        LimitViolation limitViolation = new LimitViolation(subjectId, limitType, limit, limitReductionValue, value);
+        LimitViolation limitViolation = LimitViolation.builder().subject(subjectId).type(limitType).limit(limit).reduction(limitReductionValue).value(value).build();
         limitViolation.addExtension(DummyLimitViolationExtension.class, new DummyLimitViolationExtension());
         limitViolations.add(limitViolation);
         List<ShortCircuitBusResults> busResults = new ArrayList<>();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Deprecate and replace some code.

**What is the current behavior?**
<!-- You can also link to an open issue here -->

There are a lot of constructors in `LimitViolation`, `LimitViolationBuilder` is not really used.

**What is the new behavior (if this is a feature change)?**

Deprecate most constructors of `LimitViolation` and add a call to create a `LimitViolationBuilder` directly from `LimitViolation`

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

If you are using the following constructors:
- `LimitViolation(String subjectId, @Nullable String subjectName, String operationalLimitsGroupId, LimitViolationType limitType, @Nullable String limitName, int acceptableDuration, double limit, double limitReduction, double value, @Nullable ThreeSides side, @Nullable ViolationLocation voltageLocation)`
- `LimitViolation(String subjectId, LimitViolationType limitType, double limit, double limitReduction, double value, ViolationLocation voltageLocation)`

Then no change is required.

Otherwise you can:
- use `LimitViolationBuilder`, either with `new LimitViolationBuilder()` or with `LimitViolation.builder()`, add the values and then use `.build()`
- use the constructor of `LimitViolation` with all the variables (mentionned above), and provide null values for all the variables you do not have a value for

Note that if you were using a constructor and were providing null values to it, you do not need to do that with the Builder. Also note that the default `limitReduction` is 1 and the default `acceptableDuration` is `Integer.MAX_VALUE`.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
