### PR TITLE
Copy all selected groups when converting from 3 2WT to 1 3WT

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/Replace3TwoWindingsTransformersByThreeWindingsTransformers.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/Replace3TwoWindingsTransformersByThreeWindingsTransformers.java
@@ -280,11 +280,8 @@ public class Replace3TwoWindingsTransformersByThreeWindingsTransformers extends 
     }
 
     private static void copySelectedOperationalLimitsGroup(TwoWindingsTransformer t2w, ThreeWindingsTransformer.Leg leg, boolean isWellOriented) {
-        if (isWellOriented) {
-            t2w.getSelectedOperationalLimitsGroupId1().ifPresent(leg::setSelectedOperationalLimitsGroup);
-        } else {
-            t2w.getSelectedOperationalLimitsGroupId2().ifPresent(leg::setSelectedOperationalLimitsGroup);
-        }
+        TwoSides side = isWellOriented ? TwoSides.ONE : TwoSides.TWO;
+        leg.addSelectedOperationalLimitsGroups(t2w.getAllSelectedOperationalLimitsGroupIdsOrdered(side).toArray(String[]::new));
     }
 
     private Substation findSubstation(TwoR twoR, boolean throwException) {

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/Replace3TwoWindingsTransformersByThreeWindingsTransformersTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/Replace3TwoWindingsTransformersByThreeWindingsTransformersTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Collections;
+import java.util.List;
+
 import static com.powsybl.iidm.modification.TransformersTestUtils.*;
 import static com.powsybl.iidm.modification.TransformersTestUtils.addPhaseTapChanger;
 import static com.powsybl.iidm.modification.util.ModificationReports.lostTwoWindingsTransformerExtensions;
@@ -173,10 +175,13 @@ class Replace3TwoWindingsTransformersByThreeWindingsTransformersTest {
         modifyNetworkForFlowsNotWellOrientedTest(); // t2w2 not well oriented, t3w related leg is "3WT-Leg2-notWellOriented"
         modifyNetworkForLoadingLimitsAtBothEndsTest();
 
-        t2w1.setSelectedOperationalLimitsGroup1("OperationalLimitsGroup-summer");
+        t2w1.newOperationalLimitsGroup1("other group");
+        t2w1.addSelectedOperationalLimitsGroups(TwoSides.ONE, "OperationalLimitsGroup-summer", "other group");
         t2w1.setSelectedOperationalLimitsGroup2("OperationalLimitsGroup-summer-end2");
-        network.getTwoWindingsTransformer("3WT-Leg1").setSelectedOperationalLimitsGroup1("OperationalLimitsGroup-summer");
-        network.getTwoWindingsTransformer("3WT-Leg1").setSelectedOperationalLimitsGroup2("OperationalLimitsGroup-summer-end2");
+        TwoWindingsTransformer actualT2w1 = network.getTwoWindingsTransformer("3WT-Leg1");
+        actualT2w1.newOperationalLimitsGroup1("other group");
+        actualT2w1.addSelectedOperationalLimitsGroups(TwoSides.ONE, "OperationalLimitsGroup-summer", "other group");
+        actualT2w1.setSelectedOperationalLimitsGroup2("OperationalLimitsGroup-summer-end2");
 
         t2w2.setSelectedOperationalLimitsGroup1("OperationalLimitsGroup-winter");
         t2w2.setSelectedOperationalLimitsGroup2("OperationalLimitsGroup-winter-end2");
@@ -193,7 +198,7 @@ class Replace3TwoWindingsTransformersByThreeWindingsTransformersTest {
 
         ThreeWindingsTransformer t3w = network.getThreeWindingsTransformer("3WT-Leg1-3WT-Leg2-notWellOriented-3WT-Leg3");
 
-        assertEquals("OperationalLimitsGroup-summer", t3w.getLeg1().getSelectedOperationalLimitsGroupId().orElseThrow());
+        assertEquals(List.of("OperationalLimitsGroup-summer", "other group"), t3w.getLeg1().getAllSelectedOperationalLimitsGroupIdsOrdered());
         assertEquals("OperationalLimitsGroup-winter-end2", t3w.getLeg2().getSelectedOperationalLimitsGroupId().orElseThrow());
         assertEquals("OperationalLimitsGroup-winter", t3w.getLeg3().getSelectedOperationalLimitsGroupId().orElseThrow());
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix some forgotten modifications after the multiple selected operational limits group PR.

**What is the current behavior?**
<!-- You can also link to an open issue here -->

When transforming 3 two-winding transformer to a single three-winding transformer, only the last selected group is copied.

**What is the new behavior (if this is a feature change)?**

All selected groups are copied.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
