### PR TITLE
CGMES: Set BaseVoltage based on the highest nominal voltage for lines.

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/EquipmentExport.java
@@ -708,10 +708,8 @@ public final class EquipmentExport {
 
     private static void writeLines(Network network, String cimNamespace, String euNamespace, Set<String> exportedLimitTypes, XMLStreamWriter writer, CgmesExportContext context) throws XMLStreamException {
         for (Line line : network.getLines()) {
-            String baseVoltageId = null;
-            if (line.getTerminal1().getVoltageLevel().getNominalV() == line.getTerminal2().getVoltageLevel().getNominalV()) {
-                baseVoltageId = context.getBaseVoltageIdFromNominalV(line.getTerminal1().getVoltageLevel().getNominalV());
-            }
+            double baseVoltage = Math.max(line.getTerminal1().getVoltageLevel().getNominalV(), line.getTerminal2().getVoltageLevel().getNominalV());
+            String baseVoltageId = context.getBaseVoltageIdFromNominalV(baseVoltage);
             AcLineSegmentEq.write(context.getNamingStrategy().getCgmesId(line), line.getNameOrId(), baseVoltageId, line.getR(), line.getX(), line.getG1() + line.getG2(), line.getB1() + line.getB2(), cimNamespace, writer, context);
             writeBranchLimits(line, getTerminalId(line.getTerminal1(), context), getTerminalId(line.getTerminal2(), context), cimNamespace, euNamespace, exportedLimitTypes, writer, context);
         }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/export/EquipmentExportTest.java
@@ -59,8 +59,7 @@ import com.google.common.jimfs.Jimfs;
 import static com.powsybl.cgmes.conversion.Conversion.*;
 import static com.powsybl.cgmes.conversion.export.CgmesExportUtil.getPhaseTapChangerAliasType;
 import static com.powsybl.cgmes.conversion.export.CgmesExportUtil.getRatioTapChangerAliasType;
-import static com.powsybl.cgmes.conversion.test.ConversionUtil.writeCgmesProfile;
-import static com.powsybl.cgmes.conversion.test.ConversionUtil.getFirstMatch;
+import static com.powsybl.cgmes.conversion.test.ConversionUtil.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -1949,5 +1948,27 @@ class EquipmentExportTest extends AbstractSerDeTest {
         assertEquals("onshore", getFirstMatch(eqXml, onshorePattern));
         Pattern offshorePattern = Pattern.compile(sPattern.replace("${rdfId}", "_wind_offshore_WGU"), Pattern.DOTALL);
         assertEquals("offshore", getFirstMatch(eqXml, offshorePattern));
+    }
+
+    @Test
+    void linesWithDifferentBaseVoltageOnBothSideTest() throws IOException {
+        Network network = EurostagTutorialExample1Factory.create();
+        double newNominalV = 400.0;
+        network.getVoltageLevel("VLHV1").setNominalV(newNominalV);
+        Line line = network.getLine("NHV1_NHV2_1");
+        assertEquals(newNominalV, line.getTerminal1().getVoltageLevel().getNominalV());
+        assertNotEquals(newNominalV, line.getTerminal2().getVoltageLevel().getNominalV());
+
+        String eqXml = writeCgmesProfile(network, "EQ", tmpDir);
+
+        String lineEq = getElement(eqXml, "ACLineSegment", line.getId());
+        assertNotNull(lineEq);
+
+        String baseVoltage = getResource(lineEq, "ConductingEquipment.BaseVoltage");
+        assertNotNull(baseVoltage);
+
+        String baseVoltageEq = getElement(eqXml, "BaseVoltage", baseVoltage);
+        assertNotNull(baseVoltageEq);
+        assertEquals(newNominalV, Double.parseDouble(getAttribute(baseVoltageEq, "BaseVoltage.nominalVoltage")));
     }
 }

--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -362,6 +362,9 @@ The corresponding targets are:
 ### Line
 
 PowSyBl [`Line`](../../grid_model/network_subnetwork.md#line) is exported as `ACLineSegment`.
+The attribute `ConductingEquipment.BaseVoltage` is written from the `nominalV` of the voltage level on both sides of the line:
+- if the nominal voltage is the same on both sides of the `Line`, then the `BaseVoltage` is set to this nominal voltage,
+- otherwise, it is set to the highest nominal voltage.
 
 <span style="color: red">TODO details</span>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix?


**What is the current behavior?**
<!-- You can also link to an open issue here -->
If a line is between two voltage levels that have different nominal voltages, then the attribute `ConductingEquipment.BaseVoltage` is not exported.
This leads to the error `BranchBaseVoltage` in QoCDC because the attribute is compulsory.


**What is the new behavior (if this is a feature change)?**
In that case, we write the highest nominal voltage.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No