### PR TITLE
Fix copying limits on modification ReplaceTeePointByVoltageLevelOnLine

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLine.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.computation.ComputationManager;
+import com.powsybl.iidm.modification.BranchOperationalLimitsGroupsCopy;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.BusbarSectionPosition;
 import org.slf4j.Logger;
@@ -162,25 +163,10 @@ public class ReplaceTeePointByVoltageLevelOnLine extends AbstractLineDisconnecti
         }
 
         // get line tpLine1 limits
-        TwoSides tpLine1Limits1Side = tpLine1OtherVlSide;
-        TwoSides tpLine1Limits2Side = tpLine1OtherVlSide == TwoSides.ONE ? TwoSides.TWO : TwoSides.ONE;
-        LoadingLimitsBags limits1TpLine1 = new LoadingLimitsBags(() -> tpLine1.getActivePowerLimits(tpLine1Limits1Side),
-                () -> tpLine1.getApparentPowerLimits(tpLine1Limits1Side),
-                () -> tpLine1.getCurrentLimits(tpLine1Limits1Side));
-        LoadingLimitsBags limits2TpLine1 = new LoadingLimitsBags(() -> tpLine1.getActivePowerLimits(tpLine1Limits2Side),
-                () -> tpLine1.getApparentPowerLimits(tpLine1Limits2Side),
-                () -> tpLine1.getCurrentLimits(tpLine1Limits2Side));
+        BranchOperationalLimitsGroupsCopy groupsCopyOnLine1 = new BranchOperationalLimitsGroupsCopy(tpLine1);
 
         // get line tpLine2 limits
-        TwoSides tpLine2Limits1Side = tpLine2OtherVlSide == TwoSides.ONE ? TwoSides.TWO : TwoSides.ONE;
-        TwoSides tpLine2Limits2Side = tpLine2OtherVlSide;
-
-        LoadingLimitsBags limits1TpLine2 = new LoadingLimitsBags(() -> tpLine2.getActivePowerLimits(tpLine2Limits1Side),
-                () -> tpLine2.getApparentPowerLimits(tpLine2Limits1Side),
-                () -> tpLine2.getCurrentLimits(tpLine2Limits1Side));
-        LoadingLimitsBags limits2TpLine2 = new LoadingLimitsBags(() -> tpLine2.getActivePowerLimits(tpLine2Limits2Side),
-                () -> tpLine2.getApparentPowerLimits(tpLine2Limits2Side),
-                () -> tpLine2.getCurrentLimits(tpLine2Limits2Side));
+        BranchOperationalLimitsGroupsCopy groupsCopyOnLine2 = new BranchOperationalLimitsGroupsCopy(tpLine2);
 
         // Remove the three existing lines
         tpLine1.remove();
@@ -195,14 +181,16 @@ public class ReplaceTeePointByVoltageLevelOnLine extends AbstractLineDisconnecti
 
         // Create the two new lines
         Line newLine1 = newLine1Adder.add();
-        addLoadingLimits(newLine1, limits1TpLine1, TwoSides.ONE);
-        addLoadingLimits(newLine1, limits2TpLine1, TwoSides.TWO);
+        //Cannot use LoadingLimitsUtil.copyOperationalLimits(copiedBranch, branch) since the copiedBranch and the branch we copy to do not exist at the same time
+        //And we need to delete the previous branch to create the two new branches otherwise the nodes will not be available
+        groupsCopyOnLine1.applyGroupsToBranch(newLine1, TwoSides.values());
         createdLineReport(reportNode, newLine1Id);
         LOGGER.info("Line {} created", newLine1Id);
 
         Line newLine2 = newLine2Adder.add();
-        addLoadingLimits(newLine2, limits1TpLine2, TwoSides.ONE);
-        addLoadingLimits(newLine2, limits2TpLine2, TwoSides.TWO);
+        //Cannot use LoadingLimitsUtil.copyOperationalLimits(copiedBranch, branch) since the copiedBranch and the branch we copy to do not exist at the same time
+        //And we need to delete the previous branch to create the two new branches otherwise the nodes will not be available
+        groupsCopyOnLine2.applyGroupsToBranch(newLine2, TwoSides.values());
         createdLineReport(reportNode, newLine2Id);
         LOGGER.info("Line {} created", newLine2Id);
 

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLine.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLine.java
@@ -162,10 +162,8 @@ public class ReplaceTeePointByVoltageLevelOnLine extends AbstractLineDisconnecti
             return;
         }
 
-        // get line tpLine1 limits
+        // copy all limits groups
         BranchOperationalLimitsGroupsCopy groupsCopyOnLine1 = new BranchOperationalLimitsGroupsCopy(tpLine1);
-
-        // get line tpLine2 limits
         BranchOperationalLimitsGroupsCopy groupsCopyOnLine2 = new BranchOperationalLimitsGroupsCopy(tpLine2);
 
         // Remove the three existing lines

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
@@ -9,8 +9,8 @@ package com.powsybl.iidm.modification.topology;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.report.PowsyblCoreReportResourceBundle;
-import com.powsybl.commons.test.PowsyblTestReportResourceBundle;
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.test.PowsyblTestReportResourceBundle;
 import com.powsybl.iidm.modification.AbstractNetworkModification;
 import com.powsybl.iidm.modification.NetworkModification;
 import com.powsybl.iidm.network.*;
@@ -21,7 +21,6 @@ import java.io.IOException;
 
 import static com.powsybl.iidm.modification.topology.TopologyTestUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
@@ -326,8 +325,7 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
                 .setAcceptableDuration(1200)
                 .endTemporaryLimit()
                 .add();
-        line1.addSelectedOperationalLimitsGroups(TwoSides.ONE, "group1");
-        line1.addSelectedOperationalLimitsGroups(TwoSides.ONE, "group2");
+        line1.addSelectedOperationalLimitsGroups(TwoSides.ONE, "group1", "group2");
         line1.addSelectedOperationalLimitsGroups(TwoSides.TWO, "group3");
 
         Line line2 = network.getLine("CJ_2");
@@ -353,8 +351,8 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
                 .endTemporaryLimit()
                 .add();
         line2.setSelectedOperationalLimitsGroup1("group4");
-        line2.addSelectedOperationalLimitsGroups(TwoSides.TWO, "group5");
-        line2.addSelectedOperationalLimitsGroups(TwoSides.TWO, "group6");
+        line2.cancelSelectedOperationalLimitsGroup2();
+        line2.addSelectedOperationalLimitsGroups(TwoSides.TWO, "group5", "group6");
         NetworkModification modification = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("CJ_1")
                 .withTeePointLine2("CJ_2")

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
@@ -294,4 +294,65 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
             .withNewLine2Id("NEW LINE2 ID").build();
         assertEquals("ReplaceTeePointByVoltageLevelOnLine", networkModification.getName());
     }
+
+    @Test
+    void testWithLimits() throws IOException {
+        Network network = createNetworkAdditionalLine();
+
+        ReportNode reportNode = ReportNode.newRootReportNode()
+                .withResourceBundles(PowsyblTestReportResourceBundle.TEST_BASE_NAME, PowsyblCoreReportResourceBundle.BASE_NAME)
+                .withMessageTemplate("reportTestReplaceTeePointByVoltageLevelWithLimits")
+                .build();
+
+        Line line1 = network.getLine("CJ_1");
+        line1.newOperationalLimitsGroup1("group1").newCurrentLimits()
+                .setPermanentLimit(100.0)
+                .beginTemporaryLimit().setName("20'")
+                .setValue(120.0)
+                .setAcceptableDuration(1200)
+                .endTemporaryLimit()
+                .add();
+        line1.newOperationalLimitsGroup1("group2").newCurrentLimits()
+                .setPermanentLimit(110.0)
+                .beginTemporaryLimit().setName("20'")
+                .setValue(130.0)
+                .setAcceptableDuration(1200)
+                .endTemporaryLimit()
+                .add();
+        line1.newOperationalLimitsGroup2("group3").newCurrentLimits()
+                .setPermanentLimit(90.0)
+                .beginTemporaryLimit().setName("20'")
+                .setValue(110.0)
+                .setAcceptableDuration(1200)
+                .endTemporaryLimit()
+                .add();
+        line1.setSelectedOperationalLimitsGroup1("group1");
+        line1.setSelectedOperationalLimitsGroup2("group3");
+
+        Line line2 = network.getLine("CJ_2");
+        line2.newOperationalLimitsGroup1("group4").newCurrentLimits()
+                .setPermanentLimit(100.0)
+                .beginTemporaryLimit().setName("20'")
+                .setValue(120.0)
+                .setAcceptableDuration(1200)
+                .endTemporaryLimit()
+                .add();
+        line2.newOperationalLimitsGroup2("group5").newCurrentLimits()
+                .setPermanentLimit(110.0)
+                .beginTemporaryLimit().setName("20'")
+                .setValue(130.0)
+                .setAcceptableDuration(1200)
+                .endTemporaryLimit()
+                .add();
+        line2.setSelectedOperationalLimitsGroup1("group4");
+        NetworkModification modification = new ReplaceTeePointByVoltageLevelOnLineBuilder()
+                .withTeePointLine1("CJ_1")
+                .withTeePointLine2("CJ_2")
+                .withTeePointLineToRemove("testLine")
+                .withBbsOrBusId(BBS)
+                .withNewLine1Id("NEW LINE1")
+                .withNewLine2Id("NEW LINE2").build();
+        modification.apply(network, new DefaultNamingStrategy(), false, reportNode);
+        writeXmlTest(network, "/replace-tee-point-with-vl-on-line-with-limits.xml");
+    }
 }

--- a/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
+++ b/iidm/iidm-modification/src/test/java/com/powsybl/iidm/modification/topology/ReplaceTeePointByVoltageLevelOnLineTest.java
@@ -326,8 +326,9 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
                 .setAcceptableDuration(1200)
                 .endTemporaryLimit()
                 .add();
-        line1.setSelectedOperationalLimitsGroup1("group1");
-        line1.setSelectedOperationalLimitsGroup2("group3");
+        line1.addSelectedOperationalLimitsGroups(TwoSides.ONE, "group1");
+        line1.addSelectedOperationalLimitsGroups(TwoSides.ONE, "group2");
+        line1.addSelectedOperationalLimitsGroups(TwoSides.TWO, "group3");
 
         Line line2 = network.getLine("CJ_2");
         line2.newOperationalLimitsGroup1("group4").newCurrentLimits()
@@ -344,7 +345,16 @@ class ReplaceTeePointByVoltageLevelOnLineTest extends AbstractModificationTest {
                 .setAcceptableDuration(1200)
                 .endTemporaryLimit()
                 .add();
+        line2.newOperationalLimitsGroup2("group6").newCurrentLimits()
+                .setPermanentLimit(110.0)
+                .beginTemporaryLimit().setName("20'")
+                .setValue(130.0)
+                .setAcceptableDuration(1200)
+                .endTemporaryLimit()
+                .add();
         line2.setSelectedOperationalLimitsGroup1("group4");
+        line2.addSelectedOperationalLimitsGroups(TwoSides.TWO, "group5");
+        line2.addSelectedOperationalLimitsGroups(TwoSides.TWO, "group6");
         NetworkModification modification = new ReplaceTeePointByVoltageLevelOnLineBuilder()
                 .withTeePointLine1("CJ_1")
                 .withTeePointLine2("CJ_2")

--- a/iidm/iidm-modification/src/test/resources/replace-tee-point-with-vl-on-line-with-limits.xml
+++ b/iidm/iidm-modification/src/test/resources/replace-tee-point-with-vl-on-line-with-limits.xml
@@ -138,7 +138,7 @@
         </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:line id="LINE34" r="0.1" x="0.1" g1="0.0" b1="0.0" g2="0.0" b2="0.0" voltageLevelId1="VL3" node1="1" voltageLevelId2="VL4" node2="1"/>
-    <iidm:line id="NEW LINE1" r="0.0149999985" x="0.150000036" g1="0.0" b1="0.0" g2="0.0" b2="0.0" voltageLevelId1="C" node1="4" voltageLevelId2="VLTEST" node2="3" selectedOperationalLimitsGroupIds1="group1" selectedOperationalLimitsGroupIds2="group3">
+    <iidm:line id="NEW LINE1" r="0.0149999985" x="0.150000036" g1="0.0" b1="0.0" g2="0.0" b2="0.0" voltageLevelId1="C" node1="4" voltageLevelId2="VLTEST" node2="3" selectedOperationalLimitsGroupIds1="DEFAULT,group1,group2" selectedOperationalLimitsGroupIds2="DEFAULT,group3">
         <iidm:operationalLimitsGroup1 id="DEFAULT">
             <iidm:currentLimits permanentLimit="931.0"/>
         </iidm:operationalLimitsGroup1>
@@ -164,7 +164,7 @@
             </iidm:currentLimits>
         </iidm:operationalLimitsGroup2>
     </iidm:line>
-    <iidm:line id="NEW LINE2" r="0.0149999985" x="0.150000036" g1="0.0" b1="0.0" g2="0.0" b2="0.0" voltageLevelId1="VLTEST" node1="6" voltageLevelId2="N" node2="5" selectedOperationalLimitsGroupIds1="group4" selectedOperationalLimitsGroupIds2="DEFAULT">
+    <iidm:line id="NEW LINE2" r="0.0149999985" x="0.150000036" g1="0.0" b1="0.0" g2="0.0" b2="0.0" voltageLevelId1="VLTEST" node1="6" voltageLevelId2="N" node2="5" selectedOperationalLimitsGroupIds1="group4" selectedOperationalLimitsGroupIds2="DEFAULT,group5,group6">
         <iidm:operationalLimitsGroup1 id="DEFAULT">
             <iidm:currentLimits permanentLimit="931.0"/>
         </iidm:operationalLimitsGroup1>
@@ -180,6 +180,11 @@
             </iidm:currentLimits>
         </iidm:operationalLimitsGroup2>
         <iidm:operationalLimitsGroup2 id="group5">
+            <iidm:currentLimits permanentLimit="110.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="130.0"/>
+            </iidm:currentLimits>
+        </iidm:operationalLimitsGroup2>
+        <iidm:operationalLimitsGroup2 id="group6">
             <iidm:currentLimits permanentLimit="110.0">
                 <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="130.0"/>
             </iidm:currentLimits>

--- a/iidm/iidm-modification/src/test/resources/replace-tee-point-with-vl-on-line-with-limits.xml
+++ b/iidm/iidm-modification/src/test/resources/replace-tee-point-with-vl-on-line-with-limits.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_16" id="fictitious" caseDate="2021-08-27T14:44:56.567+02:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:voltageLevel id="VLTEST" nominalV="380.0" topologyKind="NODE_BREAKER">
+        <iidm:nodeBreakerTopology>
+            <iidm:busbarSection id="bbs" node="0"/>
+            <iidm:switch id="NEW LINE1_BREAKER" kind="BREAKER" retained="true" open="false" node1="3" node2="4"/>
+            <iidm:switch id="NEW LINE1_DISCONNECTOR_4_0" kind="DISCONNECTOR" retained="false" open="false" node1="4" node2="0"/>
+            <iidm:switch id="NEW LINE2_BREAKER" kind="BREAKER" retained="true" open="false" node1="6" node2="5"/>
+            <iidm:switch id="NEW LINE2_DISCONNECTOR_5_0" kind="DISCONNECTOR" retained="false" open="false" node1="5" node2="0"/>
+        </iidm:nodeBreakerTopology>
+    </iidm:voltageLevel>
+    <iidm:voltageLevel id="VL3" nominalV="380.0" topologyKind="NODE_BREAKER">
+        <iidm:nodeBreakerTopology>
+            <iidm:busbarSection id="bbs3" node="0"/>
+            <iidm:switch id="breaker3" name="breaker3" kind="BREAKER" retained="false" open="true" node1="0" node2="1"/>
+        </iidm:nodeBreakerTopology>
+    </iidm:voltageLevel>
+    <iidm:voltageLevel id="VL4" nominalV="380.0" topologyKind="NODE_BREAKER">
+        <iidm:nodeBreakerTopology>
+            <iidm:busbarSection id="bbs4" node="0"/>
+            <iidm:switch id="breaker4" name="breaker4" kind="BREAKER" retained="false" open="true" node1="0" node2="1"/>
+        </iidm:nodeBreakerTopology>
+    </iidm:voltageLevel>
+    <iidm:substation id="A" country="FR">
+        <iidm:voltageLevel id="C" nominalV="225.0" lowVoltageLimit="0.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="D" name="E" node="0"/>
+                <iidm:switch id="F" name="G" fictitious="true" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="1"/>
+                <iidm:switch id="H" name="I" fictitious="true" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="3"/>
+                <iidm:switch id="J" name="K" fictitious="true" kind="BREAKER" retained="true" open="false" node1="1" node2="2"/>
+                <iidm:switch id="L" name="M" fictitious="true" kind="BREAKER" retained="true" open="false" node1="3" node2="4"/>
+                <iidm:bus v="234.40912" angle="0.0" nodes="0,1,2,3,4"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="N" nominalV="225.0" lowVoltageLimit="220.0" highVoltageLimit="245.00002" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="O" name="E" node="0"/>
+                <iidm:busbarSection id="P" name="Q" node="1"/>
+                <iidm:switch id="R" name="S" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="19"/>
+                <iidm:switch id="T" name="U" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="17"/>
+                <iidm:switch id="V" name="W" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="21"/>
+                <iidm:switch id="X" name="Y" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="11"/>
+                <iidm:switch id="Z" name="AA" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="13"/>
+                <iidm:switch id="AB" name="AC" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="15"/>
+                <iidm:switch id="AD" name="AE" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="8"/>
+                <iidm:switch id="AF" name="AG" fictitious="true" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="2"/>
+                <iidm:switch id="AH" name="AI" kind="DISCONNECTOR" retained="false" open="false" node1="7" node2="0"/>
+                <iidm:switch id="AJ" name="AK" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="6"/>
+                <iidm:switch id="AL" name="AM" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="19"/>
+                <iidm:switch id="AN" name="AO" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="17"/>
+                <iidm:switch id="AP" name="AQ" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="21"/>
+                <iidm:switch id="AR" name="AS" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="11"/>
+                <iidm:switch id="AT" name="AU" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="13"/>
+                <iidm:switch id="AV" name="AW" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="15"/>
+                <iidm:switch id="AX" name="AY" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="8"/>
+                <iidm:switch id="AZ" name="BA" fictitious="true" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="2"/>
+                <iidm:switch id="BB" name="BC" fictitious="true" kind="BREAKER" retained="true" open="true" node1="2" node2="3"/>
+                <iidm:switch id="BD" name="BE" kind="BREAKER" retained="true" open="false" node1="3" node2="4"/>
+                <iidm:switch id="BF" name="BG" kind="DISCONNECTOR" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="BH" name="BI" kind="DISCONNECTOR" retained="false" open="true" node1="9" node2="3"/>
+                <iidm:switch id="BJ" name="BK" kind="BREAKER" retained="true" open="false" node1="6" node2="7"/>
+                <iidm:switch id="BL" name="BM" kind="BREAKER" retained="true" open="false" node1="8" node2="9"/>
+                <iidm:switch id="BN" name="BO" kind="DISCONNECTOR" retained="false" open="false" node1="9" node2="10"/>
+                <iidm:switch id="BP" name="BQ" kind="BREAKER" retained="true" open="true" node1="11" node2="12"/>
+                <iidm:switch id="BR" name="BS" kind="BREAKER" retained="true" open="true" node1="13" node2="14"/>
+                <iidm:switch id="BT" name="BU" kind="BREAKER" retained="true" open="false" node1="15" node2="16"/>
+                <iidm:switch id="BV" name="BW" kind="BREAKER" retained="true" open="false" node1="17" node2="18"/>
+                <iidm:switch id="BX" name="BY" kind="BREAKER" retained="true" open="false" node1="19" node2="20"/>
+                <iidm:switch id="BZ" name="CA" kind="BREAKER" retained="true" open="false" node1="21" node2="22"/>
+                <iidm:bus v="236.44736" angle="15.250391" nodes="0,1,6,7,8,9,10,15,16,17,18,19,20,21,22"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="CB" energySource="HYDRO" minP="0.0" maxP="70.0" voltageRegulatorOn="false" targetP="0.0" targetV="0.0" targetQ="0.0" node="12">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>
+                    <iidm:point p="70.0" minQ="-54.55" maxQ="46.25"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CC" energySource="HYDRO" minP="0.0" maxP="80.0" voltageRegulatorOn="false" targetP="0.0" targetV="0.0" targetQ="0.0" node="14">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-56.8" maxQ="57.4"/>
+                    <iidm:point p="80.0" minQ="-53.514" maxQ="36.4"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CD" energySource="HYDRO" minP="0.0" maxP="35.0" voltageRegulatorOn="true" targetP="21.789589" targetV="236.44736" targetQ="-20.701546" node="16" p="-21.789589" q="20.693394">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-20.6" maxQ="18.1"/>
+                    <iidm:point p="35.0" minQ="-21.725" maxQ="6.3500004"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:load id="CE" loadType="UNDEFINED" p0="-72.18689" q0="50.168945" node="4" p="-72.18689" q="50.168945"/>
+            <iidm:load id="CF" loadType="UNDEFINED" p0="8.455854" q0="-23.695925" node="18" p="8.455854" q="-23.695925"/>
+            <iidm:load id="CG" loadType="UNDEFINED" p0="90.39911" q0="-51.96869" node="20" p="90.39911" q="-51.96869"/>
+            <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" node="22" p="-5.102249" q="4.9081216"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0" voltageLevelId1="C" node1="2" voltageLevelId2="N" node2="10" selectedOperationalLimitsGroupIds1="DEFAULT" selectedOperationalLimitsGroupIds2="DEFAULT">
+            <iidm:phaseTapChanger regulating="false" lowTapPosition="0" tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER" regulationValue="930.6667">
+                <iidm:terminalRef id="CI" side="ONE"/>
+                <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
+                <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>
+                <iidm:step r="23.655737" x="23.655735" g="0.0" b="0.0" rho="1.0" alpha="-37.54"/>
+                <iidm:step r="16.263271" x="16.263268" g="0.0" b="0.0" rho="1.0" alpha="-34.9"/>
+                <iidm:step r="9.542847" x="9.542842" g="0.0" b="0.0" rho="1.0" alpha="-32.26"/>
+                <iidm:step r="3.4944773" x="3.4944773" g="0.0" b="0.0" rho="1.0" alpha="-29.6"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" g="0.0" b="0.0" rho="1.0" alpha="-26.94"/>
+                <iidm:step r="-7.258195" x="-7.2581954" g="0.0" b="0.0" rho="1.0" alpha="-24.26"/>
+                <iidm:step r="-11.962485" x="-11.962484" g="0.0" b="0.0" rho="1.0" alpha="-21.58"/>
+                <iidm:step r="-15.994745" x="-15.994745" g="0.0" b="0.0" rho="1.0" alpha="-18.9"/>
+                <iidm:step r="-19.354952" x="-19.354952" g="0.0" b="0.0" rho="1.0" alpha="-16.22"/>
+                <iidm:step r="-22.043127" x="-22.043129" g="0.0" b="0.0" rho="1.0" alpha="-13.52"/>
+                <iidm:step r="-24.73129" x="-24.731287" g="0.0" b="0.0" rho="1.0" alpha="-10.82"/>
+                <iidm:step r="-26.747417" x="-26.747417" g="0.0" b="0.0" rho="1.0" alpha="-8.12"/>
+                <iidm:step r="-28.091503" x="-28.091503" g="0.0" b="0.0" rho="1.0" alpha="-5.42"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="-2.7"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="2.7"/>
+                <iidm:step r="-28.091503" x="-28.091503" g="0.0" b="0.0" rho="1.0" alpha="5.42"/>
+                <iidm:step r="-26.747417" x="-26.747417" g="0.0" b="0.0" rho="1.0" alpha="8.12"/>
+                <iidm:step r="-24.73129" x="-24.731287" g="0.0" b="0.0" rho="1.0" alpha="10.82"/>
+                <iidm:step r="-22.043127" x="-22.043129" g="0.0" b="0.0" rho="1.0" alpha="13.52"/>
+                <iidm:step r="-19.354952" x="-19.354952" g="0.0" b="0.0" rho="1.0" alpha="16.22"/>
+                <iidm:step r="-15.994745" x="-15.994745" g="0.0" b="0.0" rho="1.0" alpha="18.9"/>
+                <iidm:step r="-11.962485" x="-11.962484" g="0.0" b="0.0" rho="1.0" alpha="21.58"/>
+                <iidm:step r="-7.258195" x="-7.2581954" g="0.0" b="0.0" rho="1.0" alpha="24.26"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" g="0.0" b="0.0" rho="1.0" alpha="26.94"/>
+                <iidm:step r="3.4944773" x="3.4944773" g="0.0" b="0.0" rho="1.0" alpha="29.6"/>
+                <iidm:step r="9.542847" x="9.542842" g="0.0" b="0.0" rho="1.0" alpha="32.26"/>
+                <iidm:step r="16.263271" x="16.263268" g="0.0" b="0.0" rho="1.0" alpha="34.9"/>
+                <iidm:step r="23.655737" x="23.655735" g="0.0" b="0.0" rho="1.0" alpha="37.54"/>
+                <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="40.18"/>
+                <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="42.8"/>
+            </iidm:phaseTapChanger>
+            <iidm:operationalLimitsGroup1 id="DEFAULT">
+                <iidm:currentLimits permanentLimit="931.0"/>
+            </iidm:operationalLimitsGroup1>
+            <iidm:operationalLimitsGroup2 id="DEFAULT">
+                <iidm:currentLimits permanentLimit="931.0"/>
+            </iidm:operationalLimitsGroup2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="LINE34" r="0.1" x="0.1" g1="0.0" b1="0.0" g2="0.0" b2="0.0" voltageLevelId1="VL3" node1="1" voltageLevelId2="VL4" node2="1"/>
+    <iidm:line id="NEW LINE1" r="0.0149999985" x="0.150000036" g1="0.0" b1="0.0" g2="0.0" b2="0.0" voltageLevelId1="C" node1="4" voltageLevelId2="VLTEST" node2="3" selectedOperationalLimitsGroupIds1="group1" selectedOperationalLimitsGroupIds2="group3">
+        <iidm:operationalLimitsGroup1 id="DEFAULT">
+            <iidm:currentLimits permanentLimit="931.0"/>
+        </iidm:operationalLimitsGroup1>
+        <iidm:operationalLimitsGroup1 id="group1">
+            <iidm:currentLimits permanentLimit="100.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="120.0"/>
+            </iidm:currentLimits>
+        </iidm:operationalLimitsGroup1>
+        <iidm:operationalLimitsGroup1 id="group2">
+            <iidm:currentLimits permanentLimit="110.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="130.0"/>
+            </iidm:currentLimits>
+        </iidm:operationalLimitsGroup1>
+        <iidm:operationalLimitsGroup2 id="DEFAULT">
+            <iidm:currentLimits permanentLimit="931.0">
+                <iidm:temporaryLimit name="IST" value="1640.0" fictitious="true"/>
+                <iidm:temporaryLimit name="IT1" acceptableDuration="60"/>
+            </iidm:currentLimits>
+        </iidm:operationalLimitsGroup2>
+        <iidm:operationalLimitsGroup2 id="group3">
+            <iidm:currentLimits permanentLimit="90.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="110.0"/>
+            </iidm:currentLimits>
+        </iidm:operationalLimitsGroup2>
+    </iidm:line>
+    <iidm:line id="NEW LINE2" r="0.0149999985" x="0.150000036" g1="0.0" b1="0.0" g2="0.0" b2="0.0" voltageLevelId1="VLTEST" node1="6" voltageLevelId2="N" node2="5" selectedOperationalLimitsGroupIds1="group4" selectedOperationalLimitsGroupIds2="DEFAULT">
+        <iidm:operationalLimitsGroup1 id="DEFAULT">
+            <iidm:currentLimits permanentLimit="931.0"/>
+        </iidm:operationalLimitsGroup1>
+        <iidm:operationalLimitsGroup1 id="group4">
+            <iidm:currentLimits permanentLimit="100.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="120.0"/>
+            </iidm:currentLimits>
+        </iidm:operationalLimitsGroup1>
+        <iidm:operationalLimitsGroup2 id="DEFAULT">
+            <iidm:currentLimits permanentLimit="931.0">
+                <iidm:temporaryLimit name="IST" value="1640.0" fictitious="true"/>
+                <iidm:temporaryLimit name="IT1" acceptableDuration="60"/>
+            </iidm:currentLimits>
+        </iidm:operationalLimitsGroup2>
+        <iidm:operationalLimitsGroup2 id="group5">
+            <iidm:currentLimits permanentLimit="110.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="130.0"/>
+            </iidm:currentLimits>
+        </iidm:operationalLimitsGroup2>
+    </iidm:line>
+</iidm:network>

--- a/iidm/iidm-modification/src/test/resources/replace-tee-point-with-vl-on-line-with-limits.xml
+++ b/iidm/iidm-modification/src/test/resources/replace-tee-point-with-vl-on-line-with-limits.xml
@@ -164,7 +164,7 @@
             </iidm:currentLimits>
         </iidm:operationalLimitsGroup2>
     </iidm:line>
-    <iidm:line id="NEW LINE2" r="0.0149999985" x="0.150000036" g1="0.0" b1="0.0" g2="0.0" b2="0.0" voltageLevelId1="VLTEST" node1="6" voltageLevelId2="N" node2="5" selectedOperationalLimitsGroupIds1="group4" selectedOperationalLimitsGroupIds2="DEFAULT,group5,group6">
+    <iidm:line id="NEW LINE2" r="0.0149999985" x="0.150000036" g1="0.0" b1="0.0" g2="0.0" b2="0.0" voltageLevelId1="VLTEST" node1="6" voltageLevelId2="N" node2="5" selectedOperationalLimitsGroupIds1="group4" selectedOperationalLimitsGroupIds2="group5,group6">
         <iidm:operationalLimitsGroup1 id="DEFAULT">
             <iidm:currentLimits permanentLimit="931.0"/>
         </iidm:operationalLimitsGroup1>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
When replacing a tee point with a line with a voltage level, limits are not well copied and the `selectedOperationalLimitsGroup` is not well set too.



**What is the new behavior (if this is a feature change)?**
Fix it


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No