### PR TITLE
CGMES export documentation: Add behaviour if missing ratedS for TwoWindingsTransformers.

### DIFF
--- a/docs/grid_exchange_formats/cgmes/export.md
+++ b/docs/grid_exchange_formats/cgmes/export.md
@@ -466,6 +466,9 @@ at the regulated terminal with the regulation value.
 
 PowSyBl [`TwoWindingsTransformer`](../../grid_model/network_subnetwork.md#two-winding-transformer) is exported as `PowerTransformer` with two `PowerTransformerEnds`.
 
+If the IIDM `TwoWindingsTransformer` does not have a `ratedS`, then a default value of `100` is exported for `PowerTransformerEnd.ratedS` as this field is mandatory.
+The `ratedS` will be the same on both ends of the `PowerTransformer`.
+
 If the transformer has a `TapChanger`, the CGMES SSH `step` is written from the IIDM `TapPosition` and the CGMES SV
 `SVtapStep` is written from the IIDM `SolvedTapPosition` if it is not null, otherwise `TapPosition`.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update


**What is the new behavior (if this is a feature change)?**
Documentation now mentions the behaviour regarding the rated S of transformers at CGMES export.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No