### PR TITLE
Detect specific group of elements that could be replaced by non-electrically equivalent generator

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
@@ -481,6 +481,7 @@ public final class Networks {
     public static Stream<ReducibleTransformerData> getReducibleTransformerDataStream(Network network) {
         return network.getVoltageLevelStream()
             .filter(v -> StreamSupport.stream(v.getConnectables().spliterator(), false).allMatch(c -> isReducibleElement(c.getType())))
+            .filter(v -> StreamSupport.stream(v.getSwitches().spliterator(), false).noneMatch(Switch::isOpen))
             .flatMap(v -> v.getTwoWindingsTransformerStream()
                 .map(t -> new ReducibleTransformerData(
                     t,

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
@@ -479,15 +479,23 @@ public final class Networks {
     }
 
     public static Stream<ReducibleTransformerData> getReducibleTransformerDataStream(Network network) {
-        return network.getVoltageLevelStream()
-            .filter(v -> StreamSupport.stream(v.getConnectables().spliterator(), false).allMatch(c -> isReducibleElement(c.getType())))
-            .filter(v -> StreamSupport.stream(v.getSwitches().spliterator(), false).noneMatch(Switch::isOpen))
-            .flatMap(v -> v.getTwoWindingsTransformerStream()
-                .map(t -> new ReducibleTransformerData(
-                    t,
-                    getTransformerVoltageLevelSide(t, v))
-                )
-            );
+        return getReducibleTransformerDataStream(network.getVoltageLevelStream());
+    }
+
+    public static Stream<ReducibleTransformerData> getReducibleTransformerDataStream(Substation substation) {
+        return getReducibleTransformerDataStream(substation.getVoltageLevelStream());
+    }
+
+    private static Stream<ReducibleTransformerData> getReducibleTransformerDataStream(Stream<VoltageLevel> voltageLevelStream) {
+        return voltageLevelStream
+           .filter(v -> StreamSupport.stream(v.getConnectables().spliterator(), false).allMatch(c -> isReducibleElement(c.getType())))
+           .filter(v -> StreamSupport.stream(v.getSwitches().spliterator(), false).noneMatch(Switch::isOpen))
+           .flatMap(v -> v.getTwoWindingsTransformerStream()
+               .map(t -> new ReducibleTransformerData(
+                   t,
+                   getTransformerVoltageLevelSide(t, v))
+               )
+           );
     }
 
     /**

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
@@ -25,6 +25,8 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  *
@@ -474,5 +476,36 @@ public final class Networks {
         network.getTwoWindingsTransformerStream().forEach(TwoWindingsTransformer::applySolvedValues);
         network.getThreeWindingsTransformerStream().forEach(ThreeWindingsTransformer::applySolvedValues);
         network.getShuntCompensatorStream().forEach(ShuntCompensator::applySolvedValues);
+    }
+
+    public static Stream<ReducibleTransformerData> getReducibleTransformerDataStream(Network network) {
+        return network.getVoltageLevelStream()
+            .filter(v -> StreamSupport.stream(v.getConnectables().spliterator(), false).allMatch(c -> isReducibleElement(c.getType())))
+            .flatMap(v -> v.getTwoWindingsTransformerStream()
+                .map(t -> new ReducibleTransformerData(
+                    t,
+                    getTransformerVoltageLevelSide(t, v))
+                )
+            );
+    }
+
+    /**
+     * The voltage elements on the <code>reducibleSide</code> of the <code>transformer</code> and the transformer can be
+     * reduced into a single generator equivalent to the active / reactive power on the terminal of the side opposite to <code>reducibleSide</code>
+     * @param transformer
+     * @param reducibleSide
+     */
+    public record ReducibleTransformerData(TwoWindingsTransformer transformer, TwoSides reducibleSide) { }
+
+    private static boolean isReducibleElement(IdentifiableType type) {
+        return type == IdentifiableType.TWO_WINDINGS_TRANSFORMER
+            || type == IdentifiableType.GENERATOR
+            || type == IdentifiableType.LOAD
+            || type == IdentifiableType.BUSBAR_SECTION
+            || type == IdentifiableType.BATTERY;
+    }
+
+    private static TwoSides getTransformerVoltageLevelSide(TwoWindingsTransformer transformer, VoltageLevel voltageLevel) {
+        return transformer.getTerminal(TwoSides.ONE).getVoltageLevel().getId().equals(voltageLevel.getId()) ? TwoSides.ONE : TwoSides.TWO;
     }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
@@ -480,14 +480,44 @@ public final class Networks {
         network.getShuntCompensatorStream().forEach(ShuntCompensator::applySolvedValues);
     }
 
+    /**
+     * Get all the elements of the <code>network</code> that can be reduced into an equivalent generator. The conditions for a reduction are
+     * decided for each voltage level, with the following criteria:
+     * <ul>
+     *     <li>the voltage level must contain only reducible elements, which are {@link Generator}, {@link Load}, {@link TwoWindingsTransformer} and {@link BusbarSection}</li>
+     *     <li>all breakers in the voltage level must be closed (to prevent issue where a part of the voltage level is incorrectly reduced)</li>
+     *     <li>a given set of reducible elements must be linked to the voltage level above through a single two-winding transformer. There can be multiple transformer per voltage level</li>
+     *     <li>there must be at least one generator per set of reducible elements for the reduction</li>
+     * </ul>
+     * @param network the network on which we want to get all the sets of reducible elements and their corresponding two winding transformer
+     * @return a stream of {@link ReducibleTransformerData}, containing the information necessary for a reduction
+     */
     public static Stream<ReducibleTransformerData> getReducibleTransformerDataStream(Network network) {
         return getReducibleTransformerDataStream(network.getVoltageLevelStream());
     }
 
+    /**
+     * Get all the elements of the <code>substation</code> that can be reduced into an equivalent generator. The conditions for a reduction are
+     * decided for each voltage level, with the following criteria:
+     * <ul>
+     *     <li>the voltage level must contain only reducible elements, which are {@link Generator}, {@link Load}, {@link TwoWindingsTransformer} and {@link BusbarSection}</li>
+     *     <li>all breakers in the voltage level must be closed (to prevent issue where a part of the voltage level is incorrectly reduced)</li>
+     *     <li>a given set of reducible elements must be linked to the voltage level above through a single two-winding transformer. There can be multiple transformer per voltage level</li>
+     *     <li>there must be at least one generator per set of reducible elements for the reduction</li>
+     * </ul>
+     * @param substation the substation on which we want to get all the sets of reducible elements and their corresponding two winding transformer
+     * @return a stream of {@link ReducibleTransformerData}, containing the information necessary for a reduction
+     */
     public static Stream<ReducibleTransformerData> getReducibleTransformerDataStream(Substation substation) {
         return getReducibleTransformerDataStream(substation.getVoltageLevelStream());
     }
 
+    /**
+     * Filter the voltage levels to only keep the ones that are valid, according to the description of {@link #getReducibleTransformerDataStream(Substation)} and {@link #getReducibleTransformerDataStream(Network)}
+     * Then use a traverser to ensure each set of element contains at least one generator and corresponds to a single transformer
+     * @param voltageLevelStream the voltage levels on which to perform the filtering and traversing
+     * @return a stream of {@link ReducibleTransformerData} containing the information used for the reduction, one for each set of elements
+     */
     private static Stream<ReducibleTransformerData> getReducibleTransformerDataStream(Stream<VoltageLevel> voltageLevelStream) {
         return voltageLevelStream
            .filter(v -> StreamSupport.stream(v.getConnectables().spliterator(), false).allMatch(c -> isReducibleElement(c.getType())))
@@ -500,6 +530,13 @@ public final class Networks {
             .filter(Objects::nonNull);
     }
 
+    /**
+     * Traverse the topology starting from each two winding transformer, to check if all the sets of reducible elements are valid (ie
+     * only one two-winding transformer per set of reducible element, at least one generator per set of reducible element).
+     * @param isValid used to signify to the calling process if the voltage level is valid for reduction with regard to topology
+     * @param vl the voltage level on which to perform the checks
+     * @return a stream of {@link ReducibleTransformerData} containing the information used for the reduction, one for each set of elements
+     */
     private static Stream<ReducibleTransformerData> traverseVlTopology(RefObj<Boolean> isValid, VoltageLevel vl) {
         return vl.getTwoWindingsTransformerStream()
             .map(t -> {
@@ -523,23 +560,37 @@ public final class Networks {
             });
     }
 
+    /**
+     * @return the list of generators that can be accessed by a traverser starting from the given terminal
+     */
     private static List<Generator> getGeneratorsFromBusBreakerTopology(VoltageLevel vl, Terminal startingTerminal, String startingTransformerId, RefObj<Boolean> isValid) {
         List<Generator> toBeDeletedGenerators = new ArrayList<>();
         Bus startingBus = startingTerminal.getBusBreakerView().getBus();
-        handleBus(startingBus, toBeDeletedGenerators, startingTransformerId, isValid);
-        vl.getBusBreakerView().traverse(startingBus, (bus1, sw, bus2) -> handleBus(bus2, toBeDeletedGenerators, startingTransformerId, isValid));
+        traverseBus(startingBus, toBeDeletedGenerators, startingTransformerId, isValid);
+        vl.getBusBreakerView().traverse(startingBus, (bus1, sw, bus2) -> traverseBus(bus2, toBeDeletedGenerators, startingTransformerId, isValid));
         return toBeDeletedGenerators;
     }
 
+    /**
+     * @return the list of generators that can be accessed by a traverser starting from the given terminal
+     */
     private static List<Generator> getGeneratorsFromNodeBreakerTopology(VoltageLevel vl, Terminal startingTerminal, String startingTransformerId, RefObj<Boolean> isValid) {
         List<Generator> toBeDeletedGenerators = new ArrayList<>();
         int startingNode = startingTerminal.getNodeBreakerView().getNode();
-        handleNode(vl, null, startingNode, toBeDeletedGenerators, startingTransformerId, isValid);
-        vl.getNodeBreakerView().traverse(startingNode, (node1, sw, node2) -> handleNode(vl, sw, node2, toBeDeletedGenerators, startingTransformerId, isValid));
+        traverseNode(vl, null, startingNode, toBeDeletedGenerators, startingTransformerId, isValid);
+        vl.getNodeBreakerView().traverse(startingNode, (node1, sw, node2) -> traverseNode(vl, sw, node2, toBeDeletedGenerators, startingTransformerId, isValid));
         return toBeDeletedGenerators;
     }
 
-    private static TraverseResult handleBus(Bus bus, List<Generator> toBeDeletedGenerators, String startingTransformerId, RefObj<Boolean> isValid) {
+    /**
+     * Handle bus traversal, collecting generators along the way. Stops if the set of elements is detected as invalid for reduction.
+     * @param bus the bus whose elements we are currently looking at.
+     * @param toBeDeletedGenerators the list of generators that would be removed from the network by a reduction.
+     * @param startingTransformerId the ID of the transformer we started the traversal from. Used to identify if another transformer is encountered during the traversal.
+     * @param isValid the set of elements is valid for reduction
+     * @return an {@link TraverseResult} depending on the elements of the bus
+     */
+    private static TraverseResult traverseBus(Bus bus, List<Generator> toBeDeletedGenerators, String startingTransformerId, RefObj<Boolean> isValid) {
         if (bus == null) {
             return TraverseResult.TERMINATE_TRAVERSER;
         }
@@ -558,16 +609,25 @@ public final class Networks {
         return result;
     }
 
-    private static TraverseResult handleNode(VoltageLevel vl, Switch sw, int node, List<Generator> toBeDeletedGenerators, String startingTransformerId, RefObj<Boolean> isValid) {
+    /**
+     * Handle node traversal, collecting generators along the way. Stops if the set of elements is detected as invalid for reduction.
+     * @param vl the voltage level of this node
+     * @param sw the next switch to traverse (if it exists)
+     * @param node the node we are currently looking at.
+     * @param toBeDeletedGenerators the list of generators that would be removed from the network by a reduction.
+     * @param startingTransformerId the ID of the transformer we started the traversal from. Used to identify if another transformer is encountered during the traversal.
+     * @param isValid the set of elements is valid for reduction
+     * @return an {@link TraverseResult} depending on the elements of the bus
+     */
+    private static TraverseResult traverseNode(VoltageLevel vl, Switch sw, int node, List<Generator> toBeDeletedGenerators, String startingTransformerId, RefObj<Boolean> isValid) {
         if (node < 0) {
             return TraverseResult.TERMINATE_TRAVERSER;
         }
         if (sw != null && sw.isOpen()) {
+            //the filter already made sure there are no open breaker, that means this is an open disconnector, do not go that way
             return TraverseResult.TERMINATE_PATH;
         }
-        TraverseResult result = TraverseResult.CONTINUE;
         Connectable<?> connectable = vl.getNodeBreakerView().getTerminal(node).getConnectable();
-        String id = connectable.getId();
         return switch (connectable.getType()) {
             case IdentifiableType.GENERATOR -> handleGenerator(connectable, toBeDeletedGenerators);
             case IdentifiableType.TWO_WINDINGS_TRANSFORMER -> handleTwoWindingTransformer(connectable, startingTransformerId, isValid);
@@ -590,13 +650,17 @@ public final class Networks {
     }
 
     /**
-     * The voltage elements on the <code>reducibleSide</code> of the <code>transformer</code> and the transformer can be
-     * reduced into a single generator equivalent to the active / reactive power on the terminal of the side opposite to <code>reducibleSide</code>
+     * The voltage elements on the <code>reducibleSide</code> of the <code>transformer</code> and that transformer can be
+     * reduced into a single generator equivalent to the active / reactive power on the terminal of the side opposite to <code>reducibleSide</code>.
+     * If this reduction is performed, the <code>toBeReplacedGenerators</code> will be removed.
      * @param transformer
      * @param reducibleSide
      */
     public record ReducibleTransformerData(TwoWindingsTransformer transformer, TwoSides reducibleSide, List<Generator> toBeReplacedGenerators) { }
 
+    /**
+     * Which elements are acceptable in a voltage level for reduction.
+     */
     private static boolean isReducibleElement(IdentifiableType type) {
         return type == IdentifiableType.TWO_WINDINGS_TRANSFORMER
             || type == IdentifiableType.GENERATOR
@@ -604,6 +668,9 @@ public final class Networks {
             || type == IdentifiableType.BUSBAR_SECTION;
     }
 
+    /**
+     * Get the side of that transformer which is on the side of the given voltage level.
+     */
     private static TwoSides getTransformerVoltageLevelSide(TwoWindingsTransformer transformer, VoltageLevel voltageLevel) {
         return transformer.getTerminal(TwoSides.ONE).getVoltageLevel().getId().equals(voltageLevel.getId()) ? TwoSides.ONE : TwoSides.TWO;
     }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/Networks.java
@@ -8,10 +8,12 @@
  */
 package com.powsybl.iidm.network.util;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.io.table.AbstractTableFormatter;
 import com.powsybl.commons.io.table.AsciiTableFormatter;
 import com.powsybl.commons.io.table.Column;
 import com.powsybl.commons.io.table.HorizontalAlignment;
+import com.powsybl.commons.ref.RefObj;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.iidm.network.*;
 import com.powsybl.math.graph.TraverseResult;
@@ -489,13 +491,102 @@ public final class Networks {
     private static Stream<ReducibleTransformerData> getReducibleTransformerDataStream(Stream<VoltageLevel> voltageLevelStream) {
         return voltageLevelStream
            .filter(v -> StreamSupport.stream(v.getConnectables().spliterator(), false).allMatch(c -> isReducibleElement(c.getType())))
-           .filter(v -> StreamSupport.stream(v.getSwitches().spliterator(), false).noneMatch(Switch::isOpen))
-           .flatMap(v -> v.getTwoWindingsTransformerStream()
-               .map(t -> new ReducibleTransformerData(
-                   t,
-                   getTransformerVoltageLevelSide(t, v))
-               )
-           );
+           .filter(v -> StreamSupport.stream(v.getSwitches().spliterator(), false).noneMatch(s -> s.getKind() == SwitchKind.BREAKER && s.isOpen()))
+           .flatMap(v -> {
+               RefObj<Boolean> isValid = new RefObj<>(true);
+               Stream<ReducibleTransformerData> dataStream = traverseVlTopology(isValid, v);
+               return Boolean.TRUE.equals(isValid.get()) ? dataStream : null;
+           })
+            .filter(Objects::nonNull);
+    }
+
+    private static Stream<ReducibleTransformerData> traverseVlTopology(RefObj<Boolean> isValid, VoltageLevel vl) {
+        return vl.getTwoWindingsTransformerStream()
+            .map(t -> {
+                //check before starting traversal if another part of that voltage level is already not reducible (in which case the entire vl is not reducible)
+                if (Boolean.FALSE.equals(isValid.get())) {
+                    return null;
+                }
+                TwoSides vlSide = getTransformerVoltageLevelSide(t, vl);
+                List<Generator> toBeDeletedGenerators = switch (vl.getTopologyKind()) {
+                    case BUS_BREAKER -> getGeneratorsFromBusBreakerTopology(vl, t.getTerminal(vlSide), t.getId(), isValid);
+                    case NODE_BREAKER -> getGeneratorsFromNodeBreakerTopology(vl, t.getTerminal(vlSide), t.getId(), isValid);
+                    default -> throw new PowsyblException("Unknown topology kind: " + vl.getTopologyKind());
+                };
+                if (Boolean.TRUE.equals(isValid.get()) && !toBeDeletedGenerators.isEmpty()) {
+                    return new ReducibleTransformerData(t, vlSide, toBeDeletedGenerators);
+                } else {
+                    //set false for the case where the topology is valid (a single 2WT for the connected buses) but there are no generators
+                    isValid.set(false);
+                    return null;
+                }
+            });
+    }
+
+    private static List<Generator> getGeneratorsFromBusBreakerTopology(VoltageLevel vl, Terminal startingTerminal, String startingTransformerId, RefObj<Boolean> isValid) {
+        List<Generator> toBeDeletedGenerators = new ArrayList<>();
+        Bus startingBus = startingTerminal.getBusBreakerView().getBus();
+        handleBus(startingBus, toBeDeletedGenerators, startingTransformerId, isValid);
+        vl.getBusBreakerView().traverse(startingBus, (bus1, sw, bus2) -> handleBus(bus2, toBeDeletedGenerators, startingTransformerId, isValid));
+        return toBeDeletedGenerators;
+    }
+
+    private static List<Generator> getGeneratorsFromNodeBreakerTopology(VoltageLevel vl, Terminal startingTerminal, String startingTransformerId, RefObj<Boolean> isValid) {
+        List<Generator> toBeDeletedGenerators = new ArrayList<>();
+        int startingNode = startingTerminal.getNodeBreakerView().getNode();
+        handleNode(vl, null, startingNode, toBeDeletedGenerators, startingTransformerId, isValid);
+        vl.getNodeBreakerView().traverse(startingNode, (node1, sw, node2) -> handleNode(vl, sw, node2, toBeDeletedGenerators, startingTransformerId, isValid));
+        return toBeDeletedGenerators;
+    }
+
+    private static TraverseResult handleBus(Bus bus, List<Generator> toBeDeletedGenerators, String startingTransformerId, RefObj<Boolean> isValid) {
+        if (bus == null) {
+            return TraverseResult.TERMINATE_TRAVERSER;
+        }
+        TraverseResult result = TraverseResult.CONTINUE;
+        for (Terminal terminal : bus.getConnectedTerminals()) {
+            Connectable<?> connectable = terminal.getConnectable();
+            result = switch (connectable.getType()) {
+                case IdentifiableType.GENERATOR -> handleGenerator(connectable, toBeDeletedGenerators);
+                case IdentifiableType.TWO_WINDINGS_TRANSFORMER -> handleTwoWindingTransformer(connectable, startingTransformerId, isValid);
+                default -> TraverseResult.CONTINUE;
+            };
+            if (result == TraverseResult.TERMINATE_TRAVERSER) {
+                return result;
+            }
+        }
+        return result;
+    }
+
+    private static TraverseResult handleNode(VoltageLevel vl, Switch sw, int node, List<Generator> toBeDeletedGenerators, String startingTransformerId, RefObj<Boolean> isValid) {
+        if (node < 0) {
+            return TraverseResult.TERMINATE_TRAVERSER;
+        }
+        if (sw != null && sw.isOpen()) {
+            return TraverseResult.TERMINATE_PATH;
+        }
+        TraverseResult result = TraverseResult.CONTINUE;
+        Connectable<?> connectable = vl.getNodeBreakerView().getTerminal(node).getConnectable();
+        String id = connectable.getId();
+        return switch (connectable.getType()) {
+            case IdentifiableType.GENERATOR -> handleGenerator(connectable, toBeDeletedGenerators);
+            case IdentifiableType.TWO_WINDINGS_TRANSFORMER -> handleTwoWindingTransformer(connectable, startingTransformerId, isValid);
+            default -> TraverseResult.CONTINUE;
+        };
+    }
+
+    private static TraverseResult handleGenerator(Connectable<?> connectable, List<Generator> toBeDeletedGenerators) {
+        toBeDeletedGenerators.add((Generator) connectable);
+        return TraverseResult.CONTINUE;
+    }
+
+    private static TraverseResult handleTwoWindingTransformer(Connectable<?> connectable, String startingTransformerId, RefObj<Boolean> isValid) {
+        if (!connectable.getId().equals(startingTransformerId)) {
+            isValid.set(false);
+            return TraverseResult.TERMINATE_TRAVERSER;
+        } else {
+            return TraverseResult.CONTINUE;
+        }
     }
 
     /**
@@ -504,14 +595,13 @@ public final class Networks {
      * @param transformer
      * @param reducibleSide
      */
-    public record ReducibleTransformerData(TwoWindingsTransformer transformer, TwoSides reducibleSide) { }
+    public record ReducibleTransformerData(TwoWindingsTransformer transformer, TwoSides reducibleSide, List<Generator> toBeReplacedGenerators) { }
 
     private static boolean isReducibleElement(IdentifiableType type) {
         return type == IdentifiableType.TWO_WINDINGS_TRANSFORMER
             || type == IdentifiableType.GENERATOR
             || type == IdentifiableType.LOAD
-            || type == IdentifiableType.BUSBAR_SECTION
-            || type == IdentifiableType.BATTERY;
+            || type == IdentifiableType.BUSBAR_SECTION;
     }
 
     private static TwoSides getTransformerVoltageLevelSide(TwoWindingsTransformer transformer, VoltageLevel voltageLevel) {

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworksTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworksTest.java
@@ -250,8 +250,7 @@ public abstract class AbstractNetworksTest {
             ).containsExactlyInAnyOrder(
                 batteryTransformerId,
                 EurostagTutorialExample1Factory.NHV2_NLOAD,
-                EurostagTutorialExample1Factory.NGEN_NHV1,
-                "TB2"
+                EurostagTutorialExample1Factory.NGEN_NHV1
             );
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworksTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworksTest.java
@@ -13,6 +13,7 @@ import com.powsybl.iidm.network.test.BoundaryLineNetworkFactory;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 import com.powsybl.iidm.network.util.Networks;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -119,5 +120,138 @@ public abstract class AbstractNetworksTest {
 
         Networks.applySolvedValues(network);
         assertEquals(-dl.getTerminal().getQ(), dl.getGeneration().getTargetQ());
+    }
+
+    @Test
+    public void getSingleConnectableReducibleVoltageLevels() {
+        Network network = EurostagTutorialExample1Factory.create();
+        Substation p1 = network.getSubstation("P1");
+        double vb1NomV = 48;
+        VoltageLevel vb1 = p1.newVoltageLevel()
+            .setId("VB1")
+            .setNominalV(vb1NomV)
+            .setTopologyKind(TopologyKind.BUS_BREAKER)
+            .add();
+        Bus vb1Bus = vb1.getBusBreakerView().newBus()
+            .setId("VB1_BUS")
+            .add();
+        vb1.newBattery()
+            .setId("Battery 1")
+            .setBus(vb1Bus.getId())
+            .setConnectableBus(vb1Bus.getId())
+            .setTargetP(20)
+            .setTargetQ(2)
+            .setMinP(3)
+            .setMaxP(50)
+            .add();
+        vb1.newBattery()
+            .setId("Battery 2")
+            .setBus(vb1Bus.getId())
+            .setConnectableBus(vb1Bus.getId())
+            .setTargetP(10)
+            .setTargetQ(1)
+            .setMinP(1.5)
+            .setMaxP(25)
+            .add();
+        String batteryTransformerId = "battery transformer";
+        p1.newTwoWindingsTransformer()
+            .setId(batteryTransformerId)
+            .setVoltageLevel1(vb1.getId())
+            .setBus1(vb1Bus.getId())
+            .setConnectableBus1(vb1Bus.getId())
+            .setRatedU1(vb1NomV)
+            .setVoltageLevel2(EurostagTutorialExample1Factory.VLHV1)
+            .setBus2(EurostagTutorialExample1Factory.NHV1)
+            .setConnectableBus2(EurostagTutorialExample1Factory.NHV1)
+            .setRatedU2(380)
+            .setR(0.25)
+            .setX(11)
+            .setG(0)
+            .setB(0)
+            .add();
+
+        Substation p2 = network.getSubstation("P2");
+        double vb2NomV = 90;
+        VoltageLevel vb2 = p2.newVoltageLevel()
+            .setId("VB2")
+            .setNominalV(vb2NomV)
+            .setTopologyKind(TopologyKind.BUS_BREAKER)
+            .add();
+        Bus vb2Bus = vb2.getBusBreakerView().newBus()
+            .setId("VB2_BUS")
+            .add();
+        Bus vb2Bus2 = vb2.getBusBreakerView().newBus()
+            .setId("VB2_BUS_2")
+            .add();
+        vb2.getBusBreakerView().newSwitch()
+            .setId("VB2_S")
+            .setBus1(vb2Bus.getId())
+            .setBus2(vb2Bus2.getId())
+            .setOpen(true)
+            .add();
+        vb2.newBattery()
+            .setId("B2-1")
+            .setBus(vb2Bus2.getId())
+            .setConnectableBus(vb2Bus2.getId())
+            .setTargetP(20)
+            .setTargetQ(2)
+            .setMinP(3)
+            .setMaxP(50)
+            .add();
+        p2.newTwoWindingsTransformer()
+            .setId("TB2")
+            .setVoltageLevel1(vb2.getId())
+            .setBus1(vb2Bus.getId())
+            .setConnectableBus1(vb2Bus.getId())
+            .setRatedU1(vb2NomV)
+            .setVoltageLevel2(EurostagTutorialExample1Factory.VLHV2)
+            .setBus2(EurostagTutorialExample1Factory.NHV2)
+            .setConnectableBus2(EurostagTutorialExample1Factory.NHV2)
+            .setRatedU2(380)
+            .setR(0.25)
+            .setX(11)
+            .setG(0)
+            .setB(0)
+            .add();
+
+        double vg2NomV = 380;
+        VoltageLevel vg2 = p2.newVoltageLevel().setId("VG2")
+            .setNominalV(vg2NomV)
+            .setTopologyKind(TopologyKind.BUS_BREAKER)
+            .add();
+        Bus vg2Bus = vg2.getBusBreakerView().newBus()
+            .setId("VG2_BUS")
+            .add();
+        vg2.newLoad()
+            .setId("LOAD2-1")
+            .setBus(vg2Bus.getId())
+            .setConnectableBus(vg2Bus.getId())
+            .setP0(300)
+            .setQ0(100)
+            .add();
+        network.newLine()
+            .setId("VG2L")
+            .setVoltageLevel1(EurostagTutorialExample1Factory.VLHV2)
+            .setBus1(EurostagTutorialExample1Factory.NHV2)
+            .setConnectableBus1(EurostagTutorialExample1Factory.NHV2)
+            .setVoltageLevel2(vg2.getId())
+            .setBus2(vg2Bus.getId())
+            .setConnectableBus2(vg2Bus.getId())
+            .setR(3.0)
+            .setX(33.0)
+            .setG1(0.0)
+            .setB1(386E-6 / 2)
+            .setG2(0.0)
+            .setB2(386E-6 / 2)
+            .add();
+        Assertions.assertThat(Networks.getReducibleTransformerDataStream(network))
+            .extracting(
+                d -> d.transformer().getId()
+            ).containsExactlyInAnyOrder(
+                batteryTransformerId,
+                EurostagTutorialExample1Factory.NHV2_NLOAD,
+                EurostagTutorialExample1Factory.NGEN_NHV1,
+                "TB2"
+            );
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworksTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractNetworksTest.java
@@ -14,11 +14,13 @@ import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 import com.powsybl.iidm.network.util.Networks;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -123,134 +125,30 @@ public abstract class AbstractNetworksTest {
     }
 
     @Test
-    public void getSingleConnectableReducibleVoltageLevels() {
-        Network network = EurostagTutorialExample1Factory.create();
-        Substation p1 = network.getSubstation("P1");
-        double vb1NomV = 48;
-        VoltageLevel vb1 = p1.newVoltageLevel()
-            .setId("VB1")
-            .setNominalV(vb1NomV)
-            .setTopologyKind(TopologyKind.BUS_BREAKER)
-            .add();
-        Bus vb1Bus = vb1.getBusBreakerView().newBus()
-            .setId("VB1_BUS")
-            .add();
-        vb1.newBattery()
-            .setId("Battery 1")
-            .setBus(vb1Bus.getId())
-            .setConnectableBus(vb1Bus.getId())
-            .setTargetP(20)
-            .setTargetQ(2)
-            .setMinP(3)
-            .setMaxP(50)
-            .add();
-        vb1.newBattery()
-            .setId("Battery 2")
-            .setBus(vb1Bus.getId())
-            .setConnectableBus(vb1Bus.getId())
-            .setTargetP(10)
-            .setTargetQ(1)
-            .setMinP(1.5)
-            .setMaxP(25)
-            .add();
-        String batteryTransformerId = "battery transformer";
-        p1.newTwoWindingsTransformer()
-            .setId(batteryTransformerId)
-            .setVoltageLevel1(vb1.getId())
-            .setBus1(vb1Bus.getId())
-            .setConnectableBus1(vb1Bus.getId())
-            .setRatedU1(vb1NomV)
-            .setVoltageLevel2(EurostagTutorialExample1Factory.VLHV1)
-            .setBus2(EurostagTutorialExample1Factory.NHV1)
-            .setConnectableBus2(EurostagTutorialExample1Factory.NHV1)
-            .setRatedU2(380)
-            .setR(0.25)
-            .setX(11)
-            .setG(0)
-            .setB(0)
-            .add();
-
-        Substation p2 = network.getSubstation("P2");
-        double vb2NomV = 90;
-        VoltageLevel vb2 = p2.newVoltageLevel()
-            .setId("VB2")
-            .setNominalV(vb2NomV)
-            .setTopologyKind(TopologyKind.BUS_BREAKER)
-            .add();
-        Bus vb2Bus = vb2.getBusBreakerView().newBus()
-            .setId("VB2_BUS")
-            .add();
-        Bus vb2Bus2 = vb2.getBusBreakerView().newBus()
-            .setId("VB2_BUS_2")
-            .add();
-        vb2.getBusBreakerView().newSwitch()
-            .setId("VB2_S")
-            .setBus1(vb2Bus.getId())
-            .setBus2(vb2Bus2.getId())
-            .setOpen(true)
-            .add();
-        vb2.newBattery()
-            .setId("B2-1")
-            .setBus(vb2Bus2.getId())
-            .setConnectableBus(vb2Bus2.getId())
-            .setTargetP(20)
-            .setTargetQ(2)
-            .setMinP(3)
-            .setMaxP(50)
-            .add();
-        p2.newTwoWindingsTransformer()
-            .setId("TB2")
-            .setVoltageLevel1(vb2.getId())
-            .setBus1(vb2Bus.getId())
-            .setConnectableBus1(vb2Bus.getId())
-            .setRatedU1(vb2NomV)
-            .setVoltageLevel2(EurostagTutorialExample1Factory.VLHV2)
-            .setBus2(EurostagTutorialExample1Factory.NHV2)
-            .setConnectableBus2(EurostagTutorialExample1Factory.NHV2)
-            .setRatedU2(380)
-            .setR(0.25)
-            .setX(11)
-            .setG(0)
-            .setB(0)
-            .add();
-
-        double vg2NomV = 380;
-        VoltageLevel vg2 = p2.newVoltageLevel().setId("VG2")
-            .setNominalV(vg2NomV)
-            .setTopologyKind(TopologyKind.BUS_BREAKER)
-            .add();
-        Bus vg2Bus = vg2.getBusBreakerView().newBus()
-            .setId("VG2_BUS")
-            .add();
-        vg2.newLoad()
-            .setId("LOAD2-1")
-            .setBus(vg2Bus.getId())
-            .setConnectableBus(vg2Bus.getId())
-            .setP0(300)
-            .setQ0(100)
-            .add();
-        network.newLine()
-            .setId("VG2L")
-            .setVoltageLevel1(EurostagTutorialExample1Factory.VLHV2)
-            .setBus1(EurostagTutorialExample1Factory.NHV2)
-            .setConnectableBus1(EurostagTutorialExample1Factory.NHV2)
-            .setVoltageLevel2(vg2.getId())
-            .setBus2(vg2Bus.getId())
-            .setConnectableBus2(vg2Bus.getId())
-            .setR(3.0)
-            .setX(33.0)
-            .setG1(0.0)
-            .setB1(386E-6 / 2)
-            .setG2(0.0)
-            .setB2(386E-6 / 2)
-            .add();
+    public void getSingleConnectableReducibleVoltageLevelsBusBreaker() {
+        Network network = EurostagTutorialExample1Factory.createReducibleVoltageLevelNetworkBusBreaker();
         Assertions.assertThat(Networks.getReducibleTransformerDataStream(network))
             .extracting(
-                d -> d.transformer().getId()
+                d -> d.transformer().getId(),
+                d -> d.toBeReplacedGenerators().stream().map(Generator::getId).sorted().toList()
             ).containsExactlyInAnyOrder(
-                batteryTransformerId,
-                EurostagTutorialExample1Factory.NHV2_NLOAD,
-                EurostagTutorialExample1Factory.NGEN_NHV1
+                new Tuple("T1_1_BF", List.of("B1GEN1")),
+                new Tuple("T2_1_BF", List.of("B2GEN1", "B2GEN2")),
+                new Tuple("T3_1_BF", List.of("B3GEN1"))
+            );
+    }
+
+    @Test
+    public void getSingleConnectableReducibleVoltageLevelsNodeBreaker() {
+        Network network = EurostagTutorialExample1Factory.createReducibleVoltageLevelNetworkNodeBreaker();
+        Assertions.assertThat(Networks.getReducibleTransformerDataStream(network))
+            .extracting(
+                d -> d.transformer().getId(),
+                d -> d.toBeReplacedGenerators().stream().map(Generator::getId).sorted().toList()
+            ).containsExactlyInAnyOrder(
+                new Tuple("TBB1BF1", List.of("G1")),
+                new Tuple("TBB2BF2", List.of("G21", "G22")),
+                new Tuple("TBB3BF3", List.of("G3"))
             );
     }
 }

--- a/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
+++ b/iidm/iidm-test/src/main/java/com/powsybl/iidm/network/test/EurostagTutorialExample1Factory.java
@@ -1449,4 +1449,254 @@ public final class EurostagTutorialExample1Factory {
         gen.setTargetV(Double.NaN);
         return network;
     }
+
+    public static Network createReducibleVoltageLevelNetworkBusBreaker() {
+        Network network = NetworkFactory.findDefault().createNetwork("sim1", "test");
+        Substation p1 = network.newSubstation().setId("P1").add();
+        VoltageLevel vlFlow = p1.newVoltageLevel()
+            .setId("VLFLOW")
+            .setNominalV(400)
+            .setTopologyKind(TopologyKind.BUS_BREAKER)
+            .add();
+        vlFlow.getBusBreakerView().newBus().setId("BF").add();
+
+        VoltageLevel vlGen = p1.newVoltageLevel()
+            .setId("VLGEN")
+            .setNominalV(20)
+            .setTopologyKind(TopologyKind.BUS_BREAKER)
+            .add();
+
+        String bus11Id = "Bus_1_1";
+        String bus12Id = "Bus_1_2";
+        vlGen.getBusBreakerView().newBus().setId(bus11Id).add();
+        vlGen.getBusBreakerView().newBus().setId(bus12Id).add();
+        createBusGenerator(vlGen, "B1GEN1", bus12Id);
+        createBusSwitch(vlGen, "B1B2SW1", bus11Id, bus12Id);
+        createBusLoad(vlGen, "B1L1", bus11Id);
+        createBusTransformer(p1, "T1_1_BF", "BF", bus11Id);
+
+        String bus21Id = "Bus_2_1";
+        String bus22Id = "Bus_2_2";
+        vlGen.getBusBreakerView().newBus().setId(bus21Id).add();
+        vlGen.getBusBreakerView().newBus().setId(bus22Id).add();
+        createBusGenerator(vlGen, "B2GEN1", bus22Id);
+        createBusGenerator(vlGen, "B2GEN2", bus21Id);
+        createBusSwitch(vlGen, "B1B2SW2", bus21Id, bus22Id);
+        createBusLoad(vlGen, "B2L1", bus21Id);
+        createBusTransformer(p1, "T2_1_BF", "BF", bus21Id);
+
+        String bus31Id = "Bus_3_1";
+        vlGen.getBusBreakerView().newBus().setId(bus31Id).add();
+        createBusGenerator(vlGen, "B3GEN1", bus31Id);
+        createBusTransformer(p1, "T3_1_BF", "BF", bus31Id);
+
+        VoltageLevel vlInvalid = p1.newVoltageLevel()
+            .setId("VLINV")
+            .setNominalV(20)
+            .setTopologyKind(TopologyKind.BUS_BREAKER)
+            .add();
+
+        String bus41Id = "Bus_4_1";
+        String bus42Id = "Bus_4_2";
+        String bus43Id = "Bus_4_3";
+        vlInvalid.getBusBreakerView().newBus().setId(bus41Id).add();
+        vlInvalid.getBusBreakerView().newBus().setId(bus42Id).add();
+        vlInvalid.getBusBreakerView().newBus().setId(bus43Id).add();
+        createBusGenerator(vlInvalid, "B4GEN1", bus42Id);
+        createBusGenerator(vlInvalid, "B4GEN2", bus43Id);
+        createBusSwitch(vlInvalid, "B1B2SW4", bus41Id, bus42Id);
+        createBusSwitch(vlInvalid, "B2B3SW1", bus42Id, bus43Id);
+        createBusLoad(vlInvalid, "B4L1", bus41Id);
+        createBusTransformer(p1, "T4_1_BF", "BF", bus41Id);
+        createBusTransformer(p1, "T4_3_BF", "BF", bus43Id);
+
+        String bus51Id = "Bus_5_1";
+        vlInvalid.getBusBreakerView().newBus().setId(bus51Id).add();
+        createBusGenerator(vlInvalid, "B5GEN1", bus51Id);
+        createBusTransformer(p1, "T5_1_BF", "BF", bus51Id);
+
+        return network;
+    }
+
+    private static void createBusTransformer(Substation substation, String transformerId, String bus1Id, String bus2Id) {
+        substation.newTwoWindingsTransformer()
+            .setConnectableBus1(bus1Id)
+            .setBus1(bus1Id)
+            .setConnectableBus2(bus2Id)
+            .setBus2(bus2Id)
+            .setRatedU1(400)
+            .setRatedU2(20)
+            .setId(transformerId)
+            .setR(0.1)
+            .setX(0.1)
+            .add();
+    }
+
+    private static void createBusLoad(VoltageLevel vl, String loadId, String busId) {
+        vl.newLoad()
+            .setId(loadId)
+            .setP0(-10)
+            .setQ0(15)
+            .setBus(busId)
+            .setConnectableBus(busId)
+            .add();
+    }
+
+    private static void createBusSwitch(VoltageLevel vl, String switchId, String bus1Id, String bus2Id) {
+        vl.getBusBreakerView().newSwitch()
+            .setId(switchId)
+            .setOpen(false)
+            .setBus1(bus1Id)
+            .setBus2(bus2Id)
+            .add();
+    }
+
+    private static void createBusGenerator(VoltageLevel vl, String generatorId, String busId) {
+        vl.newGenerator()
+            .setId(generatorId)
+            .setBus(busId)
+            .setConnectableBus(busId)
+            .setMinP(100)
+            .setMaxP(900)
+            .setTargetP(750)
+            .setVoltageRegulatorOn(true)
+            .setTargetV(20)
+            .add();
+    }
+
+    public static Network createReducibleVoltageLevelNetworkNodeBreaker() {
+        Network network = NetworkFactory.findDefault().createNetwork("sim1", "test");
+        Substation p1 = network.newSubstation().setId("P1").add();
+        VoltageLevel vlFlow = p1.newVoltageLevel()
+            .setId("VLFLOW")
+            .setNominalV(400)
+            .setTopologyKind(TopologyKind.NODE_BREAKER)
+            .add();
+
+        String busbar01Id = "Busbar_01";
+        String busbar02Id = "Busbar_02";
+        String busbar03Id = "Busbar_03";
+        String busbar04Id = "Busbar_04";
+        String busbar05Id = "Busbar_05";
+        String busbar06Id = "Busbar_06";
+        VoltageLevel.NodeBreakerView vlFlowNodeView = vlFlow.getNodeBreakerView();
+        vlFlowNodeView.newBusbarSection().setId(busbar01Id).setNode(0).add();
+        vlFlowNodeView.newBusbarSection().setId(busbar02Id).setNode(1).add();
+        vlFlowNodeView.newBusbarSection().setId(busbar03Id).setNode(2).add();
+        vlFlowNodeView.newBusbarSection().setId(busbar04Id).setNode(20).add();
+        vlFlowNodeView.newBusbarSection().setId(busbar05Id).setNode(21).add();
+        vlFlowNodeView.newBusbarSection().setId(busbar06Id).setNode(22).add();
+
+        vlFlowNodeView.newDisconnector().setId("DF12").setNode1(0).setNode2(1).setOpen(true).add();
+        vlFlowNodeView.newDisconnector().setId("DF23").setNode1(1).setNode2(2).setOpen(true).add();
+        vlFlowNodeView.newDisconnector().setId("DF34").setNode1(2).setNode2(20).setOpen(true).add();
+        vlFlowNodeView.newDisconnector().setId("DF45").setNode1(20).setNode2(21).setOpen(true).add();
+        vlFlowNodeView.newDisconnector().setId("DF56").setNode1(21).setNode2(22).setOpen(true).add();
+
+        VoltageLevel vlGen = p1.newVoltageLevel()
+            .setId("VLGEN")
+            .setNominalV(20)
+            .setTopologyKind(TopologyKind.NODE_BREAKER)
+            .add();
+
+        String busbar11Id = "Busbar_11";
+        String busbar12Id = "Busbar_12";
+        String busbar13Id = "Busbar_13";
+
+        VoltageLevel.NodeBreakerView vlGenNodeView = vlGen.getNodeBreakerView();
+
+        vlGenNodeView.newBusbarSection().setId(busbar11Id).setNode(4).add();
+        vlGenNodeView.newBusbarSection().setId(busbar12Id).setNode(5).add();
+        vlGenNodeView.newBusbarSection().setId(busbar13Id).setNode(6).add();
+
+        vlGenNodeView.newDisconnector().setNode1(4).setNode2(5).setId("D12").setOpen(true).add();
+        vlGenNodeView.newDisconnector().setNode1(5).setNode2(6).setId("D23").setOpen(true).add();
+
+        //create a load on the busbar with a disconnector and a generator behind a breaker
+        createNodeLoad(vlGen, "L1", 7);
+        vlGenNodeView.newDisconnector().setId("DL1").setNode1(4).setNode2(7).setOpen(false).add();
+        createNodeGenerator(vlGen, "G1", 8);
+        vlGenNodeView.newBreaker().setId("BRG1").setNode1(4).setNode2(8).setOpen(false).setRetained(true).add();
+        createNodeTransformer(p1, "TBB1BF1", 4, vlGen, 0, vlFlow, 13, 14);
+
+        //create a load on the busbar with a disconnector, a generator behind a breaker and a generator on the busbar (with disconnector)
+        createNodeLoad(vlGen, "L2", 9);
+        vlGenNodeView.newDisconnector().setId("DL2").setNode1(5).setNode2(9).setOpen(false).add();
+        createNodeGenerator(vlGen, "G21", 10);
+        vlGenNodeView.newBreaker().setId("BRG2").setNode1(5).setNode2(10).setOpen(false).setRetained(true).add();
+        createNodeTransformer(p1, "TBB2BF2", 5, vlGen, 1, vlFlow, 15, 16);
+        createNodeGenerator(vlGen, "G22", 11);
+        vlGenNodeView.newDisconnector().setId("DG1").setNode1(5).setNode2(11).setOpen(false).add();
+
+        // create a generator directly on the third busbar
+        createNodeGenerator(vlGen, "G3", 12);
+        vlGenNodeView.newInternalConnection().setNode1(6).setNode2(12).add();
+        createNodeTransformer(p1, "TBB3BF3", 6, vlGen, 2, vlFlow, 17, 18);
+
+        VoltageLevel vlInvalid = p1.newVoltageLevel()
+            .setId("VLINV")
+            .setNominalV(20)
+            .setTopologyKind(TopologyKind.NODE_BREAKER)
+            .add();
+
+        VoltageLevel.NodeBreakerView vlInvNodeView = vlInvalid.getNodeBreakerView();
+        vlInvNodeView.newBusbarSection().setId("Busbar_20").setNode(30).add();
+        vlInvNodeView.newBusbarSection().setId("Busbar_21").setNode(35).add();
+        createNodeGenerator(vlInvalid, "G41", 32);
+        vlInvNodeView.newBreaker().setId("BRG41").setNode1(30).setNode2(32).setOpen(false).setRetained(true).add();
+        createNodeLoad(vlInvalid, "L4", 31);
+        vlInvNodeView.newDisconnector().setId("DL4").setNode1(31).setNode2(30).setOpen(false).add();
+        createNodeTransformer(p1, "TBB20BF4", 30, vlInvalid, 20, vlFlow, 33, 34);
+        vlInvNodeView.newBreaker().setId("BRBB20BB21").setNode1(30).setNode2(35).setOpen(false).setRetained(true).add();
+        createNodeGenerator(vlInvalid, "G42", 36);
+        vlInvNodeView.newInternalConnection().setNode1(36).setNode2(35).add();
+        createNodeTransformer(p1, "TBB21BF5", 35, vlInvalid, 21, vlFlow, 37, 38);
+
+        // create a generator directly on the busbar
+        vlInvNodeView.newBusbarSection().setId("Busbar_30").setNode(40).add();
+        vlInvNodeView.newDisconnector().setId("D2130").setNode1(35).setNode2(40).setOpen(true).add();
+        createNodeGenerator(vlInvalid, "G5", 41);
+        vlInvNodeView.newInternalConnection().setNode1(40).setNode2(41).add();
+        createNodeTransformer(p1, "TBB30BF6", 40, vlInvalid, 22, vlFlow, 42, 43);
+
+        return network;
+    }
+
+    private static void createNodeLoad(VoltageLevel vl, String loadId, int node) {
+        vl.newLoad()
+            .setId(loadId)
+            .setP0(-10)
+            .setQ0(15)
+            .setNode(node)
+            .add();
+    }
+
+    private static void createNodeGenerator(VoltageLevel vl, String generatorId, int node) {
+        vl.newGenerator()
+            .setId(generatorId)
+            .setNode(node)
+            .setMinP(100)
+            .setMaxP(900)
+            .setTargetP(750)
+            .setVoltageRegulatorOn(true)
+            .setTargetV(20)
+            .add();
+    }
+
+    private static void createNodeTransformer(Substation substation, String transformerId, int node1, VoltageLevel vl1, int node2, VoltageLevel vl2, int disconnectorNode1, int disconnectorNode2) {
+        vl1.getNodeBreakerView().newDisconnector().setNode1(node1).setNode2(disconnectorNode1).setOpen(false).setId(transformerId + vl1.getId()).add();
+        vl2.getNodeBreakerView().newDisconnector().setNode1(node2).setNode2(disconnectorNode2).setOpen(false).setId(transformerId + vl2.getId()).add();
+        substation.newTwoWindingsTransformer()
+            .setNode1(disconnectorNode1)
+            .setVoltageLevel1(vl1.getId())
+            .setNode2(disconnectorNode2)
+            .setVoltageLevel2(vl2.getId())
+            .setRatedU1(400)
+            .setRatedU2(20)
+            .setId(transformerId)
+            .setR(0.1)
+            .setX(0.1)
+            .add();
+    }
+
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

Fixes #3878 

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Allow detection of elements behind a two winding transformer that can be reduced to an equivalent generator.
The criteria are:
- the voltage level must contain only reducible elements
- all breakers in the voltage level must be closed (to prevent issue where a part of the network is incorrectly reduced)
- a set of reducible elements must be linked to the voltage level above through a single two-winding transformer (but there can be multiple transformer per voltage level)
- there must be at least one generator per set of reducible elements

This does not modify the network, it only does detection.

**What is the current behavior?**
<!-- You can also link to an open issue here -->

N/A

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

This is to be used only for visualisation purpose, by replacing a two-winding transformer and the elements behind it by a generator, and using the active / reactive power at the terminal of the transformer as an equivalent P/Q injection. This supposes a loadflow has been performed first.
This would not work for calculations.
