### PR TITLE
Documentation: make simulation parameters linkable

### DIFF
--- a/docs/simulation/dynamic/configuration.md
+++ b/docs/simulation/dynamic/configuration.md
@@ -49,16 +49,19 @@ The parameters may also be overridden with a JSON file, in which case the config
 
 ### Optional properties
 
-**startTime**<br>
+(param-dy-start-time)=
+#### startTime
 `startTime` defines when the simulation begins, in seconds. The default value of this property is `0`.
 
-**stopTime**<br>
+(param-dy-stop-time)=
+#### stopTime
 `stopTime` defines when the simulation stops, in seconds. The default value of this property is `1`.
 
-**debugDir**<br>
+(param-dy-debug-dir)=
+#### debugDir
 This property specifies the directory path where debug files will be dumped. If `null`, no file will be dumped.
 
-### Specific parameters
+### Implementation specific parameters
 Some implementations use specific parameters that can be defined in the configuration file or in the JSON parameters file:
 - [Dynawo](inv:powsybldynawo:*:*#dynamic_simulation/configuration) and its default parameters.
 

--- a/docs/simulation/dynamic_security/configuration.md
+++ b/docs/simulation/dynamic_security/configuration.md
@@ -51,10 +51,12 @@ The parameters may also be overridden with a JSON file, in which case the config
 
 ### Optional properties
 
-**contingencies-start-time**<br>
+(param-dysecu-contingencies-start-time)=
+#### contingencies-start-time
 `contingencies-start-time` defines when the contingencies start, in seconds. The default value of this property is `5`.
 
-**debugDir**<br>
+(param-dysecu-debug-dir)=
+#### debugDir
 This property specifies the directory path where debug files will be dumped. If `null`, no file will be dumped.
 
 ### Examples

--- a/docs/simulation/loadflow/configuration.md
+++ b/docs/simulation/loadflow/configuration.md
@@ -48,8 +48,6 @@ load-flow:
 
 ## Parameters
 
-### Optional properties
-
 You may configure some generic parameters for all load flow implementations:
 ```yaml
 load-flow-default-parameters:
@@ -76,7 +74,7 @@ load-flow-default-parameters:
 The parameters may also be overridden with a JSON file, in which case the configuration will look like:
 ```json
 {
-  "version": "1.8",
+  "version": "1.10",
   "dc": false,
   "voltageInitMode": "UNIFORM_VALUES",
   "distributedSlack": true,
@@ -96,11 +94,14 @@ The parameters may also be overridden with a JSON file, in which case the config
 }
 ```
 
-**dc**<br>
+(param-lf-dc)=
+### dc
 The `dc` property is an optional property that defines if you want to run an AC power flow (`false`) or a DC power flow (`true`).
+
 The default value is `false`.
 
-**voltageInitMode**<br>
+(param-lf-voltage-init-mode)=
+### voltageInitMode
 The `voltageInitMode` property is an optional property that defines the policy used by the load flow to initialize the
 voltage values. The available values are:
 - `UNIFORM_VALUES`: $v = 1 pu$ , $\theta = 0$
@@ -109,11 +110,14 @@ voltage values. The available values are:
 
 The default value is `UNIFORM_VALUES`.
 
-**distributedSlack**<br>
+(param-lf-distributed-slack)=
+### distributedSlack
 The `distributedSlack` property is an optional property that defines if the active power mismatch is distributed over the network or not.
+
 The default value is `true`.
 
-**balanceType**<br>
+(param-lf-balance-type)=
+### balanceType
 The `balanceType` property is an optional property that defines, if `distributedSlack` parameter is set to true, how to manage the distribution. Several algorithms are supported. All algorithms follow the same scheme: only some elements are participating in the slack distribution, with a given participation factor. Six options are available:
 - If using `PROPORTIONAL_TO_GENERATION_P_MAX` then the participating elements are the generators. The participation factor is computed using the maximum active power target $MaxP$ and the active power control droop. The default droop value is `4`. If present, the simulator uses the droop of the generator given by the [active power control extension](../../grid_model/extensions.md#active-power-control).
 - If using `PROPORTIONAL_TO_GENERATION_P` then the participating elements are the generators. The participation factor is computed using the active power set point $TargetP$.
@@ -126,60 +130,83 @@ Some algorithms may not be supported by all LoadFlow providers or all simulation
 
 This default value is `PROPORTIONAL_TO_GENERATION_P_MAX`.
 
-
-**countriesToBalance**<br>
+(param-lf-countries-to-balance)=
+### countriesToBalance
 The `countriesToBalance` property is an optional property that defines the list of [ISO-3166](https://en.wikipedia.org/wiki/ISO_3166-1)
-country which participating elements are used for slack distribution. If the slack is distributed but this parameter is not set, the slack distribution is performed over all countries present in the network.
+country which participating elements are used for slack distribution.
+If the slack is distributed but this parameter is not set, the slack distribution is performed over all countries present in the network.
 
-**readSlackBus**<br>
+(param-lf-read-slack-bus)=
+### readSlackBus
 The `readSlackBus` is an optional property that defines if the slack bus has to be selected in the network through the [slack terminal extension](../../grid_model/extensions.md#slack-terminal).
+
 The default value is `true`.
 
-**writeSlackBus**<br>
+(param-lf-write-slack-bus)=
+### writeSlackBus
 The `writeSlackBus` is an optional property that says if the slack bus has to be written in the network using the [slack terminal extension](../../grid_model/extensions.md#slack-terminal) after a load flow computation.
+
 The default value is `true`.
 
-**useReactiveLimits**<br>  
+(param-lf-use-reactive-limits  )=
+### useReactiveLimits  
 The `useReactiveLimits` property is an optional property that defines whether the load flow should take into account equipment's reactive limits. Applies to generators, batteries, static VAR compensators, boundary lines, and HVDC VSCs.  
+
 The default value is `true`.
 
-**phaseShifterRegulationOn**<br>
+(param-lf-phase-shifter-regulation-on)=
+### phaseShifterRegulationOn
 The `phaseShifterRegulationOn` property is an optional property that defines whether phase shifter regulating controls should be simulated in the load flow.
+
 The default value is `false`.
 
-**transformerVoltageControlOn**<br>
+(param-lf-transformer-voltage-control-on)=
+### transformerVoltageControlOn
 The `transformerVoltageControlOn` property is an optional property that defines whether transformer voltage regulating controls should be simulated in the load flow.
+
 The default value is `false`.
 
-**shuntCompensatorVoltageControlOn**<br>
+(param-lf-shunt-compensator-voltage-control-on)=
+### shuntCompensatorVoltageControlOn
 The `shuntCompensatorVoltageControlOn` property is an optional property that defines whether shunt compensator voltage regulating controls should be simulated in the load flow.
+
 The default value is `false`.
 
-**componentMode**<br>
+(param-lf-component-mode)=
+### componentMode
 The `componentMode` property is an optional property that defines 3 possibles modes to run power flow. These modes can be :
 - `ALL_CONNECTED`: the power flow is computed over all synchronous components of all connected components
 - `MAIN_CONNECTED` : the power flow is computed over all synchronous components of the main (largest) connected component
 - `MAIN_SYNCHRONOUS` : the power flow is computed on the main (largest) synchronous component
+
 The default value is `MAIN_CONNECTED`.
--
-**twtSplitShuntAdmittance**<br>
+
+(param-lf-twt-split-shunt-admittance)=
+### twtSplitShuntAdmittance
 The `twtSplitShuntAdmittance` property is an optional property that defines whether the shunt admittance is split at each side of the series impedance for transformers.
+
 The default value is `false`.
 
-**dcUseTransformerRatio**<br>
+(param-lf-dc-use-transformer-ratio)=
+### dcUseTransformerRatio
 The `dcUseTransformerRatio` property is an optional property that defines if the ratio of transformers should be used in
 the flow equations in a DC power flow.
+
 The default value of this parameter is `true`.
 
-**dcPowerFactor**<br>
+(param-lf-dc-power-factor)=
+### dcPowerFactor
 The `dcPowerFactor` property is an optional property that defines the power factor used to convert current limits into active power limits in DC calculations.
+
 The default value is `1.0`.
 
-**hvdcAcEmulation**<br>
+(param-lf-hvdc-ac-emulation)=
+### hvdcAcEmulation
 The `hvdcAcEmulation` property is an optional property that defines whether AC emulation for HVDC should be simulated in the load flow or not (HVDC that are in AC emulation mode should have the hvdc-angle-droop-active-power-control extension).
+
 The default value is `true`.
 
-### Specific parameters
+## Implementation specific parameters
 Some implementations use specific parameters that can be defined in the configuration file or in the JSON parameters file:
 - [PowSyBl OpenLoadFlow](inv:powsyblopenloadflow:*:*#loadflow/parameters)
 - [DynaFlow](inv:powsybldynawo:*:*#load_flow/configuration)

--- a/docs/simulation/security/configuration.md
+++ b/docs/simulation/security/configuration.md
@@ -40,19 +40,24 @@ security-analysis:
 ### Violations increase thresholds
 The user can provide parameters to define which violations must be raised after a contingency, if the violation was already present in the pre-contingency state (`IncreasedViolationsParameters`).
 
-**flow-proportional-threshold**<br>
+(param-secu-flow-proportional-threshold)=
+#### flow-proportional-threshold
 After a contingency, only flow violations (either current, active power or apparent power violations) that have increased in proportion by more than a threshold value, compared to the pre-contingency state, are listed in the limit violations. The other ones are filtered. The threshold value is unitless and should be positive. This method gets the flow violation proportional threshold. The default value is 0.1, meaning that only violations that have increased by more than 10% appear in the limit violations.
 
-**low-voltage-proportional-threshold**<br>
+(param-secu-low-voltage-proportional-threshold)=
+#### low-voltage-proportional-threshold
 After a contingency, only low-voltage violations that have increased by more than the proportional threshold compared to the pre-contingency state, are listed in the limit violations, the other ones are filtered. This method gets the low-voltage violation proportional threshold (unitless, should be positive). The default value is 0.0, meaning that only violations that have increased by more than 0.0 % appear in the limit violations (note that for low-voltage violation, it means that the voltage in the post-contingency state is lower than the voltage in the pre-contingency state).
 
-**low-voltage-absolute-threshold**<br>
+(param-secu-low-voltage-absolute-threshold)=
+#### low-voltage-absolute-threshold
 After a contingency, only low-voltage violations that have increased by more than an absolute threshold compared to the pre-contingency state, are listed in the limit violations, the other ones are filtered. This method gets the low-voltage violation absolute threshold (in kV, should be positive). The default value is 0.0, meaning that only violations that have increased by more than 0.0 kV appear in the limit violations (note that for low-voltage violation, it means that the voltage in the post-contingency state is lower than the voltage in the pre-contingency state).
 
-**high-voltage-proportional-threshold**<br>
+(param-secu-high-voltage-proportional-threshold)=
+#### high-voltage-proportional-threshold
 Same as before but for high-voltage violations.
 
-**high-voltage-absolute-threshold**<br>
+(param-secu-high-voltage-absolute-threshold)=
+#### high-voltage-absolute-threshold
 Same as before but for high-voltage violations.
 
 (violation-filtering)=
@@ -70,4 +75,3 @@ limit-violation-default-filter:
         - LOW_VOLTAGE
         - HIGH_VOLTAGE
 ```
-

--- a/docs/simulation/sensitivity/configuration.md
+++ b/docs/simulation/sensitivity/configuration.md
@@ -14,26 +14,38 @@ Use "OpenLoadFlow" to use PowSyBl OpenLoadFlow's sensitivity analysis implementa
 (sensitivity-generic-parameter)=
 ## Parameters
 
-**flowFlowSensitivityValueThreshold**
+(param-sensi-flow-flow-sensitivity-value-threshold)=
+### flowFlowSensitivityValueThreshold
 
 The `flowFlowSensitivityValueThreshold` is the threshold under which sensitivity values having a variable type among
 `INJECTION_ACTIVE_POWER`, `INJECTION_REACTIVE_POWER` and `HVDC_LINE_ACTIVE_POWER` and function type among
 `BRANCH_ACTIVE_POWER_1/2/3`, `BRANCH_REACTIVE_POWER_1/2/3` and `BRANCH_CURRENT_1/2/3` will be filtered from the
-analysis results. The default value is 0.0.
+analysis results.
 
-**voltageVoltageSensitivityValueThreshold**
+The default value is `0.0`.
+
+(param-sensi-voltage-voltage-sensitivity-value-threshold)=
+### voltageVoltageSensitivityValueThreshold
 
 The `voltageVoltageSensitivityValueThreshold` is the threshold under which sensitivity values having variable type
-`BUS_TARGET_VOLTAGE` and function type `BUS_VOLTAGE` will be filtered from the analysis results. The default value is 0.0.
+`BUS_TARGET_VOLTAGE` and function type `BUS_VOLTAGE` will be filtered from the analysis results.
 
-**flowVoltageSensitivityValueThreshold**
+The default value is `0.0`.
+
+(param-sensi-flow-voltage-sensitivity-value-threshold)=
+### flowVoltageSensitivityValueThreshold
 
 The `flowVoltageSensitivityValueThreshold` is the threshold under which sensitivity values having a variable type among
 `INJECTION_REACTIVE_POWER` and function type among `BUS_VOLTAGE`, or variable type among `BUS_TARGET_VOLTAGE` and function type among
-`BRANCH_REACTIVE_POWER_1/2/3`, `BRANCH_CURRENT_1/2/3` or `BUS_REACTIVE_POWER` will be filtered from the analysis results. The default value is 0.0.
+`BRANCH_REACTIVE_POWER_1/2/3`, `BRANCH_CURRENT_1/2/3` or `BUS_REACTIVE_POWER` will be filtered from the analysis results.
 
-**angleFlowSensitivityValueThreshold**
+The default value is `0.0`.
+
+(param-sensi-angle-flow-sensitivity-value-threshold)=
+### angleFlowSensitivityValueThreshold
 
 The `angleFlowSensitivityValueThreshold` is the threshold under which sensitivity values having a variable type among
 `TRANSFORMER_PHASE` and `TRANSFORMER_PHASE_1/2/3` and a function type among `BRANCH_ACTIVE_POWER_1/2/3`, `BRANCH_REACTIVE_POWER_1/2/3`
-and `BRANCH_CURRENT_1/2/3` will be filtered from the analysis results. The default value is 0.0.
+and `BRANCH_CURRENT_1/2/3` will be filtered from the analysis results.
+
+The default value is `0.0`.

--- a/docs/simulation/shortcircuit/parameters.md
+++ b/docs/simulation/shortcircuit/parameters.md
@@ -23,25 +23,29 @@ short-circuit-parameters:
 
 Available parameters in the short-circuit API are stored in `com.powsybl.shortcircuit.ShortCircuitParameters`. They are all optional.
 
-**with-limit-violations**
+(param-sc-with-limit-violations)=
+### with-limit-violations
 
 This property indicates whether limit violations should be returned after the computation. The violations that should be used are `LOW_SHORT_CIRCUIT_CURRENT` and `HIGH_SHORT_CIRCUIT_CURRENT`.
 It can be used to filter results where the computed short-circuit current is too high or too low. The default value is `true`.
 
-**with-fortescue-result**
+(param-sc-with-fortescue-result)=
+### with-fortescue-result
 
 This property indicates if the computed results, like currents and voltages, should be returned only in three-phased magnitude or detailed with magnitude and angle on each phase.
 According to this property, different classes to return results can be used. If it is set to false, the classes `MagnitudeFaultResult`, `MagnitudeFeederResult` and `MagnitudeShortCircuitBusResult` should be used.
 If the property is true, the classes `FortescueFaultResult`, `FortescueFeederResult` and `FortescueShortCircuitBusResult` should be used. All these classes are in `com.powsybl.shortcircuit`.
 The default value is `true`.
 
-**with-feeder-result**
+(param-sc-with-feeder-result)=
+### with-feeder-result
 
 This property indicates if the contributions of each feeder to the short-circuit current at the fault should be computed.
 If the property is set to true, the results can be stored in class `com.powsybl.shortcircuit.FeederResult`.
 The default value is `true`.
 
-**study-type**
+(param-sc-study-type)=
+### study-type
 
 This property indicates the type of short-circuit study. It can be:
 - `SUB_TRANSIENT`: it is the first stage of the short circuit, right when the fault happens. In this case, it is the sub-transient reactance of generators and batteries that is used.
@@ -52,7 +56,8 @@ This property indicates the type of short-circuit study. It can be:
 The default value is `TRANSIENT`. The transient and sub-transient reactances of the generators are stored in the [short-circuit generator extension.](../../grid_model/extensions.md#generator-short-circuit)
 and the ones of batteries are stored in the  [short-circuit battery extension.](../../grid_model/extensions.md#battery-short-circuit)
 
-**sub-transient-coefficient**
+(param-sc-sub-transient-coefficient)=
+### sub-transient-coefficient
 
 This property allows defining an optional coefficient, in case of a sub-transient study, to apply to the transient reactance of generators to get the sub-transient one:
 
@@ -66,38 +71,45 @@ with:
 
 By default, the value of the coefficient is 0.7, and it should not be higher than 1.
 
-**with-voltage-result**
+(param-sc-with-voltage-result)=
+### with-voltage-result
 
 This property indicates if the voltage profile should be computed on every node of the network. The results, if this property is `true`, should be stored in class `com.powsybl.shortcircuit.ShortCircuitBusResult`. The default value is `true`.
 
-**min-voltage-drop-proportional-threshold**
+(param-sc-min-voltage-drop-proportional-threshold)=
+### min-voltage-drop-proportional-threshold
 
 This property indicates a threshold to filter the voltage results. Thus, it only makes sense if `with-voltage-result` is set to true.
 Only the nodes where the voltage drop due to the short circuit in absolute value is above this property are kept.
 The voltage drop is calculated as the ratio between the initial voltage magnitude on the node and the voltage magnitude on the node after the fault. The default value is `0`.
 
-**with-loads**
+(param-sc-with-loads)=
+### with-loads
 
 This property indicates whether loads should be taken into account during the calculation. If `true`, the loads are modeled as an equivalent reactance, and the equivalent reactance at the fault point will be lowered. If `false`, then they will be ignored.
 
-**with-shunt-compensators**
+(param-sc-with-shunt-compensators)=
+### with-shunt-compensators
 
 This property indicates if shunt compensators should be taken into account during the computation. If `true`, the shunt compensators will be modeled as an equivalent reactance.
 If `false`, then the shunt compensators will be ignored.
 
-**with-vsc-converter-stations**
+(param-sc-with-vsc-converter-stations)=
+### with-vsc-converter-stations
 
 This property is a boolean property that indicates whether the VSC converter stations should be included in the calculation.
 If `true`, the VSC converter stations will be modeled as an equivalent reactance. If `false`, they will be ignored.
 
-**with-neutral-position**
+(param-sc-with-neutral-position)=
+### with-neutral-position
 
 This property indicates which position of the tap changer of transformers should be used for the calculation. If `true`, the neutral step of the tap changer
 is used. The neutral step is the one for which $\rho = 1$ and $\alpha = 0$. If `false`, then the step that is in the model will be used.
 By default, this property is set to false.
 For more information about tap changers, see [the documentation about it](../../grid_model/additional.md#phase-tap-changer).
 
-**initial-voltage-profile-mode**
+(param-sc-initial-voltage-profile-mode)=
+### initial-voltage-profile-mode
 
 This property defines the voltage profile that should be used for the calculation. Three options are available:
 - `NOMINAL`: the nominal voltage profile is used for the calculation
@@ -106,7 +118,8 @@ This property defines the voltage profile that should be used for the calculatio
   In the case of `CONFIGURED` voltage profile, ranges of nominal voltages with multiplicative coefficients must be specified in the `voltage-ranges` property.
   By default, the initial voltage profile mode is set to `NOMINAL`.
 
-**voltage-ranges**
+(param-sc-voltage-ranges)=
+### voltage-ranges
 
 This property specifies a path to a JSON file containing the voltage ranges and associated coefficients to be used when `initial-voltage-profile-mode` is set to `CONFIGURED`.
 The JSON file must contain a list of voltage ranges and for each range, coefficients and/or voltages.
@@ -138,11 +151,13 @@ Here is an example of this JSON file:
 ]
 ````
 
-**detailedReport**
+(param-sc-detailedReport)=
+### detailedReport
 This property indicates whether the computation should produce detailed reporting. If `true`, detailed reports are returned.
 If `false`, summarized reports are returned.
 
-**debugDir**
+(param-sc-debug-dir)=
+### debugDir
 This property specifies the directory path where debug files will be dumped. If `null`, no file will be dumped.
 
 (shortcircuit-fault-parameters)=


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

No

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Docs update

**What is the current behavior?**
<!-- You can also link to an open issue here -->

simulation parameters (loadflow, security analysis, ...) are not linkable, typically only with bold formatting:

```
**param-name**<br/>
The param description.
```

**What is the new behavior (if this is a feature change)?**

simulation parameters are now headers, hence they appear in the TOC and can be linked internally within powsybl-core docs, and added also anchors for external / inter-sphinx navigation.

```
(sphinx-anchor-for-param-name)=
### param-name
The param description.
```

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
