### PR TITLE
Improve error and doc when deserializing json without version on top

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/json/JsonUtil.java
+++ b/commons/src/main/java/com/powsybl/commons/json/JsonUtil.java
@@ -490,7 +490,7 @@ public final class JsonUtil {
     }
 
     public static void assertSupportedVersion(String contextName, String version, String maxSupportedVersion) {
-        Objects.requireNonNull(version);
+        checkVersion(contextName, version);
         if (compareVersions(version, maxSupportedVersion) > 0) {
             String exception = String.format(
                     "%s. Unsupported version %s. Version should be <= %s %n",
@@ -500,7 +500,7 @@ public final class JsonUtil {
     }
 
     public static void assertLessThanOrEqualToReferenceVersion(String contextName, String elementName, String version, String referenceVersion) {
-        Objects.requireNonNull(version);
+        checkVersion(contextName, version);
         if (compareVersions(version, referenceVersion) > 0) {
             String exception = String.format(
                     "%s. %s is not valid for version %s. Version should be <= %s %n",
@@ -510,7 +510,7 @@ public final class JsonUtil {
     }
 
     public static void assertGreaterThanReferenceVersion(String contextName, String elementName, String version, String referenceVersion) {
-        Objects.requireNonNull(version);
+        checkVersion(contextName, version);
         if (compareVersions(version, referenceVersion) <= 0) {
             String exception = String.format(
                     "%s. %s is not valid for version %s. Version should be > %s %n",
@@ -520,7 +520,7 @@ public final class JsonUtil {
     }
 
     public static void assertGreaterOrEqualThanReferenceVersion(String contextName, String elementName, String version, String referenceVersion) {
-        Objects.requireNonNull(version);
+        checkVersion(contextName, version);
         if (compareVersions(version, referenceVersion) < 0) {
             String exception = String.format(
                     "%s. %s is not valid for version %s. Version should be >= %s %n",
@@ -530,11 +530,20 @@ public final class JsonUtil {
     }
 
     public static void assertLessThanReferenceVersion(String contextName, String elementName, String version, String referenceVersion) {
-        Objects.requireNonNull(version);
+        checkVersion(contextName, version);
         if (compareVersions(version, referenceVersion) >= 0) {
             String exception = String.format(
                     "%s. %s is not valid for version %s. Version should be < %s %n",
                     contextName, elementName, version, referenceVersion);
+            throw new PowsyblException(exception);
+        }
+    }
+
+    public static void checkVersion(String contextName, String version) {
+        if (version == null) {
+            String exception = String.format(
+                    "%s. 'version' field should be positioned at the top of the JSON object.",
+                    contextName);
             throw new PowsyblException(exception);
         }
     }

--- a/docs/simulation/dynamic/configuration.md
+++ b/docs/simulation/dynamic/configuration.md
@@ -47,6 +47,10 @@ The parameters may also be overridden with a JSON file, in which case the config
 }
 ```
 
+```{warning}
+The "version" field of a JSON parameters file must be located at the top of the file.
+```
+
 ### Optional properties
 
 (param-dy-start-time)=

--- a/docs/simulation/dynamic_security/configuration.md
+++ b/docs/simulation/dynamic_security/configuration.md
@@ -48,6 +48,10 @@ The parameters may also be overridden with a JSON file, in which case the config
   "debugDir": "/tmp/debugDir"
 }
 ```
+```{warning}
+The "version" field of a JSON parameters file must be located at the top of the file.
+```
+
 
 ### Optional properties
 

--- a/docs/simulation/loadflow/configuration.md
+++ b/docs/simulation/loadflow/configuration.md
@@ -93,6 +93,10 @@ The parameters may also be overridden with a JSON file, in which case the config
   "hvdcAcEmulation": true
 }
 ```
+```{warning}
+The "version" field of a JSON parameters file must be located at the top of the file.
+```
+
 
 (param-lf-dc)=
 ### dc

--- a/docs/user/itools/security-analysis.md
+++ b/docs/user/itools/security-analysis.md
@@ -305,6 +305,9 @@ itools security-analysis \
   }]
 }
 ```
+```{warning}
+The "type" and "version" fields of a JSON contingency list must be located at the top of the file.
+```
 </details>
 
 <details>
@@ -326,6 +329,9 @@ itools security-analysis \
     } ]
   } ]
 }
+```
+```{warning}
+The "version" field of a JSON operator strategy list must be located at the top of the object.
 ```
 </details> 
 
@@ -351,6 +357,9 @@ itools security-analysis \
     }
   ]
 }
+```
+```{warning}
+The "version" field of a JSON action list must be located at the top of the object.
 ```
 </details>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
The issue was brought up in pypowsybl (https://github.com/powsybl/pypowsybl/issues/1168).


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Doc + error logging update 


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**
The doc clearly states that the 'version' field (and 'type' for contingency lists) should be positioned at the top of the object.
When deserializing an object not meeting this criteria, the error now states that version was not found instead of throwing a NullPointerException.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

