### PR TITLE
Add ObservableList + retain TimeSeries values array to avoid recomputation when not necessary

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/list/ListChangeListener.java
+++ b/commons/src/main/java/com/powsybl/commons/list/ListChangeListener.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, RTE (https://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.commons.list;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
+ */
+public interface ListChangeListener<E> {
+
+    /**
+     * Called after one or more elements were added, starting at {@code fromIndex}.
+     */
+    default void onAdded(List<E> added, int fromIndex) {
+    }
+
+    /**
+     * Called after one or more elements were removed; {@code fromIndex} is where they were.
+     */
+    default void onRemoved(List<E> removed, int fromIndex) {
+    }
+
+    /**
+     * Called after elements were replaced starting at {@code fromIndex}.
+     */
+    default void onSet(List<E> oldElements, List<E> newElements, int fromIndex) {
+    }
+
+    /**
+     * Called after the list was sorted with the given comparator (which may be {@code null} for natural order).
+     */
+    default void onSorted(Comparator<? super E> comparator) {
+    }
+
+    /**
+     * Called after the list was fully cleared.
+     */
+    default void onCleared() {
+    }
+}

--- a/commons/src/main/java/com/powsybl/commons/list/ObservableArrayList.java
+++ b/commons/src/main/java/com/powsybl/commons/list/ObservableArrayList.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026, RTE (https://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.commons.list;
+
+import com.powsybl.commons.util.WeakListenerList;
+import org.jspecify.annotations.NonNull;
+
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+/**
+ * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
+ */
+// The listeners field is not part of the list's value and must not participate in equality.
+// Equality is intentionally delegated to ArrayList, which correctly implements the List contract.
+@SuppressWarnings("java:S2160")
+public class ObservableArrayList<E> extends ArrayList<E> implements ObservableList<E> {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final WeakListenerList<ListChangeListener<E>> listeners = new WeakListenerList<>();
+
+    public ObservableArrayList() {
+        super();
+    }
+
+    public ObservableArrayList(Collection<? extends E> c) {
+        super(c);
+    }
+
+    /**
+     * Adds a listener to this list.
+     * <p>
+     * <strong>Note:</strong> listeners are held weakly by the list. The caller is responsible
+     * for retaining a strong reference to the listener for as long as notifications are needed;
+     * otherwise the listener may be garbage-collected and silently stop receiving events.
+     */
+    public void addListener(ListChangeListener<E> listener) {
+        listeners.add(listener);
+    }
+
+    public void removeListener(ListChangeListener<E> listener) {
+        listeners.remove(listener);
+    }
+
+    @Override
+    public boolean add(E e) {
+        int index = size();
+        boolean result = super.add(e);
+        if (result) {
+            fireAdded(List.of(e), index);
+        }
+        return result;
+    }
+
+    @Override
+    public void add(int index, E element) {
+        super.add(index, element);
+        fireAdded(List.of(element), index);
+    }
+
+    @Override
+    public void addFirst(E element) {
+        super.addFirst(element);
+        fireAdded(List.of(element), 0);
+    }
+
+    @Override
+    public boolean addAll(@NonNull Collection<? extends E> c) {
+        int fromIndex = size();
+        boolean result = super.addAll(c);
+        if (result) {
+            fireAdded(List.copyOf(subList(fromIndex, size())), fromIndex);
+        }
+        return result;
+    }
+
+    @Override
+    public boolean addAll(int index, @NonNull Collection<? extends E> c) {
+        boolean result = super.addAll(index, c);
+        if (result) {
+            fireAdded(List.copyOf(subList(index, index + c.size())), index);
+        }
+        return result;
+    }
+
+    @Override
+    public E remove(int index) {
+        E removed = super.remove(index);
+        fireRemoved(List.of(removed), index);
+        return removed;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        int index = indexOf(o);
+        if (index < 0) {
+            return false;
+        }
+        E removed = super.remove(index);
+        fireRemoved(List.of(removed), index);
+        return true;
+    }
+
+    @Override
+    public E removeFirst() {
+        E removed = super.removeFirst();
+        fireRemoved(List.of(removed), 0);
+        return removed;
+    }
+
+    @Override
+    public E removeLast() {
+        int index = size();
+        E removed = super.removeLast();
+        fireRemoved(List.of(removed), index - 1);
+        return removed;
+    }
+
+    @Override
+    public boolean removeAll(@NonNull Collection<?> c) {
+        List<E> toRemove = stream().filter(c::contains).toList();
+        boolean result = super.removeAll(c);
+        if (result) {
+            fireRemoved(toRemove, 0);
+        }
+        return result;
+    }
+
+    @Override
+    public boolean removeIf(@NonNull Predicate<? super E> filter) {
+        List<E> toRemove = stream().filter(filter).toList();
+        boolean result = super.removeIf(filter);
+        if (result) {
+            fireRemoved(toRemove, 0);
+        }
+        return result;
+    }
+
+    @Override
+    protected void removeRange(int fromIndex, int toIndex) {
+        List<E> removed = List.copyOf(subList(fromIndex, toIndex));
+        super.removeRange(fromIndex, toIndex);
+        fireRemoved(removed, fromIndex);
+    }
+
+    @Override
+    public boolean retainAll(@NonNull Collection<?> c) {
+        List<E> toRemove = stream().filter(e -> !c.contains(e)).toList();
+        boolean result = super.retainAll(c);
+        if (result) {
+            fireRemoved(toRemove, 0);
+        }
+        return result;
+    }
+
+    @Override
+    public void replaceAll(@NonNull UnaryOperator<E> operator) {
+        List<E> oldElements = List.copyOf(this);
+        super.replaceAll(operator);
+        fireSet(oldElements, List.copyOf(this), 0);
+    }
+
+    @Override
+    public E set(int index, E element) {
+        E old = super.set(index, element);
+        fireSet(List.of(old), List.of(element), index);
+        return old;
+    }
+
+    @Override
+    public void sort(Comparator<? super E> comparator) {
+        super.sort(comparator);
+        fireSorted(comparator);
+    }
+
+    @Override
+    public void clear() {
+        super.clear();
+        fireCleared();
+    }
+
+    private void fireAdded(List<E> added, int fromIndex) {
+        listeners.notify(l -> l.onAdded(added, fromIndex));
+    }
+
+    private void fireRemoved(List<E> removed, int fromIndex) {
+        listeners.notify(l -> l.onRemoved(removed, fromIndex));
+    }
+
+    private void fireSet(List<E> oldElements, List<E> newElements, int fromIndex) {
+        listeners.notify(l -> l.onSet(oldElements, newElements, fromIndex));
+    }
+
+    private void fireSorted(Comparator<? super E> comparator) {
+        listeners.notify(l -> l.onSorted(comparator));
+    }
+
+    private void fireCleared() {
+        listeners.notify(ListChangeListener::onCleared);
+    }
+}

--- a/commons/src/main/java/com/powsybl/commons/list/ObservableArrayList.java
+++ b/commons/src/main/java/com/powsybl/commons/list/ObservableArrayList.java
@@ -29,7 +29,7 @@ public class ObservableArrayList<E> extends ArrayList<E> implements ObservableLi
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private final WeakListenerList<ListChangeListener<E>> listeners = new WeakListenerList<>();
+    private final transient WeakListenerList<ListChangeListener<E>> listeners = new WeakListenerList<>();
 
     public ObservableArrayList() {
         super();

--- a/commons/src/main/java/com/powsybl/commons/list/ObservableList.java
+++ b/commons/src/main/java/com/powsybl/commons/list/ObservableList.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026, RTE (https://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.commons.list;
+
+import java.util.List;
+
+/**
+ * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
+ */
+public interface ObservableList<E> extends List<E> {
+
+    void addListener(ListChangeListener<E> listener);
+
+    void removeListener(ListChangeListener<E> listener);
+}

--- a/commons/src/test/java/com/powsybl/commons/list/ObservableArrayListTest.java
+++ b/commons/src/test/java/com/powsybl/commons/list/ObservableArrayListTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026, RTE (https://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.commons.list;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Nicolas Rol {@literal <nicolas.rol at rte-france.com>}
+ */
+class ObservableArrayListTest {
+
+    private ObservableArrayList<Integer> list;
+    private ListChangeListener<Integer> chunkListChangeListener;
+    private boolean firedAdd = false;
+    private boolean firedRemove = false;
+    private boolean firedSet = false;
+    private boolean firedSort = false;
+    private boolean firedClear = false;
+
+    @BeforeEach
+    void setUp() {
+        list = new ObservableArrayList<>(List.of(1, 2, 3));
+        chunkListChangeListener = new ListChangeListener<>() {
+            @Override
+            public void onAdded(List<Integer> added, int fromIndex) {
+                firedAdd = true;
+            }
+
+            @Override
+            public void onRemoved(List<Integer> removed, int fromIndex) {
+                firedRemove = true;
+            }
+
+            @Override
+            public void onSet(List<Integer> oldElements, List<Integer> newElements, int fromIndex) {
+                firedSet = true;
+            }
+
+            @Override
+            public void onSorted(Comparator<? super Integer> comparator) {
+                firedSort = true;
+            }
+
+            @Override
+            public void onCleared() {
+                firedClear = true;
+            }
+        };
+        list.addListener(chunkListChangeListener);
+    }
+
+    @Test
+    void testRemoveListener() {
+        list.removeListener(chunkListChangeListener);
+        list.add(4);
+        assertFalse(firedAdd);
+    }
+
+    @Test
+    void testAdd() {
+        list.add(4);
+        assertTrue(firedAdd);
+    }
+
+    @Test
+    void testAddByIndex() {
+        list.add(1, 5);
+        assertTrue(firedAdd);
+    }
+
+    @Test
+    void testAddAll() {
+        list.addAll(List.of(6, 7));
+        assertTrue(firedAdd);
+    }
+
+    @Test
+    void testAddFirst() {
+        list.addFirst(8);
+        assertTrue(firedAdd);
+    }
+
+    @Test
+    void testAddAllByIndex() {
+        list.addAll(3, List.of(9, 10));
+        assertTrue(firedAdd);
+    }
+
+    @Test
+    void testRemove() {
+        list.remove(1);
+        assertTrue(firedRemove);
+    }
+
+    @Test
+    void testRemoveFirst() {
+        list.removeFirst();
+        assertTrue(firedRemove);
+    }
+
+    @Test
+    void testRemoveLast() {
+        list.removeLast();
+        assertTrue(firedRemove);
+    }
+
+    @Test
+    void testRemoveAllNok() {
+        // Try to remove elements that are not in the list
+        list.removeAll(List.of(6, 7));
+        assertFalse(firedRemove);
+    }
+
+    @Test
+    void testRemoveAllOk() {
+        // Try to remove elements that are in the list
+        list.removeAll(List.of(0, 1));
+        assertTrue(firedRemove);
+    }
+
+    @Test
+    void testRemoveIfNok() {
+        list.removeIf(i -> i > 5);
+        assertFalse(firedRemove);
+    }
+
+    @Test
+    void testRemoveIfOk() {
+        list.removeIf(i -> i % 2 == 0);
+        assertTrue(firedRemove);
+    }
+
+    @Test
+    void testRemoveRange() {
+        list.removeRange(1, 2);
+        assertTrue(firedRemove);
+    }
+
+    @Test
+    void testRetainAllNok() {
+        list.retainAll(List.of(1, 2, 3));
+        assertFalse(firedRemove);
+    }
+
+    @Test
+    void testRetainAllOk() {
+        list.retainAll(List.of(1, 2));
+        assertTrue(firedRemove);
+    }
+
+    @Test
+    void testSet() {
+        list.set(1, 4);
+        assertTrue(firedSet);
+    }
+
+    @Test
+    void testReplaceAll() {
+        list.replaceAll(i -> i * 2);
+        assertTrue(firedSet);
+    }
+
+    @Test
+    void testSort() {
+        list.sort(Comparator.naturalOrder());
+        assertTrue(firedSort);
+    }
+
+    @Test
+    void testClear() {
+        list.clear();
+        assertTrue(firedClear);
+    }
+
+    @Test
+    void testEquals() {
+        ObservableArrayList<Integer> newList = new ObservableArrayList<>();
+        assertNotEquals(list, newList);
+
+        newList.addAll(List.of(1, 2, 3));
+        assertEquals(list, newList);
+    }
+}

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/AbstractTimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/AbstractTimeSeries.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Range;
 import com.powsybl.commons.json.JsonUtil;
+import com.powsybl.commons.list.ListChangeListener;
+import com.powsybl.commons.list.ObservableArrayList;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,13 +34,44 @@ public abstract class AbstractTimeSeries<P extends AbstractPoint, C extends Data
 
     protected final List<C> chunks;
 
+    // This listener needs to be strongly held, so cannot be converted to a local variable
+    private final ListChangeListener<C> chunkListChangeListener;
+
     protected AbstractTimeSeries(TimeSeriesMetadata metadata, C... chunks) {
         this(metadata, Arrays.asList(chunks));
     }
 
     protected AbstractTimeSeries(TimeSeriesMetadata metadata, List<C> chunks) {
         this.metadata = Objects.requireNonNull(metadata);
-        this.chunks = Objects.requireNonNull(chunks);
+        ObservableArrayList<C> observableChunks = new ObservableArrayList<>(Objects.requireNonNull(chunks));
+        chunkListChangeListener = new ListChangeListener<>() {
+            @Override
+            public void onAdded(List<C> added, int fromIndex) {
+                invalidateArrays();
+            }
+
+            @Override
+            public void onRemoved(List<C> removed, int fromIndex) {
+                invalidateArrays();
+            }
+
+            @Override
+            public void onSet(List<C> oldElements, List<C> newElements, int fromIndex) {
+                invalidateArrays();
+            }
+
+            @Override
+            public void onSorted(Comparator<? super C> comparator) {
+                invalidateArrays();
+            }
+
+            @Override
+            public void onCleared() {
+                invalidateArrays();
+            }
+        };
+        observableChunks.addListener(chunkListChangeListener);
+        this.chunks = observableChunks;
     }
 
     public void synchronize(TimeSeriesIndex newIndex) {
@@ -383,5 +416,9 @@ public abstract class AbstractTimeSeries<P extends AbstractPoint, C extends Data
             return metadata.equals(other.metadata) && chunks.equals(other.chunks);
         }
         return false;
+    }
+
+    protected void invalidateArrays() {
+        // Default implementation does nothing
     }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CalculatedTimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/CalculatedTimeSeries.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.DoubleBuffer;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -57,6 +58,8 @@ public class CalculatedTimeSeries implements DoubleTimeSeries {
 
     private TimeSeriesIndex index;
 
+    private final AtomicReference<double[]> toArrayRef = new AtomicReference<>();
+
     public CalculatedTimeSeries(String name, NodeCalc nodeCalc, TimeSeriesNameResolver resolver) {
         this.name = Objects.requireNonNull(name);
         this.nodeCalc = Objects.requireNonNull(nodeCalc);
@@ -76,6 +79,7 @@ public class CalculatedTimeSeries implements DoubleTimeSeries {
     @Override
     public void setTimeSeriesNameResolver(TimeSeriesNameResolver resolver) {
         this.resolver = Objects.requireNonNull(resolver);
+        invalidateArrays();
     }
 
     private List<DoubleTimeSeries> loadData() {
@@ -160,6 +164,7 @@ public class CalculatedTimeSeries implements DoubleTimeSeries {
                 throw new UnsupportedOperationException("Not yet implemented");
             }
         }
+        invalidateArrays();
     }
 
     //To remove if we ever get it from somewhere else
@@ -201,9 +206,12 @@ public class CalculatedTimeSeries implements DoubleTimeSeries {
 
     @Override
     public double[] toArray() {
-        DoubleBuffer buffer = DoubleBuffer.allocate(metadata.getIndex().getPointCount());
-        fillBuffer(buffer, 0);
-        return buffer.array();
+        if (toArrayRef.get() == null) {
+            DoubleBuffer buffer = DoubleBuffer.allocate(metadata.getIndex().getPointCount());
+            fillBuffer(buffer, 0);
+            toArrayRef.set(buffer.array());
+        }
+        return toArrayRef.get();
     }
 
     @Override
@@ -299,5 +307,9 @@ public class CalculatedTimeSeries implements DoubleTimeSeries {
             return name.equals(other.name) && nodeCalc.equals(other.nodeCalc);
         }
         return false;
+    }
+
+    protected void invalidateArrays() {
+        toArrayRef.set(null);
     }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/StoredDoubleTimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/StoredDoubleTimeSeries.java
@@ -10,6 +10,7 @@ package com.powsybl.timeseries;
 import java.nio.DoubleBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 /**
@@ -18,6 +19,9 @@ import java.util.function.Consumer;
 public class StoredDoubleTimeSeries extends AbstractTimeSeries<DoublePoint, DoubleDataChunk, DoubleTimeSeries> implements DoubleTimeSeries {
 
     private static final double[] NAN_ARRAY = new double[]{Double.NaN};
+
+    private final AtomicReference<double[]> toArrayRef = new AtomicReference<>();
+    private final AtomicReference<double[]> toCompactArrayRef = new AtomicReference<>();
 
     public StoredDoubleTimeSeries(TimeSeriesMetadata metadata, DoubleDataChunk... chunks) {
         super(metadata, chunks);
@@ -52,12 +56,15 @@ public class StoredDoubleTimeSeries extends AbstractTimeSeries<DoublePoint, Doub
 
     @Override
     public double[] toArray() {
-        DoubleBuffer buffer = DoubleBuffer.allocate(metadata.getIndex().getPointCount());
-        for (int i = 0; i < metadata.getIndex().getPointCount(); i++) {
-            buffer.put(i, Double.NaN);
+        if (toArrayRef.get() == null) {
+            DoubleBuffer buffer = DoubleBuffer.allocate(metadata.getIndex().getPointCount());
+            for (int i = 0; i < metadata.getIndex().getPointCount(); i++) {
+                buffer.put(i, Double.NaN);
+            }
+            fillBuffer(buffer, 0);
+            toArrayRef.set(buffer.array());
         }
-        fillBuffer(buffer, 0);
-        return buffer.array();
+        return toArrayRef.get();
     }
 
     @Override
@@ -65,13 +72,16 @@ public class StoredDoubleTimeSeries extends AbstractTimeSeries<DoublePoint, Doub
         if (chunks.isEmpty()) {
             return new double[0];
         }
-        int minOffset = getMinOffset();
-        int compactLength = getMaxChunkEnd() - minOffset;
-        double[] array = new double[compactLength];
-        Arrays.fill(array, Double.NaN);
-        DoubleBuffer buffer = DoubleBuffer.wrap(array);
-        chunks.forEach(chunk -> chunk.fillBuffer(buffer, -minOffset));
-        return array;
+        if (toCompactArrayRef.get() == null) {
+            int minOffset = getMinOffset();
+            int compactLength = getMaxChunkEnd() - minOffset;
+            double[] array = new double[compactLength];
+            Arrays.fill(array, Double.NaN);
+            DoubleBuffer buffer = DoubleBuffer.wrap(array);
+            chunks.forEach(chunk -> chunk.fillBuffer(buffer, -minOffset));
+            toCompactArrayRef.set(array);
+        }
+        return toCompactArrayRef.get();
     }
 
     @Override
@@ -79,4 +89,9 @@ public class StoredDoubleTimeSeries extends AbstractTimeSeries<DoublePoint, Doub
         return new DoubleTimeSeriesValues(toCompactArray(), getMinOffset());
     }
 
+    @Override
+    protected void invalidateArrays() {
+        toArrayRef.set(null);
+        toCompactArrayRef.set(null);
+    }
 }

--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/StringTimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/StringTimeSeries.java
@@ -9,6 +9,7 @@ package com.powsybl.timeseries;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 /**
@@ -17,6 +18,9 @@ import java.util.function.Consumer;
 public class StringTimeSeries extends AbstractTimeSeries<StringPoint, StringDataChunk, StringTimeSeries> implements TimeSeries<StringPoint, StringTimeSeries> {
 
     private static final String[] NULL_ARRAY = new String[] {null};
+
+    private final AtomicReference<String[]> toArrayRef = new AtomicReference<>();
+    private final AtomicReference<String[]> toCompactArrayRef = new AtomicReference<>();
 
     public StringTimeSeries(TimeSeriesMetadata metadata, StringDataChunk... chunks) {
         super(metadata, chunks);
@@ -48,20 +52,26 @@ public class StringTimeSeries extends AbstractTimeSeries<StringPoint, StringData
     }
 
     public String[] toArray() {
-        CompactStringBuffer buffer = new CompactStringBuffer(ByteBuffer::allocate, metadata.getIndex().getPointCount());
-        chunks.forEach(chunk -> chunk.fillBuffer(buffer, 0));
-        return buffer.toArray();
+        if (toArrayRef.get() == null) {
+            CompactStringBuffer buffer = new CompactStringBuffer(ByteBuffer::allocate, metadata.getIndex().getPointCount());
+            chunks.forEach(chunk -> chunk.fillBuffer(buffer, 0));
+            toArrayRef.set(buffer.toArray());
+        }
+        return toArrayRef.get();
     }
 
     public String[] toCompactArray() {
         if (chunks.isEmpty()) {
             return new String[0];
         }
-        int minOffset = getMinOffset();
-        int compactLength = getMaxChunkEnd() - minOffset;
-        CompactStringBuffer buffer = new CompactStringBuffer(ByteBuffer::allocate, compactLength);
-        chunks.forEach(chunk -> chunk.fillBuffer(buffer, -minOffset));
-        return buffer.toArray();
+        if (toCompactArrayRef.get() == null) {
+            int minOffset = getMinOffset();
+            int compactLength = getMaxChunkEnd() - minOffset;
+            CompactStringBuffer buffer = new CompactStringBuffer(ByteBuffer::allocate, compactLength);
+            chunks.forEach(chunk -> chunk.fillBuffer(buffer, -minOffset));
+            toCompactArrayRef.set(buffer.toArray());
+        }
+        return toCompactArrayRef.get();
     }
 
     public String get(int index) {
@@ -72,4 +82,9 @@ public class StringTimeSeries extends AbstractTimeSeries<StringPoint, StringData
         return new StringTimeSeriesValues(toCompactArray(), getMinOffset());
     }
 
+    @Override
+    protected void invalidateArrays() {
+        toArrayRef.set(null);
+        toCompactArrayRef.set(null);
+    }
 }

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/CalculatedTimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/CalculatedTimeSeriesTest.java
@@ -457,4 +457,58 @@ class CalculatedTimeSeriesTest {
         assertNotSame(v1, v2);
         assertEquals(v1, v2);
     }
+
+    @Test
+    void testCacheInvalidatedOnDependencyUpdate() {
+        // This test verifies that the internal cache of a calculated time series is invalidated when a dependency is updated.
+        // This ensures that if the underlying data provided by the resolver changes, the calculated time series
+        // will re-evaluate its expression using the updated data.
+        RegularTimeSeriesIndex index = RegularTimeSeriesIndex.create(Interval.parse("2015-01-01T00:00:00Z/2015-01-01T00:15:00Z"), Duration.ofMinutes(15));
+        String doubleTimeSeriesName = "doubleTimeSeries";
+        DoubleTimeSeries constantTimeSeries = TimeSeries.createDouble(doubleTimeSeriesName, index, 1d, 1d);
+        CalculatedTimeSeries calculatedTimeSeriesWithDependencies = new CalculatedTimeSeries("calculatedTimeSeriesNoDependencies", BinaryOperation.plus(
+            new TimeSeriesNameNodeCalc(doubleTimeSeriesName), new TimeSeriesNameNodeCalc(doubleTimeSeriesName)
+        ));
+
+        final List<TimeSeriesMetadata> metadata = new ArrayList<>();
+        metadata.add(constantTimeSeries.getMetadata());
+        final List<DoubleTimeSeries> doubleTimeSeries = new ArrayList<>();
+        doubleTimeSeries.add(constantTimeSeries);
+
+        TimeSeriesNameResolver resolver = new TimeSeriesNameResolver() {
+            @Override
+            public List<TimeSeriesMetadata> getTimeSeriesMetadata(Set<String> timeSeriesNames) {
+                return metadata;
+            }
+
+            @Override
+            public Set<Integer> getTimeSeriesDataVersions(String timeSeriesName) {
+                return Set.of(1);
+            }
+
+            @Override
+            public List<DoubleTimeSeries> getDoubleTimeSeries(Set<String> timeSeriesNames) {
+                return doubleTimeSeries;
+            }
+        };
+        calculatedTimeSeriesWithDependencies.setTimeSeriesNameResolver(resolver);
+        calculatedTimeSeriesWithDependencies.synchronize(index);
+
+        double[] arrayValue2 = calculatedTimeSeriesWithDependencies.toArray();
+        assertArrayEquals(new double[] {2.0, 2.0}, arrayValue2);
+
+        // Simulate new value for the constantTimeSeries: value 1.0 is replaced by 123.0
+        constantTimeSeries = TimeSeries.createDouble(doubleTimeSeriesName, index, 123d, 123d);
+        // We remove metadata from the list used in the resolver
+        metadata.removeFirst();
+        // And we add the timeSeries metadata with the new value
+        metadata.add(constantTimeSeries.getMetadata());
+        // We do the same thing with DoubleTimeSeries
+        doubleTimeSeries.removeFirst();
+        doubleTimeSeries.add(constantTimeSeries);
+
+        // We collect the new array expected to be 246 = 123 + 123
+        double[] arrayValue246 = calculatedTimeSeriesWithDependencies.toArray();
+        assertArrayEquals(new double[] {246.0, 246.0}, arrayValue246);
+    }
 }

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/CalculatedTimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/CalculatedTimeSeriesTest.java
@@ -437,4 +437,24 @@ class CalculatedTimeSeriesTest {
         e0 = assertThrows(TimeSeriesException.class, () -> TimeSeries.parseJson(jsonValueNull));
         assertEquals("Unexpected JSON token: VALUE_NULL", e0.getMessage());
     }
+
+    @Test
+    void testCacheReturnsSameInstance() {
+        timeSeries.synchronize(RegularTimeSeriesIndex.create(
+            Interval.parse("2015-01-01T00:00:00Z/2015-01-01T00:15:00Z"), Duration.ofMinutes(15)));
+        double[] values1 = timeSeries.toArray();
+        double[] values2 = timeSeries.toArray();
+        assertSame(values1, values2);
+    }
+
+    @Test
+    void testCacheInvalidatedOnSetTimeSeriesNameResolver() {
+        timeSeries.synchronize(RegularTimeSeriesIndex.create(
+            Interval.parse("2015-01-01T00:00:00Z/2015-01-01T00:15:00Z"), Duration.ofMinutes(15)));
+        DoubleTimeSeriesValues v1 = timeSeries.getDoubleTimeSeriesValues();
+        timeSeries.setTimeSeriesNameResolver(CalculatedTimeSeries.EMPTY_RESOLVER);
+        DoubleTimeSeriesValues v2 = timeSeries.getDoubleTimeSeriesValues();
+        assertNotSame(v1, v2);
+        assertEquals(v1, v2);
+    }
 }

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/StoredDoubleTimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/StoredDoubleTimeSeriesTest.java
@@ -463,4 +463,42 @@ class StoredDoubleTimeSeriesTest {
         assertArrayEquals(new double[] {1d, 2d, 3d, NaN, NaN, NaN, 7d, 8d}, timeSeries.toCompactArray());
     }
 
+    @Test
+    void testReturnsSameArrayInstance() {
+        RegularTimeSeriesIndex index = RegularTimeSeriesIndex.create(
+            Interval.parse("2015-01-01T00:00:00Z/2015-01-01T00:15:00Z"), Duration.ofMinutes(15));
+        StoredDoubleTimeSeries ts = TimeSeries.createDouble("ts", index, 1d, 2d);
+
+        double[] values1 = ts.toArray();
+        double[] values2 = ts.toArray();
+        assertSame(values1, values2);
+
+        double[] compactValues1 = ts.toCompactArray();
+        double[] compactValues2 = ts.toCompactArray();
+        assertSame(compactValues1, compactValues2);
+    }
+
+    @Test
+    void testArraysInvalidatedOnChunkModification() {
+        RegularTimeSeriesIndex index = RegularTimeSeriesIndex.create(
+            Interval.parse("2015-01-01T00:00:00Z/2015-01-01T00:15:00Z"), Duration.ofMinutes(15));
+        StoredDoubleTimeSeries ts = TimeSeries.createDouble("ts", index, 1d, 2d);
+        // Original values
+        double[] values1 = ts.toArray();
+        double[] compactValues1 = ts.toCompactArray();
+
+        // Add a chunk
+        ts.addChunk(new UncompressedDoubleDataChunk(0, new double[]{1d, 2d}));
+        double[] values2 = ts.toArray();
+        double[] compactValues2 = ts.toCompactArray();
+        assertNotSame(values1, values2);
+        assertNotSame(compactValues1, compactValues2);
+
+        // Remove a chunk
+        ts.getChunks().removeFirst();
+        double[] values3 = ts.toArray();
+        double[] compactValues3 = ts.toCompactArray();
+        assertNotSame(values2, values3);
+        assertNotSame(compactValues2, compactValues3);
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
When a TimeSeries is computed, if you call `.toArray()` on it twice in a row, the array is computed twice, even if no modification has been made on the TimeSeries in between.

**What is the new behavior (if this is a feature change)?**
When a TimeSeries is computed, if you call `.toArray()` on it, the array is computed once and then saved in memory for future use.
If any modification is done on the TimeSeries, the saved array is discarded so that it is recomputed at the next call.
To help, a new interface `ObservableList` and its implementation `ObservableArrayList` were added, so that you can add listeners (via a new class `ListChangeListener`) on any list modification

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
