### PR TITLE
Add active power limits to AC/DC converters

### DIFF
--- a/docs/grid_model/network_subnetwork.md
+++ b/docs/grid_model/network_subnetwork.md
@@ -1010,8 +1010,7 @@ $V_{DC} \in [V_{min}, V_{max}]$ where $V_{DC}$ is the DC Voltage at converter's 
 `MinP` and `MaxP` define the operational active power limits of the converter at the Point of Common Coupling, using the
 same load sign convention as `TargetP`.
 
-`MinP` must be less than or equal to `MaxP`. Both attributes are optional; if not set, `MinP` defaults to $-\infty$ and
-`MaxP` defaults to $+\infty$, meaning no operational limit is enforced.
+`MinP` must be less than or equal to `MaxP`. Both attributes are optional; if not set, the converter is considered with unlimited active power capability.
 
 `MinP` and `MaxP` are not serializable as of today. Trying to serialize AC-DC converters with non-default values of `MinP` or `MaxP` will raise an error.
 

--- a/docs/grid_model/network_subnetwork.md
+++ b/docs/grid_model/network_subnetwork.md
@@ -946,6 +946,8 @@ LCC and VSC share the following characteristics.
 | $ControlMode$   |          | The converter's control mode: P_PCC, V_DC or P_PCC_DROOP              |
 | $TargetP$       | MW       | Active power target at point of common coupling, load sign convention |
 | $TargetVdc$     | kV       | DC voltage target                                                     |
+| $MinP$          | MW       | Minimum active power at point of common coupling, load sign convention |
+| $MaxP$          | MW       | Maximum active power at point of common coupling, load sign convention |
 | $DroopCurve$    |          | Droop curve for droop control mode                                    |
 
 Converter losses are modeled using the `IdleLoss`, `SwitchingLoss` and `ResistiveLoss` parameters, all positive values.
@@ -1005,6 +1007,13 @@ Each droop segment in the `DroopCurve` is defined with minimal and maximal volta
 droop segment should be the one which verifies:
 $V_{DC} \in [V_{min}, V_{max}]$ where $V_{DC}$ is the DC Voltage at converter's Terminals.
 
+`MinP` and `MaxP` define the operational active power limits of the converter at the Point of Common Coupling, using the
+same load sign convention as `TargetP`.
+
+`MinP` must be less than or equal to `MaxP`. Both attributes are optional; if not set, `MinP` defaults to $-\infty$ and
+`MaxP` defaults to $+\infty$, meaning no operational limit is enforced.
+
+`MinP` and `MaxP` are not serializable as of today. Trying to serialize AC-DC converters with non-default values of `MinP` or `MaxP` will raise an error.
 
 
 (line-commutated-converter)=

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
@@ -113,7 +113,7 @@ import java.util.Optional;
  *             <td style="border: 1px solid black">MW</td>
  *             <td style="border: 1px solid black"> - </td>
  *             <td style="border: 1px solid black">no</td>
- *             <td style="border: 1px solid black"> -inf MW</td>
+ *             <td style="border: 1px solid black"> -Double.MAX_VALUE MW</td>
  *             <td style="border: 1px solid black">Minimum operating active power at point of common coupling, load sign convention</td>
  *         </tr>
  *         <tr>
@@ -121,7 +121,7 @@ import java.util.Optional;
  *             <td style="border: 1px solid black">MW</td>
  *             <td style="border: 1px solid black"> - </td>
  *             <td style="border: 1px solid black">no</td>
- *             <td style="border: 1px solid black"> +inf MW</td>
+ *             <td style="border: 1px solid black"> +Double.MAX_VALUE MW</td>
  *             <td style="border: 1px solid black">Maximum operating active power at point of common coupling, load sign convention</td>
  *         </tr>
  *     </tbody>
@@ -190,28 +190,28 @@ public interface AcDcConverter<I extends AcDcConverter<I>> extends Connectable<I
 
     /**
      * Get the minimal active power in MW.
-     * Defaults to {@link Double#NEGATIVE_INFINITY} if not set.
+     * Defaults to -{@link Double#MAX_VALUE} if not set.
      */
     double getMinP();
 
     /**
      * Set the minimal active power in MW.
-     * <p><b>Note:</b> XML serialization is not yet supported for non-default values.
-     * Setting a value other than {@link Double#NEGATIVE_INFINITY} will cause
+     * <p><b>Note:</b> IIDM serialization is not yet supported for non-default values.
+     * Setting a value other than -{@link Double#MAX_VALUE} will cause
      * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
      */
     I setMinP(double minP);
 
     /**
      * Get the maximal active power in MW.
-     * Defaults to {@link Double#POSITIVE_INFINITY} if not set.
+     * Defaults to {@link Double#MAX_VALUE} if not set.
      */
     double getMaxP();
 
     /**
      * Set the maximal active power in MW.
-     * <p><b>Note:</b> XML serialization is not yet supported for non-default values.
-     * Setting a value other than {@link Double#POSITIVE_INFINITY} will cause
+     * <p><b>Note:</b> IIDM serialization is not yet supported for non-default values.
+     * Setting a value other than {@link Double#MAX_VALUE} will cause
      * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
      */
     I setMaxP(double maxP);

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
@@ -173,6 +173,28 @@ public interface AcDcConverter<I extends AcDcConverter<I>> extends Connectable<I
     DcTerminal getDcTerminal(TerminalNumber terminalNumber);
 
     /**
+     * Get the minimal active power in MW.
+     * Defaults to {@link Double#NEGATIVE_INFINITY} if not set.
+     */
+    double getMinP();
+
+    /**
+     * Set the minimal active power in MW.
+     */
+    I setMinP(double minP);
+
+    /**
+     * Get the maximal active power in MW.
+     * Defaults to {@link Double#POSITIVE_INFINITY} if not set.
+     */
+    double getMaxP();
+
+    /**
+     * Set the maximal active power in MW.
+     */
+    I setMaxP(double maxP);
+
+    /**
      * Set the idle loss (MW).
      */
     I setIdleLoss(double idleLoss);

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
@@ -108,6 +108,22 @@ import java.util.Optional;
  *             <td style="border: 1px solid black"> - </td>
  *             <td style="border: 1px solid black">Curve which contains multiple droop segments</td>
  *         </tr>
+ *         <tr>
+ *             <td style="border: 1px solid black">minP</td>
+ *             <td style="border: 1px solid black">MW</td>
+ *             <td style="border: 1px solid black"> - </td>
+ *             <td style="border: 1px solid black">no</td>
+ *             <td style="border: 1px solid black"> -inf MW</td>
+ *             <td style="border: 1px solid black">Minimum operating active power at point of common coupling, load sign convention</td>
+ *         </tr>
+ *         <tr>
+ *             <td style="border: 1px solid black">maxP</td>
+ *             <td style="border: 1px solid black">MW</td>
+ *             <td style="border: 1px solid black"> - </td>
+ *             <td style="border: 1px solid black">no</td>
+ *             <td style="border: 1px solid black"> +inf MW</td>
+ *             <td style="border: 1px solid black">Maximum operating active power at point of common coupling, load sign convention</td>
+ *         </tr>
  *     </tbody>
  * </table>
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
@@ -180,6 +180,9 @@ public interface AcDcConverter<I extends AcDcConverter<I>> extends Connectable<I
 
     /**
      * Set the minimal active power in MW.
+     * <p><b>Note:</b> XML serialization is not yet supported for non-default values.
+     * Setting a value other than {@link Double#NEGATIVE_INFINITY} will cause
+     * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
      */
     I setMinP(double minP);
 
@@ -191,6 +194,9 @@ public interface AcDcConverter<I extends AcDcConverter<I>> extends Connectable<I
 
     /**
      * Set the maximal active power in MW.
+     * <p><b>Note:</b> XML serialization is not yet supported for non-default values.
+     * Setting a value other than {@link Double#POSITIVE_INFINITY} will cause
+     * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
      */
     I setMaxP(double maxP);
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverterAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverterAdder.java
@@ -34,16 +34,16 @@ public interface AcDcConverterAdder<T extends AcDcConverter<T> & Connectable<T> 
 
     /**
      * Set the minimal active power in MW.
-     * <p><b>Note:</b> XML serialization is not yet supported for non-default values.
-     * Setting a value other than {@link Double#NEGATIVE_INFINITY} will cause
+     * <p><b>Note:</b> IIDM serialization is not yet supported for non-default values.
+     * Setting a value other than -{@link Double#MAX_VALUE} will cause
      * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
      */
     A setMinP(double minP);
 
     /**
      * Set the maximal active power in MW.
-     * <p><b>Note:</b> XML serialization is not yet supported for non-default values.
-     * Setting a value other than {@link Double#POSITIVE_INFINITY} will cause
+     * <p><b>Note:</b> IIDM serialization is not yet supported for non-default values.
+     * Setting a value other than {@link Double#MAX_VALUE} will cause
      * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
      */
     A setMaxP(double maxP);

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverterAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverterAdder.java
@@ -32,8 +32,20 @@ public interface AcDcConverterAdder<T extends AcDcConverter<T> & Connectable<T> 
 
     A setDcConnected2(boolean connected2);
 
+    /**
+     * Set the minimal active power in MW.
+     * <p><b>Note:</b> XML serialization is not yet supported for non-default values.
+     * Setting a value other than {@link Double#NEGATIVE_INFINITY} will cause
+     * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
+     */
     A setMinP(double minP);
 
+    /**
+     * Set the maximal active power in MW.
+     * <p><b>Note:</b> XML serialization is not yet supported for non-default values.
+     * Setting a value other than {@link Double#POSITIVE_INFINITY} will cause
+     * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
+     */
     A setMaxP(double maxP);
 
     A setIdleLoss(double idleLoss);

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverterAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverterAdder.java
@@ -32,6 +32,10 @@ public interface AcDcConverterAdder<T extends AcDcConverter<T> & Connectable<T> 
 
     A setDcConnected2(boolean connected2);
 
+    A setMinP(double minP);
+
+    A setMaxP(double maxP);
+
     A setIdleLoss(double idleLoss);
 
     A setSwitchingLoss(double switchingLoss);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverter.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverter.java
@@ -21,6 +21,8 @@ import java.util.Optional;
  */
 abstract class AbstractAcDcConverter<I extends AcDcConverter<I>> extends AbstractConnectable<I> implements AcDcConverter<I>, MultiVariantObject {
 
+    public static final String MIN_P = "minP";
+    public static final String MAX_P = "maxP";
     public static final String IDLE_LOSS = "idleLoss";
     public static final String SWITCHING_LOSS = "switchingLoss";
     public static final String RESISTIVE_LOSS = "resistiveLoss";
@@ -30,6 +32,8 @@ abstract class AbstractAcDcConverter<I extends AcDcConverter<I>> extends Abstrac
     public static final String TARGET_VDC = "targetVdc";
     protected final List<DcTerminalImpl> dcTerminals = new ArrayList<>();
 
+    private double minP;
+    private double maxP;
     private double idleLoss;
     private double switchingLoss;
     private double resistiveLoss;
@@ -45,9 +49,12 @@ abstract class AbstractAcDcConverter<I extends AcDcConverter<I>> extends Abstrac
     private final TDoubleArrayList targetVdc;
 
     AbstractAcDcConverter(Ref<NetworkImpl> ref, String id, String name, boolean fictitious,
+                          double minP, double maxP,
                           double idleLoss, double switchingLoss, double resistiveLoss,
                           TerminalExt pccTerminal, ControlMode controlMode, double targetP, double targetVdc) {
         super(ref, id, name, fictitious);
+        this.minP = minP;
+        this.maxP = maxP;
         this.idleLoss = idleLoss;
         this.switchingLoss = switchingLoss;
         this.resistiveLoss = resistiveLoss;
@@ -164,6 +171,40 @@ abstract class AbstractAcDcConverter<I extends AcDcConverter<I>> extends Abstrac
             getDcTerminals(),
             getNetwork().getReportNodeContext().getReportNode()
         );
+    }
+
+    @Override
+    public double getMinP() {
+        ValidationUtil.checkAccessOfRemovedEquipment(this.id, this.removed, MIN_P);
+        return this.minP;
+    }
+
+    @Override
+    public I setMinP(double minP) {
+        ValidationUtil.checkModifyOfRemovedEquipment(this.id, this.removed, MIN_P);
+        ValidationUtil.checkMinP(this, minP);
+        ValidationUtil.checkActivePowerLimits(this, minP, this.maxP);
+        double oldValue = this.minP;
+        this.minP = minP;
+        getNetwork().getListeners().notifyUpdate(this, MIN_P, oldValue, minP);
+        return self();
+    }
+
+    @Override
+    public double getMaxP() {
+        ValidationUtil.checkAccessOfRemovedEquipment(this.id, this.removed, MAX_P);
+        return this.maxP;
+    }
+
+    @Override
+    public I setMaxP(double maxP) {
+        ValidationUtil.checkModifyOfRemovedEquipment(this.id, this.removed, MAX_P);
+        ValidationUtil.checkMaxP(this, maxP);
+        ValidationUtil.checkActivePowerLimits(this, this.minP, maxP);
+        double oldValue = this.maxP;
+        this.maxP = maxP;
+        getNetwork().getListeners().notifyUpdate(this, MAX_P, oldValue, maxP);
+        return self();
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverter.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverter.java
@@ -181,6 +181,8 @@ abstract class AbstractAcDcConverter<I extends AcDcConverter<I>> extends Abstrac
 
     @Override
     public I setMinP(double minP) {
+        // We do no consistency check with target P here to avoid blocking the user
+        // when editing the network.
         ValidationUtil.checkModifyOfRemovedEquipment(this.id, this.removed, MIN_P);
         ValidationUtil.checkMinP(this, minP);
         ValidationUtil.checkActivePowerLimits(this, minP, this.maxP);
@@ -198,6 +200,8 @@ abstract class AbstractAcDcConverter<I extends AcDcConverter<I>> extends Abstrac
 
     @Override
     public I setMaxP(double maxP) {
+        // We do no consistency check with target P here to avoid blocking the user
+        // when editing the network.
         ValidationUtil.checkModifyOfRemovedEquipment(this.id, this.removed, MAX_P);
         ValidationUtil.checkMaxP(this, maxP);
         ValidationUtil.checkActivePowerLimits(this, this.minP, maxP);
@@ -295,6 +299,8 @@ abstract class AbstractAcDcConverter<I extends AcDcConverter<I>> extends Abstrac
 
     @Override
     public I setTargetP(double targetP) {
+        // We do no consistency check with min/max P here to avoid blocking the user
+        // when editing the network.
         ValidationUtil.checkModifyOfRemovedEquipment(this.id, this.removed, TARGET_P);
         NetworkImpl n = getNetwork();
         ValidationUtil.checkAcDcConverterControl(this, getControlMode(), targetP, getTargetVdc(),

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverterAdder.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverterAdder.java
@@ -36,6 +36,8 @@ abstract class AbstractAcDcConverterAdder<T extends AbstractAcDcConverterAdder<T
 
     private String connectableBus2;
 
+    protected double minP = Double.NEGATIVE_INFINITY;
+    protected double maxP = Double.POSITIVE_INFINITY;
     protected double idleLoss = 0.;
     protected double switchingLoss = 0.;
     protected double resistiveLoss = 0.;
@@ -122,6 +124,16 @@ abstract class AbstractAcDcConverterAdder<T extends AbstractAcDcConverterAdder<T
         return Optional.empty();
     }
 
+    public T setMinP(double minP) {
+        this.minP = minP;
+        return self();
+    }
+
+    public T setMaxP(double maxP) {
+        this.maxP = maxP;
+        return self();
+    }
+
     public T setIdleLoss(double idleLoss) {
         this.idleLoss = idleLoss;
         return self();
@@ -162,6 +174,9 @@ abstract class AbstractAcDcConverterAdder<T extends AbstractAcDcConverterAdder<T
         network.setValidationLevelIfGreaterThan(ValidationUtil.checkAcDcConverterControl(this, controlMode, targetP, targetVdc,
                 network.getMinValidationLevel(), network.getReportNodeContext().getReportNode()));
         ValidationUtil.checkAcDcConverterPccTerminal(this, pccTerminal, voltageLevel);
+        ValidationUtil.checkMinP(this, minP);
+        ValidationUtil.checkMaxP(this, maxP);
+        ValidationUtil.checkActivePowerLimits(this, minP, maxP);
     }
 
     private boolean hasTwoAcTerminals() {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverterAdder.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractAcDcConverterAdder.java
@@ -36,8 +36,8 @@ abstract class AbstractAcDcConverterAdder<T extends AbstractAcDcConverterAdder<T
 
     private String connectableBus2;
 
-    protected double minP = Double.NEGATIVE_INFINITY;
-    protected double maxP = Double.POSITIVE_INFINITY;
+    protected double minP = -Double.MAX_VALUE;
+    protected double maxP = Double.MAX_VALUE;
     protected double idleLoss = 0.;
     protected double switchingLoss = 0.;
     protected double resistiveLoss = 0.;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LineCommutatedConverterAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LineCommutatedConverterAdderImpl.java
@@ -46,6 +46,7 @@ public class LineCommutatedConverterAdderImpl extends AbstractAcDcConverterAdder
         ValidationUtil.checkPositivePowerFactor(this, powerFactor);
         ValidationUtil.checkLccReactiveModel(this, reactiveModel);
         LineCommutatedConverterImpl dcCsConverter = new LineCommutatedConverterImpl(voltageLevel.getNetworkRef(), id, getName(), isFictitious(),
+                minP, maxP,
                 idleLoss, switchingLoss, resistiveLoss,
                 pccTerminal, controlMode, targetP, targetVdc,
                 reactiveModel, powerFactor);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LineCommutatedConverterImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/LineCommutatedConverterImpl.java
@@ -23,9 +23,10 @@ public class LineCommutatedConverterImpl extends AbstractAcDcConverter<LineCommu
     private double powerFactor;
 
     LineCommutatedConverterImpl(Ref<NetworkImpl> ref, String id, String name, boolean fictitious,
+                                double minP, double maxP,
                                 double idleLoss, double switchingLoss, double resistiveLoss,
                                 TerminalExt pccTerminal, ControlMode controlMode, double targetP, double targetVdc, ReactiveModel reactiveModel, double powerFactor) {
-        super(ref, id, name, fictitious, idleLoss, switchingLoss, resistiveLoss,
+        super(ref, id, name, fictitious, minP, maxP, idleLoss, switchingLoss, resistiveLoss,
                 pccTerminal, controlMode, targetP, targetVdc);
         this.reactiveModel = reactiveModel;
         this.powerFactor = powerFactor;

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageSourceConverterAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageSourceConverterAdderImpl.java
@@ -57,6 +57,7 @@ public class VoltageSourceConverterAdderImpl extends AbstractAcDcConverterAdder<
                 reactivePowerSetpoint, network.getMinValidationLevel(), network.getReportNodeContext().getReportNode()));
         ValidationUtil.checkRegulatingTerminal(this, this.pccTerminal, network);
         VoltageSourceConverterImpl dcVsConverter = new VoltageSourceConverterImpl(voltageLevel.getNetworkRef(), id, getName(), isFictitious(),
+                minP, maxP,
                 idleLoss, switchingLoss, resistiveLoss,
                 pccTerminal, controlMode, targetP, targetVdc,
                 voltageRegulatorOn, reactivePowerSetpoint, voltageSetpoint);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageSourceConverterImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/VoltageSourceConverterImpl.java
@@ -32,10 +32,11 @@ public class VoltageSourceConverterImpl extends AbstractAcDcConverter<VoltageSou
     private final RegulatingPoint regulatingPoint;
 
     VoltageSourceConverterImpl(Ref<NetworkImpl> ref, String id, String name, boolean fictitious,
+                               double minP, double maxP,
                                double idleLoss, double switchingLoss, double resistiveLoss,
                                TerminalExt pccTerminal, ControlMode controlMode, double targetP, double targetVdc,
                                boolean voltageRegulatorOn, double reactivePowerSetpoint, double voltageSetpoint) {
-        super(ref, id, name, fictitious, idleLoss, switchingLoss, resistiveLoss,
+        super(ref, id, name, fictitious, minP, maxP, idleLoss, switchingLoss, resistiveLoss,
                 pccTerminal, controlMode, targetP, targetVdc);
         int variantArraySize = ref.get().getVariantManager().getVariantArraySize();
         this.reactivePowerSetpoint = new TDoubleArrayList(variantArraySize);

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
@@ -38,10 +38,10 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
         context.getWriter().writeEnumAttribute("controlMode", converter.getControlMode());
         context.getWriter().writeDoubleAttribute("targetP", converter.getTargetP());
         context.getWriter().writeDoubleAttribute("targetVdc", converter.getTargetVdc());
-        if (converter.getMinP() != Double.NEGATIVE_INFINITY) {
+        if (converter.getMinP() != -Double.MAX_VALUE) {
             throw new PowsyblException(getRootElementName() + " '" + converter.getId() + "': minP serialization is not yet supported");
         }
-        if (converter.getMaxP() != Double.POSITIVE_INFINITY) {
+        if (converter.getMaxP() != Double.MAX_VALUE) {
             throw new PowsyblException(getRootElementName() + " '" + converter.getId() + "': maxP serialization is not yet supported");
         }
 

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
@@ -38,11 +38,15 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
         context.getWriter().writeEnumAttribute("controlMode", converter.getControlMode());
         context.getWriter().writeDoubleAttribute("targetP", converter.getTargetP());
         context.getWriter().writeDoubleAttribute("targetVdc", converter.getTargetVdc());
-        if (converter.getMinP() != -Double.MAX_VALUE) {
-            throw new PowsyblException(getRootElementName() + " '" + converter.getId() + "': minP serialization is not yet supported");
+        if (converter.getMinP() != -Double.MAX_VALUE && !context.getOptions().isForceExportNetworkWithBetaFeatures()) {
+            throw new PowsyblException(getRootElementName() + " '" + converter.getId() + "': minP serialization is not yet supported. " +
+                "To force the export of the network and ignore this value, either use the config parameter iidm.export.xml.force-export-network-with-beta-features, " +
+                "or ExportOptions.setForceExportNetworkWithBetaFeatures");
         }
-        if (converter.getMaxP() != Double.MAX_VALUE) {
-            throw new PowsyblException(getRootElementName() + " '" + converter.getId() + "': maxP serialization is not yet supported");
+        if (converter.getMaxP() != Double.MAX_VALUE && !context.getOptions().isForceExportNetworkWithBetaFeatures()) {
+            throw new PowsyblException(getRootElementName() + " '" + converter.getId() + "': maxP serialization is not yet supported. " +
+                "To force the export of the network and ignore this value, either use the config parameter iidm.export.xml.force-export-network-with-beta-features, " +
+                "or ExportOptions.setForceExportNetworkWithBetaFeatures");
         }
 
         writeNodeOrBus(converter, context);

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
@@ -7,10 +7,11 @@
  */
 package com.powsybl.iidm.serde;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 
 import static com.powsybl.iidm.serde.ConnectableSerDeUtil.*;
+
+import org.apache.commons.lang3.NotImplementedException;
 
 /**
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
@@ -39,12 +40,12 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
         context.getWriter().writeDoubleAttribute("targetP", converter.getTargetP());
         context.getWriter().writeDoubleAttribute("targetVdc", converter.getTargetVdc());
         if (converter.getMinP() != -Double.MAX_VALUE && !context.getOptions().isForceExportNetworkWithBetaFeatures()) {
-            throw new PowsyblException(getRootElementName() + " '" + converter.getId() + "': minP serialization is not yet supported. " +
+            throw new NotImplementedException(getRootElementName() + " '" + converter.getId() + "': minP serialization is not yet supported. " +
                 "To force the export of the network and ignore this value, either use the config parameter iidm.export.xml.force-export-network-with-beta-features, " +
                 "or ExportOptions.setForceExportNetworkWithBetaFeatures");
         }
         if (converter.getMaxP() != Double.MAX_VALUE && !context.getOptions().isForceExportNetworkWithBetaFeatures()) {
-            throw new PowsyblException(getRootElementName() + " '" + converter.getId() + "': maxP serialization is not yet supported. " +
+            throw new NotImplementedException(getRootElementName() + " '" + converter.getId() + "': maxP serialization is not yet supported. " +
                 "To force the export of the network and ignore this value, either use the config parameter iidm.export.xml.force-export-network-with-beta-features, " +
                 "or ExportOptions.setForceExportNetworkWithBetaFeatures");
         }

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.iidm.serde;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 
 import static com.powsybl.iidm.serde.ConnectableSerDeUtil.*;
@@ -37,6 +38,12 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
         context.getWriter().writeEnumAttribute("controlMode", converter.getControlMode());
         context.getWriter().writeDoubleAttribute("targetP", converter.getTargetP());
         context.getWriter().writeDoubleAttribute("targetVdc", converter.getTargetVdc());
+        if (converter.getMinP() != Double.NEGATIVE_INFINITY) {
+            throw new PowsyblException(getRootElementName() + " '" + converter.getId() + "': minP serialization is not yet supported");
+        }
+        if (converter.getMaxP() != Double.POSITIVE_INFINITY) {
+            throw new PowsyblException(getRootElementName() + " '" + converter.getId() + "': maxP serialization is not yet supported");
+        }
 
         writeNodeOrBus(converter, context);
     }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.iidm.serde;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
 
@@ -14,11 +15,18 @@ import java.io.IOException;
 import java.time.ZonedDateTime;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
  */
 class LineCommutatedConverterSerDeTest extends AbstractIidmSerDeTest {
+
+    @Test
+    void testMinPNotSupported() {
+        Network network = createNetworkWithNonDefaultMinP();
+        assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, tmpDir.resolve("fail")));
+    }
 
     @Test
     void testNetworkLineCommutatedConverter() throws IOException {
@@ -174,6 +182,28 @@ class LineCommutatedConverterSerDeTest extends AbstractIidmSerDeTest {
         lcc3.getTerminal1().setP(-105.); // no Q
         lcc3.getTerminal2().orElseThrow().setQ(-200.8); // no P
 
+        return network;
+    }
+
+    private static Network createNetworkWithNonDefaultMinP() {
+        Network network = Network.create("lineCommutatedConverterTest", "code");
+        network.setCaseDate(ZonedDateTime.parse("2025-01-02T03:04:05.000+01:00"));
+        DcNode dcNode1 = network.newDcNode().setId("dcNode1").setNominalV(500.).add();
+        DcNode dcNode2 = network.newDcNode().setId("dcNode2").setNominalV(500.).add();
+        Substation s = network.newSubstation().setId("S").add();
+        VoltageLevel vl = s.newVoltageLevel().setId("vl").setTopologyKind(TopologyKind.BUS_BREAKER).setNominalV(400.).add();
+        vl.getBusBreakerView().newBus().setId("bus").add();
+        vl.newLineCommutatedConverter()
+                .setId("lcc")
+                .setDcNode1(dcNode1.getId()).setDcConnected1(false)
+                .setDcNode2(dcNode2.getId()).setDcConnected2(false)
+                .setConnectableBus1("bus")
+                .setReactiveModel(LineCommutatedConverter.ReactiveModel.FIXED_POWER_FACTOR)
+                .setPowerFactor(0.92)
+                .setControlMode(AcDcConverter.ControlMode.V_DC)
+                .setTargetVdc(500.)
+                .setMinP(-100.)
+                .add();
         return network;
     }
 

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -28,6 +29,13 @@ class LineCommutatedConverterSerDeTest extends AbstractIidmSerDeTest {
         Network network = createNetworkWithNonDefaultMinP();
         Path filename = tmpDir.resolve("fail");
         assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, filename));
+    }
+
+    @Test
+    void testMinPWithForceExport() {
+        Network network = createNetworkWithNonDefaultMinP();
+        Path filename = tmpDir.resolve("lcc-minP-force-export");
+        assertDoesNotThrow(() -> NetworkSerDe.write(network, new ExportOptions().setForceExportNetworkWithBetaFeatures(true), filename));
     }
 
     @Test

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
@@ -12,6 +12,7 @@ import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.ZonedDateTime;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
@@ -25,7 +26,8 @@ class LineCommutatedConverterSerDeTest extends AbstractIidmSerDeTest {
     @Test
     void testMinPNotSupported() {
         Network network = createNetworkWithNonDefaultMinP();
-        assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, tmpDir.resolve("fail")));
+        Path filename = tmpDir.resolve("fail");
+        assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, filename));
     }
 
     @Test

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
@@ -7,8 +7,9 @@
  */
 package com.powsybl.iidm.serde;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
+
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -28,7 +29,7 @@ class LineCommutatedConverterSerDeTest extends AbstractIidmSerDeTest {
     void testMinPNotSupported() {
         Network network = createNetworkWithNonDefaultMinP();
         Path filename = tmpDir.resolve("fail");
-        assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, filename));
+        assertThrows(NotImplementedException.class, () -> NetworkSerDe.write(network, filename));
     }
 
     @Test

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
@@ -7,8 +7,9 @@
  */
 package com.powsybl.iidm.serde;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
+
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -28,7 +29,7 @@ class VoltageSourceConverterSerDeTest extends AbstractIidmSerDeTest {
     void testMaxPNotSupported() {
         Network network = createNetworkWithNonDefaultMaxP();
         Path filename = tmpDir.resolve("fail");
-        assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, filename));
+        assertThrows(NotImplementedException.class, () -> NetworkSerDe.write(network, filename));
     }
 
     @Test

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
@@ -12,6 +12,7 @@ import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.ZonedDateTime;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
@@ -25,7 +26,8 @@ class VoltageSourceConverterSerDeTest extends AbstractIidmSerDeTest {
     @Test
     void testMaxPNotSupported() {
         Network network = createNetworkWithNonDefaultMaxP();
-        assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, tmpDir.resolve("fail")));
+        Path filename = tmpDir.resolve("fail");
+        assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, filename));
     }
 
     @Test

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -28,6 +29,13 @@ class VoltageSourceConverterSerDeTest extends AbstractIidmSerDeTest {
         Network network = createNetworkWithNonDefaultMaxP();
         Path filename = tmpDir.resolve("fail");
         assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, filename));
+    }
+
+    @Test
+    void testMaxPWithForceExport() {
+        Network network = createNetworkWithNonDefaultMaxP();
+        Path filename = tmpDir.resolve("vsc-maxP-force-export");
+        assertDoesNotThrow(() -> NetworkSerDe.write(network, new ExportOptions().setForceExportNetworkWithBetaFeatures(true), filename));
     }
 
     @Test

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.iidm.serde;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
 
@@ -14,11 +15,18 @@ import java.io.IOException;
 import java.time.ZonedDateTime;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
  */
 class VoltageSourceConverterSerDeTest extends AbstractIidmSerDeTest {
+
+    @Test
+    void testMaxPNotSupported() {
+        Network network = createNetworkWithNonDefaultMaxP();
+        assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, tmpDir.resolve("fail")));
+    }
 
     @Test
     void testNetworkVoltageSourceConverter() throws IOException {
@@ -181,6 +189,28 @@ class VoltageSourceConverterSerDeTest extends AbstractIidmSerDeTest {
         vsc3.getTerminal1().setP(-105.); // no Q
         vsc3.getTerminal2().orElseThrow().setQ(-200.8); // no P
 
+        return network;
+    }
+
+    private static Network createNetworkWithNonDefaultMaxP() {
+        Network network = Network.create("voltageSourceConverterTest", "code");
+        network.setCaseDate(ZonedDateTime.parse("2025-01-02T03:04:05.000+01:00"));
+        DcNode dcNode1 = network.newDcNode().setId("dcNode1").setNominalV(500.).add();
+        DcNode dcNode2 = network.newDcNode().setId("dcNode2").setNominalV(500.).add();
+        Substation s = network.newSubstation().setId("S").add();
+        VoltageLevel vl = s.newVoltageLevel().setId("vl").setTopologyKind(TopologyKind.BUS_BREAKER).setNominalV(400.).add();
+        vl.getBusBreakerView().newBus().setId("bus").add();
+        vl.newVoltageSourceConverter()
+                .setId("vsc")
+                .setDcNode1(dcNode1.getId()).setDcConnected1(false)
+                .setDcNode2(dcNode2.getId()).setDcConnected2(false)
+                .setConnectableBus1("bus")
+                .setControlMode(AcDcConverter.ControlMode.V_DC)
+                .setTargetVdc(500.)
+                .setVoltageRegulatorOn(false)
+                .setReactivePowerSetpoint(0.)
+                .setMaxP(500.)
+                .add();
         return network;
     }
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
@@ -975,6 +975,7 @@ public abstract class AbstractAcDcConverterTest {
         network.addListener(minPListener);
         converter.setMinP(-100.0);
         assertTrue(minPListener.updated);
+        network.removeListener(minPListener);
 
         var maxPListener = new DefaultNetworkListener() {
             boolean updated = false;
@@ -992,6 +993,7 @@ public abstract class AbstractAcDcConverterTest {
         network.addListener(maxPListener);
         converter.setMaxP(2000.0);
         assertTrue(maxPListener.updated);
+        network.removeListener(minPListener);
     }
 
     // ---- minP / maxP test methods ----

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
@@ -899,8 +899,8 @@ public abstract class AbstractAcDcConverterTest {
     }
 
     private void checkMinMaxPDefaults(AcDcConverter<?> converter) {
-        assertEquals(Double.NEGATIVE_INFINITY, converter.getMinP());
-        assertEquals(Double.POSITIVE_INFINITY, converter.getMaxP());
+        assertEquals(-Double.MAX_VALUE, converter.getMinP());
+        assertEquals(Double.MAX_VALUE, converter.getMaxP());
     }
 
     private void checkMinMaxPSetter(AcDcConverter<?> converter) {

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
@@ -959,7 +959,7 @@ public abstract class AbstractAcDcConverterTest {
         converter.setMinP(-500.0);
         converter.setMaxP(1000.0);
 
-        var minPListener = new DefaultNetworkListener() {
+        var minPListener = new NetworkListener() {
             boolean updated = false;
 
             @Override
@@ -977,7 +977,7 @@ public abstract class AbstractAcDcConverterTest {
         assertTrue(minPListener.updated);
         network.removeListener(minPListener);
 
-        var maxPListener = new DefaultNetworkListener() {
+        var maxPListener = new NetworkListener() {
             boolean updated = false;
 
             @Override

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
@@ -959,35 +959,39 @@ public abstract class AbstractAcDcConverterTest {
         converter.setMinP(-500.0);
         converter.setMaxP(1000.0);
 
-        boolean[] minPUpdated = new boolean[1];
-        network.addListener(new DefaultNetworkListener() {
+        var minPListener = new DefaultNetworkListener() {
+            boolean updated = false;
+
             @Override
             public void onUpdate(Identifiable<?> identifiable, String attribute, String variantId, Object oldValue, Object newValue) {
                 if ("minP".equals(attribute) && identifiable.getId().equals(converter.getId())) {
                     assertNull(variantId);
                     assertEquals(-500.0, (double) oldValue, 0.0);
                     assertEquals(-100.0, (double) newValue, 0.0);
-                    minPUpdated[0] = true;
+                    updated = true;
                 }
             }
-        });
+        };
+        network.addListener(minPListener);
         converter.setMinP(-100.0);
-        assertTrue(minPUpdated[0]);
+        assertTrue(minPListener.updated);
 
-        boolean[] maxPUpdated = new boolean[1];
-        network.addListener(new DefaultNetworkListener() {
+        var maxPListener = new DefaultNetworkListener() {
+            boolean updated = false;
+
             @Override
             public void onUpdate(Identifiable<?> identifiable, String attribute, String variantId, Object oldValue, Object newValue) {
                 if ("maxP".equals(attribute) && identifiable.getId().equals(converter.getId())) {
                     assertNull(variantId);
                     assertEquals(1000.0, (double) oldValue, 0.0);
                     assertEquals(2000.0, (double) newValue, 0.0);
-                    maxPUpdated[0] = true;
+                    updated = true;
                 }
             }
-        });
+        };
+        network.addListener(maxPListener);
         converter.setMaxP(2000.0);
-        assertTrue(maxPUpdated[0]);
+        assertTrue(maxPListener.updated);
     }
 
     // ---- minP / maxP test methods ----

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
@@ -849,6 +849,185 @@ public abstract class AbstractAcDcConverterTest {
         assertSame(acDcConverterA.getTerminal1(), acDcConverterA.getPccTerminal());
     }
 
+    // ---- minP / maxP test infrastructure ----
+
+    private static final String LCC_TYPE_LABEL = "AC/DC Line Commutated Converter";
+    private static final String VSC_TYPE_LABEL = "AC/DC Voltage Source Converter";
+    private static final String LCC_MIN_MAX_TEST_ID = "lccMinMaxTest";
+    private static final String VSC_MIN_MAX_TEST_ID = "vscMinMaxTest";
+    private static final String LCC_MIN_MAX_TEST_PREFIX = LCC_TYPE_LABEL + " '" + LCC_MIN_MAX_TEST_ID + "'";
+    private static final String VSC_MIN_MAX_TEST_PREFIX = VSC_TYPE_LABEL + " '" + VSC_MIN_MAX_TEST_ID + "'";
+
+    @FunctionalInterface
+    private interface ConverterFactory {
+        AcDcConverter<?> create(double minP, double maxP);
+    }
+
+    private ConverterFactory lccFactory() {
+        return (minP, maxP) -> createLccAdder(vla)
+                .setId(LCC_MIN_MAX_TEST_ID)
+                .setBus1(b1a.getId()).setConnectableBus1(b1a.getId())
+                .setBus2(b2a.getId()).setConnectableBus2(b2a.getId())
+                .setDcNode1(dcNode1a.getId()).setDcNode2(dcNode2a.getId())
+                .setDcConnected1(true).setDcConnected2(true)
+                .setMinP(minP).setMaxP(maxP)
+                .add();
+    }
+
+    private ConverterFactory vscFactory() {
+        return (minP, maxP) -> createVscAdder(vlb)
+                .setId(VSC_MIN_MAX_TEST_ID)
+                .setBus1(b1b.getId()).setConnectableBus1(b1b.getId())
+                .setBus2(b2b.getId()).setConnectableBus2(b2b.getId())
+                .setDcNode1(dcNode1b.getId()).setDcNode2(dcNode2b.getId())
+                .setDcConnected1(true).setDcConnected2(true)
+                .setVoltageRegulatorOn(false).setReactivePowerSetpoint(0.0)
+                .setMinP(minP).setMaxP(maxP)
+                .add();
+    }
+
+    private void checkMinMaxPDefaults(AcDcConverter<?> converter) {
+        assertEquals(Double.NEGATIVE_INFINITY, converter.getMinP());
+        assertEquals(Double.POSITIVE_INFINITY, converter.getMaxP());
+    }
+
+    private void checkMinMaxPSetter(AcDcConverter<?> converter) {
+        converter.setMinP(-500.0);
+        assertEquals(-500.0, converter.getMinP());
+        converter.setMaxP(1000.0);
+        assertEquals(1000.0, converter.getMaxP());
+    }
+
+    private void checkMinMaxPAdder(ConverterFactory factory) {
+        AcDcConverter<?> converter = factory.create(-200.0, 800.0);
+        assertEquals(-200.0, converter.getMinP());
+        assertEquals(800.0, converter.getMaxP());
+    }
+
+    private static String converterLabel(AcDcConverter<?> converter) {
+        String typeLabel = switch (converter.getType()) {
+            case LINE_COMMUTATED_CONVERTER -> LCC_TYPE_LABEL;
+            case VOLTAGE_SOURCE_CONVERTER -> VSC_TYPE_LABEL;
+            default -> throw new IllegalStateException("Unknown type: " + converter.getType());
+        };
+        return typeLabel + " '" + converter.getId() + "'";
+    }
+
+    private void checkMinMaxPSetterRejectsNaN(AcDcConverter<?> converter) {
+        String prefix = converterLabel(converter);
+        PowsyblException e1 = assertThrows(PowsyblException.class, () -> converter.setMinP(Double.NaN));
+        assertEquals(prefix + ": invalid value (NaN) for minimum P", e1.getMessage());
+        PowsyblException e2 = assertThrows(PowsyblException.class, () -> converter.setMaxP(Double.NaN));
+        assertEquals(prefix + ": invalid value (NaN) for maximum P", e2.getMessage());
+    }
+
+    private void checkMinMaxPAdderRejectsNaN(ConverterFactory factory, String expectedPrefix) {
+        PowsyblException e1 = assertThrows(PowsyblException.class, () -> factory.create(Double.NaN, 1000.0));
+        assertEquals(expectedPrefix + ": invalid value (NaN) for minimum P", e1.getMessage());
+        PowsyblException e2 = assertThrows(PowsyblException.class, () -> factory.create(-500.0, Double.NaN));
+        assertEquals(expectedPrefix + ": invalid value (NaN) for maximum P", e2.getMessage());
+    }
+
+    private void checkMinMaxPSetterRejectsInconsistentLimits(AcDcConverter<?> converter) {
+        String prefix = converterLabel(converter);
+        converter.setMinP(-500.0);
+        converter.setMaxP(1000.0);
+        PowsyblException e1 = assertThrows(PowsyblException.class, () -> converter.setMinP(2000.0));
+        assertEquals(prefix + ": invalid active limits [2000.0, 1000.0]", e1.getMessage());
+        PowsyblException e2 = assertThrows(PowsyblException.class, () -> converter.setMaxP(-1000.0));
+        assertEquals(prefix + ": invalid active limits [-500.0, -1000.0]", e2.getMessage());
+    }
+
+    private void checkMinMaxPAdderRejectsInconsistentLimits(ConverterFactory factory, String expectedPrefix) {
+        PowsyblException e = assertThrows(PowsyblException.class, () -> factory.create(2000.0, 1000.0));
+        assertEquals(expectedPrefix + ": invalid active limits [2000.0, 1000.0]", e.getMessage());
+    }
+
+    private void checkMinMaxPNotifyUpdate(AcDcConverter<?> converter) {
+        converter.setMinP(-500.0);
+        converter.setMaxP(1000.0);
+
+        boolean[] minPUpdated = new boolean[1];
+        network.addListener(new DefaultNetworkListener() {
+            @Override
+            public void onUpdate(Identifiable<?> identifiable, String attribute, String variantId, Object oldValue, Object newValue) {
+                if ("minP".equals(attribute) && identifiable.getId().equals(converter.getId())) {
+                    assertNull(variantId);
+                    assertEquals(-500.0, (double) oldValue, 0.0);
+                    assertEquals(-100.0, (double) newValue, 0.0);
+                    minPUpdated[0] = true;
+                }
+            }
+        });
+        converter.setMinP(-100.0);
+        assertTrue(minPUpdated[0]);
+
+        boolean[] maxPUpdated = new boolean[1];
+        network.addListener(new DefaultNetworkListener() {
+            @Override
+            public void onUpdate(Identifiable<?> identifiable, String attribute, String variantId, Object oldValue, Object newValue) {
+                if ("maxP".equals(attribute) && identifiable.getId().equals(converter.getId())) {
+                    assertNull(variantId);
+                    assertEquals(1000.0, (double) oldValue, 0.0);
+                    assertEquals(2000.0, (double) newValue, 0.0);
+                    maxPUpdated[0] = true;
+                }
+            }
+        });
+        converter.setMaxP(2000.0);
+        assertTrue(maxPUpdated[0]);
+    }
+
+    // ---- minP / maxP test methods ----
+
+    @Test
+    public void testMinMaxPDefaultValues() {
+        checkMinMaxPDefaults(createLccA(vla));
+        checkMinMaxPDefaults(createVscB(vlb));
+    }
+
+    @Test
+    public void testMinMaxPSetter() {
+        checkMinMaxPSetter(createLccA(vla));
+        checkMinMaxPSetter(createVscB(vlb));
+    }
+
+    @Test
+    public void testMinMaxPAdder() {
+        checkMinMaxPAdder(lccFactory());
+        checkMinMaxPAdder(vscFactory());
+    }
+
+    @Test
+    public void testMinMaxPSetterRejectsNaN() {
+        checkMinMaxPSetterRejectsNaN(createLccA(vla));
+        checkMinMaxPSetterRejectsNaN(createVscB(vlb));
+    }
+
+    @Test
+    public void testMinMaxPAdderRejectsNaN() {
+        checkMinMaxPAdderRejectsNaN(lccFactory(), LCC_MIN_MAX_TEST_PREFIX);
+        checkMinMaxPAdderRejectsNaN(vscFactory(), VSC_MIN_MAX_TEST_PREFIX);
+    }
+
+    @Test
+    public void testMinMaxPSetterRejectsInconsistentLimits() {
+        checkMinMaxPSetterRejectsInconsistentLimits(createLccA(vla));
+        checkMinMaxPSetterRejectsInconsistentLimits(createVscB(vlb));
+    }
+
+    @Test
+    public void testMinMaxPAdderRejectsInconsistentLimits() {
+        checkMinMaxPAdderRejectsInconsistentLimits(lccFactory(), LCC_MIN_MAX_TEST_PREFIX);
+        checkMinMaxPAdderRejectsInconsistentLimits(vscFactory(), VSC_MIN_MAX_TEST_PREFIX);
+    }
+
+    @Test
+    public void testMinMaxPNotifyUpdate() {
+        checkMinMaxPNotifyUpdate(createLccA(vla));
+        checkMinMaxPNotifyUpdate(createVscB(vlb));
+    }
+
     @Test
     public void testSetterGetterInMultiVariants() {
         VoltageSourceConverter vscA = vla.newVoltageSourceConverter()

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
@@ -498,11 +498,23 @@ public abstract class AbstractAcDcConverterTest {
         PowsyblException e6 = assertThrows(PowsyblException.class, acDcConverterA::getResistiveLoss);
         assertEquals("Cannot access resistiveLoss of removed equipment converterA", e6.getMessage());
 
-        PowsyblException e7 = assertThrows(PowsyblException.class, t1::isConnected);
-        assertEquals("Cannot access removed equipment converterA", e7.getMessage());
+        PowsyblException e7 = assertThrows(PowsyblException.class, () -> acDcConverterA.setMinP(2.));
+        assertEquals("Cannot modify minP of removed equipment converterA", e7.getMessage());
 
-        PowsyblException e8 = assertThrows(PowsyblException.class, () -> t2.setConnected(false));
-        assertEquals("Cannot modify removed equipment converterA", e8.getMessage());
+        PowsyblException e8 = assertThrows(PowsyblException.class, acDcConverterA::getMinP);
+        assertEquals("Cannot access minP of removed equipment converterA", e8.getMessage());
+
+        PowsyblException e9 = assertThrows(PowsyblException.class, () -> acDcConverterA.setMaxP(2.));
+        assertEquals("Cannot modify maxP of removed equipment converterA", e9.getMessage());
+
+        PowsyblException e10 = assertThrows(PowsyblException.class, acDcConverterA::getMaxP);
+        assertEquals("Cannot access maxP of removed equipment converterA", e10.getMessage());
+
+        PowsyblException e11 = assertThrows(PowsyblException.class, t1::isConnected);
+        assertEquals("Cannot access removed equipment converterA", e11.getMessage());
+
+        PowsyblException e12 = assertThrows(PowsyblException.class, () -> t2.setConnected(false));
+        assertEquals("Cannot modify removed equipment converterA", e12.getMessage());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
https://github.com/powsybl/powsybl-core/issues/3954

**What kind of change does this PR introduce?**
Introduce AC power limits for AC-DC converters.

**What is the current behavior?**
No power bounds.

**What is the new behavior (if this is a feature change)?**
It is possible to define AC power bounds for AC-DC converters.
**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
- Implementations of `AcDcConverterAdder` will need to implement methods `setMinP` and `setMaxP` to set power limits of ACDC converters.
- Implementations of `AcDcConverter` will need to implement methods `getMinP`, `setMinP`, `getMaxP` and `setMaxP`.
- Default values are -Double.MAX_VALUE (resp. Double.MAX_VALUE) for minP (resp. maxP) so you only need to assign these bounds if you actually need them.

**Other information**:
The intention is to carry on with the implementation in Open Load Flow after the 2026.1 release.

Serialization and deserialization are not implemented due to the short time before the release train. They are intended to be implemented in IIDM 1.18, in the 2026.2 release. This is supposed to avoid increased risk.
