### PR TITLE
IIDM Modification - Scaling: Fix scalingType missing from JSON and Platform Config

### DIFF
--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/ScalingParameters.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/ScalingParameters.java
@@ -266,6 +266,7 @@ public class ScalingParameters {
         ScalingParameters scalingParameters = new ScalingParameters();
         platformConfig.getOptionalModuleConfig("scaling-default-parameters").ifPresent(config -> {
             scalingParameters.setScalingConvention(config.getEnumProperty("scalingConvention", Scalable.ScalingConvention.class, DEFAULT_SCALING_CONVENTION));
+            scalingParameters.setScalingType(config.getEnumProperty("scalingType", ScalingParameters.ScalingType.class, DEFAULT_SCALING_TYPE));
             scalingParameters.setConstantPowerFactor(config.getBooleanProperty("constantPowerFactor", DEFAULT_CONSTANT_POWER_FACTOR));
             scalingParameters.setReconnect(config.getBooleanProperty("reconnect", DEFAULT_RECONNECT));
             scalingParameters.setPriority(config.getEnumProperty("priority", ScalingParameters.Priority.class, DEFAULT_PRIORITY));

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/json/ScalingParametersDeserializer.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/json/ScalingParametersDeserializer.java
@@ -50,6 +50,11 @@ public class ScalingParametersDeserializer extends StdDeserializer<ScalingParame
                     parser.nextToken();
                     parameters.setScalingConvention(JsonUtil.readValue(context, parser, Scalable.ScalingConvention.class));
                 }
+                case "scalingType" -> {
+                    JsonUtil.assertGreaterOrEqualThanReferenceVersion(CONTEXT_NAME, "Tag: scalingType", version, "1.3");
+                    parser.nextToken();
+                    parameters.setScalingType(JsonUtil.readValue(context, parser, ScalingParameters.ScalingType.class));
+                }
                 case "constantPowerFactor" -> {
                     parser.nextToken();
                     parameters.setConstantPowerFactor(parser.readValueAs(Boolean.class));

--- a/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/json/ScalingParametersSerializer.java
+++ b/iidm/iidm-modification/src/main/java/com/powsybl/iidm/modification/scalable/json/ScalingParametersSerializer.java
@@ -29,6 +29,7 @@ public class ScalingParametersSerializer extends StdSerializer<ScalingParameters
 
         jsonGenerator.writeStringField("version", ScalingParameters.VERSION);
         jsonGenerator.writeStringField("scalingConvention", scalingParameters.getScalingConvention().name());
+        jsonGenerator.writeStringField("scalingType", scalingParameters.getScalingType().name());
         jsonGenerator.writeBooleanField("constantPowerFactor", scalingParameters.isConstantPowerFactor());
         jsonGenerator.writeBooleanField("reconnect", scalingParameters.isReconnect());
         jsonGenerator.writeStringField("priority", scalingParameters.getPriority().name());

--- a/iidm/iidm-modification/src/test/resources/json/ScalingParameters.json
+++ b/iidm/iidm-modification/src/test/resources/json/ScalingParameters.json
@@ -1,6 +1,7 @@
 {
   "version" : "1.3",
   "scalingConvention" : "LOAD",
+  "scalingType" : "DELTA_P",
   "constantPowerFactor" : false,
   "reconnect" : true,
   "priority" : "ONESHOT",

--- a/iidm/iidm-modification/src/test/resources/json/ScalingParameters_v1.3.json
+++ b/iidm/iidm-modification/src/test/resources/json/ScalingParameters_v1.3.json
@@ -1,6 +1,7 @@
 {
   "version" : "1.3",
   "scalingConvention" : "LOAD",
+  "scalingType" : "DELTA_P",
   "constantPowerFactor" : false,
   "reconnect" : true,
   "priority" : "ONESHOT",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
ScalingType parameter missing from PlatformConfig and JSON SerDe of ScalingParameters.


**What is the new behavior (if this is a feature change)?**
ScalingType parameter handling added for PlatformConfig and JSON SerDe of ScalingParameters.



**Does this PR introduce a breaking change or deprecate an API?**
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
ScalingParameters JSON version bump to 1.3 was already made for this release in #3896.