### PR TITLE
Export updated network with the dynamic simulation tool

### DIFF
--- a/docs/user/itools/dynamic-simulation.md
+++ b/docs/user/itools/dynamic-simulation.md
@@ -5,6 +5,7 @@ In the end, the results and the modified network can be exported to files.
 
 ## Usage
 ```
+$> itools dynamic-simulation --help
 usage: itools [OPTIONS] dynamic-simulation --case-file <FILE> [--output-variables-file
        <FILE>] --dynamic-models-file <FILE> [--event-models-file <FILE>]
        [--help] [-I <property=value>] [--import-parameters <IMPORT_PARAMETERS>]
@@ -32,6 +33,9 @@ Available arguments are:
  -I <property=value>                          use value for given importer
                                               parameter
     --import-parameters <IMPORT_PARAMETERS>   the importer configuation file
+    --output-case-file <FILE>                 modified network base name
+    --output-case-format <CASE_FORMAT>         modified network output format
+                                              [CGMES, AMPL, JIIDM, XIIDM, BIIDM]
     --output-file <FILE>                      dynamic simulation results output
                                               path
     --parameters-file <FILE>                  dynamic simulation parameters as

--- a/docs/user/itools/dynamic-simulation.md
+++ b/docs/user/itools/dynamic-simulation.md
@@ -24,6 +24,9 @@ Available arguments are:
                                               Groovy file: defines the dynamic
                                               models to be associated to chosen
                                               equipments of the network
+-E <property=value>                           use value for given exporter
+                                              parameter
+    --export-parameters <EXPORT_PARAMETERS>   the exporter configuration file    
     --event-models-file <FILE>                dynamic event models description
                                               as a Groovy file: defines the
                                               dynamic event models to be
@@ -33,8 +36,8 @@ Available arguments are:
  -I <property=value>                          use value for given importer
                                               parameter
     --import-parameters <IMPORT_PARAMETERS>   the importer configuation file
-    --output-case-file <FILE>                 modified network base name
-    --output-case-format <CASE_FORMAT>         modified network output format
+    --output-case-file <FILE>                 modified network path
+    --output-case-format <CASE_FORMAT>        modified network output format
                                               [CGMES, AMPL, JIIDM, XIIDM, BIIDM]
     --output-file <FILE>                      dynamic simulation results output
                                               path

--- a/docs/user/itools/list-dynamic-simulation-models.md
+++ b/docs/user/itools/list-dynamic-simulation-models.md
@@ -4,6 +4,7 @@ The `list-dynamic-simulation-models` command lists all models used by the [time 
 
 ## Usage
 ```
+$> itools list-dynamic-simulation-models --help
 usage: itools [OPTIONS] list-dynamic-simulation-models [--dynamic-models]
        [--event-models] [--help]
 

--- a/dynamic-simulation/dynamic-simulation-tool/src/main/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationTool.java
+++ b/dynamic-simulation/dynamic-simulation-tool/src/main/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationTool.java
@@ -16,6 +16,7 @@ import com.powsybl.dynamicsimulation.groovy.DynamicSimulationReports;
 import com.powsybl.dynamicsimulation.groovy.DynamicSimulationSupplierFactory;
 import com.powsybl.dynamicsimulation.json.DynamicSimulationResultSerializer;
 import com.powsybl.dynamicsimulation.json.JsonDynamicSimulationParameters;
+import com.powsybl.iidm.network.Exporter;
 import com.powsybl.iidm.network.ImportConfig;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VariantManagerConstants;
@@ -26,6 +27,7 @@ import com.powsybl.tools.ToolRunningContext;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -33,6 +35,8 @@ import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.file.Path;
 import java.util.Properties;
+
+import static com.powsybl.iidm.network.tools.ConversionToolUtils.readProperties;
 
 /**
  * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
@@ -47,6 +51,8 @@ public class DynamicSimulationTool implements Tool {
     private static final String PARAMETERS_FILE = "parameters-file";
     private static final String OUTPUT_FILE = "output-file";
     private static final String OUTPUT_LOG_FILE = "output-log-file";
+    private static final String OUTPUT_CASE_FILE = "output-case-file";
+    private static final String OUTPUT_CASE_FORMAT = "output-case-format";
 
     @Override
     public Command getCommand() {
@@ -70,43 +76,61 @@ public class DynamicSimulationTool implements Tool {
             @Override
             public Options getOptions() {
                 Options options = new Options();
-                options.addOption(Option.builder().longOpt(CASE_FILE)
-                    .desc("the case path")
-                    .hasArg()
-                    .argName("FILE")
-                    .required()
-                    .build());
-                options.addOption(Option.builder().longOpt(DYNAMIC_MODELS_FILE)
-                    .desc("dynamic models description as a Groovy file: defines the dynamic models to be associated to chosen equipments of the network")
-                    .hasArg()
-                    .argName("FILE")
-                    .required()
-                    .build());
-                options.addOption(Option.builder().longOpt(EVENT_MODELS_FILE)
-                    .desc("dynamic event models description as a Groovy file: defines the dynamic event models to be associated to chosen equipments of the network")
-                    .hasArg()
-                    .argName("FILE")
-                    .build());
-                options.addOption(Option.builder().longOpt(OUTPUT_VARIABLES_FILE)
-                    .desc("output variables description as Groovy file: defines a list of variables to plot or get the final value")
-                    .hasArg()
-                    .argName("FILE")
-                    .build());
-                options.addOption(Option.builder().longOpt(PARAMETERS_FILE)
-                    .desc("dynamic simulation parameters as JSON file")
-                    .hasArg()
-                    .argName("FILE")
-                    .build());
-                options.addOption(Option.builder().longOpt(OUTPUT_FILE)
-                    .desc("dynamic simulation results output path")
-                    .hasArg()
-                    .argName("FILE")
-                    .build());
-                options.addOption(Option.builder().longOpt(OUTPUT_LOG_FILE)
-                    .desc("dynamic simulation logs output path")
-                    .hasArg()
-                    .argName("FILE")
-                    .build());
+                options.addOption(Option.builder()
+                        .longOpt(CASE_FILE)
+                        .desc("the case path")
+                        .hasArg()
+                        .argName("FILE")
+                        .required()
+                        .get());
+                options.addOption(Option.builder()
+                        .longOpt(DYNAMIC_MODELS_FILE)
+                        .desc("dynamic models description as a Groovy file: defines the dynamic models to be associated to chosen equipments of the network")
+                        .hasArg()
+                        .argName("FILE")
+                        .required()
+                        .get());
+                options.addOption(Option.builder()
+                        .longOpt(EVENT_MODELS_FILE)
+                        .desc("dynamic event models description as a Groovy file: defines the dynamic event models to be associated to chosen equipments of the network")
+                        .hasArg()
+                        .argName("FILE")
+                        .get());
+                options.addOption(Option.builder()
+                        .longOpt(OUTPUT_VARIABLES_FILE)
+                        .desc("output variables description as Groovy file: defines a list of variables to plot or get the final value")
+                        .hasArg()
+                        .argName("FILE")
+                        .get());
+                options.addOption(Option.builder()
+                        .longOpt(PARAMETERS_FILE)
+                        .desc("dynamic simulation parameters as JSON file")
+                        .hasArg()
+                        .argName("FILE")
+                        .get());
+                options.addOption(Option.builder()
+                        .longOpt(OUTPUT_FILE)
+                        .desc("dynamic simulation results output path")
+                        .hasArg()
+                        .argName("FILE")
+                        .get());
+                options.addOption(Option.builder()
+                        .longOpt(OUTPUT_LOG_FILE)
+                        .desc("dynamic simulation logs output path")
+                        .hasArg()
+                        .argName("FILE")
+                        .get());
+                options.addOption(Option.builder()
+                        .longOpt(OUTPUT_CASE_FILE)
+                        .desc("modified network base name")
+                        .hasArg()
+                        .argName("FILE").get());
+                options.addOption(Option.builder()
+                        .longOpt(OUTPUT_CASE_FORMAT)
+                        .desc("modified network output format " + Exporter.getFormats())
+                        .hasArg()
+                        .argName("CASE_FORMAT")
+                        .get());
                 options.addOption(ConversionToolUtils.createImportParametersFileOption());
                 options.addOption(ConversionToolUtils.createImportParameterOption());
                 return options;
@@ -125,8 +149,19 @@ public class DynamicSimulationTool implements Tool {
         Path caseFile = context.getFileSystem().getPath(line.getOptionValue(CASE_FILE));
         // process a single network: output-file/output-format options available
 
+        Path outputCaseFile = null;
+        String outputCaseFormat = null;
+        if (line.hasOption(OUTPUT_CASE_FILE)) {
+            outputCaseFile = context.getFileSystem().getPath(line.getOptionValue(OUTPUT_CASE_FILE));
+            if (line.hasOption(OUTPUT_CASE_FORMAT)) {
+                outputCaseFormat = line.getOptionValue(OUTPUT_CASE_FORMAT);
+            } else {
+                throw new ParseException("Missing required option: " + OUTPUT_CASE_FORMAT);
+            }
+        }
+
         context.getOutputStream().println("Loading network '" + caseFile + "'");
-        Properties inputParams = ConversionToolUtils.readProperties(line, ConversionToolUtils.OptionType.IMPORT, context);
+        Properties inputParams = readProperties(line, ConversionToolUtils.OptionType.IMPORT, context);
         Network network = Network.read(caseFile, context.getShortTimeExecutionComputationManager(), ImportConfig.load(), inputParams);
         if (network == null) {
             throw new PowsyblException("Case '" + caseFile + "' not found");
@@ -170,6 +205,12 @@ public class DynamicSimulationTool implements Tool {
             exportResult(result, context, outputFile);
         } else {
             printResult(result, context);
+        }
+
+        if (outputCaseFile != null) {
+            context.getOutputStream().println("Writing case file to '" + outputCaseFile + "'");
+            Properties outputParams = readProperties(line, ConversionToolUtils.OptionType.EXPORT, context);
+            network.write(outputCaseFormat, outputParams, outputCaseFile);
         }
     }
 

--- a/dynamic-simulation/dynamic-simulation-tool/src/main/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationTool.java
+++ b/dynamic-simulation/dynamic-simulation-tool/src/main/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationTool.java
@@ -36,8 +36,6 @@ import java.io.Writer;
 import java.nio.file.Path;
 import java.util.Properties;
 
-import static com.powsybl.iidm.network.tools.ConversionToolUtils.readProperties;
-
 /**
  * @author Marcos de Miguel {@literal <demiguelm at aia.es>}
  */
@@ -124,7 +122,8 @@ public class DynamicSimulationTool implements Tool {
                         .longOpt(OUTPUT_CASE_FILE)
                         .desc("modified network base name")
                         .hasArg()
-                        .argName("FILE").get());
+                        .argName("FILE")
+                        .get());
                 options.addOption(Option.builder()
                         .longOpt(OUTPUT_CASE_FORMAT)
                         .desc("modified network output format " + Exporter.getFormats())
@@ -133,6 +132,8 @@ public class DynamicSimulationTool implements Tool {
                         .get());
                 options.addOption(ConversionToolUtils.createImportParametersFileOption());
                 options.addOption(ConversionToolUtils.createImportParameterOption());
+                options.addOption(ConversionToolUtils.createExportParametersFileOption());
+                options.addOption(ConversionToolUtils.createExportParameterOption());
                 return options;
             }
 
@@ -161,7 +162,7 @@ public class DynamicSimulationTool implements Tool {
         }
 
         context.getOutputStream().println("Loading network '" + caseFile + "'");
-        Properties inputParams = readProperties(line, ConversionToolUtils.OptionType.IMPORT, context);
+        Properties inputParams = ConversionToolUtils.readProperties(line, ConversionToolUtils.OptionType.IMPORT, context);
         Network network = Network.read(caseFile, context.getShortTimeExecutionComputationManager(), ImportConfig.load(), inputParams);
         if (network == null) {
             throw new PowsyblException("Case '" + caseFile + "' not found");
@@ -209,7 +210,7 @@ public class DynamicSimulationTool implements Tool {
 
         if (outputCaseFile != null) {
             context.getOutputStream().println("Writing case file to '" + outputCaseFile + "'");
-            Properties outputParams = readProperties(line, ConversionToolUtils.OptionType.EXPORT, context);
+            Properties outputParams = ConversionToolUtils.readProperties(line, ConversionToolUtils.OptionType.EXPORT, context);
             network.write(outputCaseFormat, outputParams, outputCaseFile);
         }
     }

--- a/dynamic-simulation/dynamic-simulation-tool/src/test/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationToolTest.java
+++ b/dynamic-simulation/dynamic-simulation-tool/src/test/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationToolTest.java
@@ -39,7 +39,7 @@ class DynamicSimulationToolTest extends AbstractToolTest {
     public void assertCommand() {
         Command command = tool.getCommand();
 
-        assertCommand(command, "dynamic-simulation", 9, 2);
+        assertCommand(command, "dynamic-simulation", 11, 2);
         assertEquals("Computation", command.getTheme());
         assertEquals("Run dynamic simulation", command.getDescription());
         assertNull(command.getUsageFooter());
@@ -49,6 +49,8 @@ class DynamicSimulationToolTest extends AbstractToolTest {
         assertOption(command.getOptions(), "output-variables-file", false, true);
         assertOption(command.getOptions(), "output-file", false, true);
         assertOption(command.getOptions(), "output-log-file", false, true);
+        assertOption(command.getOptions(), "output-case-file", false, true);
+        assertOption(command.getOptions(), "output-case-format", false, true);
     }
 
     @BeforeEach
@@ -112,6 +114,22 @@ class DynamicSimulationToolTest extends AbstractToolTest {
         String expectedOutputFile = "Dynamic Simulation Tool\n";
         assertCommandSuccessful(new String[]{"dynamic-simulation", "--case-file", "/network.xiidm", "--dynamic-models-file", "/dynamicModels.groovy", "--output-log-file", "outputTest.log"}, expectedOut);
         ComparisonUtils.assertTxtEquals(expectedOutputFile, Files.newInputStream(fileSystem.getPath("outputTest.log")));
+    }
+
+    @Test
+    void testDynamicSimulationWithOutputCaseFile() throws IOException {
+        String expectedOut = String.join(System.lineSeparator(),
+                "Loading network '/network.xiidm'",
+                "Dynamic Simulation Tool",
+                "dynamic simulation results:",
+                "+---------+",
+                "| Result  |",
+                "+---------+",
+                "| SUCCESS |",
+                "+---------+",
+                "Writing case file to 'outputCaseFile.xiidm'" + System.lineSeparator());
+        assertCommandSuccessful(new String[]{"dynamic-simulation", "--case-file", "/network.xiidm", "--dynamic-models-file", "/dynamicModels.groovy", "--output-case-file", "outputCaseFile.xiidm", "--output-case-format", "XIIDM"}, expectedOut);
+        ComparisonUtils.assertXmlEquals(getClass().getResourceAsStream("/network.xiidm"), Files.newInputStream(fileSystem.getPath("outputCaseFile.xiidm")));
     }
 
     @Test

--- a/dynamic-simulation/dynamic-simulation-tool/src/test/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationToolTest.java
+++ b/dynamic-simulation/dynamic-simulation-tool/src/test/java/com/powsybl/dynamicsimulation/tool/DynamicSimulationToolTest.java
@@ -39,7 +39,7 @@ class DynamicSimulationToolTest extends AbstractToolTest {
     public void assertCommand() {
         Command command = tool.getCommand();
 
-        assertCommand(command, "dynamic-simulation", 11, 2);
+        assertCommand(command, "dynamic-simulation", 13, 2);
         assertEquals("Computation", command.getTheme());
         assertEquals("Run dynamic simulation", command.getDescription());
         assertNull(command.getUsageFooter());
@@ -51,6 +51,10 @@ class DynamicSimulationToolTest extends AbstractToolTest {
         assertOption(command.getOptions(), "output-log-file", false, true);
         assertOption(command.getOptions(), "output-case-file", false, true);
         assertOption(command.getOptions(), "output-case-format", false, true);
+        assertOption(command.getOptions(), "import-parameters", false, true);
+        assertOption(command.getOptions(), "I", false, true);
+        assertOption(command.getOptions(), "export-parameters", false, true);
+        assertOption(command.getOptions(), "E", false, true);
     }
 
     @BeforeEach

--- a/dynamic-simulation/dynamic-simulation-tool/src/test/resources/network.xiidm
+++ b/dynamic-simulation/dynamic-simulation-tool/src/test/resources/network.xiidm
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_4" id="network" caseDate="2019-11-07T10:30:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" id="network" caseDate="2019-11-07T10:30:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
 </iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`DynamicSimulationTool` cannot export the updated network after a dynamic simulation.


**What is the new behavior (if this is a feature change)?**
`DynamicSimulationTool` export the updated network using the 2 options `output-case-file` and `output-case-format`.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
