### PR TITLE
Fix use of channels for biidm and network copy

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/binary/BinReader.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BinReader.java
@@ -94,10 +94,7 @@ public class BinReader extends AbstractTreeDataReader {
     }
 
     private int readNameIndex() {
-        if (in.isEndOfStream()) {
-            return END_OF_FILE;
-        }
-        return in.readUnsignedShort();
+        return in.readOptionalUnsignedShort();
     }
 
     private boolean isAttrAbsent(String name) {

--- a/commons/src/main/java/com/powsybl/commons/binary/BinWriter.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BinWriter.java
@@ -30,7 +30,7 @@ public class BinWriter extends AbstractTreeDataWriter {
     private final String rootVersion;
     private final byte[] binaryMagicNumber;
     private final OutputStream outputStream;
-    private final GrowingByteBuffer body = new GrowingByteBuffer();
+    private final SegmentedByteBuffer body = new SegmentedByteBuffer();
     private final Map<TypedName, Integer> namesIndex = new LinkedHashMap<>();
     private Map<String, String> extensionVersions = Collections.emptyMap();
 
@@ -42,7 +42,7 @@ public class BinWriter extends AbstractTreeDataWriter {
         this.rootVersion = Objects.requireNonNull(rootVersion);
     }
 
-    private static void writeString(String value, GrowingByteBuffer buf) {
+    private static void writeString(String value, SegmentedByteBuffer buf) {
         if (value == null) {
             buf.writeShort(NULL_STRING_SENTINEL);
             return;
@@ -213,8 +213,8 @@ public class BinWriter extends AbstractTreeDataWriter {
         }
     }
 
-    private GrowingByteBuffer buildHeader() {
-        GrowingByteBuffer header = new GrowingByteBuffer(HEADER_BLOCK_SIZE);
+    private SegmentedByteBuffer buildHeader() {
+        SegmentedByteBuffer header = new SegmentedByteBuffer(HEADER_BLOCK_SIZE);
         header.writeBytes(binaryMagicNumber);
         writeString(rootVersion, header);
 

--- a/commons/src/main/java/com/powsybl/commons/binary/BinWriter.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BinWriter.java
@@ -25,8 +25,6 @@ import static com.powsybl.commons.binary.BinUtil.*;
  */
 public class BinWriter extends AbstractTreeDataWriter {
 
-    private static final int HEADER_BLOCK_SIZE = 4 * 1024;
-
     private final String rootVersion;
     private final byte[] binaryMagicNumber;
     private final OutputStream outputStream;
@@ -40,19 +38,6 @@ public class BinWriter extends AbstractTreeDataWriter {
         this.outputStream = Objects.requireNonNull(os);
         this.binaryMagicNumber = Objects.requireNonNull(binaryMagicNumber);
         this.rootVersion = Objects.requireNonNull(rootVersion);
-    }
-
-    private static void writeString(String value, SegmentedByteBuffer buf) {
-        if (value == null) {
-            buf.writeShort(NULL_STRING_SENTINEL);
-            return;
-        }
-        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
-        if (bytes.length >= NULL_STRING_SENTINEL) {
-            throw new PowsyblException("Binary format: string too long (max " + (NULL_STRING_SENTINEL - 1) + " bytes)");
-        }
-        buf.writeShort(bytes.length);
-        buf.writeBytes(bytes);
     }
 
     @Override
@@ -102,13 +87,44 @@ public class BinWriter extends AbstractTreeDataWriter {
     @Override
     public void writeNodeContent(String value) {
         writeEntry("", TYPE_STRING_CONTENT);
-        writeString(value, body);
+        writeString(value);
     }
 
     @Override
     public void writeStringAttribute(String name, String value) {
         writeEntry(name, TYPE_STRING);
-        writeString(value, body);
+        writeString(value);
+    }
+
+    private void writeString(String value) {
+        if (value == null) {
+            body.writeShort(NULL_STRING_SENTINEL);
+            return;
+        }
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length >= NULL_STRING_SENTINEL) {
+            throw new PowsyblException("Binary format: string too long (max " + (NULL_STRING_SENTINEL - 1) + " bytes)");
+        }
+        body.writeShort(bytes.length);
+        body.writeBytes(bytes);
+    }
+
+    private static void writeString(String value, OutputStream out) throws IOException {
+        if (value == null) {
+            writeShort(out, NULL_STRING_SENTINEL);
+            return;
+        }
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length >= NULL_STRING_SENTINEL) {
+            throw new PowsyblException("Binary format: string too long (max " + (NULL_STRING_SENTINEL - 1) + " bytes)");
+        }
+        writeShort(out, bytes.length);
+        out.write(bytes);
+    }
+
+    private static void writeShort(OutputStream out, int s) throws IOException {
+        out.write((s >>> 8) & 0xFF);
+        out.write(s & 0xFF);
     }
 
     @Override
@@ -194,7 +210,7 @@ public class BinWriter extends AbstractTreeDataWriter {
         writeEntry(name, TYPE_STRING_ARRAY);
         body.writeShort(values.size());
         for (String s : values) {
-            writeString(s, body);
+            writeString(s);
         }
     }
 
@@ -206,29 +222,28 @@ public class BinWriter extends AbstractTreeDataWriter {
     @Override
     public void close() {
         try (var zstdOut = new ZstdOutputStream(outputStream, -2).setChecksum(false)) {
-            buildHeader().writeTo(zstdOut);
+            writeHeader(zstdOut);
             body.writeTo(zstdOut);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
-    private SegmentedByteBuffer buildHeader() {
-        SegmentedByteBuffer header = new SegmentedByteBuffer(HEADER_BLOCK_SIZE);
-        header.writeBytes(binaryMagicNumber);
-        writeString(rootVersion, header);
+    private void writeHeader(OutputStream out) throws IOException {
+        out.write(binaryMagicNumber);
+        writeString(rootVersion, out);
 
-        header.writeShort(extensionVersions.size());
+        writeShort(out, extensionVersions.size());
         for (var entry : extensionVersions.entrySet()) {
-            writeString(entry.getKey(), header);
-            writeString(entry.getValue(), header);
+            writeString(entry.getKey(), out);
+            writeString(entry.getValue(), out);
         }
 
-        header.writeShort(namesIndex.size());
+        writeShort(out, namesIndex.size());
         for (TypedName key : namesIndex.keySet()) {
-            writeString(key.name(), header);
-            header.writeByte(key.type());
+            writeString(key.name(), out);
+            out.write(key.type());
         }
-        return header;
+        out.flush();
     }
 }

--- a/commons/src/main/java/com/powsybl/commons/binary/BufferedChannelReader.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BufferedChannelReader.java
@@ -75,6 +75,19 @@ final class BufferedChannelReader implements AutoCloseable {
         return Short.toUnsignedInt(buffer.getShort());
     }
 
+    /**
+     * Reads an unsigned short, or returns {@link BinUtil#END_OF_FILE} if the end of the stream is reached before.
+     */
+    int readOptionalUnsignedShort() {
+        int readCount = fill(2);
+        if (readCount == 0) {
+            return BinUtil.END_OF_FILE;
+        } else if (readCount < 2) {
+            throw new PowsyblException("Unexpected end of stream: needed 2 bytes, got only 1");
+        }
+        return Short.toUnsignedInt(buffer.getShort());
+    }
+
     int readInt() {
         require(4);
         return buffer.getInt();
@@ -118,14 +131,6 @@ final class BufferedChannelReader implements AutoCloseable {
             buffer.position(buffer.position() + skip);
             remaining -= skip;
         }
-    }
-
-    /** Returns true when no more bytes are available in the buffer or the channel. */
-    boolean isEndOfStream() {
-        if (buffer.hasRemaining()) {
-            return false;
-        }
-        return fill(1) == 0;
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/binary/BufferedChannelReader.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BufferedChannelReader.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  */
 final class BufferedChannelReader implements AutoCloseable {
 
-    static final int DEFAULT_BUFFER_SIZE = 64 * 1024;
+    static final int DEFAULT_BUFFER_SIZE = 8 * 1024;
 
     private final ReadableByteChannel channel;
     private final ByteBuffer buffer;

--- a/commons/src/main/java/com/powsybl/commons/binary/SegmentedByteBuffer.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/SegmentedByteBuffer.java
@@ -18,7 +18,7 @@ import java.util.List;
  *
  * @author Clement Leclerc {@literal <clement.leclerc at rte-france.com>}
  */
-final class GrowingByteBuffer {
+final class SegmentedByteBuffer {
 
     private static final int BLOCK_SIZE = 64 * 1024;
 
@@ -26,11 +26,11 @@ final class GrowingByteBuffer {
     private final List<ByteBuffer> filledBlocks = new ArrayList<>();
     private ByteBuffer current;
 
-    GrowingByteBuffer() {
+    SegmentedByteBuffer() {
         this(BLOCK_SIZE);
     }
 
-    GrowingByteBuffer(int blockSize) {
+    SegmentedByteBuffer(int blockSize) {
         this.blockSize = blockSize;
         this.current = ByteBuffer.allocate(blockSize);
     }

--- a/commons/src/test/java/com/powsybl/commons/binary/BufferedChannelReaderTest.java
+++ b/commons/src/test/java/com/powsybl/commons/binary/BufferedChannelReaderTest.java
@@ -67,7 +67,6 @@ class BufferedChannelReaderTest {
             assertTrue(r.readBoolean());
             assertFalse(r.readBoolean());
             assertArrayEquals(new byte[] {1, 2, 3, 4, 5}, r.readNBytes(5));
-            assertTrue(r.isEndOfStream());
         }
     }
 
@@ -84,7 +83,6 @@ class BufferedChannelReaderTest {
             for (int i = 0; i < 100; i++) {
                 assertEquals(i, r.readInt());
             }
-            assertTrue(r.isEndOfStream());
         }
     }
 
@@ -111,14 +109,6 @@ class BufferedChannelReaderTest {
             r.skipNBytes(4L * 25);
             assertEquals(25, r.readInt());
             r.skipNBytes(4L * 24);
-            assertTrue(r.isEndOfStream());
-        }
-    }
-
-    @Test
-    void isEndOfStreamWorksWithoutRead() throws Exception {
-        try (BufferedChannelReader r = new BufferedChannelReader(readerOf(new byte[0]))) {
-            assertTrue(r.isEndOfStream());
         }
     }
 

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
@@ -1311,30 +1311,16 @@ public final class NetworkSerDe {
         Objects.requireNonNull(executor);
         try {
             Pipe pipe = Pipe.open();
-            Pipe.SinkChannel sink = pipe.sink();
-            Pipe.SourceChannel source = pipe.source();
-            if (format == TreeDataFormat.BIN) {
-                ExportOptions exportOptions = new ExportOptions().setFormat(format);
-                executor.execute(() -> {
-                    try (BinWriter writer = new BinWriter(Channels.newOutputStream(sink), BIIDM_MAGIC_NUMBER, exportOptions.getVersion().toString("."))) {
-                        write(network, exportOptions, writer);
-                    } catch (Exception t) {
-                        LOGGER.error(t.toString(), t);
-                    }
-                });
-                try (BinReader reader = new BinReader(Channels.newInputStream(source), BIIDM_MAGIC_NUMBER)) {
-                    return read(reader, new ImportOptions().setFormat(format), null, networkFactory, ReportNode.NO_OP);
-                }
-            }
             executor.execute(() -> {
-                try (OutputStream os = new BufferedOutputStream(Channels.newOutputStream(sink))) {
-                    write(network, new ExportOptions().setFormat(format), os);
+                try (Pipe.SinkChannel sinkChannel = pipe.sink()) {
+                    write(network, new ExportOptions().setFormat(format), Channels.newOutputStream(sinkChannel));
                 } catch (Exception t) {
                     LOGGER.error(t.toString(), t);
                 }
             });
-            try (InputStream is = new BufferedInputStream(Channels.newInputStream(source))) {
-                return read(is, new ImportOptions().setFormat(format), null, networkFactory, ReportNode.NO_OP);
+            try (Pipe.SourceChannel sourceChannel = pipe.source()) {
+                return read(Channels.newInputStream(sourceChannel),
+                        new ImportOptions().setFormat(format), null, networkFactory, ReportNode.NO_OP);
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No, but issues brought by #3919 were written [there](https://github.com/powsybl/powsybl-core/pull/3919#pullrequestreview-4525324306) 

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
- Duplicate code + code smell for Network copy
- Reading direct memory buffer size oversized
- isEndOfStream method mainly added for unit tests
- GrowingByteBuffer badly named

**What is the new behavior (if this is a feature change)?**
- Network copy code unified
- Reading direct memory buffer size reduced
- isEndOfStream method removed, specific method added to detect end of stream when reading next name index
- GrowingByteBuffer renamed

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
