### PR TITLE
Biidm format natively ZSTD-compressed

### DIFF
--- a/commons/src/main/java/com/powsybl/commons/binary/BinReader.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BinReader.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.commons.binary;
 
+import com.github.luben.zstd.ZstdInputStream;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.io.AbstractTreeDataReader;
 import com.powsybl.commons.io.TreeDataHeader;
@@ -36,7 +37,11 @@ public class BinReader extends AbstractTreeDataReader {
 
     public BinReader(InputStream inputStream, byte[] binaryMagicNumber) {
         this.binaryMagicNumber = Objects.requireNonNull(binaryMagicNumber);
-        this.in = new BufferedChannelReader(Objects.requireNonNull(inputStream));
+        try {
+            this.in = new BufferedChannelReader(new ZstdInputStream(Objects.requireNonNull(inputStream)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/binary/BinReader.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BinReader.java
@@ -12,12 +12,9 @@ import com.powsybl.commons.io.AbstractTreeDataReader;
 import com.powsybl.commons.io.TreeDataHeader;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.*;
 
 import static com.powsybl.commons.binary.BinUtil.*;
@@ -37,13 +34,9 @@ public class BinReader extends AbstractTreeDataReader {
     private int nextNameIdx = END_NODE;
     private byte nextType;
 
-    public BinReader(ReadableByteChannel channel, byte[] binaryMagicNumber) {
+    public BinReader(InputStream inputStream, byte[] binaryMagicNumber) {
         this.binaryMagicNumber = Objects.requireNonNull(binaryMagicNumber);
-        this.in = new BufferedChannelReader(Objects.requireNonNull(channel));
-    }
-
-    public BinReader(Path path, byte[] binaryMagicNumber) throws IOException {
-        this(Files.newByteChannel(Objects.requireNonNull(path), StandardOpenOption.READ), binaryMagicNumber);
+        this.in = new BufferedChannelReader(Objects.requireNonNull(inputStream));
     }
 
     @Override

--- a/commons/src/main/java/com/powsybl/commons/binary/BinWriter.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BinWriter.java
@@ -10,6 +10,8 @@ package com.powsybl.commons.binary;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.io.AbstractTreeDataWriter;
 
+import com.github.luben.zstd.ZstdOutputStream;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -206,9 +208,10 @@ public class BinWriter extends AbstractTreeDataWriter {
 
     @Override
     public void close() {
-        try (channel) {
-            buildHeader().drainTo(channel);
-            body.drainTo(channel);
+        try (channel; var zstdOut = new ZstdOutputStream(Channels.newOutputStream(channel), -2).setChecksum(false)) {
+            WritableByteChannel zstdChannel = Channels.newChannel(zstdOut);
+            buildHeader().drainTo(zstdChannel);
+            body.drainTo(zstdChannel);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/commons/src/main/java/com/powsybl/commons/binary/BinWriter.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BinWriter.java
@@ -7,16 +7,13 @@
  */
 package com.powsybl.commons.binary;
 
+import com.github.luben.zstd.ZstdOutputStream;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.io.AbstractTreeDataWriter;
-
-import com.github.luben.zstd.ZstdOutputStream;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
@@ -32,15 +29,15 @@ public class BinWriter extends AbstractTreeDataWriter {
 
     private final String rootVersion;
     private final byte[] binaryMagicNumber;
-    private final WritableByteChannel channel;
+    private final OutputStream outputStream;
     private final GrowingByteBuffer body = new GrowingByteBuffer();
     private final Map<TypedName, Integer> namesIndex = new LinkedHashMap<>();
     private Map<String, String> extensionVersions = Collections.emptyMap();
 
     private record TypedName(String name, byte type) { }
 
-    public BinWriter(OutputStream outputStream, byte[] binaryMagicNumber, String rootVersion) {
-        this.channel = Channels.newChannel(Objects.requireNonNull(outputStream));
+    public BinWriter(OutputStream os, byte[] binaryMagicNumber, String rootVersion) {
+        this.outputStream = Objects.requireNonNull(os);
         this.binaryMagicNumber = Objects.requireNonNull(binaryMagicNumber);
         this.rootVersion = Objects.requireNonNull(rootVersion);
     }
@@ -208,10 +205,9 @@ public class BinWriter extends AbstractTreeDataWriter {
 
     @Override
     public void close() {
-        try (channel; var zstdOut = new ZstdOutputStream(Channels.newOutputStream(channel), -2).setChecksum(false)) {
-            WritableByteChannel zstdChannel = Channels.newChannel(zstdOut);
-            buildHeader().drainTo(zstdChannel);
-            body.drainTo(zstdChannel);
+        try (var zstdOut = new ZstdOutputStream(outputStream, -2).setChecksum(false)) {
+            buildHeader().writeTo(zstdOut);
+            body.writeTo(zstdOut);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/commons/src/main/java/com/powsybl/commons/binary/BinWriter.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BinWriter.java
@@ -11,12 +11,11 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.io.AbstractTreeDataWriter;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.*;
 
 import static com.powsybl.commons.binary.BinUtil.*;
@@ -38,16 +37,10 @@ public class BinWriter extends AbstractTreeDataWriter {
 
     private record TypedName(String name, byte type) { }
 
-    public BinWriter(WritableByteChannel channel, byte[] binaryMagicNumber, String rootVersion) {
-        this.channel = Objects.requireNonNull(channel);
+    public BinWriter(OutputStream outputStream, byte[] binaryMagicNumber, String rootVersion) {
+        this.channel = Channels.newChannel(Objects.requireNonNull(outputStream));
         this.binaryMagicNumber = Objects.requireNonNull(binaryMagicNumber);
         this.rootVersion = Objects.requireNonNull(rootVersion);
-    }
-
-    public BinWriter(Path path, byte[] binaryMagicNumber, String rootVersion) throws IOException {
-        this(Files.newByteChannel(Objects.requireNonNull(path),
-                StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING),
-            binaryMagicNumber, rootVersion);
     }
 
     private static void writeString(String value, GrowingByteBuffer buf) {

--- a/commons/src/main/java/com/powsybl/commons/binary/BufferedChannelReader.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/BufferedChannelReader.java
@@ -10,8 +10,10 @@ package com.powsybl.commons.binary;
 import com.powsybl.commons.PowsyblException;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Objects;
 
@@ -28,12 +30,12 @@ final class BufferedChannelReader implements AutoCloseable {
     private final ByteBuffer buffer;
     private boolean channelExhausted;
 
-    BufferedChannelReader(ReadableByteChannel channel) {
-        this(channel, DEFAULT_BUFFER_SIZE);
+    BufferedChannelReader(InputStream inputStream) {
+        this(inputStream, DEFAULT_BUFFER_SIZE);
     }
 
-    BufferedChannelReader(ReadableByteChannel channel, int bufferSize) {
-        this.channel = Objects.requireNonNull(channel);
+    BufferedChannelReader(InputStream inputStream, int bufferSize) {
+        this.channel = Objects.requireNonNull(Channels.newChannel(inputStream));
         this.buffer = ByteBuffer.allocateDirect(bufferSize);
         this.buffer.flip();
     }

--- a/commons/src/main/java/com/powsybl/commons/binary/GrowingByteBuffer.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/GrowingByteBuffer.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Segmented heap buffer used to stage binary payloads in memory before draining them to a channel.
+ * Segmented heap buffer used to stage binary payloads in memory before writing them to a stream.
  *
  * @author Clement Leclerc {@literal <clement.leclerc at rte-france.com>}
  */
@@ -89,7 +89,7 @@ final class GrowingByteBuffer {
         current.flip();
         filledBlocks.add(current);
         for (ByteBuffer block : filledBlocks) {
-            os.write(block.array());
+            os.write(block.array(), block.arrayOffset() + block.position(), block.remaining());
         }
     }
 }

--- a/commons/src/main/java/com/powsybl/commons/binary/GrowingByteBuffer.java
+++ b/commons/src/main/java/com/powsybl/commons/binary/GrowingByteBuffer.java
@@ -8,8 +8,8 @@
 package com.powsybl.commons.binary;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -85,14 +85,11 @@ final class GrowingByteBuffer {
         }
     }
 
-    /** Writes every staged byte to the channel in order, blocking until fully drained. */
-    void drainTo(WritableByteChannel channel) throws IOException {
+    void writeTo(OutputStream os) throws IOException {
         current.flip();
         filledBlocks.add(current);
         for (ByteBuffer block : filledBlocks) {
-            while (block.hasRemaining()) {
-                channel.write(block);
-            }
+            os.write(block.array());
         }
     }
 }

--- a/commons/src/test/java/com/powsybl/commons/binary/BinWriterReaderTest.java
+++ b/commons/src/test/java/com/powsybl/commons/binary/BinWriterReaderTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.nio.channels.Channels;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,7 +27,7 @@ class BinWriterReaderTest {
     /** Write a single root node, close the writer, return an initialised reader. */
     private BinReader roundTrip(WriterAction action) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (BinWriter writer = new BinWriter(Channels.newChannel(baos), MAGIC, ROOT_VERSION)) {
+        try (BinWriter writer = new BinWriter(baos, MAGIC, ROOT_VERSION)) {
             writer.setVersions(Collections.emptyMap());
             writer.writeStartNode(null, "root");
             action.run(writer);
@@ -36,7 +35,7 @@ class BinWriterReaderTest {
         } catch (Exception e) {
             throw new PowsyblException(e);
         }
-        BinReader reader = new BinReader(Channels.newChannel(new ByteArrayInputStream(baos.toByteArray())), MAGIC);
+        BinReader reader = new BinReader(new ByteArrayInputStream(baos.toByteArray()), MAGIC);
         reader.readHeader();
         return reader;
     }
@@ -271,7 +270,7 @@ class BinWriterReaderTest {
     @Test
     void testInvalidMagicNumber() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (BinWriter writer = new BinWriter(Channels.newChannel(baos), MAGIC, ROOT_VERSION)) {
+        try (BinWriter writer = new BinWriter(baos, MAGIC, ROOT_VERSION)) {
             writer.setVersions(Collections.emptyMap());
             writer.writeStartNode(null, "root");
             writer.writeEndNode();
@@ -279,7 +278,7 @@ class BinWriterReaderTest {
             throw new RuntimeException(e);
         }
         byte[] wrongMagic = {0x00, 0x00, 0x00, 0x00};
-        BinReader reader = new BinReader(Channels.newChannel(new ByteArrayInputStream(baos.toByteArray())), wrongMagic);
+        BinReader reader = new BinReader(new ByteArrayInputStream(baos.toByteArray()), wrongMagic);
         assertThrows(PowsyblException.class, reader::readHeader);
         reader.close();
     }

--- a/commons/src/test/java/com/powsybl/commons/binary/BufferedChannelReaderTest.java
+++ b/commons/src/test/java/com/powsybl/commons/binary/BufferedChannelReaderTest.java
@@ -10,14 +10,9 @@ package com.powsybl.commons.binary;
 import com.powsybl.commons.PowsyblException;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -26,8 +21,8 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class BufferedChannelReaderTest {
 
-    private static ReadableByteChannel readerOf(byte[] data) {
-        return Channels.newChannel(new ByteArrayInputStream(data));
+    private static InputStream readerOf(byte[] data) {
+        return new ByteArrayInputStream(data);
     }
 
     @FunctionalInterface

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/BinaryImporter.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/BinaryImporter.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.iidm.serde;
 
+import com.github.luben.zstd.ZstdInputStream;
 import com.google.auto.service.AutoService;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.io.TreeDataFormat;
@@ -47,7 +48,7 @@ public class BinaryImporter extends AbstractTreeDataImporter {
     @Override
     protected boolean exists(ReadOnlyDataSource dataSource, String ext) throws IOException {
         if (ext != null) {
-            try (InputStream dis = dataSource.newInputStream(null, ext)) {
+            try (InputStream dis = new ZstdInputStream(dataSource.newInputStream(null, ext))) {
                 return Arrays.equals(dis.readNBytes(NetworkSerDe.BIIDM_MAGIC_NUMBER.length), NetworkSerDe.BIIDM_MAGIC_NUMBER);
             }
         }

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
@@ -38,7 +38,10 @@ import com.powsybl.iidm.serde.extensions.util.ExtensionsSupplier;
 import com.powsybl.iidm.serde.util.IidmSerDeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.*;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLFilter;
 import org.xml.sax.helpers.XMLFilterImpl;
 
 import javax.xml.XMLConstants;
@@ -549,7 +552,7 @@ public final class NetworkSerDe {
     }
 
     private static TreeDataWriter createBinWriter(OutputStream os, ExportOptions options) {
-        return new BinWriter(Channels.newChannel(os), BIIDM_MAGIC_NUMBER, options.getVersion().toString("."));
+        return new BinWriter(os, BIIDM_MAGIC_NUMBER, options.getVersion().toString("."));
     }
 
     private static void writeRootElement(Network n, NetworkSerializerContext context) {
@@ -826,13 +829,6 @@ public final class NetworkSerDe {
     }
 
     public static Anonymizer write(Network n, ExportOptions options, Path xmlFile) {
-        if (options.getFormat() == TreeDataFormat.BIN) {
-            try (BinWriter writer = new BinWriter(xmlFile, BIIDM_MAGIC_NUMBER, options.getVersion().toString("."))) {
-                return write(n, options, writer);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
         try (OutputStream os = new BufferedOutputStream(Files.newOutputStream(xmlFile))) {
             return write(n, options, os);
         } catch (IOException e) {
@@ -880,7 +876,7 @@ public final class NetworkSerDe {
         return switch (config.getFormat()) {
             case XML -> createXmlReader(is, config, extensionsSupplier);
             case JSON -> createJsonReader(is, config, extensionsSupplier);
-            case BIN -> new BinReader(Channels.newChannel(is), BIIDM_MAGIC_NUMBER);
+            case BIN -> new BinReader(is, BIIDM_MAGIC_NUMBER);
         };
     }
 
@@ -1188,13 +1184,6 @@ public final class NetworkSerDe {
     }
 
     public static Network read(Path xmlFile, ImportOptions options, Anonymizer anonymizer, NetworkFactory networkFactory, ReportNode reportNode) {
-        if (options.getFormat() == TreeDataFormat.BIN) {
-            try (BinReader reader = new BinReader(xmlFile, BIIDM_MAGIC_NUMBER)) {
-                return read(reader, options, anonymizer, networkFactory, reportNode);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
         try (InputStream is = Files.newInputStream(xmlFile)) {
             return read(is, options, anonymizer, networkFactory, reportNode);
         } catch (IOException e) {
@@ -1327,13 +1316,13 @@ public final class NetworkSerDe {
             if (format == TreeDataFormat.BIN) {
                 ExportOptions exportOptions = new ExportOptions().setFormat(format);
                 executor.execute(() -> {
-                    try (BinWriter writer = new BinWriter(sink, BIIDM_MAGIC_NUMBER, exportOptions.getVersion().toString("."))) {
+                    try (BinWriter writer = new BinWriter(Channels.newOutputStream(sink), BIIDM_MAGIC_NUMBER, exportOptions.getVersion().toString("."))) {
                         write(network, exportOptions, writer);
                     } catch (Exception t) {
                         LOGGER.error(t.toString(), t);
                     }
                 });
-                try (BinReader reader = new BinReader(source, BIIDM_MAGIC_NUMBER)) {
+                try (BinReader reader = new BinReader(Channels.newInputStream(source), BIIDM_MAGIC_NUMBER)) {
                     return read(reader, new ImportOptions().setFormat(format), null, networkFactory, ReportNode.NO_OP);
                 }
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
The biidm file for a given 8000 voltage levels network weighs about 30Mb

**What is the new behavior (if this is a feature change)?**
The biidm file for a given 8000 voltage levels network weighs about 6Mb

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No