### PR TITLE
Fix javadoc jar generation in action-ial/action-ial-util

### DIFF
--- a/action-ial/action-ial-util/pom.xml
+++ b/action-ial/action-ial-util/pom.xml
@@ -22,6 +22,13 @@
     <name>Action utilities</name>
     <description>A set of DSL extensions and utility functions</description>
 
+    <properties>
+        <groovydoc.attach>true</groovydoc.attach>
+        <groovydoc.classifier>javadoc</groovydoc.classifier>
+        <groovydoc.groovyDocJavaSources>true</groovydoc.groovyDocJavaSources>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix javadoc jars generation


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The `action-ial-util` javadoc jar is not generated. This blocks the release deployment on Sonatype since this jar is required.


**What is the new behavior (if this is a feature change)?**
The groovydoc jar is renamed and used for the javadoc.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

Before this PR, the deployment fails with the following error:
```
Deployment ... failed
pkg:maven/com.powsybl/powsybl-action-ial-util@7.3.0-RC1:
 - Javadocs must be provided but not found in entries
```

[Documentation on Sonatype requirements](https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources)