### PR TITLE
Add coverage detection on WindowsLocalCommandExecutor

### DIFF
--- a/computation-local/src/main/java/com/powsybl/computation/local/WindowsLocalCommandExecutor.java
+++ b/computation-local/src/main/java/com/powsybl/computation/local/WindowsLocalCommandExecutor.java
@@ -101,7 +101,7 @@ public class WindowsLocalCommandExecutor extends AbstractLocalCommandExecutor {
             .replace("\r", "");
     }
 
-    private static String escapeCmdArg(String arg) {
+    protected static String escapeCmdArg(String arg) {
         // Double any trailing backslashes before the closing quote
         int trailingBackslashes = 0;
         for (int i = arg.length() - 1; i >= 0 && arg.charAt(i) == '\\'; i--) {

--- a/computation-local/src/test/java/com/powsybl/computation/local/LocalCommandExecutorSecurityTest.java
+++ b/computation-local/src/test/java/com/powsybl/computation/local/LocalCommandExecutorSecurityTest.java
@@ -144,8 +144,9 @@ class LocalCommandExecutorSecurityTest {
         assertFalse(Files.exists(pwndFileEnvVariable), String.format("[!] Command injection confirmed: %s created", pwndFileEnvVariable));
     }
 
+    // The following test can be executed on every OS.
+    // It asserts that no system command is run when invalid environment variable names are detected.
     @Test
-    @EnabledOnOs(OS.WINDOWS)
     void testCommandInjectionViaEnvVarNameOnWindows() {
         // 7. Injection via environment variable name: names cannot be safely escaped,
         //    so the executor must reject invalid names outright.
@@ -165,8 +166,9 @@ class LocalCommandExecutorSecurityTest {
         assertFalse(Files.exists(pwndFileEnvVarName), String.format("[!] Command injection confirmed: %s created", pwndFileEnvVarName));
     }
 
+    // The following test can be executed on every OS.
+    // It asserts that no system command is run when an invalid program name is detected.
     @Test
-    @EnabledOnOs(OS.WINDOWS)
     void testCommandInjectionViaProgramNameOnWindows() {
         // 8. Injection via program name containing a double quote.
         //    The executor must reject program names with quotes rather than pass them raw.
@@ -191,5 +193,15 @@ class LocalCommandExecutorSecurityTest {
         );
         assertEquals("Program name must not contain spaces", exception2.getMessage());
         assertFalse(Files.exists(pwndFileEnvVarName), String.format("[!] Command injection confirmed: %s created", pwndFileEnvVarName));
+    }
+
+    @Test
+    void testEscapeCmdArgOnWindows() {
+        assertEquals("abc\\\\\\\\", WindowsLocalCommandExecutor.escapeCmdArg("abc\\\\"));
+        assertEquals("a^^b", WindowsLocalCommandExecutor.escapeCmdArg("a^b"));
+        assertEquals("a^%", WindowsLocalCommandExecutor.escapeCmdArg("a%"));
+        assertEquals("^!ab", WindowsLocalCommandExecutor.escapeCmdArg("!ab"));
+        assertEquals("a\"\"b", WindowsLocalCommandExecutor.escapeCmdArg("a\"b"));
+        assertEquals("ab", WindowsLocalCommandExecutor.escapeCmdArg("a\n\rb"));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Quality (kind of)


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Existing unit tests on `WindowsLocalCommandExecutor` are run on Windows machine only.
Our workflow executes on Unix, Windows and MacOS, but the code coverage is only computed on Unix. Therefore `WindowsLocalCommandExecutor` appears as non-tested.


**What is the new behavior (if this is a feature change)?**
All the `WindowsLocalCommandExecutor` that don't finally execute a system command are run on every OS. As a consequence, they are taken into account for the code coverage.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
