### PR TITLE
Security analysis: monitored elements power threshold changed to absolute

### DIFF
--- a/docs/simulation/security/configuration.md
+++ b/docs/simulation/security/configuration.md
@@ -5,9 +5,11 @@ The `security-analysis` module is used to configure the execution of the [securi
 ## Implementation
 
 **preprocessor**<br>
-The `preprocessor` property is an optional property which requires that the `SecurityAnalysisPreprocessor` with specified name is used to preprocess inputs, based on the contingency file, before actually running the security analysis.
+The `preprocessor` property is an optional property which requires that the `SecurityAnalysisPreprocessor` with specified
+name is used to preprocess inputs, based on the contingency file, before actually running the security analysis.
 
-Such a preprocessor will have the possibility to programmatically transform the following objects before the security analysis is actually executed :
+Such a preprocessor will have the possibility to programmatically transform the following objects before the security
+analysis is actually executed :
 - The `Network`
 - The `ContingenciesProvider`
 - The `LimitViolationDetector`
@@ -38,19 +40,33 @@ security-analysis:
 
 (violations-increase-thresholds)=
 ### Violations increase thresholds
-The user can provide parameters to define which violations must be raised after a contingency, if the violation was already present in the pre-contingency state (`IncreasedViolationsParameters`).
+The user can provide parameters to define which violations must be raised after a contingency, if the violation was already
+present in the pre-contingency state (`IncreasedViolationsParameters`).
 
 (param-secu-flow-proportional-threshold)=
 #### flow-proportional-threshold
-After a contingency, only flow violations (either current, active power or apparent power violations) that have increased in proportion by more than a threshold value, compared to the pre-contingency state, are listed in the limit violations. The other ones are filtered. The threshold value is unitless and should be positive. This method gets the flow violation proportional threshold. The default value is 0.1, meaning that only violations that have increased by more than 10% appear in the limit violations.
+After a contingency, only flow violations (either current, active power or apparent power violations) that have increased
+in proportion by more than a threshold value, compared to the pre-contingency state, are listed in the limit violations.
+The other ones are filtered. The threshold value is unitless and should be positive.
+This method gets the flow violation proportional threshold.
+
+The default value is 0.1, meaning that only violations that have increased by more than 10% appear in the limit violations.
 
 (param-secu-low-voltage-proportional-threshold)=
 #### low-voltage-proportional-threshold
-After a contingency, only low-voltage violations that have increased by more than the proportional threshold compared to the pre-contingency state, are listed in the limit violations, the other ones are filtered. This method gets the low-voltage violation proportional threshold (unitless, should be positive). The default value is 0.0, meaning that only violations that have increased by more than 0.0 % appear in the limit violations (note that for low-voltage violation, it means that the voltage in the post-contingency state is lower than the voltage in the pre-contingency state).
+After a contingency, only low-voltage violations that have increased by more than the proportional threshold compared to
+the pre-contingency state, are listed in the limit violations, the other ones are filtered. This method gets the low-voltage
+violation proportional threshold (unitless, should be positive). The default value is 0.0, meaning that only violations
+that have increased by more than 0.0 % appear in the limit violations (note that for low-voltage violation, it means that
+the voltage in the post-contingency state is lower than the voltage in the pre-contingency state).
 
 (param-secu-low-voltage-absolute-threshold)=
 #### low-voltage-absolute-threshold
-After a contingency, only low-voltage violations that have increased by more than an absolute threshold compared to the pre-contingency state, are listed in the limit violations, the other ones are filtered. This method gets the low-voltage violation absolute threshold (in kV, should be positive). The default value is 0.0, meaning that only violations that have increased by more than 0.0 kV appear in the limit violations (note that for low-voltage violation, it means that the voltage in the post-contingency state is lower than the voltage in the pre-contingency state).
+After a contingency, only low-voltage violations that have increased by more than an absolute threshold compared to the
+pre-contingency state, are listed in the limit violations, the other ones are filtered. This method gets the low-voltage
+violation absolute threshold (in kV, should be positive). The default value is 0.0, meaning that only violations that
+have increased by more than 0.0 kV appear in the limit violations (note that for low-voltage violation, it means that
+the voltage in the post-contingency state is lower than the voltage in the pre-contingency state).
 
 (param-secu-high-voltage-proportional-threshold)=
 #### high-voltage-proportional-threshold
@@ -62,24 +78,38 @@ Same as before but for high-voltage violations.
 
 (monitoring-modification-thresholds)=
 ### Monitoring modification thresholds
-When monitoring elements both before and after contingencies, it is possible to define thresholds that limit the number of element states stored in the post-contingency state.
+When monitoring elements before and after contingencies, thresholds can be defined to limit the number
+of element states stored in the post-contingency results.
 
 #### Thresholds on power
 **power-modification-threshold**<br>
-After a contingency, all the monitored branches and 3 windings transformers whose power has not changed by more than the threshold (in percentage) compared to pre-contingency state are filtered from the post-contingency results. It is set at 0 by default, so it doesn't filter anything.
+After a contingency, all the monitored branches and three-windings transformers whose active and reactive power has not
+changed by more than the threshold (in MW and MVAr) compared to pre-contingency state are filtered from the post-contingency results.
+
+It is set to 0 MW/MVAr by default, meaning no filtering is performed.
 
 #### Thresholds on voltage
-These two following parameters are not exclusive. When both are defined, the threshold in kV that will be used will be the minimum between the value of the absolute parameter and the result of the proportional parameter applied to the pre-contingency value.
+The following two parameters are not mutually exclusive. When both are defined, the effective threshold in kV is the minimum
+of the absolute threshold and the value obtained by applying the proportional threshold to the pre-contingency voltage.
 
 **voltage-modification-proportional-threshold**<br>
-After a contingency, all the monitored buses whose voltage has not changed by more than the threshold (in percentage) compared to pre-contingency state are filtered from the post-contingency results. It is set at 0 by default, so it doesn't filter anything.
+After a contingency, monitored buses whose voltage magnitude has not changed by more than the specified threshold relative
+to the pre-contingency state are filtered out of the post-contingency results.
+For example, when set to 0.01, voltage magnitude changes lower than 1% of pre-contingency bus voltage magnitude value are not reported.
+
+It is set to 0 by default, meaning no filtering is performed.
 
 **voltage-modification-absolute-threshold**<br>
-After a contingency, all the monitored buses whose voltage has not changed by more than the threshold (in kV) compared to pre-contingency state are filtered from the post-contingency results. It is set at 0 by default, so it doesn't filter anything.
+After a contingency, monitored buses whose voltage magnitude has not changed by more than the specified absolute threshold (in kV)
+compared to pre-contingency state are filtered from the post-contingency results.
+
+It is set to 0 kV by default, meaning no filtering is performed.
 
 (violation-filtering)=
 ### Violations filtering
-The violations listed in the results can be filtered to consider only a certain type of violations, to consider only a few voltage levels or to limit the geographical area by filtering equipment by countries. Check out the documentation of the [limit-violation-default-filter](../../user/configuration/limit-violation-default-filter.md) configuration module.
+The violations listed in the results can be filtered to consider only a certain type of violations, to consider only a
+few voltage levels or to limit the geographical area by filtering equipment by countries. Check out the documentation
+of the [limit-violation-default-filter](../../user/configuration/limit-violation-default-filter.md) configuration module.
 
 **Example**<br>
 Using the following configuration, the results will contain only voltage violations for equipment in France or Belgium:
@@ -110,6 +140,9 @@ security-analysis-default-parameters:
   increased-high-voltage-violations-proportional-threshold: 0.1
   increased-low-voltage-violations-absolute-threshold: 0.1
   increased-high-voltage-violations-absolute-threshold: 0.1
+  power-modification-threshold: 0.0
+  voltage-modification-proportional-threshold: 0.0
+  voltage-modification-absolute-threshold: 0.0
   debug-dir: /tmp/debugDir
 ```
 
@@ -122,6 +155,9 @@ security-analysis-default-parameters:
   <increased-high-voltage-violations-proportional-threshold>0.1</increased-high-voltage-violations-proportional-threshold>
   <increased-low-voltage-violations-absolute-threshold>0.1</increased-low-voltage-violations-absolute-threshold>
   <increased-high-voltage-violations-absolute-threshold>0.1</increased-high-voltage-violations-absolute-threshold>
+  <power-modification-threshold>0.0</power-modification-threshold>
+  <voltage-modification-proportional-threshold>0.0</voltage-modification-proportional-threshold>
+  <voltage-modification-absolute-threshold>0.0</voltage-modification-absolute-threshold>
   <debug-dir>/tmp/debugDir</debug-dir>
 </security-analysis-default-parameters>
 ```

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisParameters.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/SecurityAnalysisParameters.java
@@ -180,9 +180,10 @@ public class SecurityAnalysisParameters extends AbstractExtendable<SecurityAnaly
         }
 
         /**
-         * If a branch is monitored in N and N-1 state, a result will only be added for it after a contingency if the power on the line
-         * is modified of at least the proportional threshold (without unit) compared to the pre-contingency state.
-         * The default value is 0.0, meaning that no branch is filtered in the post-contingency results.
+         * If a branch or three-winding transformer is monitored in both the N and N-1 states, a result is added after a contingency
+         * only if the active or reactive power at at least one terminal changes by more than the power threshold (in MW and MVAr)
+         * compared to the pre-contingency state.
+         * The default value is 0.0, meaning that no branches or three-winding transformers are filtered from the post-contingency results.
          */
         public double getPowerModificationThreshold() {
             return powerModificationThreshold;
@@ -195,7 +196,8 @@ public class SecurityAnalysisParameters extends AbstractExtendable<SecurityAnaly
 
         /**
          * If a bus is monitored in N and N-1 state, a result will only be added for it after a contingency if its voltage
-         * is modified of at least the proportional threshold (without unit) compared to the pre-contingency state.
+         * magnitude is modified of at least the proportional threshold (without unit) compared to the pre-contingency state.
+         * For example, when set to 0.01, voltage magnitude changes lower than 1% of pre-contingency bus voltage magnitude value are not reported.
          * The default value is 0.0, meaning that no bus is filtered in the post-contingency results.
          */
         public double getVoltageModificationProportionalThreshold() {
@@ -209,8 +211,8 @@ public class SecurityAnalysisParameters extends AbstractExtendable<SecurityAnaly
 
         /**
          * If a bus is monitored in N and N-1 state, a result will only be added for it after a contingency if its voltage
-         * is modified of at least the absolute threshold (in kV) compared to the pre-contingency state.
-         * The default value is 0.0, meaning that no bus is filtered in the post-contingency results.
+         * magnitude is modified of at least the absolute threshold (in kV) compared to the pre-contingency state.
+         * The default value is 0.0 kV, meaning that no bus is filtered in the post-contingency results.
          */
         public double getVoltageModificationAbsoluteThreshold() {
             return voltageModificationAbsoluteThreshold;
@@ -229,8 +231,7 @@ public class SecurityAnalysisParameters extends AbstractExtendable<SecurityAnaly
 
         /**
          * Returns the voltage modification threshold for a given pre-contingency voltage.
-         * If absolute threshold is not 0, it is returned. Otherwise, proportional threshold is used.
-         * If both thresholds are set, the minimum of the two is returned.
+         * If both absolute and proportional thresholds are set, the minimum of the two is returned.
          *
          * @param preContingencyVoltage the voltage for which to calculate the threshold
          * @return the voltage modification threshold


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Related: #3903



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature but only via documentation update.
As part of the current June 26 release, `powerModificationThreshold` introduced in #3903 is documented as a relative/percentage filter. After discussions in https://github.com/powsybl/powsybl-open-loadflow/pull/1398 and implementing the filter, it was agreed to change the filter to be in absolute MW/MVAr, instead of a relative threshold.
Actual usage of the parameter is only within security analysis implementations (e.g. OLF). Therefore this PR is a documentation only change for powsybl-core (readthedocs and javadoc).


**What is the current behavior?**
<!-- You can also link to an open issue here -->
- `powerModificationThreshold` documented as being a relative filter


**What is the new behavior (if this is a feature change)?**

- `powerModificationThreshold` documented as being an absolute MW/MVAr filter (readthedocs and javadoc)
- some documentation precisions about voltage filtering (0.01 vs. 1% clarification)
- rephrasings for clarity.
- added the new parameters from #3903 in the YML and XML examples


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
The original doc had very long lines. I added line breaks but did not modify the content for the parts not relevant to this PR.