### PR TITLE
Fix split for time series with gaps

### DIFF
--- a/time-series/time-series-api/src/main/java/com/powsybl/timeseries/AbstractTimeSeries.java
+++ b/time-series/time-series-api/src/main/java/com/powsybl/timeseries/AbstractTimeSeries.java
@@ -170,7 +170,10 @@ public abstract class AbstractTimeSeries<P extends AbstractPoint, C extends Data
         C previousChunk = splitChunks.isEmpty() ? null : splitChunks.get(splitChunks.size() - 1);
         int previousChunkSize = 0;
         //We can complete the previous chunk if 1) it is uncomplete and 2) the current offset is not a multiple of newChunkSize
-        if (previousChunk != null && previousChunk.getLength() < newChunkSize && chunkToSplit.getOffset() % newChunkSize != 0) {
+        if (previousChunk != null
+                && previousChunk.getLength() < newChunkSize
+                && previousChunk.getOffset() + previousChunk.getLength() == chunkToSplit.getOffset()
+                && chunkToSplit.getOffset() % newChunkSize != 0) {
             usePreviousChunk = true;
             previousChunkSize = previousChunk.getLength();
         }

--- a/time-series/time-series-api/src/test/java/com/powsybl/timeseries/StoredDoubleTimeSeriesTest.java
+++ b/time-series/time-series-api/src/test/java/com/powsybl/timeseries/StoredDoubleTimeSeriesTest.java
@@ -463,4 +463,26 @@ class StoredDoubleTimeSeriesTest {
         assertArrayEquals(new double[] {1d, 2d, 3d, NaN, NaN, NaN, 7d, 8d}, timeSeries.toCompactArray());
     }
 
+    @Test
+    void splitNonSuccessiveChunksShouldPreserveGap() {
+        TimeSeriesIndex index = Mockito.mock(TimeSeriesIndex.class);
+        Mockito.when(index.getPointCount()).thenReturn(8);
+        TimeSeriesMetadata metadata = new TimeSeriesMetadata("ts1", TimeSeriesDataType.DOUBLE, index);
+        DoubleDataChunk chunk1 = new UncompressedDoubleDataChunk(0, new double[]{1d, 2d, 3d});
+        DoubleDataChunk chunk2 = new UncompressedDoubleDataChunk(6, new double[]{7d, 8d});
+        StoredDoubleTimeSeries timeSeries = new StoredDoubleTimeSeries(metadata, chunk1, chunk2);
+
+        List<DoubleTimeSeries> split = timeSeries.split(4);
+
+        assertEquals(2, split.size());
+        StoredDoubleTimeSeries first = (StoredDoubleTimeSeries) split.getFirst();
+        StoredDoubleTimeSeries second = (StoredDoubleTimeSeries) split.get(1);
+        assertEquals(0, first.getChunks().getFirst().getOffset());
+        assertEquals(3, first.getChunks().getFirst().getLength());
+        assertEquals(6, second.getChunks().getFirst().getOffset());
+        assertEquals(2, second.getChunks().getFirst().getLength());
+        assertArrayEquals(new double[]{1d, 2d, 3d, NaN, NaN, NaN, NaN, NaN}, first.toArray());
+        assertArrayEquals(new double[]{NaN, NaN, NaN, NaN, NaN, NaN, 7d, 8d}, second.toArray());
+    }
+
 }


### PR DESCRIPTION
Fixes #3941

## Summary
- avoid merging a partial output chunk with the next chunk when there is a gap between their offsets
- keep sparse/non-successive chunks split consistently for all valid chunk sizes
- add regression coverage for `StoredDoubleTimeSeries.split(4)` on a time series containing a gap

## Verification
- `./mvnw.cmd -pl time-series/time-series-api -am "-Dtest=StoredDoubleTimeSeriesTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`