### PR TITLE
Fix service loader to use the ClassLoader of the class

### DIFF
--- a/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
+++ b/loadflow/loadflow-api/src/main/java/com/powsybl/loadflow/LoadFlowParameters.java
@@ -262,7 +262,7 @@ public class LoadFlowParameters extends AbstractExtendable<LoadFlowParameters> {
     }
 
     private static List<LoadFlowDefaultParametersLoader> getDefaultParametersLoaders() {
-        return ServiceLoader.load(LoadFlowDefaultParametersLoader.class)
+        return ServiceLoader.load(LoadFlowDefaultParametersLoader.class, LoadFlowParameters.class.getClassLoader())
                 .stream()
                 .map(ServiceLoader.Provider::get)
                 .toList();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix / feature

**What is the current behavior?**
The class loader is not specified, leading to the thread context ClassLoader to be used instead. On the opposite, all the other ServiceLoader::load calls in powsybl-core use the class loader of the loader class or at least of a given related class.

**What is the new behavior (if this is a feature change)?**
The class loader used when looking for a LoadFlowDefaultParametersLoader is using the LoadFlowParameters class ClassLoader


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

