### PR TITLE
Remove dead tie-line limits group deserialization (#3961)

### DIFF
--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/TieLineSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/TieLineSerDe.java
@@ -180,11 +180,6 @@ class TieLineSerDe extends AbstractSimpleIdentifiableSerDe<TieLine, TieLineAdder
 
     private void readChildNode(TieLine tl, NetworkDeserializerContext context, String elementName) {
         switch (elementName) {
-            case LIMITS_GROUP_1 -> {
-                IidmSerDeUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, LIMITS_GROUP_1, IidmSerDeUtil.ErrorMessage.NOT_SUPPORTED, IidmVersion.V_1_12, context);
-                IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_12, context,
-                    () -> readLoadingLimitsGroups(tl.getBoundaryLine1(), tl.getBoundaryLine1().getId(), ThreeSides.ONE, LIMITS_GROUP_1, context));
-            }
             case ACTIVE_POWER_LIMITS_1 -> {
                 IidmSerDeUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, ACTIVE_POWER_LIMITS_1, IidmSerDeUtil.ErrorMessage.NOT_SUPPORTED, IidmVersion.V_1_5, context);
                 IidmSerDeUtil.assertMaximumVersion(ROOT_ELEMENT_NAME, ACTIVE_POWER_LIMITS_1, IidmSerDeUtil.ErrorMessage.NOT_SUPPORTED, IidmVersion.V_1_9, context);
@@ -200,12 +195,6 @@ class TieLineSerDe extends AbstractSimpleIdentifiableSerDe<TieLine, TieLineAdder
             case "currentLimits1" -> {
                 IidmSerDeUtil.assertMaximumVersion(ROOT_ELEMENT_NAME, ACTIVE_POWER_LIMITS_1, IidmSerDeUtil.ErrorMessage.NOT_SUPPORTED, IidmVersion.V_1_9, context);
                 readCurrentLimits(tl.getBoundaryLine1().getOrCreateSelectedOperationalLimitsGroup().newCurrentLimits(), context);
-            }
-            case LIMITS_GROUP_2 -> {
-                IidmSerDeUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, LIMITS_GROUP_2, IidmSerDeUtil.ErrorMessage.NOT_SUPPORTED, IidmVersion.V_1_12, context);
-                //use side one since side is relative to the boundary line, not the tie line
-                IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_12, context,
-                    () -> readLoadingLimitsGroups(tl.getBoundaryLine2(), tl.getBoundaryLine2().getId(), ThreeSides.ONE, LIMITS_GROUP_2, context));
             }
             case ACTIVE_POWER_LIMITS_2 -> {
                 IidmSerDeUtil.assertMinimumVersion(ROOT_ELEMENT_NAME, ACTIVE_POWER_LIMITS_2, IidmSerDeUtil.ErrorMessage.NOT_SUPPORTED, IidmVersion.V_1_5, context);

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/TieLineSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/TieLineSerDeTest.java
@@ -8,6 +8,7 @@
 
 package com.powsybl.iidm.serde;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TieLine;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
@@ -17,6 +18,9 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 
 import static com.powsybl.iidm.network.test.EurostagTutorialExample1Factory.NHV1_NHV2_1;
 import static org.junit.jupiter.api.Assertions.*;
@@ -65,4 +69,28 @@ class TieLineSerDeTest extends AbstractIidmSerDeTest {
         });
     }
 
+    @Test
+    void tieLineOperationalLimitsGroupsShouldBeRejectedFromV112() {
+        String xml = readVersionedXml("tieline.xml", IidmVersion.V_1_12).replace(
+            "<iidm:tieLine id=\"NHV1_NHV2_1\" danglingLineId1=\"NHV1_NHV2_1.1\" danglingLineId2=\"NHV1_NHV2_1.2\"/>",
+            """
+            <iidm:tieLine id="NHV1_NHV2_1" danglingLineId1="NHV1_NHV2_1.1" danglingLineId2="NHV1_NHV2_1.2">
+                <iidm:operationalLimitsGroup1 id="DEFAULT">
+                    <iidm:currentLimits permanentLimit="111.0"/>
+                </iidm:operationalLimitsGroup1>
+            </iidm:tieLine>"""
+        );
+
+        PowsyblException e = assertThrows(PowsyblException.class,
+            () -> NetworkSerDe.read(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))));
+        assertTrue(e.getMessage().contains("operationalLimitsGroup1"));
+    }
+
+    private String readVersionedXml(String fileName, IidmVersion version) {
+        try (InputStream inputStream = getVersionedNetworkAsStream(fileName, version)) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #3961.

## Summary
- remove the dead `operationalLimitsGroup1/2` tie-line deserialization branches from `TieLineSerDe`
- add a regression test proving a v1.12 tie-line still rejects those unsupported elements

## Verification
- `./mvnw.cmd -pl iidm/iidm-serde -am "-Dtest=TieLineSerDeTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`