### PR TITLE
[ShortCircuit API] Fix wrong casting in AbstractFaultResult.getCurrent

### DIFF
--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/AbstractFaultResult.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/AbstractFaultResult.java
@@ -96,7 +96,7 @@ abstract class AbstractFaultResult extends AbstractExtendable<FaultResult> imple
                 if (feederResult instanceof FortescueFeederResult fortescueFeederResult) {
                     return fortescueFeederResult.getCurrent().getPositiveMagnitude();
                 } else {
-                    return ((MagnitudeFaultResult) feederResult).getCurrent();
+                    return ((MagnitudeFeederResult) feederResult).getCurrent();
                 }
             }
         }

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisTest.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisTest.java
@@ -180,4 +180,15 @@ class ShortCircuitAnalysisTest {
         assertEquals(ThreeSides.ONE, feederResult.getSide());
         assertEquals(TwoSides.ONE, feederResult.getSideAsTwoSides());
     }
+
+    @Test
+    void testGetFeederCurrent() {
+        ShortCircuitAnalysisResult magnitudeResult = TestingResultFactory.createWithFeederResults(ThreeSides.ONE);
+        assertEquals(1, magnitudeResult.getFaultResult("id").getFeederCurrent("connectableId"));
+        assertTrue(Double.isNaN(magnitudeResult.getFaultResult("id").getFeederCurrent("wrongConnectableId")));
+
+        ShortCircuitAnalysisResult fortescueResult = TestingResultFactory.createFortescueResult();
+        assertEquals(1, fortescueResult.getFaultResult("id").getFeederCurrent("id2"));
+        assertTrue(Double.isNaN(fortescueResult.getFaultResult("id").getFeederCurrent("wrongConnectableId")));
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In case of a MagnitudeFeederResult, the feeder in getFeederCurrent is casted to MagnitudeFaultResult, which is wrong.


**What is the new behavior (if this is a feature change)?**
The cast is fixed and test is added.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
