### PR TITLE
[ShortCircuit API] Add equivalent resistance and reactance to fault results.

### DIFF
--- a/docs/simulation/shortcircuit/outputs.md
+++ b/docs/simulation/shortcircuit/outputs.md
@@ -18,25 +18,29 @@ Both classes contain the following attributes:
 | feederResults          | List<FeederResult>          | -    | no       | Empty list    | A list of FeederResult, should not be empty if the parameter `with-feeder-result` is set to `true`.        |
 | limitViolations        | List<LimitViolation>        | -    | no       | Empty list    | A list of LimitViolation, should be empty if the parameter `with-limit-violations` is set to `false`.      |
 | shortCircuitBusResults | List<ShortCircuitBusResult> | -    | no       | Empty list    | A list of ShortCircuitBusResult, should be empty if the parameter `with-voltage-result` is set to `false`. |
+| equivalentR            | double                      | Ohm  | no       | -             | The equivalent resistance of the network seen from the fault                                               |
+| equivalentX            | double                      | Ohm  | no       | -             | The equivalent reactance of the network seen from the fault                                                |
 
 However, in these classes, the short-circuit current and voltage are represented differently.
 
 In `MagnitudeFaultResult`, the additional attributes are:
 
-| Attribute | Type   | Unit | Required | Default value | Description                                                      |
-|-----------|--------|------|----------|---------------|------------------------------------------------------------------|
-| current   | double | A    | yes      | -             | The three-phased magnitude of the computed short-circuit current |
-| voltage   | double | kV   | yes      | -             | The three-phased magnitude of the computed short-circuit voltage |
+| Attribute   | Type   | Unit | Required | Default value | Description                                                      |
+|-------------|--------|------|----------|---------------|------------------------------------------------------------------|
+| current     | double | A    | yes      | -             | The three-phased magnitude of the computed short-circuit current |
+| voltage     | double | kV   | yes      | -             | The three-phased magnitude of the computed short-circuit voltage |
 
 
 In `FortescueFaultResult`, they are:
 
-| Attribute | Type             | Unit | Required | Default value | Description                                                                                |
-|-----------|------------------|------|----------|---------------|--------------------------------------------------------------------------------------------|
-| current   | `FortescueValue` | A    | yes      | -             | The magnitude and angle of the computed short-circuit current detailed on the three phases |
-| voltage   | `FortescueValue` | kV   | yes      | -             | The magnitude and angle of the computed short-circuit voltage detailed on the three phases |
+| Attribute       | Type             | Unit | Required | Default value | Description                                                                                             |
+|-----------------|------------------|------|----------|---------------|---------------------------------------------------------------------------------------------------------|
+| current         | `FortescueValue` | A    | yes      | -             | The magnitude and angle of the computed short-circuit current detailed on the three phases              |
+| voltage         | `FortescueValue` | kV   | yes      | -             | The magnitude and angle of the computed short-circuit voltage detailed on the three phases              |
+| equivalentRZero | double           | Ohm  | no       | -             | The zero-sequence equivalent resistance of the network seen from the fault detailed on the three phases |
+| equivalentXZero | double           | Ohm  | no       | -             | The zero-sequence equivalent reactance of the network seen from the fault detailed on the three phases  |
 
-
+The negative-sequence equivalents are, as a first approach, assumed to be equal to the positive-sequence equivalents that are common for `MagnitudeFaultResult` and `FortescueFaultResult`.
 
 **The status of the computation**
 

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/AbstractFaultResult.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/AbstractFaultResult.java
@@ -34,8 +34,12 @@ abstract class AbstractFaultResult extends AbstractExtendable<FaultResult> imple
 
     private final List<ShortCircuitBusResults> shortCircuitBusResults;
 
+    private final double equivalentR;
+
+    private final double equivalentX;
+
     protected AbstractFaultResult(Fault fault, Status status, double shortCircuitPower, Duration timeConstant, List<FeederResult> feederResults,
-                               List<LimitViolation> limitViolations, List<ShortCircuitBusResults> shortCircuitBusResults) {
+                               List<LimitViolation> limitViolations, List<ShortCircuitBusResults> shortCircuitBusResults, double equivalentR, double equivalentX) {
         this.fault = Objects.requireNonNull(fault);
         this.shortCircuitPower = shortCircuitPower;
         this.limitViolations = new ArrayList<>();
@@ -52,6 +56,8 @@ abstract class AbstractFaultResult extends AbstractExtendable<FaultResult> imple
             this.feederResults.addAll(feederResults);
         }
         this.status = Objects.requireNonNull(status);
+        this.equivalentR = equivalentR;
+        this.equivalentX = equivalentX;
     }
 
     @Override
@@ -103,4 +109,13 @@ abstract class AbstractFaultResult extends AbstractExtendable<FaultResult> imple
         return Double.NaN;
     }
 
+    @Override
+    public double getEquivalentR() {
+        return equivalentR;
+    }
+
+    @Override
+    public double getEquivalentX() {
+        return equivalentX;
+    }
 }

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/FailedFaultResult.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/FailedFaultResult.java
@@ -15,6 +15,6 @@ package com.powsybl.shortcircuit;
 public class FailedFaultResult extends AbstractFaultResult {
 
     public FailedFaultResult(Fault fault, Status status) {
-        super(fault, status, Double.NaN, null, null, null, null);
+        super(fault, status, Double.NaN, null, null, null, null, Double.NaN, Double.NaN);
     }
 }

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/FaultResult.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/FaultResult.java
@@ -78,7 +78,17 @@ public interface FaultResult extends Extendable<FaultResult> {
     Status getStatus();
 
     /**
-     * Returns the three-phase current associated to a feeder.
+     * Returns the three-phase current associated with a feeder.
      */
     double getFeederCurrent(String feederId);
+
+    /**
+     * The equivalent resistance of the network seen from the fault.
+     */
+    double getEquivalentR();
+
+    /**
+     * The equivalent reactance of the network seen from the fault.
+     */
+    double getEquivalentX();
 }

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/FortescueFaultResult.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/FortescueFaultResult.java
@@ -24,12 +24,25 @@ public final class FortescueFaultResult extends AbstractFaultResult {
 
     private final FortescueValue voltage;
 
+    private final double equivalentRZero;
+
+    private final double equivalentXZero;
+
+    public FortescueFaultResult(Fault fault, double shortCircuitPower, List<FeederResult> feederResults,
+                                List<LimitViolation> limitViolations, FortescueValue current, FortescueValue voltage, List<ShortCircuitBusResults> shortCircuitBusResults,
+                                Duration timeConstant, Status status, double equivalentR, double equivalentRZero,
+                                double equivalentX, double equivalentXZero) {
+        super(fault, status, shortCircuitPower, timeConstant, feederResults, limitViolations, shortCircuitBusResults, equivalentR, equivalentX);
+        this.current = current;
+        this.voltage = voltage;
+        this.equivalentRZero = equivalentRZero;
+        this.equivalentXZero = equivalentXZero;
+    }
+
     public FortescueFaultResult(Fault fault, double shortCircuitPower, List<FeederResult> feederResults,
                                 List<LimitViolation> limitViolations, FortescueValue current, FortescueValue voltage, List<ShortCircuitBusResults> shortCircuitBusResults,
                                 Duration timeConstant, Status status) {
-        super(fault, status, shortCircuitPower, timeConstant, feederResults, limitViolations, shortCircuitBusResults);
-        this.current = current;
-        this.voltage = voltage;
+        this(fault, shortCircuitPower, feederResults, limitViolations, current, voltage, shortCircuitBusResults, timeConstant, status, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
     }
 
     public FortescueFaultResult(Fault fault, double shortCircuitPower, List<FeederResult> feederResults,
@@ -46,6 +59,12 @@ public final class FortescueFaultResult extends AbstractFaultResult {
         this(fault, Double.NaN, null, null, null, null, Collections.emptyList(), null, status);
     }
 
+    public FortescueFaultResult(Fault fault, double shortCircuitPower, FortescueValue current, FortescueValue voltage,
+                                Duration timeConstant, Status status, double equivalentR, double equivalentRZero, double equivalentX, double equivalentXZero) {
+        this(fault, shortCircuitPower, Collections.emptyList(), Collections.emptyList(), current, voltage, Collections.emptyList(),
+                timeConstant, status, equivalentR, equivalentRZero, equivalentX, equivalentXZero);
+    }
+
     /**
      * The results on three phases for current [in A]
      */
@@ -58,6 +77,20 @@ public final class FortescueFaultResult extends AbstractFaultResult {
      */
     public FortescueValue getVoltage() {
         return voltage;
+    }
+
+    /**
+     * The zero-sequence equivalent resistance of the network seen from the fault.
+     */
+    public double getEquivalentRZero() {
+        return equivalentRZero;
+    }
+
+    /**
+     * The zero-sequence equivalent three-phase reactance of the network seen from the fault.
+     */
+    public double getEquivalentXZero() {
+        return equivalentXZero;
     }
 
 }

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/MagnitudeFaultResult.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/MagnitudeFaultResult.java
@@ -26,10 +26,16 @@ public class MagnitudeFaultResult extends AbstractFaultResult {
 
     public MagnitudeFaultResult(Fault fault, double shortCircuitPower, List<FeederResult> feederResults,
                                 List<LimitViolation> limitViolations, double current, double voltage, List<ShortCircuitBusResults> shortCircuitBusResults,
-                                Duration timeConstant, Status status) {
-        super(fault, status, shortCircuitPower, timeConstant, feederResults, limitViolations, shortCircuitBusResults);
+                                Duration timeConstant, Status status, double equivalentR, double equivalentX) {
+        super(fault, status, shortCircuitPower, timeConstant, feederResults, limitViolations, shortCircuitBusResults, equivalentR, equivalentX);
         this.current = current;
         this.voltage = voltage;
+    }
+
+    public MagnitudeFaultResult(Fault fault, double shortCircuitPower, List<FeederResult> feederResults,
+                                List<LimitViolation> limitViolations, double current, double voltage, List<ShortCircuitBusResults> shortCircuitBusResults,
+                                Duration timeConstant, Status status) {
+        this(fault, shortCircuitPower, feederResults, limitViolations, current, voltage, shortCircuitBusResults, timeConstant, status, Double.NaN, Double.NaN);
     }
 
     public MagnitudeFaultResult(Fault fault, double shortCircuitPower, List<FeederResult> feederResults,
@@ -52,6 +58,12 @@ public class MagnitudeFaultResult extends AbstractFaultResult {
         this(fault, Double.NaN, null, null, Double.NaN, Double.NaN, Collections.emptyList(), null, status);
     }
 
+    public MagnitudeFaultResult(Fault fault, double shortCircuitPower, double current, double voltage,
+                                Duration timeConstant, Status status, double equivalentR, double equivalentX) {
+        this(fault, shortCircuitPower, Collections.emptyList(), Collections.emptyList(), current, voltage, Collections.emptyList(),
+                timeConstant, status, equivalentR, equivalentX);
+    }
+
     /**
      * The three-phase current magnitude [in A].
      */
@@ -65,5 +77,4 @@ public class MagnitudeFaultResult extends AbstractFaultResult {
     public double getVoltage() {
         return voltage;
     }
-
 }

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/ShortCircuitAnalysisResult.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/ShortCircuitAnalysisResult.java
@@ -25,7 +25,8 @@ public class ShortCircuitAnalysisResult extends AbstractExtendable<ShortCircuitA
     // VERSION = 1.3 voltageLocation in LimitViolation
     // VERSION = 1.4 operationalLimitsGroupId in LimitViolation
     // VERSION = 1.5 LINE_TO_LINE and LINE_TO_LINE_WITH_EARTH_CONNECTION in FaultType
-    public static final String VERSION = "1.5";
+    // VERSION = 1.6 equivalentR and equivalentX in faultResult
+    public static final String VERSION = "1.6";
 
     private final Map<String, FaultResult> resultByFaultId = new TreeMap<>();
     private final Map<String, List<FaultResult>> resultByElementId = new TreeMap<>();

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultResultDeserializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultResultDeserializer.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
 class FaultResultDeserializer {
 
     private static final String CONTEXT_NAME = "FaultResult";
+    public static final String TAG = "Tag: ";
 
     private static final Supplier<ExtensionProviders<ExtensionJsonSerializer>> SUPPLIER =
             Suppliers.memoize(() -> ExtensionProviders.createProvider(ExtensionJsonSerializer.class, "short-circuit-analysis"));
@@ -85,9 +86,29 @@ class FaultResultDeserializer {
                     case "shortCircuitBusResults" ->
                         faultResultParameters.shortCircuitBusResults = new ShortCircuitBusResultsDeserializer().deserialize(parser, version);
                     case "status" -> {
-                        JsonUtil.assertGreaterOrEqualThanReferenceVersion(CONTEXT_NAME, "Tag: " + parser.currentName(), version, "1.1");
+                        JsonUtil.assertGreaterOrEqualThanReferenceVersion(CONTEXT_NAME, TAG + parser.currentName(), version, "1.1");
                         parser.nextToken();
                         faultResultParameters.status = FaultResult.Status.valueOf(parser.getValueAsString());
+                    }
+                    case "equivalentR" -> {
+                        JsonUtil.assertGreaterOrEqualThanReferenceVersion(CONTEXT_NAME, TAG + parser.currentName(), version, "1.6");
+                        parser.nextToken();
+                        faultResultParameters.equivalentR = parser.readValueAs(Double.class);
+                    }
+                    case "equivalentX" -> {
+                        JsonUtil.assertGreaterOrEqualThanReferenceVersion(CONTEXT_NAME, TAG + parser.currentName(), version, "1.6");
+                        parser.nextToken();
+                        faultResultParameters.equivalentX = parser.readValueAs(Double.class);
+                    }
+                    case "equivalentRZero" -> {
+                        JsonUtil.assertGreaterOrEqualThanReferenceVersion(CONTEXT_NAME, TAG + parser.currentName(), version, "1.6");
+                        parser.nextToken();
+                        faultResultParameters.equivalentRZero = parser.readValueAs(Double.class);
+                    }
+                    case "equivalentXZero" -> {
+                        JsonUtil.assertGreaterOrEqualThanReferenceVersion(CONTEXT_NAME, TAG + parser.currentName(), version, "1.6");
+                        parser.nextToken();
+                        faultResultParameters.equivalentXZero = parser.readValueAs(Double.class);
                     }
                     case "extensions" -> {
                         parser.nextToken();
@@ -112,6 +133,10 @@ class FaultResultDeserializer {
         Fault fault = null;
         double shortCircuitPower = Double.NaN;
         Duration timeConstant = null;
+        double equivalentR = Double.NaN;
+        double equivalentX = Double.NaN;
+        double equivalentRZero = Double.NaN;
+        double equivalentXZero = Double.NaN;
         FortescueValue current = null;
         FortescueValue voltage = null;
         double currentMagnitude = Double.NaN;
@@ -130,11 +155,12 @@ class FaultResultDeserializer {
             } else {
                 if (!Double.isNaN(parameters.currentMagnitude)) {
                     return new MagnitudeFaultResult(parameters.fault, parameters.shortCircuitPower, parameters.feederResults,
-                        parameters.limitViolations, parameters.currentMagnitude, parameters.voltageMagnitude, parameters.shortCircuitBusResults,
-                        parameters.timeConstant, FaultResult.Status.SUCCESS);
+                            parameters.limitViolations, parameters.currentMagnitude, parameters.voltageMagnitude, parameters.shortCircuitBusResults,
+                            parameters.timeConstant, FaultResult.Status.SUCCESS, parameters.equivalentR, parameters.equivalentX);
                 } else {
                     return new FortescueFaultResult(parameters.fault, parameters.shortCircuitPower, parameters.feederResults,
-                        parameters.limitViolations, parameters.current, parameters.voltage, parameters.shortCircuitBusResults, parameters.timeConstant, FaultResult.Status.SUCCESS);
+                            parameters.limitViolations, parameters.current, parameters.voltage, parameters.shortCircuitBusResults, parameters.timeConstant,
+                            FaultResult.Status.SUCCESS, parameters.equivalentR, parameters.equivalentRZero, parameters.equivalentX, parameters.equivalentXZero);
                 }
             }
         } else {
@@ -142,11 +168,12 @@ class FaultResultDeserializer {
                 return new FailedFaultResult(parameters.fault, parameters.status);
             } else if (!Double.isNaN(parameters.currentMagnitude)) {
                 return new MagnitudeFaultResult(parameters.fault, parameters.shortCircuitPower, parameters.feederResults,
-                    parameters.limitViolations, parameters.currentMagnitude, parameters.voltageMagnitude, parameters.shortCircuitBusResults,
-                    parameters.timeConstant, parameters.status);
+                        parameters.limitViolations, parameters.currentMagnitude, parameters.voltageMagnitude, parameters.shortCircuitBusResults,
+                        parameters.timeConstant, parameters.status, parameters.equivalentR, parameters.equivalentX);
             } else {
                 return new FortescueFaultResult(parameters.fault, parameters.shortCircuitPower, parameters.feederResults,
-                    parameters.limitViolations, parameters.current, parameters.voltage, parameters.shortCircuitBusResults, parameters.timeConstant, parameters.status);
+                        parameters.limitViolations, parameters.current, parameters.voltage, parameters.shortCircuitBusResults, parameters.timeConstant,
+                        parameters.status, parameters.equivalentR, parameters.equivalentRZero, parameters.equivalentX, parameters.equivalentXZero);
             }
         }
     }

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultResultSerializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultResultSerializer.java
@@ -68,13 +68,13 @@ public class FaultResultSerializer extends StdSerializer<FaultResult> {
             serializerProvider.defaultSerializeField("equivalentR", result.getEquivalentR(), jsonGenerator);
         }
         if (!Double.isNaN(result.getEquivalentRZero())) {
-            serializerProvider.defaultSerializeField("equivalentRZero", result.getEquivalentR(), jsonGenerator);
+            serializerProvider.defaultSerializeField("equivalentRZero", result.getEquivalentRZero(), jsonGenerator);
         }
         if (!Double.isNaN(result.getEquivalentX())) {
             serializerProvider.defaultSerializeField("equivalentX", result.getEquivalentX(), jsonGenerator);
         }
         if (!Double.isNaN(result.getEquivalentXZero())) {
-            serializerProvider.defaultSerializeField("equivalentXZero", result.getEquivalentX(), jsonGenerator);
+            serializerProvider.defaultSerializeField("equivalentXZero", result.getEquivalentXZero(), jsonGenerator);
         }
     }
 

--- a/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultResultSerializer.java
+++ b/shortcircuit-api/src/main/java/com/powsybl/shortcircuit/json/FaultResultSerializer.java
@@ -39,7 +39,6 @@ public class FaultResultSerializer extends StdSerializer<FaultResult> {
         }
         if (faultResult instanceof FortescueFaultResult fortescueFaultResult) {
             fortescueResultSerialization(fortescueFaultResult, jsonGenerator, serializerProvider);
-
         } else if (faultResult instanceof MagnitudeFaultResult) {
             magnitudeResultSerialization(faultResult, jsonGenerator, serializerProvider);
         }
@@ -65,17 +64,36 @@ public class FaultResultSerializer extends StdSerializer<FaultResult> {
         if (result.getVoltage() != null) {
             serializerProvider.defaultSerializeField("voltage", result.getVoltage(), jsonGenerator);
         }
+        if (!Double.isNaN(result.getEquivalentR())) {
+            serializerProvider.defaultSerializeField("equivalentR", result.getEquivalentR(), jsonGenerator);
+        }
+        if (!Double.isNaN(result.getEquivalentRZero())) {
+            serializerProvider.defaultSerializeField("equivalentRZero", result.getEquivalentR(), jsonGenerator);
+        }
+        if (!Double.isNaN(result.getEquivalentX())) {
+            serializerProvider.defaultSerializeField("equivalentX", result.getEquivalentX(), jsonGenerator);
+        }
+        if (!Double.isNaN(result.getEquivalentXZero())) {
+            serializerProvider.defaultSerializeField("equivalentXZero", result.getEquivalentX(), jsonGenerator);
+        }
     }
 
     private void magnitudeResultSerialization(FaultResult faultResult, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        MagnitudeFaultResult magnitudeFaultResult = (MagnitudeFaultResult) faultResult;
         if (!((faultResult.getFeederResults()).isEmpty())) {
             serializerProvider.defaultSerializeField("feederResult", faultResult.getFeederResults(), jsonGenerator);
         }
-        if (!Double.isNaN(((MagnitudeFaultResult) faultResult).getCurrent())) {
-            serializerProvider.defaultSerializeField("currentMagnitude", ((MagnitudeFaultResult) faultResult).getCurrent(), jsonGenerator);
+        if (!Double.isNaN(magnitudeFaultResult.getCurrent())) {
+            serializerProvider.defaultSerializeField("currentMagnitude", magnitudeFaultResult.getCurrent(), jsonGenerator);
         }
-        if (!Double.isNaN(((MagnitudeFaultResult) faultResult).getVoltage())) {
-            serializerProvider.defaultSerializeField("voltageMagnitude", ((MagnitudeFaultResult) faultResult).getVoltage(), jsonGenerator);
+        if (!Double.isNaN(magnitudeFaultResult.getVoltage())) {
+            serializerProvider.defaultSerializeField("voltageMagnitude", magnitudeFaultResult.getVoltage(), jsonGenerator);
+        }
+        if (!Double.isNaN(magnitudeFaultResult.getEquivalentR())) {
+            serializerProvider.defaultSerializeField("equivalentR", magnitudeFaultResult.getEquivalentR(), jsonGenerator);
+        }
+        if (!Double.isNaN(magnitudeFaultResult.getEquivalentX())) {
+            serializerProvider.defaultSerializeField("equivalentX", magnitudeFaultResult.getEquivalentX(), jsonGenerator);
         }
     }
 

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisTest.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/ShortCircuitAnalysisTest.java
@@ -180,4 +180,22 @@ class ShortCircuitAnalysisTest {
         assertEquals(ThreeSides.ONE, feederResult.getSide());
         assertEquals(TwoSides.ONE, feederResult.getSideAsTwoSides());
     }
+
+    @Test
+    void testFortescueWithEquivalentImpedance() {
+        ShortCircuitAnalysisResult result = TestingResultFactory.createFortescueResultWithEquivalentImpedance();
+        FortescueFaultResult faultResult = (FortescueFaultResult) result.getFaultResult("id1");
+        assertEquals(2.0, faultResult.getEquivalentR());
+        assertEquals(3.0, faultResult.getEquivalentRZero());
+        assertEquals(4.0, faultResult.getEquivalentX());
+        assertEquals(5.0, faultResult.getEquivalentXZero());
+    }
+
+    @Test
+    void testMagnitudeWithEquivalentImpedance() {
+        ShortCircuitAnalysisResult result = TestingResultFactory.createMagnitudeResultWithEquivalentImpedance();
+        MagnitudeFaultResult faultResult = (MagnitudeFaultResult) result.getFaultResult("id1");
+        assertEquals(4, faultResult.getEquivalentR());
+        assertEquals(5, faultResult.getEquivalentX());
+    }
 }

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/TestingResultFactory.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/TestingResultFactory.java
@@ -204,6 +204,23 @@ public final class TestingResultFactory {
         return shortCircuitAnalysisResult;
     }
 
+    public static ShortCircuitAnalysisResult createFortescueResultWithEquivalentImpedance() {
+        Fault fault1 = new BusFault("id1", "busId");
+        List<FaultResult> faultResults = new ArrayList<>();
+        FortescueFaultResult faultResult1 = new FortescueFaultResult(fault1, 1.0, new FortescueValue(1.0, 10),
+                new FortescueValue(2.0, 20), null, SUCCESS, 2.0, 3.0, 4.0, 5.0);
+        faultResults.add(faultResult1);
+        return new ShortCircuitAnalysisResult(faultResults);
+    }
+
+    public static ShortCircuitAnalysisResult createMagnitudeResultWithEquivalentImpedance() {
+        Fault fault1 = new BusFault("id1", "busId");
+        List<FaultResult> faultResults = new ArrayList<>();
+        MagnitudeFaultResult faultResult1 = new MagnitudeFaultResult(fault1, 1.0, 2.0, 3.0, null, SUCCESS, 4.0, 5.0);
+        faultResults.add(faultResult1);
+        return new ShortCircuitAnalysisResult(faultResults);
+    }
+
     public static class DummyFaultResultExtension extends AbstractExtension<FaultResult> {
 
         @Override

--- a/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/converter/ShortCircuitAnalysisResultExportersTest.java
+++ b/shortcircuit-api/src/test/java/com/powsybl/shortcircuit/converter/ShortCircuitAnalysisResultExportersTest.java
@@ -160,6 +160,44 @@ class ShortCircuitAnalysisResultExportersTest extends AbstractSerDeTest {
         assertEquals(List.of("BBS1"), locationBusBreaker.getBusIds());
     }
 
+    @Test
+    void readJsonFaultResultVersion16() {
+        ShortCircuitAnalysisResult result = ShortCircuitAnalysisResultDeserializer
+                .read(getClass().getResourceAsStream("/shortcircuit-results-version16.json"));
+        assertEquals(1, result.getFaultResults().size());
+
+        MagnitudeFaultResult faultResult = (MagnitudeFaultResult) result.getFaultResult("id");
+        assertEquals(Fault.FaultType.SINGLE_PHASE, faultResult.getFault().getFaultType());
+        assertEquals(1.0, faultResult.getCurrent(), 0);
+        assertEquals(1, faultResult.getLimitViolations().size());
+        assertEquals(1, faultResult.getFeederResults().size());
+        assertEquals(2.0, faultResult.getVoltage(), 0);
+        assertEquals(1.0, faultResult.getEquivalentR(), 0);
+        assertEquals(2.0, faultResult.getEquivalentX(), 0);
+
+        LimitViolation violation = faultResult.getLimitViolations().getFirst();
+        assertEquals("activated_limits_group", violation.getOperationalLimitsGroupId());
+        assertEquals("activated_limits_group", violation.getOperationalLimitsGroupId());
+
+        ViolationLocation location = violation.getViolationLocation().orElseThrow();
+        assertEquals(ViolationLocation.Type.BUS_BREAKER, location.getType());
+        BusBreakerViolationLocation locationBusBreaker = (BusBreakerViolationLocation) location;
+        assertEquals(List.of("BBS1"), locationBusBreaker.getBusIds());
+    }
+
+    @Test
+    void readJsonFortescueFaultResultWithEquivalentImpedance() {
+        ShortCircuitAnalysisResult result = ShortCircuitAnalysisResultDeserializer
+                .read(getClass().getResourceAsStream("/shortcircuit-fortescue-results-with-equivalent-impedance.json"));
+        assertEquals(1, result.getFaultResults().size());
+
+        FortescueFaultResult faultResult = (FortescueFaultResult) result.getFaultResult("id");
+        assertEquals(2.0, faultResult.getEquivalentR(), 0);
+        assertEquals(4.0, faultResult.getEquivalentX(), 0);
+        assertEquals(3.0, faultResult.getEquivalentRZero(), 0);
+        assertEquals(5.0, faultResult.getEquivalentXZero(), 0);
+    }
+
     void writeCsv(ShortCircuitAnalysisResult result, Path path) {
         Network network = EurostagTutorialExample1Factory.create();
         ShortCircuitAnalysisResultExporters.export(result, path, "CSV", network);

--- a/shortcircuit-api/src/test/resources/shortcircuit-failed-result.json
+++ b/shortcircuit-api/src/test/resources/shortcircuit-failed-result.json
@@ -1,5 +1,5 @@
 {
-  "version" : "1.5",
+  "version" : "1.6",
   "faultResults" : [ {
     "status" : "FAILURE",
     "fault" : {

--- a/shortcircuit-api/src/test/resources/shortcircuit-fortescue-results-with-equivalent-impedance.json
+++ b/shortcircuit-api/src/test/resources/shortcircuit-fortescue-results-with-equivalent-impedance.json
@@ -1,0 +1,29 @@
+{
+  "version" : "1.6",
+  "faultResults" : [ {
+    "status" : "SUCCESS",
+    "fault" : {
+      "type" : "BUS",
+      "id" : "id",
+      "elementId" : "busId",
+      "r" : 0.0,
+      "x" : 0.0,
+      "connection" : "SERIES",
+      "faultType" : "THREE_PHASE"
+    },
+    "shortCircuitPower" : 1.0,
+    "timeConstant" : "PT1S",
+    "current" : {
+      "directMagnitude" : 1.0,
+      "directAngle" : 10.0
+    },
+    "voltage" : {
+      "directMagnitude" : 50.0,
+      "directAngle" : 50.0
+    },
+    "equivalentR" : 2.0,
+    "equivalentRZero" : 3.0,
+    "equivalentX" : 4.0,
+    "equivalentXZero" : 5.0
+  } ]
+}

--- a/shortcircuit-api/src/test/resources/shortcircuit-fortescue-results.json
+++ b/shortcircuit-api/src/test/resources/shortcircuit-fortescue-results.json
@@ -1,5 +1,5 @@
 {
-  "version" : "1.5",
+  "version" : "1.6",
   "faultResults" : [ {
     "status" : "SUCCESS",
     "fault" : {

--- a/shortcircuit-api/src/test/resources/shortcircuit-magnitude-results.json
+++ b/shortcircuit-api/src/test/resources/shortcircuit-magnitude-results.json
@@ -1,5 +1,5 @@
 {
-  "version" : "1.5",
+  "version" : "1.6",
   "faultResults" : [ {
     "status" : "SUCCESS",
     "fault" : {

--- a/shortcircuit-api/src/test/resources/shortcircuit-multiple-feeder-results.json
+++ b/shortcircuit-api/src/test/resources/shortcircuit-multiple-feeder-results.json
@@ -1,5 +1,5 @@
 {
-  "version" : "1.5",
+  "version" : "1.6",
   "faultResults" : [ {
     "status" : "SUCCESS",
     "fault" : {

--- a/shortcircuit-api/src/test/resources/shortcircuit-results-version16.json
+++ b/shortcircuit-api/src/test/resources/shortcircuit-results-version16.json
@@ -9,19 +9,26 @@
       "r" : 0.0,
       "x" : 0.0,
       "connection" : "SERIES",
-      "faultType" : "THREE_PHASE"
+      "faultType" : "SINGLE_PHASE"
     },
     "shortCircuitPower" : 0.1,
+    "currentMagnitude" : 1.0,
+    "voltageMagnitude" : 2.0,
     "timeConstant" : "PT1S",
+    "equivalentR" : 1.0,
+    "equivalentX" : 2.0,
     "feederResult" : [ {
       "connectableId" : "connectableId",
-      "currentMagnitude" : 1.0,
-      "side" : "ONE"
+      "currentMagnitude" : 1.0
     } ],
-    "currentMagnitude" : 1.0,
     "limitViolations" : [ {
       "subjectId" : "id",
+      "operationalLimitsGroupId" : "activated_limits_group",
       "limitType" : "HIGH_SHORT_CIRCUIT_CURRENT",
+      "violationLocation" : {
+        "type" : "BUS_BREAKER",
+        "busIds" : [ "BBS1" ]
+      },
       "limit" : 2000.0,
       "limitReduction" : 1.0,
       "value" : 2500.0

--- a/shortcircuit-api/src/test/resources/shortcircuit-results-with-operational-limits-group-id.json
+++ b/shortcircuit-api/src/test/resources/shortcircuit-results-with-operational-limits-group-id.json
@@ -1,5 +1,5 @@
 {
-  "version" : "1.5",
+  "version" : "1.6",
   "faultResults" : [ {
     "status" : "SUCCESS",
     "fault" : {

--- a/shortcircuit-api/src/test/resources/shortcircuit-results-with-two-fault-types.json
+++ b/shortcircuit-api/src/test/resources/shortcircuit-results-with-two-fault-types.json
@@ -1,5 +1,5 @@
 {
-  "version" : "1.5",
+  "version" : "1.6",
   "faultResults" : [ {
     "status" : "SUCCESS",
     "fault" : {

--- a/shortcircuit-api/src/test/resources/shortcircuit-results-with-two-faults.json
+++ b/shortcircuit-api/src/test/resources/shortcircuit-results-with-two-faults.json
@@ -1,5 +1,5 @@
 {
-  "version" : "1.5",
+  "version" : "1.6",
   "faultResults" : [ {
     "status" : "SUCCESS",
     "fault" : {

--- a/shortcircuit-api/src/test/resources/shortcircuit-with-extensions-results.json
+++ b/shortcircuit-api/src/test/resources/shortcircuit-with-extensions-results.json
@@ -1,5 +1,5 @@
 {
-  "version" : "1.5",
+  "version" : "1.6",
   "faultResults" : [ {
     "status" : "SUCCESS",
     "fault" : {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Short circuit fault result do not have the equivalent impedance of the network seen from the fault.


**What is the new behavior (if this is a feature change)?**
FaultResult now has an optional equivalent resistance and an equivalent reactance 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
