### PR TITLE
Rework SVC pilot point to distinguish buses from busbar sections.

### DIFF
--- a/docs/grid_model/extensions.md
+++ b/docs/grid_model/extensions.md
@@ -754,15 +754,18 @@ A control zone groups a pilot point with the generators that regulate its voltag
 | Attribute    | Type              | Unit | Required | Default value | Description                                                                                                          |
 |--------------|-------------------|------|----------|---------------|----------------------------------------------------------------------------------------------------------------------|
 | name         | String            | -    | yes      | -             | The unique name of the control zone                                                                                  |
-| pilotPoint   | PilotPoint        | -    | yes      | -             | The pilot point whose voltage is regulated (has a target voltage and a list of regulated busbar sections or bus IDs) |
+| pilotPoint   | PilotPoint        | -    | yes      | -             | The pilot point whose voltage is regulated (has a target voltage and a list of regulated buses and busbar sections) |
 | controlUnits | List<ControlUnit> | -    | yes      | -             | The list of control units (generators) with their active flag to indicate their participation in the zone control    |
 
 **Pilot point**
 
-| Attribute                | Type         | Unit | Required | Default value | Description                                                     |
-|--------------------------|--------------|------|----------|---------------|-----------------------------------------------------------------|
-| busbarSectionsOrBusesIds | List<String> | -    | yes      | -             | The IDs of the busbar sections or buses forming the pilot point |
-| targetV                  | double       | kV   | yes      | -             | The target voltage at the pilot point                           |
+| Attribute        | Type                 | Unit | Required | Default value | Description                                                                                  |
+|------------------|----------------------|------|----------|---------------|----------------------------------------------------------------------------------------------|
+| buses            | List<BusRef>         | -    | no       | empty         | The buses of the bus/breaker view forming the pilot point, each referenced by its voltage level ID and bus ID |
+| busbarSectionIds | List<String>         | -    | no       | empty         | The IDs of the busbar sections forming the pilot point                                       |
+| targetV          | double               | kV   | yes      | -             | The target voltage at the pilot point                                                        |
+
+At least one bus or busbar section is required to define a pilot point.
 
 **Control unit**
 
@@ -779,7 +782,7 @@ network.newExtension(SecondaryVoltageControlAdder.class)
     .newControlZone()
         .withName("z1")
         .newPilotPoint()
-            .withBusbarSectionsOrBusesIds(List.of("NLOAD"))
+            .withBuses(List.of(new PilotPoint.BusRef("VLLOAD", "NLOAD")))
             .withTargetV(15d)
         .add()
         .newControlUnit()

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/PilotPoint.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/PilotPoint.java
@@ -8,6 +8,7 @@
 package com.powsybl.iidm.network.extensions;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -18,9 +19,25 @@ public interface PilotPoint {
     }
 
     /**
-     * Get pilot point busbar section ID or bus ID of the bus/breaker view.
+     * A bus of the bus/breaker view referenced by a pilot point, identified by its voltage level ID and its bus ID.
      */
-    List<String> getBusbarSectionsOrBusesIds();
+    record BusRef(String voltageLevelId, String busId) {
+
+        public BusRef {
+            Objects.requireNonNull(voltageLevelId, "Pilot point bus voltage level ID is null");
+            Objects.requireNonNull(busId, "Pilot point bus ID is null");
+        }
+    }
+
+    /**
+     * Get pilot point buses of the bus/breaker view.
+     */
+    List<BusRef> getBuses();
+
+    /**
+     * Get pilot point busbar section IDs.
+     */
+    List<String> getBusbarSectionIds();
 
     double getTargetV();
 

--- a/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/PilotPointAdder.java
+++ b/iidm/iidm-extensions/src/main/java/com/powsybl/iidm/network/extensions/PilotPointAdder.java
@@ -14,7 +14,9 @@ import java.util.List;
  */
 public interface PilotPointAdder {
 
-    PilotPointAdder withBusbarSectionsOrBusesIds(List<String> busbarSectionsOrBusesIds);
+    PilotPointAdder withBuses(List<PilotPoint.BusRef> buses);
+
+    PilotPointAdder withBusbarSectionIds(List<String> busbarSectionIds);
 
     PilotPointAdder withTargetV(double targetV);
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/PilotPointAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/PilotPointAdderImpl.java
@@ -8,8 +8,10 @@
 package com.powsybl.iidm.network.impl.extensions;
 
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.extensions.PilotPoint;
 import com.powsybl.iidm.network.extensions.PilotPointAdder;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -20,7 +22,9 @@ public class PilotPointAdderImpl implements PilotPointAdder {
 
     private final ControlZoneAdderImpl parent;
 
-    private List<String> busbarSectionsOrBusesIds;
+    private List<PilotPoint.BusRef> buses = Collections.emptyList();
+
+    private List<String> busbarSectionIds = Collections.emptyList();
 
     private double targetV = Double.NaN;
 
@@ -29,8 +33,14 @@ public class PilotPointAdderImpl implements PilotPointAdder {
     }
 
     @Override
-    public PilotPointAdderImpl withBusbarSectionsOrBusesIds(List<String> busbarSectionsOrBusesIds) {
-        this.busbarSectionsOrBusesIds = Objects.requireNonNull(busbarSectionsOrBusesIds);
+    public PilotPointAdderImpl withBuses(List<PilotPoint.BusRef> buses) {
+        this.buses = Objects.requireNonNull(buses);
+        return this;
+    }
+
+    @Override
+    public PilotPointAdderImpl withBusbarSectionIds(List<String> busbarSectionIds) {
+        this.busbarSectionIds = Objects.requireNonNull(busbarSectionIds);
         return this;
     }
 
@@ -42,18 +52,23 @@ public class PilotPointAdderImpl implements PilotPointAdder {
 
     @Override
     public ControlZoneAdderImpl add() {
-        if (busbarSectionsOrBusesIds.isEmpty()) {
-            throw new PowsyblException("Empty busbar section or bus ID list");
+        if (buses.isEmpty() && busbarSectionIds.isEmpty()) {
+            throw new PowsyblException("Empty pilot point bus and busbar section ID list");
         }
-        for (String busbarSectionsOrBusesId : busbarSectionsOrBusesIds) {
-            if (busbarSectionsOrBusesId == null) {
-                throw new PowsyblException("Null busbar section or bus ID");
+        for (PilotPoint.BusRef bus : buses) {
+            if (bus == null) {
+                throw new PowsyblException("Null pilot point bus");
+            }
+        }
+        for (String busbarSectionId : busbarSectionIds) {
+            if (busbarSectionId == null) {
+                throw new PowsyblException("Null pilot point busbar section ID");
             }
         }
         if (Double.isNaN(targetV)) {
             throw new PowsyblException("Invalid target voltage");
         }
-        parent.setPilotPoint(new PilotPointImpl(busbarSectionsOrBusesIds, targetV, parent.getParent().getNetwork()));
+        parent.setPilotPoint(new PilotPointImpl(buses, busbarSectionIds, targetV, parent.getParent().getNetwork()));
         return parent;
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/PilotPointImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/PilotPointImpl.java
@@ -25,14 +25,17 @@ import java.util.function.UnaryOperator;
  */
 class PilotPointImpl implements PilotPoint {
 
-    private final List<String> busbarSectionsOrBusesIds;
+    private final List<BusRef> buses;
+
+    private final List<String> busbarSectionIds;
 
     private final TDoubleArrayList targetV;
 
     private ControlZoneImpl controlZone;
 
-    PilotPointImpl(List<String> busbarSectionsOrBusesIds, double targetV, VariantManagerHolder variantManagerHolder) {
-        this.busbarSectionsOrBusesIds = new ArrayList<>(Objects.requireNonNull(busbarSectionsOrBusesIds));
+    PilotPointImpl(List<BusRef> buses, List<String> busbarSectionIds, double targetV, VariantManagerHolder variantManagerHolder) {
+        this.buses = new ArrayList<>(Objects.requireNonNull(buses));
+        this.busbarSectionIds = new ArrayList<>(Objects.requireNonNull(busbarSectionIds));
         int variantArraySize = variantManagerHolder.getVariantManager().getVariantArraySize();
         this.targetV = new TDoubleArrayList(variantArraySize);
         for (int i = 0; i < variantArraySize; i++) {
@@ -48,20 +51,24 @@ class PilotPointImpl implements PilotPoint {
         return controlZone.getSecondaryVoltageControl().getVariantManagerHolder().getVariantIndex();
     }
 
-    /**
-     * Get pilot point busbar section ID or bus ID of the bus/breaker view.
-     */
     @Override
-    public List<String> getBusbarSectionsOrBusesIds() {
-        return Collections.unmodifiableList(busbarSectionsOrBusesIds);
+    public List<BusRef> getBuses() {
+        return Collections.unmodifiableList(buses);
     }
 
-    protected void updateBusbarSectionsOrBusesIds(UnaryOperator<String> updater) {
-        busbarSectionsOrBusesIds.replaceAll(updater);
+    @Override
+    public List<String> getBusbarSectionIds() {
+        return Collections.unmodifiableList(busbarSectionIds);
     }
 
-    protected void removeBusbarSectionsOrBusesIdIf(Predicate<String> predicate) {
-        busbarSectionsOrBusesIds.removeIf(predicate);
+    protected void updateIds(UnaryOperator<String> updater) {
+        buses.replaceAll(bus -> new BusRef(updater.apply(bus.voltageLevelId()), updater.apply(bus.busId())));
+        busbarSectionIds.replaceAll(updater);
+    }
+
+    protected void removeIdIf(Predicate<String> predicate) {
+        buses.removeIf(bus -> predicate.test(bus.voltageLevelId()) || predicate.test(bus.busId()));
+        busbarSectionIds.removeIf(predicate);
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/SecondaryVoltageControlImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/extensions/SecondaryVoltageControlImpl.java
@@ -33,7 +33,7 @@ public class SecondaryVoltageControlImpl extends AbstractMultiVariantIdentifiabl
     public void afterRemoval(String identifiable) {
         for (var zone : controlZones) {
             ((ControlZoneImpl) zone).removeControlUnitIf(e -> e.getId().equals(identifiable));
-            ((PilotPointImpl) zone.getPilotPoint()).removeBusbarSectionsOrBusesIdIf(e -> e.equals(identifiable));
+            ((PilotPointImpl) zone.getPilotPoint()).removeIdIf(e -> e.equals(identifiable));
         }
     }
 
@@ -48,7 +48,7 @@ public class SecondaryVoltageControlImpl extends AbstractMultiVariantIdentifiabl
                     }
                     return unit;
                 });
-                ((PilotPointImpl) zone.getPilotPoint()).updateBusbarSectionsOrBusesIds(e -> e.equals(oldValue) ? (String) newValue : e);
+                ((PilotPointImpl) zone.getPilotPoint()).updateIds(e -> e.equals(oldValue) ? (String) newValue : e);
             }
         }
     }

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/SecondaryVoltageControlSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/extensions/SecondaryVoltageControlSerDe.java
@@ -9,13 +9,15 @@ package com.powsybl.iidm.serde.extensions;
 
 import com.google.auto.service.AutoService;
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.commons.extensions.AbstractExtensionSerDe;
 import com.powsybl.commons.extensions.ExtensionSerDe;
 import com.powsybl.commons.io.DeserializerContext;
 import com.powsybl.commons.io.SerializerContext;
 import com.powsybl.commons.io.TreeDataWriter;
+import com.powsybl.iidm.network.Bus;
+import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.extensions.*;
+import com.powsybl.iidm.serde.IidmVersion;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,59 +27,113 @@ import java.util.Map;
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ExtensionSerDe.class)
-public class SecondaryVoltageControlSerDe extends AbstractExtensionSerDe<Network, SecondaryVoltageControl> {
+public class SecondaryVoltageControlSerDe extends AbstractVersionableNetworkExtensionSerDe<Network, SecondaryVoltageControl, SecondaryVoltageControlSerDe.Version> {
+
+    public enum Version implements SerDeVersion<Version> {
+        V_1_0("/xsd/secondaryVoltageControl_V1_0.xsd", "http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0",
+                new VersionNumbers(1, 0), IidmVersion.V_1_0, null),
+        V_1_1("/xsd/secondaryVoltageControl_V1_1.xsd", "http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1",
+                new VersionNumbers(1, 1), IidmVersion.V_1_0, null);
+
+        private final VersionInfo versionInfo;
+
+        Version(String xsdResourcePath, String namespaceUri, VersionNumbers versionNumbers, IidmVersion minIidmVersionIncluded, IidmVersion maxIidmVersionExcluded) {
+            this.versionInfo = new VersionInfo(xsdResourcePath, namespaceUri, "svc", versionNumbers,
+                    minIidmVersionIncluded, maxIidmVersionExcluded, SecondaryVoltageControl.NAME);
+        }
+
+        @Override
+        public VersionInfo getVersionInfo() {
+            return versionInfo;
+        }
+    }
 
     private static final String CONTROL_ZONE_ROOT_ELEMENT = "controlZone";
     private static final String CONTROL_ZONE_ARRAY_ELEMENT = "controlZones";
     private static final String PILOT_POINT_ELEMENT = "pilotPoint";
+    private static final String BUS_ROOT_ELEMENT = "bus";
+    private static final String BUS_ARRAY_ELEMENT = "buses";
+    private static final String BUSBAR_SECTION_ROOT_ELEMENT = "busbarSection";
+    private static final String BUSBAR_SECTION_ARRAY_ELEMENT = "busbarSections";
     private static final String BUSBAR_SECTION_OR_BUS_ID_ROOT_ELEMENT = "busbarSectionOrBusId";
     private static final String BUSBAR_SECTION_OR_BUS_ID_ARRAY_ELEMENT = "busbarSectionOrBusIds";
+    private static final String VOLTAGE_LEVEL_ATTRIBUTE = "voltageLevel";
     private static final String CONTROL_UNIT_ROOT_ELEMENT = "controlUnit";
     private static final String CONTROL_UNIT_ARRAY_ELEMENT = "controlUnits";
 
     public SecondaryVoltageControlSerDe() {
-        super(SecondaryVoltageControl.NAME, "network", SecondaryVoltageControl.class,
-                "secondaryVoltageControl_V1_0.xsd", "http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0", "svc");
+        super(SecondaryVoltageControl.NAME, SecondaryVoltageControl.class, Version.values());
     }
 
     @Override
     public Map<String, String> getArrayNameToSingleNameMap() {
         return Map.of(CONTROL_ZONE_ARRAY_ELEMENT, CONTROL_ZONE_ROOT_ELEMENT,
                 CONTROL_UNIT_ARRAY_ELEMENT, CONTROL_UNIT_ROOT_ELEMENT,
+                BUS_ARRAY_ELEMENT, BUS_ROOT_ELEMENT,
+                BUSBAR_SECTION_ARRAY_ELEMENT, BUSBAR_SECTION_ROOT_ELEMENT,
                 BUSBAR_SECTION_OR_BUS_ID_ARRAY_ELEMENT, BUSBAR_SECTION_OR_BUS_ID_ROOT_ELEMENT);
     }
 
     @Override
     public void write(SecondaryVoltageControl control, SerializerContext context) {
+        Version version = getExtensionVersionToExport(context);
+        String namespaceUri = getNamespaceUri(version.getVersionString());
         TreeDataWriter writer = context.getWriter();
         writer.writeStartNodes();
         for (ControlZone controlZone : control.getControlZones()) {
-            writer.writeStartNode(getNamespaceUri(), CONTROL_ZONE_ROOT_ELEMENT);
+            writer.writeStartNode(namespaceUri, CONTROL_ZONE_ROOT_ELEMENT);
             writer.writeStringAttribute("name", controlZone.getName());
-            writePilotPoint(controlZone, writer);
-            writeControlUnits(controlZone.getControlUnits(), writer);
+            writePilotPoint(controlZone, writer, version, namespaceUri);
+            writeControlUnits(controlZone.getControlUnits(), writer, namespaceUri);
             writer.writeEndNode();
         }
         writer.writeEndNodes();
     }
 
-    private void writePilotPoint(ControlZone controlZone, TreeDataWriter writer) {
-        writer.writeStartNode(getNamespaceUri(), PILOT_POINT_ELEMENT);
-        writer.writeDoubleAttribute("targetV", controlZone.getPilotPoint().getTargetV());
-        writer.writeStartNodes();
-        for (String busbarSectionOrBusId : controlZone.getPilotPoint().getBusbarSectionsOrBusesIds()) {
-            writer.writeStartNode(getNamespaceUri(), BUSBAR_SECTION_OR_BUS_ID_ROOT_ELEMENT);
-            writer.writeNodeContent(busbarSectionOrBusId);
-            writer.writeEndNode();
+    private void writePilotPoint(ControlZone controlZone, TreeDataWriter writer, Version version, String namespaceUri) {
+        PilotPoint pilotPoint = controlZone.getPilotPoint();
+        writer.writeStartNode(namespaceUri, PILOT_POINT_ELEMENT);
+        writer.writeDoubleAttribute("targetV", pilotPoint.getTargetV());
+        if (version.isGreaterThan(Version.V_1_0)) {
+            writer.writeStartNodes();
+            for (PilotPoint.BusRef bus : pilotPoint.getBuses()) {
+                writer.writeStartNode(namespaceUri, BUS_ROOT_ELEMENT);
+                writer.writeStringAttribute(VOLTAGE_LEVEL_ATTRIBUTE, bus.voltageLevelId());
+                writer.writeNodeContent(bus.busId());
+                writer.writeEndNode();
+            }
+            writer.writeEndNodes();
+            writer.writeStartNodes();
+            for (String busbarSectionId : pilotPoint.getBusbarSectionIds()) {
+                writer.writeStartNode(namespaceUri, BUSBAR_SECTION_ROOT_ELEMENT);
+                writer.writeNodeContent(busbarSectionId);
+                writer.writeEndNode();
+            }
+            writer.writeEndNodes();
+        } else {
+            // Version 1.0 does not distinguish buses from busbar sections: the bus and busbar section IDs
+            // are written as a flat list. The voltage level of the buses is not serialized (it is resolved
+            // from the network when reading back a 1.0 file).
+            writer.writeStartNodes();
+            for (PilotPoint.BusRef bus : pilotPoint.getBuses()) {
+                writer.writeStartNode(namespaceUri, BUSBAR_SECTION_OR_BUS_ID_ROOT_ELEMENT);
+                writer.writeNodeContent(bus.busId());
+                writer.writeEndNode();
+            }
+            for (String busbarSectionId : pilotPoint.getBusbarSectionIds()) {
+                writer.writeStartNode(namespaceUri, BUSBAR_SECTION_OR_BUS_ID_ROOT_ELEMENT);
+                writer.writeNodeContent(busbarSectionId);
+                writer.writeEndNode();
+            }
+            writer.writeEndNodes();
         }
-        writer.writeEndNodes();
         writer.writeEndNode();
     }
 
-    private void writeControlUnits(List<ControlUnit> controlUnits, TreeDataWriter writer) {
+    private void writeControlUnits(List<ControlUnit> controlUnits, TreeDataWriter writer, String namespaceUri) {
         writer.writeStartNodes();
         for (ControlUnit controlUnit : controlUnits) {
-            writer.writeStartNode(getNamespaceUri(), CONTROL_UNIT_ROOT_ELEMENT);
+            writer.writeStartNode(namespaceUri, CONTROL_UNIT_ROOT_ELEMENT);
             writer.writeBooleanAttribute("participate", controlUnit.isParticipate());
             writer.writeNodeContent(controlUnit.getId());
             writer.writeEndNode();
@@ -87,23 +143,24 @@ public class SecondaryVoltageControlSerDe extends AbstractExtensionSerDe<Network
 
     @Override
     public SecondaryVoltageControl read(Network network, DeserializerContext context) {
+        Version version = getExtensionVersionImported(context);
         SecondaryVoltageControlAdder adder = network.newExtension(SecondaryVoltageControlAdder.class);
         context.getReader().readChildNodes(elementName -> {
             if (!elementName.equals(CONTROL_ZONE_ROOT_ELEMENT)) {
                 throw new PowsyblException(getExceptionMessageUnknownElement(elementName, "secondaryVoltageControl"));
             }
-            readControlZone(context, adder);
+            readControlZone(network, context, adder, version);
         });
         return adder.add();
     }
 
-    private static void readControlZone(DeserializerContext context, SecondaryVoltageControlAdder adder) {
+    private static void readControlZone(Network network, DeserializerContext context, SecondaryVoltageControlAdder adder, Version version) {
         String name = context.getReader().readStringAttribute("name");
         ControlZoneAdder controlZoneAdder = adder.newControlZone()
                 .withName(name);
         context.getReader().readChildNodes(elementName -> {
             switch (elementName) {
-                case PILOT_POINT_ELEMENT -> readPilotPoint(context, controlZoneAdder);
+                case PILOT_POINT_ELEMENT -> readPilotPoint(network, context, controlZoneAdder, version);
                 case CONTROL_UNIT_ROOT_ELEMENT -> readControlUnit(context, controlZoneAdder);
                 default -> throw new PowsyblException(getExceptionMessageUnknownElement(elementName, "'controlZone'"));
             }
@@ -111,17 +168,40 @@ public class SecondaryVoltageControlSerDe extends AbstractExtensionSerDe<Network
         controlZoneAdder.add();
     }
 
-    private static void readPilotPoint(DeserializerContext context, ControlZoneAdder controlZoneAdder) {
+    private static void readPilotPoint(Network network, DeserializerContext context, ControlZoneAdder controlZoneAdder, Version version) {
         double targetV = context.getReader().readDoubleAttribute("targetV");
-        List<String> busbarSectionsOrBusesIds = new ArrayList<>();
-        context.getReader().readChildNodes(elementName -> {
-            if (!elementName.equals(BUSBAR_SECTION_OR_BUS_ID_ROOT_ELEMENT)) {
-                throw new PowsyblException(getExceptionMessageUnknownElement(elementName, PILOT_POINT_ELEMENT));
-            }
-            busbarSectionsOrBusesIds.add(context.getReader().readContent());
-        });
+        List<PilotPoint.BusRef> buses = new ArrayList<>();
+        List<String> busbarSectionIds = new ArrayList<>();
+        if (version.isGreaterThan(Version.V_1_0)) {
+            context.getReader().readChildNodes(elementName -> {
+                switch (elementName) {
+                    case BUS_ROOT_ELEMENT -> {
+                        String voltageLevelId = context.getReader().readStringAttribute(VOLTAGE_LEVEL_ATTRIBUTE);
+                        buses.add(new PilotPoint.BusRef(voltageLevelId, context.getReader().readContent()));
+                    }
+                    case BUSBAR_SECTION_ROOT_ELEMENT -> busbarSectionIds.add(context.getReader().readContent());
+                    default -> throw new PowsyblException(getExceptionMessageUnknownElement(elementName, PILOT_POINT_ELEMENT));
+                }
+            });
+        } else {
+            // Version 1.0: a flat list of busbar section or bus IDs. Each ID is resolved against the network
+            // to rebuild the distinction between buses (with their voltage level) and busbar sections.
+            context.getReader().readChildNodes(elementName -> {
+                if (!elementName.equals(BUSBAR_SECTION_OR_BUS_ID_ROOT_ELEMENT)) {
+                    throw new PowsyblException(getExceptionMessageUnknownElement(elementName, PILOT_POINT_ELEMENT));
+                }
+                String id = context.getReader().readContent();
+                Identifiable<?> identifiable = network.getIdentifiable(id);
+                if (identifiable instanceof Bus bus) {
+                    buses.add(new PilotPoint.BusRef(bus.getVoltageLevel().getId(), id));
+                } else {
+                    busbarSectionIds.add(id);
+                }
+            });
+        }
         controlZoneAdder.newPilotPoint()
-                .withBusbarSectionsOrBusesIds(busbarSectionsOrBusesIds)
+                .withBuses(buses)
+                .withBusbarSectionIds(busbarSectionIds)
                 .withTargetV(targetV)
                 .add();
     }

--- a/iidm/iidm-serde/src/main/resources/xsd/secondaryVoltageControl_V1_1.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/secondaryVoltageControl_V1_1.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1"
+           elementFormDefault="qualified">
+    <xs:complexType name="Bus">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="voltageLevel" use="required" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="PilotPoint">
+        <xs:sequence>
+            <xs:element name="bus" type="svc:Bus" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="busbarSection" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="targetV" use="required" type="xs:double"/>
+    </xs:complexType>
+    <xs:complexType name="ControlUnit">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="participate" use="required" type="xs:boolean"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="ControlZone">
+        <xs:sequence>
+            <xs:element name="pilotPoint" type="svc:PilotPoint" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="controlUnit" type="svc:ControlUnit" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+    <xs:element name="secondaryVoltageControl">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="controlZone" type="svc:ControlZone" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/SecondaryVoltageControlXmlTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/extensions/SecondaryVoltageControlXmlTest.java
@@ -8,10 +8,13 @@
 package com.powsybl.iidm.serde.extensions;
 
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.extensions.PilotPoint;
 import com.powsybl.iidm.network.extensions.SecondaryVoltageControl;
 import com.powsybl.iidm.network.extensions.SecondaryVoltageControlAdder;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.network.test.NetworkTest1Factory;
 import com.powsybl.iidm.serde.AbstractIidmSerDeTest;
+import com.powsybl.iidm.serde.ExportOptions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -27,16 +30,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 class SecondaryVoltageControlXmlTest extends AbstractIidmSerDeTest {
 
-    @Test
-    void test() throws IOException {
+    private static Network createNetwork() {
         Network network = EurostagTutorialExample1Factory.createWithMoreGenerators();
         network.setCaseDate(ZonedDateTime.parse("2023-01-07T20:43:11.819+01:00"));
 
-        SecondaryVoltageControl control = network.newExtension(SecondaryVoltageControlAdder.class)
+        network.newExtension(SecondaryVoltageControlAdder.class)
                 .newControlZone()
                     .withName("z1")
                     .newPilotPoint()
-                        .withBusbarSectionsOrBusesIds(List.of("NLOAD"))
+                        .withBuses(List.of(new PilotPoint.BusRef("VLLOAD", "NLOAD")))
                         .withTargetV(15d)
                     .add()
                     .newControlUnit()
@@ -45,18 +47,19 @@ class SecondaryVoltageControlXmlTest extends AbstractIidmSerDeTest {
                     .add()
                     .newControlUnit()
                         .withId("GEN2")
-                        .add()
                     .add()
-                .add();
+                .add()
+            .add();
+        return network;
+    }
 
-        Network network2 = allFormatsRoundTripTest(network, "/secondaryVoltageControlRoundTripRef.xml", CURRENT_IIDM_VERSION);
-
-        SecondaryVoltageControl control2 = network2.getExtension(SecondaryVoltageControl.class);
+    private static void assertControlEquals(SecondaryVoltageControl control, SecondaryVoltageControl control2) {
         assertNotNull(control2);
-
         assertEquals(control.getControlZones().size(), control2.getControlZones().size());
-        assertEquals(control.getControlZones().get(0).getPilotPoint().getBusbarSectionsOrBusesIds(),
-                     control2.getControlZones().get(0).getPilotPoint().getBusbarSectionsOrBusesIds());
+        assertEquals(control.getControlZones().get(0).getPilotPoint().getBuses(),
+                     control2.getControlZones().get(0).getPilotPoint().getBuses());
+        assertEquals(control.getControlZones().get(0).getPilotPoint().getBusbarSectionIds(),
+                     control2.getControlZones().get(0).getPilotPoint().getBusbarSectionIds());
         assertEquals(control.getControlZones().get(0).getPilotPoint().getTargetV(),
                      control2.getControlZones().get(0).getPilotPoint().getTargetV(), 0d);
         assertEquals(control.getControlZones().get(0).getControlUnits().size(),
@@ -69,5 +72,59 @@ class SecondaryVoltageControlXmlTest extends AbstractIidmSerDeTest {
                      control2.getControlZones().get(0).getControlUnits().get(1).getId());
         assertEquals(control.getControlZones().get(0).getControlUnits().get(1).isParticipate(),
                      control2.getControlZones().get(0).getControlUnits().get(1).isParticipate());
+    }
+
+    @Test
+    void test() throws IOException {
+        Network network = createNetwork();
+        SecondaryVoltageControl control = network.getExtension(SecondaryVoltageControl.class);
+
+        Network network2 = allFormatsRoundTripTest(network, "/secondaryVoltageControlRoundTripRef.xml", CURRENT_IIDM_VERSION);
+
+        assertControlEquals(control, network2.getExtension(SecondaryVoltageControl.class));
+    }
+
+    @Test
+    void testNodeBreakerWithBusbarSections() throws IOException {
+        Network network = NetworkTest1Factory.create();
+        network.setCaseDate(ZonedDateTime.parse("2023-01-07T20:43:11.819+01:00"));
+
+        SecondaryVoltageControl control = network.newExtension(SecondaryVoltageControlAdder.class)
+                .newControlZone()
+                    .withName("z1")
+                    .newPilotPoint()
+                        .withBusbarSectionIds(List.of("voltageLevel1BusbarSection1", "voltageLevel1BusbarSection2"))
+                        .withTargetV(400d)
+                    .add()
+                    .newControlUnit()
+                        .withId("generator1")
+                        .withParticipate(false)
+                    .add()
+                .add()
+            .add();
+
+        Network network2 = allFormatsRoundTripTest(network, "/secondaryVoltageControlNodeBreakerRoundTripRef.xml", CURRENT_IIDM_VERSION);
+
+        SecondaryVoltageControl control2 = network2.getExtension(SecondaryVoltageControl.class);
+        assertNotNull(control2);
+        PilotPoint pilotPoint = control.getControlZones().get(0).getPilotPoint();
+        PilotPoint pilotPoint2 = control2.getControlZones().get(0).getPilotPoint();
+        assertEquals(List.of(), pilotPoint2.getBuses());
+        assertEquals(List.of("voltageLevel1BusbarSection1", "voltageLevel1BusbarSection2"), pilotPoint2.getBusbarSectionIds());
+        assertEquals(pilotPoint.getBusbarSectionIds(), pilotPoint2.getBusbarSectionIds());
+        assertEquals(pilotPoint.getTargetV(), pilotPoint2.getTargetV(), 0d);
+    }
+
+    @Test
+    void testVersion10() throws IOException {
+        Network network = createNetwork();
+        SecondaryVoltageControl control = network.getExtension(SecondaryVoltageControl.class);
+
+        // Version 1.0 does not distinguish buses from busbar sections and does not serialize the voltage level.
+        // On reading back, the flat "NLOAD" reference is resolved against the network into the bus of VLLOAD.
+        Network network2 = allFormatsRoundTripTest(network, "/secondaryVoltageControlRoundTripRef-1.0.xml", CURRENT_IIDM_VERSION,
+                new ExportOptions().addExtensionVersion(SecondaryVoltageControl.NAME, "1.0"));
+
+        assertControlEquals(control, network2.getExtension(SecondaryVoltageControl.class));
     }
 }

--- a/iidm/iidm-serde/src/test/resources/V1_10/secondaryVoltageControlRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_10/secondaryVoltageControlRoundTripRef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_10" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_10" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
         <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -50,7 +50,7 @@
         <svc:secondaryVoltageControl>
             <svc:controlZone name="z1">
                 <svc:pilotPoint targetV="15.0">
-                    <svc:busbarSectionOrBusId>NLOAD</svc:busbarSectionOrBusId>
+                    <svc:bus voltageLevel="VLLOAD">NLOAD</svc:bus>
                 </svc:pilotPoint>
                 <svc:controlUnit participate="false">GEN</svc:controlUnit>
                 <svc:controlUnit participate="true">GEN2</svc:controlUnit>

--- a/iidm/iidm-serde/src/test/resources/V1_11/secondaryVoltageControlRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_11/secondaryVoltageControlRoundTripRef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_11" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_11" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
         <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -50,7 +50,7 @@
         <svc:secondaryVoltageControl>
             <svc:controlZone name="z1">
                 <svc:pilotPoint targetV="15.0">
-                    <svc:busbarSectionOrBusId>NLOAD</svc:busbarSectionOrBusId>
+                    <svc:bus voltageLevel="VLLOAD">NLOAD</svc:bus>
                 </svc:pilotPoint>
                 <svc:controlUnit participate="false">GEN</svc:controlUnit>
                 <svc:controlUnit participate="true">GEN2</svc:controlUnit>

--- a/iidm/iidm-serde/src/test/resources/V1_12/secondaryVoltageControlRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_12/secondaryVoltageControlRoundTripRef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_12" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_12" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
         <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -50,7 +50,7 @@
         <svc:secondaryVoltageControl>
             <svc:controlZone name="z1">
                 <svc:pilotPoint targetV="15.0">
-                    <svc:busbarSectionOrBusId>NLOAD</svc:busbarSectionOrBusId>
+                    <svc:bus voltageLevel="VLLOAD">NLOAD</svc:bus>
                 </svc:pilotPoint>
                 <svc:controlUnit participate="false">GEN</svc:controlUnit>
                 <svc:controlUnit participate="true">GEN2</svc:controlUnit>

--- a/iidm/iidm-serde/src/test/resources/V1_13/secondaryVoltageControlRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_13/secondaryVoltageControlRoundTripRef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_13" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_13" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
         <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -50,7 +50,7 @@
         <svc:secondaryVoltageControl>
             <svc:controlZone name="z1">
                 <svc:pilotPoint targetV="15.0">
-                    <svc:busbarSectionOrBusId>NLOAD</svc:busbarSectionOrBusId>
+                    <svc:bus voltageLevel="VLLOAD">NLOAD</svc:bus>
                 </svc:pilotPoint>
                 <svc:controlUnit participate="false">GEN</svc:controlUnit>
                 <svc:controlUnit participate="true">GEN2</svc:controlUnit>

--- a/iidm/iidm-serde/src/test/resources/V1_14/secondaryVoltageControlRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/secondaryVoltageControlRoundTripRef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_14" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_14" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
         <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -50,7 +50,7 @@
         <svc:secondaryVoltageControl>
             <svc:controlZone name="z1">
                 <svc:pilotPoint targetV="15.0">
-                    <svc:busbarSectionOrBusId>NLOAD</svc:busbarSectionOrBusId>
+                    <svc:bus voltageLevel="VLLOAD">NLOAD</svc:bus>
                 </svc:pilotPoint>
                 <svc:controlUnit participate="false">GEN</svc:controlUnit>
                 <svc:controlUnit participate="true">GEN2</svc:controlUnit>

--- a/iidm/iidm-serde/src/test/resources/V1_15/secondaryVoltageControlRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_15/secondaryVoltageControlRoundTripRef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_15" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_15" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
         <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -50,7 +50,7 @@
         <svc:secondaryVoltageControl>
             <svc:controlZone name="z1">
                 <svc:pilotPoint targetV="15.0">
-                    <svc:busbarSectionOrBusId>NLOAD</svc:busbarSectionOrBusId>
+                    <svc:bus voltageLevel="VLLOAD">NLOAD</svc:bus>
                 </svc:pilotPoint>
                 <svc:controlUnit participate="false">GEN</svc:controlUnit>
                 <svc:controlUnit participate="true">GEN2</svc:controlUnit>

--- a/iidm/iidm-serde/src/test/resources/V1_16/secondaryVoltageControlRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_16/secondaryVoltageControlRoundTripRef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_16" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_16" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
         <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -50,7 +50,7 @@
         <svc:secondaryVoltageControl>
             <svc:controlZone name="z1">
                 <svc:pilotPoint targetV="15.0">
-                    <svc:busbarSectionOrBusId>NLOAD</svc:busbarSectionOrBusId>
+                    <svc:bus voltageLevel="VLLOAD">NLOAD</svc:bus>
                 </svc:pilotPoint>
                 <svc:controlUnit participate="false">GEN</svc:controlUnit>
                 <svc:controlUnit participate="true">GEN2</svc:controlUnit>

--- a/iidm/iidm-serde/src/test/resources/V1_17/secondaryVoltageControlNodeBreakerRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_17/secondaryVoltageControlNodeBreakerRoundTripRef.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1" id="network" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="substation1" country="FR" tso="TSO1" geographicalTags="region1">
+        <iidm:voltageLevel id="voltageLevel1" nominalV="400.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="voltageLevel1BusbarSection1" node="0"/>
+                <iidm:busbarSection id="voltageLevel1BusbarSection2" node="1"/>
+                <iidm:switch id="voltageLevel1Breaker1" kind="BREAKER" retained="true" open="false" node1="0" node2="1"/>
+                <iidm:switch id="load1Disconnector1" kind="DISCONNECTOR" open="false" node1="2" node2="3"/>
+                <iidm:switch id="load1Breaker1" kind="DISCONNECTOR" open="false" node1="3" node2="0"/>
+                <iidm:switch id="generator1Disconnector1" kind="DISCONNECTOR" open="false" node1="5" node2="6"/>
+                <iidm:switch id="generator1Breaker1" kind="DISCONNECTOR" open="false" node1="6" node2="1"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="generator1" energySource="NUCLEAR" minP="200.0" maxP="900.0" voltageRegulatorOn="true" targetP="900.0" targetV="380.0" node="5">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="200.0" minQ="300.0" maxQ="500.0"/>
+                    <iidm:point p="900.0" minQ="300.0" maxQ="500.0"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:load id="load1" loadType="UNDEFINED" p0="10.0" q0="3.0" node="2"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:extension id="network">
+        <svc:secondaryVoltageControl>
+            <svc:controlZone name="z1">
+                <svc:pilotPoint targetV="400.0">
+                    <svc:busbarSection>voltageLevel1BusbarSection1</svc:busbarSection>
+                    <svc:busbarSection>voltageLevel1BusbarSection2</svc:busbarSection>
+                </svc:pilotPoint>
+                <svc:controlUnit participate="false">generator1</svc:controlUnit>
+            </svc:controlZone>
+        </svc:secondaryVoltageControl>
+    </iidm:extension>
+</iidm:network>

--- a/iidm/iidm-serde/src/test/resources/V1_17/secondaryVoltageControlRoundTripRef-1.0.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_17/secondaryVoltageControlRoundTripRef-1.0.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_9" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
         <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -21,7 +21,7 @@
                 <iidm:bus id="NHV1"/>
             </iidm:busBreakerTopology>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1"/>
     </iidm:substation>
     <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
         <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
@@ -35,22 +35,22 @@
             </iidm:busBreakerTopology>
             <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD"/>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
-            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD">
+            <iidm:ratioTapChanger tapPosition="1" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="true" regulationMode="VOLTAGE" regulationValue="158.0">
                 <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
-                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
-                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
-                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+                <iidm:step rho="0.8505666905244191"/>
+                <iidm:step rho="1.0006666666666666"/>
+                <iidm:step rho="1.150766642808914"/>
             </iidm:ratioTapChanger>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
-    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
-    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" b1="1.93E-4" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" b1="1.93E-4" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2"/>
     <iidm:extension id="sim1">
         <svc:secondaryVoltageControl>
             <svc:controlZone name="z1">
                 <svc:pilotPoint targetV="15.0">
-                    <svc:bus voltageLevel="VLLOAD">NLOAD</svc:bus>
+                    <svc:busbarSectionOrBusId>NLOAD</svc:busbarSectionOrBusId>
                 </svc:pilotPoint>
                 <svc:controlUnit participate="false">GEN</svc:controlUnit>
                 <svc:controlUnit participate="true">GEN2</svc:controlUnit>

--- a/iidm/iidm-serde/src/test/resources/V1_17/secondaryVoltageControlRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_17/secondaryVoltageControlRoundTripRef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
         <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -50,7 +50,7 @@
         <svc:secondaryVoltageControl>
             <svc:controlZone name="z1">
                 <svc:pilotPoint targetV="15.0">
-                    <svc:busbarSectionOrBusId>NLOAD</svc:busbarSectionOrBusId>
+                    <svc:bus voltageLevel="VLLOAD">NLOAD</svc:bus>
                 </svc:pilotPoint>
                 <svc:controlUnit participate="false">GEN</svc:controlUnit>
                 <svc:controlUnit participate="true">GEN2</svc:controlUnit>

--- a/iidm/iidm-serde/src/test/resources/V1_8/secondaryVoltageControlRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_8/secondaryVoltageControlRoundTripRef.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_0" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" xmlns:svc="http://www.powsybl.org/schema/iidm/ext/secondary_voltage_control/1_1" id="sim1" caseDate="2023-01-07T20:43:11.819+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
         <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
             <iidm:busBreakerTopology>
@@ -50,7 +50,7 @@
         <svc:secondaryVoltageControl>
             <svc:controlZone name="z1">
                 <svc:pilotPoint targetV="15.0">
-                    <svc:busbarSectionOrBusId>NLOAD</svc:busbarSectionOrBusId>
+                    <svc:bus voltageLevel="VLLOAD">NLOAD</svc:bus>
                 </svc:pilotPoint>
                 <svc:controlUnit participate="false">GEN</svc:controlUnit>
                 <svc:controlUnit participate="true">GEN2</svc:controlUnit>

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractMergeNetworkTest.java
@@ -247,7 +247,7 @@ public abstract class AbstractMergeNetworkTest {
                 .newControlZone()
                     .withName("z1")
                     .newPilotPoint()
-                        .withBusbarSectionsOrBusesIds(List.of("NLOAD"))
+                        .withBuses(List.of(new PilotPoint.BusRef("VLLOAD", "NLOAD")))
                         .withTargetV(15d)
                     .add()
                     .newControlUnit()

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractSecondaryVoltageControlTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/extensions/AbstractSecondaryVoltageControlTest.java
@@ -15,6 +15,7 @@ import com.powsybl.iidm.network.events.ExtensionRemovalNetworkEvent;
 import com.powsybl.iidm.network.events.ExtensionUpdateNetworkEvent;
 import com.powsybl.iidm.network.extensions.*;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.iidm.network.test.NetworkTest1Factory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +39,7 @@ public abstract class AbstractSecondaryVoltageControlTest {
                     .newControlZone()
                         .withName("z1")
                         .newPilotPoint()
-                            .withBusbarSectionsOrBusesIds(List.of("NLOAD"))
+                            .withBuses(List.of(new PilotPoint.BusRef("VLLOAD", "NLOAD")))
                             .withTargetV(15d)
                         .add()
                         .newControlUnit()
@@ -59,7 +60,7 @@ public abstract class AbstractSecondaryVoltageControlTest {
         ControlZone z1 = control.getControlZones().get(0);
         assertEquals("z1", z1.getName());
         assertNotNull(z1.getPilotPoint());
-        assertEquals(List.of("NLOAD"), z1.getPilotPoint().getBusbarSectionsOrBusesIds());
+        assertEquals(List.of(new PilotPoint.BusRef("VLLOAD", "NLOAD")), z1.getPilotPoint().getBuses());
         assertEquals(15d, z1.getPilotPoint().getTargetV(), 0d);
         assertEquals(2, z1.getControlUnits().size());
         assertEquals("GEN", z1.getControlUnits().get(0).getId());
@@ -109,7 +110,7 @@ public abstract class AbstractSecondaryVoltageControlTest {
                 .newControlZone()
                     .withName("z2")
                     .newPilotPoint()
-                        .withBusbarSectionsOrBusesIds(List.of("NGEN"))
+                        .withBuses(List.of(new PilotPoint.BusRef("VLGEN", "NGEN")))
                         .withTargetV(7d)
                     .add()
                     .newControlUnit()
@@ -194,13 +195,13 @@ public abstract class AbstractSecondaryVoltageControlTest {
         ControlZone z1 = control.getControlZones().get(0);
         assertEquals("z1", z1.getName());
         assertNotNull(z1.getPilotPoint());
-        assertEquals(List.of("NLOAD"), z1.getPilotPoint().getBusbarSectionsOrBusesIds());
+        assertEquals(List.of(new PilotPoint.BusRef("VLLOAD", "NLOAD")), z1.getPilotPoint().getBuses());
         assertEquals("GEN", z1.getControlUnits().get(0).getId());
 
         network.getIdentifiable("NLOAD").setId("NLOAD_NEW_ID");
         network.getIdentifiable("GEN").setId("GEN_NEW_ID");
 
-        assertEquals(List.of("NLOAD_NEW_ID"), z1.getPilotPoint().getBusbarSectionsOrBusesIds());
+        assertEquals(List.of(new PilotPoint.BusRef("VLLOAD", "NLOAD_NEW_ID")), z1.getPilotPoint().getBuses());
         assertEquals("GEN_NEW_ID", z1.getControlUnits().get(0).getId());
         assertEquals(2, z1.getControlUnits().size());
 
@@ -208,5 +209,36 @@ public abstract class AbstractSecondaryVoltageControlTest {
 
         assertEquals("GEN2", z1.getControlUnits().get(0).getId());
         assertEquals(1, z1.getControlUnits().size());
+    }
+
+    @Test
+    public void secondaryVoltageControlBusbarSectionUpdateListenerTest() {
+        Network nodeBreakerNetwork = NetworkTest1Factory.create();
+        SecondaryVoltageControl nodeBreakerControl = nodeBreakerNetwork.newExtension(SecondaryVoltageControlAdder.class)
+                .newControlZone()
+                    .withName("z1")
+                    .newPilotPoint()
+                        .withBusbarSectionIds(List.of("voltageLevel1BusbarSection1", "voltageLevel1BusbarSection2"))
+                        .withTargetV(400d)
+                    .add()
+                    .newControlUnit()
+                        .withId("generator1")
+                        .withParticipate(false)
+                    .add()
+                .add()
+            .add();
+
+        PilotPoint pilotPoint = nodeBreakerControl.getControlZones().get(0).getPilotPoint();
+        assertEquals(List.of(), pilotPoint.getBuses());
+        assertEquals(List.of("voltageLevel1BusbarSection1", "voltageLevel1BusbarSection2"), pilotPoint.getBusbarSectionIds());
+
+        // renaming a busbar section is propagated to the pilot point busbar section IDs
+        nodeBreakerNetwork.getIdentifiable("voltageLevel1BusbarSection1").setId("voltageLevel1BusbarSection1_NEW_ID");
+        assertEquals(List.of("voltageLevel1BusbarSection1_NEW_ID", "voltageLevel1BusbarSection2"), pilotPoint.getBusbarSectionIds());
+
+        // removing a busbar section removes it from the pilot point busbar section IDs
+        nodeBreakerNetwork.getBusbarSection("voltageLevel1BusbarSection2").remove();
+        assertEquals(List.of("voltageLevel1BusbarSection1_NEW_ID"), pilotPoint.getBusbarSectionIds());
+        assertEquals(List.of(), pilotPoint.getBuses());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
https://github.com/powsybl/powsybl-core/issues/3902


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
It reworkds the Secondary voltage control extension to distinguish bus bar sectin ids from buses ids.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The list is fused between bus bar section ids and buses ids


**What is the new behavior (if this is a feature change)?**
The list is separate 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
