### PR TITLE
Enforce valid reactive capability curve minQ/maxQ ordering in IIDM

### DIFF
--- a/docs/grid_exchange_formats/iidm/import.md
+++ b/docs/grid_exchange_formats/iidm/import.md
@@ -25,6 +25,9 @@ The `iidm.import.xml.with-automation-systems` property is an optional property t
 
 By default, the value is `true`, the overload management systems are imported when deserializing a network.
 
+**iidm.import.xml.check-reverted-minqmaxq**<br>
+The `iidm.import.xml.check-reverted-minqmaxq` property is an optional property that enables a check in the XIIDM importer to detect reversed Qmin > QMax values in ReactiveCapabilityCurves and put them in the right order.
+
 **iidm.import.xml.missing-permanent-limit-percentage**<br>
 The `iidm.import.xml.missing-permanent-limit-percentage` property is an optional property that defines the percentage applied to the lowest temporary limit to compute the permanent limit when missing (for IIDM < 1.12 only).
 

--- a/docs/grid_exchange_formats/iidm/import.md
+++ b/docs/grid_exchange_formats/iidm/import.md
@@ -25,12 +25,16 @@ The `iidm.import.xml.with-automation-systems` property is an optional property t
 
 By default, the value is `true`, the overload management systems are imported when deserializing a network.
 
-**iidm.import.xml.check-reverted-minqmaxq**<br>
-The `iidm.import.xml.check-reverted-minqmaxq` property is an optional property that enables the XIIDM importer to detect reversed `minQ > maxQ` values in `ReactiveCapabilityCurve` points and automatically reorder them before validation.
+**iidm.import.xml.repair-invalid-reactive-curve-limits**<br>
+The `iidm.import.xml.repair-invalid-reactive-curve-limits` property is an optional property that enables the IIDM importer to detect reversed `minQ > maxQ` values in `ReactiveCapabilityCurve` points and automatically reorder them before validation.
 
-By default, the value is `false`.  
-When set to `false`, a reactive capability curve point with `minQ > maxQ` is considered invalid and the import fails with a validation error.  
-When set to `true`, the importer automatically swaps the values so that `minQ <= maxQ`, allowing the import to succeed.  
+By default, the value is `false`.<br>
+When set to `false`, a reactive capability curve point with `minQ > maxQ` is considered invalid and the import fails with a validation error.<br>
+When set to `true`, the importer automatically swaps the values so that `minQ <= maxQ`, allowing the import to succeed.<br>
+
+```{note}
+This parameter should normally be left at its default value. Earlier versions of PowSyBl accepted invalid ordered minQ/maxQ limits. Change this parameter only if you need to import older IIDM files that contain such invalid values.
+```
 
 **iidm.import.xml.missing-permanent-limit-percentage**<br>
 The `iidm.import.xml.missing-permanent-limit-percentage` property is an optional property that defines the percentage applied to the lowest temporary limit to compute the permanent limit when missing (for IIDM < 1.12 only).

--- a/docs/grid_exchange_formats/iidm/import.md
+++ b/docs/grid_exchange_formats/iidm/import.md
@@ -26,7 +26,11 @@ The `iidm.import.xml.with-automation-systems` property is an optional property t
 By default, the value is `true`, the overload management systems are imported when deserializing a network.
 
 **iidm.import.xml.check-reverted-minqmaxq**<br>
-The `iidm.import.xml.check-reverted-minqmaxq` property is an optional property that enables a check in the XIIDM importer to detect reversed Qmin > QMax values in ReactiveCapabilityCurves and put them in the right order.
+The `iidm.import.xml.check-reverted-minqmaxq` property is an optional property that enables the XIIDM importer to detect reversed `minQ > maxQ` values in `ReactiveCapabilityCurve` points and automatically reorder them before validation.
+
+By default, the value is `false`.  
+When set to `false`, a reactive capability curve point with `minQ > maxQ` is considered invalid and the import fails with a validation error.  
+When set to `true`, the importer automatically swaps the values so that `minQ <= maxQ`, allowing the import to succeed.  
 
 **iidm.import.xml.missing-permanent-limit-percentage**<br>
 The `iidm.import.xml.missing-permanent-limit-percentage` property is an optional property that defines the percentage applied to the lowest temporary limit to compute the permanent limit when missing (for IIDM < 1.12 only).

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/ReactiveCapabilityCurveAdderImpl.java
@@ -77,11 +77,10 @@ class ReactiveCapabilityCurveAdderImpl<O extends ReactiveLimitsOwner & Validable
                             owner.getMessageHeader().id(), p);
                 }
             }
-            // TODO: to be activated in IIDM v1.1
-            // if (maxQ < minQ) {
-            //     throw new ValidationException(owner,
-            //             "maximum reactive power is expected to be greater than or equal to minimum reactive power");
-            // }
+            if (maxQ < minQ) {
+                throw new ValidationException(owner,
+                        "maximum reactive power is expected to be greater than or equal to minimum reactive power");
+            }
             PointImpl pointImpl = new PointImpl(p, minQ, maxQ);
             this.copyPropertiesTo(pointImpl);
             points.put(p, pointImpl);

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTreeDataImporter.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractTreeDataImporter.java
@@ -60,6 +60,8 @@ public abstract class AbstractTreeDataImporter implements Importer {
 
     public static final String ONLY_SELECTED_OPERATIONAL_LIMITS_GROUPS = "iidm.import.only-selected-operational-limits-groups";
 
+    public static final String CHECK_REVERTED_MIN_Q_MAX_Q = "iidm.import.xml.check-reverted-minqmaxq";
+
     private static final Parameter THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER
             = new Parameter(THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND, ParameterType.BOOLEAN, "Throw exception if extension not found", Boolean.FALSE)
             .addAdditionalNames("throwExceptionIfExtensionNotFound");
@@ -78,6 +80,10 @@ public abstract class AbstractTreeDataImporter implements Importer {
     public static final Parameter MISSING_PERMANENT_LIMIT_PERCENTAGE_PARAMETER = new Parameter(MISSING_PERMANENT_LIMIT_PERCENTAGE,
             ParameterType.DOUBLE, "Percentage applied to lowest temporary limit to compute the permanent limit when missing (for IIDM < 1.12 only)",
             100.);
+
+    public static final Parameter CHECK_REVERTED_MIN_Q_MAX_Q_PARAMETER = new Parameter(CHECK_REVERTED_MIN_Q_MAX_Q,
+            ParameterType.BOOLEAN, "Check and reorder reversed minQ/maxQ values in reactive capability curves",
+            false);
 
     public static final Parameter MINIMAL_VALIDATION_LEVEL_PARAMETER = new Parameter(MINIMAL_VALIDATION_LEVEL,
             ParameterType.STRING, "Minimal validation level accepted",
@@ -104,7 +110,8 @@ public abstract class AbstractTreeDataImporter implements Importer {
         List<Parameter> parameters = List.of(THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND_PARAMETER,
                 EXTENSIONS_INCLUDED_LIST_PARAMETER, EXTENSIONS_EXCLUDED_LIST_PARAMETER,
                 WITH_AUTOMATION_SYSTEMS_PARAMETER, MISSING_PERMANENT_LIMIT_PERCENTAGE_PARAMETER,
-                MINIMAL_VALIDATION_LEVEL_PARAMETER, ONLY_SELECTED_OPERATIONAL_LIMITS_GROUPS_PARAMETER);
+                CHECK_REVERTED_MIN_Q_MAX_Q_PARAMETER, MINIMAL_VALIDATION_LEVEL_PARAMETER,
+                ONLY_SELECTED_OPERATIONAL_LIMITS_GROUPS_PARAMETER);
         return ConfiguredParameter.load(parameters, getFormat(), defaultValueConfig);
     }
 
@@ -194,6 +201,7 @@ public abstract class AbstractTreeDataImporter implements Importer {
                     new HashSet<>(Parameter.readStringList(getFormat(), parameters, EXTENSIONS_EXCLUDED_LIST_PARAMETER, defaultValueConfig)) : null)
                 .setWithAutomationSystems(Parameter.readBoolean(getFormat(), parameters, WITH_AUTOMATION_SYSTEMS_PARAMETER, defaultValueConfig))
                 .setMissingPermanentLimitPercentage(Parameter.readDouble(getFormat(), parameters, MISSING_PERMANENT_LIMIT_PERCENTAGE_PARAMETER, defaultValueConfig))
+                .setCheckRevertedMinQMaxQ(Parameter.readBoolean(getFormat(), parameters, CHECK_REVERTED_MIN_Q_MAX_Q_PARAMETER, defaultValueConfig))
                 .setMinimalValidationLevel(Parameter.readString(getFormat(), parameters, MINIMAL_VALIDATION_LEVEL_PARAMETER, defaultValueConfig))
                 .setOnlySelectedOperationalLimitsGroups(Parameter.readBoolean(getFormat(), parameters, ONLY_SELECTED_OPERATIONAL_LIMITS_GROUPS_PARAMETER, defaultValueConfig));
         getAndCheckExtensionsToInclude(parameters, importOptions, getFormat(), defaultValueConfig, EXTENSIONS_INCLUDED_LIST_PARAMETER, EXTENSIONS_EXCLUDED_LIST_PARAMETER, false);

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ImportOptions.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ImportOptions.java
@@ -22,6 +22,7 @@ public class ImportOptions extends AbstractOptions<ImportOptions> {
     private boolean throwExceptionIfExtensionNotFound = false;
     private boolean withAutomationSystems = true;
     private double missingPermanentLimitPercentage = 100.;
+    private boolean checkRevertedMinQMaxQ = false;
 
     private ValidationLevel minimalValidationLevel = null;
 
@@ -67,6 +68,15 @@ public class ImportOptions extends AbstractOptions<ImportOptions> {
      */
     public double getMissingPermanentLimitPercentage() {
         return missingPermanentLimitPercentage;
+    }
+
+    public boolean isCheckRevertedMinQMaxQ() {
+        return checkRevertedMinQMaxQ;
+    }
+
+    public ImportOptions setCheckRevertedMinQMaxQ(boolean checkRevertedMinQMaxQ) {
+        this.checkRevertedMinQMaxQ = checkRevertedMinQMaxQ;
+        return this;
     }
 
     public ImportOptions setMinimalValidationLevel(String minimalValidationLevel) {

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ReactiveLimitsSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ReactiveLimitsSerDe.java
@@ -73,24 +73,42 @@ public class ReactiveLimitsSerDe {
 
     public void readReactiveCapabilityCurve(ReactiveLimitsHolder holder, NetworkDeserializerContext context) {
         ReactiveCapabilityCurveAdder curveAdder = holder.newReactiveCapabilityCurve();
-        context.getReader().readChildNodes(elementName -> {
-            if (elementName.equals(PropertiesSerDe.ROOT_ELEMENT_NAME)) {
-                PropertiesSerDe.read(curveAdder, context);
-            } else if (elementName.equals(POINT_ROOT_ELEMENT_NAME)) {
-                double p = context.getReader().readDoubleAttribute(ATTR_P);
-                double minQ = context.getReader().readDoubleAttribute(ATTR_MIN_Q);
-                double maxQ = context.getReader().readDoubleAttribute(ATTR_MAX_Q);
-                ReactiveCapabilityCurveAdder.PointAdder pointAdder = curveAdder.beginPoint();
-                PropertiesSerDe.readProperties(context, pointAdder);
-                pointAdder.setP(p)
-                        .setMinQ(minQ)
-                        .setMaxQ(maxQ)
-                        .endPoint();
-            } else {
-                throw new PowsyblException("Unknown element name '" + elementName + "' in 'reactiveCapabilityCurve'");
-            }
-        });
+        context.getReader().readChildNodes(elementName ->
+                readReactiveCapabilityCurveElement(elementName, curveAdder, context));
         curveAdder.add();
+    }
+
+    private void readReactiveCapabilityCurveElement(String elementName,
+                                                    ReactiveCapabilityCurveAdder curveAdder,
+                                                    NetworkDeserializerContext context) {
+        if (elementName.equals(PropertiesSerDe.ROOT_ELEMENT_NAME)) {
+            PropertiesSerDe.read(curveAdder, context);
+        } else if (elementName.equals(POINT_ROOT_ELEMENT_NAME)) {
+            readReactiveCapabilityCurvePoint(curveAdder, context);
+        } else {
+            throw new PowsyblException("Unknown element name '" + elementName + "' in 'reactiveCapabilityCurve'");
+        }
+    }
+
+    private void readReactiveCapabilityCurvePoint(ReactiveCapabilityCurveAdder curveAdder,
+                                                  NetworkDeserializerContext context) {
+        double p = context.getReader().readDoubleAttribute(ATTR_P);
+        double minQ = context.getReader().readDoubleAttribute(ATTR_MIN_Q);
+        double maxQ = context.getReader().readDoubleAttribute(ATTR_MAX_Q);
+
+        ReactiveCapabilityCurveAdder.PointAdder pointAdder = curveAdder.beginPoint();
+        PropertiesSerDe.readProperties(context, pointAdder);
+
+        if (context.getOptions().isCheckRevertedMinQMaxQ() && minQ > maxQ) {
+            double tmp = minQ;
+            minQ = maxQ;
+            maxQ = tmp;
+        }
+
+        pointAdder.setP(p)
+                .setMinQ(minQ)
+                .setMaxQ(maxQ)
+                .endPoint();
     }
 
     public void readMinMaxReactiveLimits(ReactiveLimitsHolder holder, NetworkDeserializerContext context) {

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ReactiveLimitsSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ReactiveLimitsSerDe.java
@@ -14,11 +14,15 @@ import com.powsybl.iidm.network.ReactiveCapabilityCurveAdder;
 import com.powsybl.iidm.network.ReactiveLimitsHolder;
 import com.powsybl.iidm.serde.util.IidmSerDeUtil;
 import org.apache.commons.lang3.NotImplementedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
  */
 public class ReactiveLimitsSerDe {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveLimitsSerDe.class);
 
     static final ReactiveLimitsSerDe INSTANCE = new ReactiveLimitsSerDe();
 
@@ -100,6 +104,7 @@ public class ReactiveLimitsSerDe {
         PropertiesSerDe.readProperties(context, pointAdder);
 
         if (context.getOptions().isCheckRevertedMinQMaxQ() && minQ > maxQ) {
+            LOGGER.warn("Reactive capability curve point at P={} has reversed limits (minQ={} > maxQ={}); values have been reordered", p, minQ, maxQ);
             double tmp = minQ;
             minQ = maxQ;
             maxQ = tmp;

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/BinaryImporterTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/BinaryImporterTest.java
@@ -25,6 +25,6 @@ class BinaryImporterTest {
         assertEquals("BIIDM", importer.getFormat());
         assertEquals("IIDM binary v " + CURRENT_IIDM_VERSION.toString(".") + " importer", importer.getComment());
         assertEquals(List.of("biidm", "bin"), importer.getSupportedExtensions());
-        assertEquals(7, importer.getParameters().size());
+        assertEquals(8, importer.getParameters().size());
     }
 }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/JsonImporterTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/JsonImporterTest.java
@@ -25,6 +25,6 @@ class JsonImporterTest {
         assertEquals("JIIDM", importer.getFormat());
         assertEquals("IIDM JSON v " + CURRENT_IIDM_VERSION.toString(".") + " importer", importer.getComment());
         assertEquals(List.of("jiidm", "json"), importer.getSupportedExtensions());
-        assertEquals(7, importer.getParameters().size());
+        assertEquals(8, importer.getParameters().size());
     }
 }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
@@ -12,8 +12,6 @@ import com.powsybl.iidm.network.ReactiveCapabilityCurve;
 import com.powsybl.iidm.network.ValidationException;
 import com.powsybl.iidm.network.test.ReactiveLimitsTestNetworkFactory;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -35,9 +33,8 @@ class ReactiveLimitsSerDeTest extends AbstractIidmSerDeTest {
         allFormatsRoundTripTest(ReactiveLimitsTestNetworkFactory.create(), "reactiveLimitsRoundTripRef.xml", CURRENT_IIDM_VERSION);
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    void testImportRevertedMinQMaxQ(boolean checkRevertedMinQMaxQ) {
+    @Test
+    void importShouldSucceedWhenRevertedMinQMaxQ() {
         String xml = """
 <?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" id="ReactiveLimits" sourceFormat="test" caseDate="2025-07-29T10:00:00.000+02:00" forecastDistance="0" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
@@ -62,29 +59,56 @@ class ReactiveLimitsSerDeTest extends AbstractIidmSerDeTest {
             """;
 
         ImportOptions options = new ImportOptions()
-                .setCheckRevertedMinQMaxQ(checkRevertedMinQMaxQ);
+                .setCheckRevertedMinQMaxQ(true);
 
-        if (checkRevertedMinQMaxQ) {
-            Network network = NetworkSerDe.read(
-                    new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)),
-                    options,
-                    null);
+        Network network = NetworkSerDe.read(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)),
+                options,
+                null);
 
-            ReactiveCapabilityCurve curve = network.getGenerator("G1")
-                    .getReactiveLimits(ReactiveCapabilityCurve.class);
+        ReactiveCapabilityCurve curve = network.getGenerator("G1")
+                .getReactiveLimits(ReactiveCapabilityCurve.class);
 
-            assertEquals(2.0, curve.getMinQ(100.0));
-            assertEquals(10.0, curve.getMaxQ(100.0));
-        } else {
-            byte[] xmlBytes = xml.getBytes(StandardCharsets.UTF_8);
-            ByteArrayInputStream inputStream = new ByteArrayInputStream(xmlBytes);
+        assertEquals(2.0, curve.getMinQ(100.0));
+        assertEquals(10.0, curve.getMaxQ(100.0));
+    }
 
-            ValidationException e = assertThrows(
-                    ValidationException.class,
-                    () -> NetworkSerDe.read(inputStream, options, null));
+    @Test
+    void importShouldThrowExceptionWhenNotRevertedMinQMaxQ() {
+        String xml = """
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" id="ReactiveLimits" sourceFormat="test" caseDate="2025-07-29T10:00:00.000+02:00" forecastDistance="0" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S" country="FR" tso="RTE">
+        <iidm:voltageLevel id="VL" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="G1" energySource="OTHER" maxP="10.0" minP="0.0" targetV="380.0" voltageRegulatorOn="true" targetP="10.0" bus="B" connectableBus="B">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="5.0" minQ="1.0" maxQ="10.0"/>
+                    <iidm:point p="10.0" minQ="10.0" maxQ="2.0"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="G2" energySource="OTHER" maxP="10.0" minP="0.0" targetV="380.0" voltageRegulatorOn="true" targetP="10.0" bus="B" connectableBus="B">
+                <iidm:minMaxReactiveLimits minQ="1.0" maxQ="10.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+</iidm:network>
 
-            assertTrue(e.getMessage().contains(
-                    "maximum reactive power is expected to be greater than or equal to minimum reactive power"));
-        }
+            """;
+
+        ImportOptions options = new ImportOptions()
+                .setCheckRevertedMinQMaxQ(false);
+
+        byte[] xmlBytes = xml.getBytes(StandardCharsets.UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(xmlBytes);
+
+        ValidationException e = assertThrows(
+                ValidationException.class,
+                () -> NetworkSerDe.read(inputStream, options, null));
+
+        assertTrue(e.getMessage().contains(
+                "maximum reactive power is expected to be greater than or equal to minimum reactive power"));
     }
 }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
@@ -86,6 +86,6 @@ class ReactiveLimitsSerDeTest extends AbstractIidmSerDeTest {
                 () -> NetworkSerDe.read(inputStream, options, null));
 
         assertTrue(e.getMessage().contains(
-                "maximum reactive power is expected to be greater than or equal to minimum reactive power"));
+                "Generator 'G1': maximum reactive power is expected to be greater than or equal to minimum reactive power"));
     }
 }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
@@ -7,12 +7,20 @@
  */
 package com.powsybl.iidm.serde;
 
+import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.ReactiveCapabilityCurve;
 import com.powsybl.iidm.network.test.ReactiveLimitsTestNetworkFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
@@ -25,5 +33,52 @@ class ReactiveLimitsSerDeTest extends AbstractIidmSerDeTest {
         allFormatsRoundTripAllPreviousVersionedXmlTest("reactiveLimitsRoundTripRef.xml");
 
         allFormatsRoundTripTest(ReactiveLimitsTestNetworkFactory.create(), "reactiveLimitsRoundTripRef.xml", CURRENT_IIDM_VERSION);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testImportRevertedMinQMaxQ(boolean checkRevertedMinQMaxQ) {
+        String xml = """
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" id="ReactiveLimits" sourceFormat="test" caseDate="2025-07-29T10:00:00.000+02:00" forecastDistance="0" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="S" country="FR" tso="RTE">
+        <iidm:voltageLevel id="VL" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="G1" energySource="OTHER" maxP="10.0" minP="0.0" targetV="380.0" voltageRegulatorOn="true" targetP="10.0" bus="B" connectableBus="B">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="5.0" minQ="1.0" maxQ="10.0"/>
+                    <iidm:point p="10.0" minQ="10.0" maxQ="2.0"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="G2" energySource="OTHER" maxP="10.0" minP="0.0" targetV="380.0" voltageRegulatorOn="true" targetP="10.0" bus="B" connectableBus="B">
+                <iidm:minMaxReactiveLimits minQ="1.0" maxQ="10.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+</iidm:network>
+
+            """;
+
+        ImportOptions options = new ImportOptions()
+                .setCheckRevertedMinQMaxQ(checkRevertedMinQMaxQ);
+
+        Network network = NetworkSerDe.read(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)),
+                options,
+                null);
+
+        Generator g = network.getGenerator("G1");
+        ReactiveCapabilityCurve curve =
+                g.getReactiveLimits(ReactiveCapabilityCurve.class);
+
+        if (checkRevertedMinQMaxQ) {
+            assertEquals(2.0, curve.getMinQ(100.0));
+            assertEquals(10.0, curve.getMaxQ(100.0));
+        } else {
+            assertEquals(10.0, curve.getMinQ(100.0));
+            assertEquals(2.0, curve.getMaxQ(100.0));
+        }
     }
 }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
@@ -76,12 +76,12 @@ class ReactiveLimitsSerDeTest extends AbstractIidmSerDeTest {
             assertEquals(2.0, curve.getMinQ(100.0));
             assertEquals(10.0, curve.getMaxQ(100.0));
         } else {
+            byte[] xmlBytes = xml.getBytes(StandardCharsets.UTF_8);
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(xmlBytes);
+
             ValidationException e = assertThrows(
                     ValidationException.class,
-                    () -> NetworkSerDe.read(
-                            new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)),
-                            options,
-                            null));
+                    () -> NetworkSerDe.read(inputStream, options, null));
 
             assertTrue(e.getMessage().contains(
                     "maximum reactive power is expected to be greater than or equal to minimum reactive power"));

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
@@ -7,9 +7,9 @@
  */
 package com.powsybl.iidm.serde;
 
-import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ReactiveCapabilityCurve;
+import com.powsybl.iidm.network.ValidationException;
 import com.powsybl.iidm.network.test.ReactiveLimitsTestNetworkFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
@@ -64,21 +64,27 @@ class ReactiveLimitsSerDeTest extends AbstractIidmSerDeTest {
         ImportOptions options = new ImportOptions()
                 .setCheckRevertedMinQMaxQ(checkRevertedMinQMaxQ);
 
-        Network network = NetworkSerDe.read(
-                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)),
-                options,
-                null);
-
-        Generator g = network.getGenerator("G1");
-        ReactiveCapabilityCurve curve =
-                g.getReactiveLimits(ReactiveCapabilityCurve.class);
-
         if (checkRevertedMinQMaxQ) {
+            Network network = NetworkSerDe.read(
+                    new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)),
+                    options,
+                    null);
+
+            ReactiveCapabilityCurve curve = network.getGenerator("G1")
+                    .getReactiveLimits(ReactiveCapabilityCurve.class);
+
             assertEquals(2.0, curve.getMinQ(100.0));
             assertEquals(10.0, curve.getMaxQ(100.0));
         } else {
-            assertEquals(10.0, curve.getMinQ(100.0));
-            assertEquals(2.0, curve.getMaxQ(100.0));
+            ValidationException e = assertThrows(
+                    ValidationException.class,
+                    () -> NetworkSerDe.read(
+                            new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)),
+                            options,
+                            null));
+
+            assertTrue(e.getMessage().contains(
+                    "maximum reactive power is expected to be greater than or equal to minimum reactive power"));
         }
     }
 }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/ReactiveLimitsSerDeTest.java
@@ -25,17 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class ReactiveLimitsSerDeTest extends AbstractIidmSerDeTest {
 
-    @Test
-    void roundTripTest() throws IOException {
-        // backward compatibility
-        allFormatsRoundTripAllPreviousVersionedXmlTest("reactiveLimitsRoundTripRef.xml");
-
-        allFormatsRoundTripTest(ReactiveLimitsTestNetworkFactory.create(), "reactiveLimitsRoundTripRef.xml", CURRENT_IIDM_VERSION);
-    }
-
-    @Test
-    void importShouldSucceedWhenRevertedMinQMaxQ() {
-        String xml = """
+    private static final String XML_WITH_REVERTED_MINQ_MAXQ = """
 <?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
 <iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" id="ReactiveLimits" sourceFormat="test" caseDate="2025-07-29T10:00:00.000+02:00" forecastDistance="0" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
     <iidm:substation id="S" country="FR" tso="RTE">
@@ -58,11 +48,21 @@ class ReactiveLimitsSerDeTest extends AbstractIidmSerDeTest {
 
             """;
 
+    @Test
+    void roundTripTest() throws IOException {
+        // backward compatibility
+        allFormatsRoundTripAllPreviousVersionedXmlTest("reactiveLimitsRoundTripRef.xml");
+
+        allFormatsRoundTripTest(ReactiveLimitsTestNetworkFactory.create(), "reactiveLimitsRoundTripRef.xml", CURRENT_IIDM_VERSION);
+    }
+
+    @Test
+    void importShouldSucceedWhenRevertedMinQMaxQ() {
         ImportOptions options = new ImportOptions()
                 .setCheckRevertedMinQMaxQ(true);
 
         Network network = NetworkSerDe.read(
-                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)),
+                new ByteArrayInputStream(XML_WITH_REVERTED_MINQ_MAXQ.getBytes(StandardCharsets.UTF_8)),
                 options,
                 null);
 
@@ -75,33 +75,10 @@ class ReactiveLimitsSerDeTest extends AbstractIidmSerDeTest {
 
     @Test
     void importShouldThrowExceptionWhenNotRevertedMinQMaxQ() {
-        String xml = """
-<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
-<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" id="ReactiveLimits" sourceFormat="test" caseDate="2025-07-29T10:00:00.000+02:00" forecastDistance="0" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
-    <iidm:substation id="S" country="FR" tso="RTE">
-        <iidm:voltageLevel id="VL" nominalV="380.0" topologyKind="BUS_BREAKER">
-            <iidm:busBreakerTopology>
-                <iidm:bus id="B"/>
-            </iidm:busBreakerTopology>
-            <iidm:generator id="G1" energySource="OTHER" maxP="10.0" minP="0.0" targetV="380.0" voltageRegulatorOn="true" targetP="10.0" bus="B" connectableBus="B">
-                <iidm:reactiveCapabilityCurve>
-                    <iidm:point p="5.0" minQ="1.0" maxQ="10.0"/>
-                    <iidm:point p="10.0" minQ="10.0" maxQ="2.0"/>
-                </iidm:reactiveCapabilityCurve>
-            </iidm:generator>
-            <iidm:generator id="G2" energySource="OTHER" maxP="10.0" minP="0.0" targetV="380.0" voltageRegulatorOn="true" targetP="10.0" bus="B" connectableBus="B">
-                <iidm:minMaxReactiveLimits minQ="1.0" maxQ="10.0"/>
-            </iidm:generator>
-        </iidm:voltageLevel>
-    </iidm:substation>
-</iidm:network>
-
-            """;
-
         ImportOptions options = new ImportOptions()
                 .setCheckRevertedMinQMaxQ(false);
 
-        byte[] xmlBytes = xml.getBytes(StandardCharsets.UTF_8);
+        byte[] xmlBytes = XML_WITH_REVERTED_MINQ_MAXQ.getBytes(StandardCharsets.UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(xmlBytes);
 
         ValidationException e = assertThrows(

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/XMLImporterTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/XMLImporterTest.java
@@ -143,7 +143,7 @@ class XMLImporterTest extends AbstractIidmSerDeTest {
         assertEquals("XIIDM", importer.getFormat());
         assertEquals("IIDM XML v " + CURRENT_IIDM_VERSION.toString(".") + " importer", importer.getComment());
         assertEquals(List.of("xiidm", "iidm", "xml"), importer.getSupportedExtensions());
-        assertEquals(7, importer.getParameters().size());
+        assertEquals(8, importer.getParameters().size());
         assertEquals("iidm.import.xml.throw-exception-if-extension-not-found", importer.getParameters().get(0).getName());
         assertEquals(Arrays.asList("iidm.import.xml.throw-exception-if-extension-not-found", "throwExceptionIfExtensionNotFound"), importer.getParameters().get(0).getNames());
     }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractReactiveCapabilityCurveTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractReactiveCapabilityCurveTest.java
@@ -13,7 +13,6 @@ import com.powsybl.iidm.network.ReactiveCapabilityCurve;
 import com.powsybl.iidm.network.ValidationException;
 import com.powsybl.iidm.network.test.FictitiousSwitchFactory;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -123,7 +122,6 @@ public abstract class AbstractReactiveCapabilityCurveTest {
         assertTrue(e.getMessage().contains("min Q is not set"));
     }
 
-    @Disabled(value = "To be reactivated in IIDM v1.1")
     @Test
     public void invalidMinQGreaterThanMaxQ() {
         ValidationException e = assertThrows(ValidationException.class, () -> generator.newReactiveCapabilityCurve()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**

https://github.com/powsybl/powsybl-core/issues/3648 


**What kind of change does this PR introduce?**

Feature.

**What is the current behavior?**

Reactive Capability Curve points can be defined in IIDM with invalid `minQ > maxQ`.

**What is the new behavior (if this is a feature change)?**

Reactive Capability Curve points are enforced by IIDM validation to have `minQ <= maxQ`.

To support re-importing older serialized IIDM files having invalid values, a new IIDM import option (`iidm.import.xml.repair-invalid-reactive-curve-limits`) is introduced.

When this option is disabled (default behavior), reactive capability curve points with minQ > maxQ remain invalid and the import fails with a ValidationException.

When this option is enabled, the XIIDM importer detects reversed minQ/maxQ values in reactive capability curve points and automatically swaps them before IIDM validation occurs. The import can therefore succeed even when the source file contains reversed values.

For users of other formats:
- **UCTE-DEF**: not applicable since UCTE-DEF only uses min/max Q limits where proper ordering was already enforced by IIDM.
- **CGMES**: [QoCDC](https://eepublicdownloads.azureedge.net/clean-documents/digital/Quality%20Of%20CGMES%20Datasets%20and%20Calculations%20v4.1.4_clean.pdf) rule `RCCYValues` enforces proper minQ/maxQ ordering with level error. Hence rejecting within PowSyBl is valid.
- Other formats (PowerFactory, PSS/E, etc...): to be assessed. In principle the IIDM validation introduced here is legitimate, however specific importers may need to also implement an auto-repairing option as well in the case these formats allow invalid values. This is not covered in this PR.

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**What changes might users need to make in their application due to this PR? (migration steps)**

Reactive capability curve points with minQ > maxQ are now rejected by IIDM validation.

Applications importing IIDM files containing reversed values should either fix the source data or enable the `iidm.import.repair-invalid-reactive-curve-limits` import option to automatically reorder minQ and maxQ during import.

Applications importing from other formats (e.g. CGMES) with invalid values need to fix the data at the source, no option is provided to automatically repair in this case.

Custom IIDM implementations maintainers must ensure that all their implementations of `ReactiveCapabilityCurveAdder` check that `minQ <= maxQ` (on `endPoint()`).