### PR TITLE
prevent zip path traversal in LocalComputationManager unzip

### DIFF
--- a/computation-local/src/main/java/com/powsybl/computation/local/LocalComputationManager.java
+++ b/computation-local/src/main/java/com/powsybl/computation/local/LocalComputationManager.java
@@ -275,8 +275,13 @@ public class LocalComputationManager implements ComputationManager {
                         try (ZipFile zipFile = ZipFile.builder()
                             .setSeekableByteChannel(Files.newByteChannel(path))
                             .get()) {
+                            Path root = workingDir.normalize();
                             for (ZipArchiveEntry ze : Collections.list(zipFile.getEntries())) {
-                                Files.copy(zipFile.getInputStream(zipFile.getEntry(ze.getName())), workingDir.resolve(ze.getName()), REPLACE_EXISTING);
+                                Path target = workingDir.resolve(ze.getName()).normalize();
+                                if (!target.startsWith(root)) {
+                                    throw new IOException("Zip entry '" + ze.getName() + "' is outside of the working directory");
+                                }
+                                Files.copy(zipFile.getInputStream(zipFile.getEntry(ze.getName())), target, REPLACE_EXISTING);
                             }
                         }
                         break;

--- a/computation-local/src/test/java/com/powsybl/computation/local/LocalComputationManagerTest.java
+++ b/computation-local/src/test/java/com/powsybl/computation/local/LocalComputationManagerTest.java
@@ -222,6 +222,49 @@ class LocalComputationManagerTest {
     }
 
     @Test
+    void archiveUnzipDoesNotEscapeWorkingDir() throws Exception {
+        LocalCommandExecutor localCommandExecutor = new AbstractLocalCommandExecutor() {
+            @Override
+            void nonZeroLog(List<String> cmdLs, int exitCode) {
+            }
+
+            @Override
+            public int execute(String program, List<String> args, Path outFile, Path errFile, Path workingDir, Map<String, String> env) {
+                return 0;
+            }
+        };
+        Path[] capturedWorkingDir = new Path[1];
+        try (ComputationManager computationManager = new LocalComputationManager(config, localCommandExecutor, ForkJoinPool.commonPool())) {
+            computationManager.execute(new ExecutionEnvironment(ImmutableMap.of(), PREFIX, false),
+                    new AbstractExecutionHandler<Object>() {
+                        @Override
+                        public List<CommandExecution> before(Path workingDir) throws IOException {
+                            capturedWorkingDir[0] = workingDir;
+                            // craft an archive whose entry name traverses out of the working directory
+                            try (ZipOutputStream os = new ZipOutputStream(Files.newOutputStream(workingDir.resolve("evil.zip")))) {
+                                os.putNextEntry(new ZipEntry("../evil.txt"));
+                                os.write("owned".getBytes());
+                                os.closeEntry();
+                            }
+                            Command command = new SimpleCommandBuilder()
+                                    .id("unzip_cmd")
+                                    .program("unzip")
+                                    .inputFiles(new InputFile("evil.zip", FilePreProcessor.ARCHIVE_UNZIP))
+                                    .build();
+                            return Collections.singletonList(new CommandExecution(command, 1));
+                        }
+
+                        @Override
+                        public Object after(Path workingDir, ExecutionReport report) {
+                            return null;
+                        }
+                    }).join();
+        }
+        // the traversal target sits in the parent of the working directory and must not have been written
+        assertFalse(Files.exists(capturedWorkingDir[0].getParent().resolve("evil.txt")));
+    }
+
+    @Test
     void hangingIssue() throws Exception {
         LocalCommandExecutor localCommandExecutor = new AbstractLocalCommandExecutor() {
             @Override


### PR DESCRIPTION
Repro: register a Command input file with FilePreProcessor.ARCHIVE_UNZIP whose archive holds an entry named ../evil.txt; preProcess writes it into the parent of the execution working directory.
Cause: the ARCHIVE_UNZIP branch resolves ze.getName() against workingDir with no containment check, so ../ segments and absolute entry names land outside the sandboxed working directory.
Fix: normalize each resolved target and reject any entry that does not stay under the working directory before copying.