### PR TITLE
quote program name and validate env var name in unix executor

### DIFF
--- a/computation-local/src/main/java/com/powsybl/computation/local/UnixLocalCommandExecutor.java
+++ b/computation-local/src/main/java/com/powsybl/computation/local/UnixLocalCommandExecutor.java
@@ -42,13 +42,19 @@ public class UnixLocalCommandExecutor extends AbstractLocalCommandExecutor {
         for (Map.Entry<String, String> entry : env2.entrySet()) {
             String name = entry.getKey();
             String value = entry.getValue();
+            // A variable name sits before the '=' assignment and after '$', so it cannot be
+            // single-quoted like the value. Reject anything but alphanumerics and underscores
+            // to keep a hostile name from breaking out of the command.
+            if (!name.matches("[a-zA-Z_]\\w*")) {
+                throw new IllegalArgumentException("Invalid environment variable name");
+            }
             internalCmd.append(name).append("=").append("'").append(singleQuoteEscape(value)).append("'");
             if (name.endsWith("PATH")) {
                 internalCmd.append(File.pathSeparator).append("$").append(name);
             }
             internalCmd.append(" ");
         }
-        internalCmd.append(program);
+        internalCmd.append("'").append(singleQuoteEscape(program)).append("'");
         for (String arg : args) {
             internalCmd.append(" '").append(singleQuoteEscape(arg)).append("'");
         }

--- a/computation-local/src/test/java/com/powsybl/computation/local/LocalCommandExecutorSecurityTest.java
+++ b/computation-local/src/test/java/com/powsybl/computation/local/LocalCommandExecutorSecurityTest.java
@@ -39,6 +39,8 @@ class LocalCommandExecutorSecurityTest {
     Path pwndFileNewline;
     Path pwndFilePercentExpansion;
     Path pwndFileUnixNewline;
+    Path pwndFileUnixEnvVarName;
+    Path pwndFileUnixProgramName;
 
     @BeforeEach
     void setUp() throws IOException {
@@ -53,6 +55,8 @@ class LocalCommandExecutorSecurityTest {
         pwndFileNewline = tempDir.resolve("pwned6.txt");
         pwndFilePercentExpansion = tempDir.resolve("pwned7.txt");
         pwndFileUnixNewline = tempDir.resolve("pwned8.txt");
+        pwndFileUnixEnvVarName = tempDir.resolve("pwned9.txt");
+        pwndFileUnixProgramName = tempDir.resolve("pwned10.txt");
     }
 
     @AfterEach
@@ -67,6 +71,8 @@ class LocalCommandExecutorSecurityTest {
         Files.deleteIfExists(pwndFileNewline);
         Files.deleteIfExists(pwndFilePercentExpansion);
         Files.deleteIfExists(pwndFileUnixNewline);
+        Files.deleteIfExists(pwndFileUnixEnvVarName);
+        Files.deleteIfExists(pwndFileUnixProgramName);
         Files.deleteIfExists(tempDir);
     }
 
@@ -193,6 +199,42 @@ class LocalCommandExecutorSecurityTest {
         );
         assertEquals("Program name must not contain spaces", exception2.getMessage());
         assertFalse(Files.exists(pwndFileEnvVarName), String.format("[!] Command injection confirmed: %s created", pwndFileEnvVarName));
+    }
+
+    // Injection via environment variable name: a name sits before the '=' assignment
+    // (and after '$' for PATH-like names) so it cannot be single-quoted like the value.
+    // The Unix executor must reject invalid names outright, as the Windows one does.
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void testCommandInjectionViaEnvVarNameOnUnix() {
+        Map<String, String> maliciousEnv = new HashMap<>();
+        maliciousEnv.put(
+            String.format("FOO=1; touch %s; BAR", pwndFileUnixEnvVarName),
+            "value"
+        );
+        List<String> cmdArgs = List.of("test");
+
+        UnixLocalCommandExecutor executor = new UnixLocalCommandExecutor();
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> executor.execute("echo", cmdArgs, outFile, errFile, tempDir, maliciousEnv)
+        );
+        assertEquals("Invalid environment variable name", exception.getMessage());
+        assertFalse(Files.exists(pwndFileUnixEnvVarName), String.format("[!] Command injection confirmed: %s created", pwndFileUnixEnvVarName));
+    }
+
+    // Injection via program name: the program word must be quoted like the other tokens
+    // so a command substitution or chaining in it stays inert.
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void testCommandInjectionViaProgramNameOnUnix() {
+        String maliciousProgram = String.format("echo $(touch %s)", pwndFileUnixProgramName);
+        Map<String, String> env = Map.of();
+        List<String> cmdArgs = List.of();
+
+        UnixLocalCommandExecutor executor = new UnixLocalCommandExecutor();
+        assertDoesNotThrow(() -> executor.execute(maliciousProgram, cmdArgs, outFile, errFile, tempDir, env));
+        assertFalse(Files.exists(pwndFileUnixProgramName), String.format("[!] Command injection confirmed: %s created", pwndFileUnixProgramName));
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Security fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
On Unix systems, the local command executor doesn't escape the program name, nor the envvar names.


**What is the new behavior (if this is a feature change)?**
<!-- -->
On Unix systems, the local command executor **does** escape the program name and the envvar names.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

Repro: on a unix host, hand `LocalCommandExecutor` an environment variable whose name is `FOO=1; touch /tmp/pwned; BAR`, or a program name like `echo $(touch /tmp/pwned)` — the injected command runs.

Cause: the GHSA-jqvf-j3ww-r8c7 fix single-quoted the env values and the args in `UnixLocalCommandExecutor`, but the variable name and the program are still concatenated into the `bash -c` string raw. `WindowsLocalCommandExecutor` already guards both (name regex, program quote/space checks), so this is the unix side of that same fix.

Fix: reject names outside `[a-zA-Z_]\w*` with the same message the windows executor uses — a name sits before `=` and after `$`, so it can't be single-quoted like a value — and single-quote the program the way the values and args already are. Added the two matching unix cases to `LocalCommandExecutorSecurityTest`.