### PR TITLE
bound declared matrix dimensions before allocation in powerfactory

### DIFF
--- a/powerfactory/powerfactory-db/src/main/java/com/powsybl/powerfactory/db/DataObjectBuilder.java
+++ b/powerfactory/powerfactory-db/src/main/java/com/powsybl/powerfactory/db/DataObjectBuilder.java
@@ -121,6 +121,10 @@ public class DataObjectBuilder {
 
     public void setDoubleMatrixAttributeValue(long objectId, String attributeName, int rowCount, int columnCount, List<Double> value) {
         DataObject object = getObjectById(objectId);
+        if (rowCount < 0 || columnCount < 0 || (long) rowCount * columnCount > value.size()) {
+            throw new PowerFactoryException("Matrix data holds " + value.size()
+                    + " values, less than the declared " + rowCount + "x" + columnCount);
+        }
         RealMatrix matrix = new BlockRealMatrix(rowCount, columnCount);
         for (int row = 0; row < rowCount; row++) {
             for (int col = 0; col < columnCount; col++) {

--- a/powerfactory/powerfactory-dgs/src/main/java/com/powsybl/powerfactory/dgs/DgsParser.java
+++ b/powerfactory/powerfactory-dgs/src/main/java/com/powsybl/powerfactory/dgs/DgsParser.java
@@ -511,6 +511,13 @@ public class DgsParser {
                 throw new PowerFactoryException("RealMatrix: Unexpected number of cols: '"
                     + attributeName + "' rows: " + actualRows + " cols: " + actualCols + " expected cols: " + this.cols);
             }
+            // The record must actually carry actualRows x actualCols values. The read loop below already
+            // returns empty when a declared cell is missing, but only after allocating the whole matrix, so a
+            // row declaring more values than it holds would force an oversized allocation from a tiny input.
+            long availableValues = (long) fields.length - indexField - 2;
+            if (actualRows < 0 || (long) actualRows * actualCols > availableValues) {
+                return Optional.empty();
+            }
             RealMatrix realMatrix = new BlockRealMatrix(actualRows, actualCols);
             for (int i = 0; i < actualRows; i++) {
                 for (int j = 0; j < actualCols; j++) {

--- a/powerfactory/powerfactory-dgs/src/test/java/com/powsybl/powerfactory/dgs/DgsDataTest.java
+++ b/powerfactory/powerfactory-dgs/src/test/java/com/powsybl/powerfactory/dgs/DgsDataTest.java
@@ -74,6 +74,13 @@ class DgsDataTest extends AbstractSerDeTest {
     }
 
     @Test
+    void matrixOversizedRowsTest() {
+        // A matrix row declaring far more values than it carries must not allocate a matrix of that size.
+        StudyCase studyCase = assertDoesNotThrow(() -> loadCase("/MatrixOversizedRows.dgs"));
+        assertNotNull(studyCase);
+    }
+
+    @Test
     void v6ErrorTest() {
         assertThrows(PowerFactoryException.class, () -> loadCase("/ascii_v6.dgs"));
     }

--- a/powerfactory/powerfactory-dgs/src/test/resources/MatrixOversizedRows.dgs
+++ b/powerfactory/powerfactory-dgs/src/test/resources/MatrixOversizedRows.dgs
@@ -1,0 +1,5 @@
+$$General;ID(a:40);Descr(a:40);Val(a:40)
+1;Version;5.0
+
+$$ElmFoo;ID(a:40);M:SIZEROW(i);M:SIZECOL(i);M:0:0(r);M:0:1(r)
+2;2147483647;2

--- a/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObject.java
+++ b/powerfactory/powerfactory-model/src/main/java/com/powsybl/powerfactory/model/DataObject.java
@@ -482,6 +482,10 @@ public class DataObject {
                             throw new PowerFactoryException("Data has to be specified after row and column count");
                         }
                         List<Double> data = JsonUtil.parseDoubleArray(parser);
+                        if (rowCount < 0 || columnCount < 0 || (long) rowCount * columnCount > data.size()) {
+                            throw new PowerFactoryException("Matrix data holds " + data.size()
+                                    + " values, less than the declared " + rowCount + "x" + columnCount);
+                        }
                         BlockRealMatrix matrix = new BlockRealMatrix(rowCount, columnCount);
                         for (int row = 0; row < rowCount; row++) {
                             for (int col = 0; col < columnCount; col++) {

--- a/powerfactory/powerfactory-model/src/test/java/com/powsybl/powerfactory/model/StudyCaseTest.java
+++ b/powerfactory/powerfactory-model/src/test/java/com/powsybl/powerfactory/model/StudyCaseTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,6 +57,14 @@ class StudyCaseTest extends AbstractPowerFactoryTest {
         assertEquals(List.of(1.3949d, 2.34d, 3.1223d), objFoo.getDoubleVectorAttributeValue("dv"));
         assertEquals(List.of(3L), objFoo.getObjectVectorAttributeValue("ov").stream().map(DataObjectRef::getId).toList());
         assertEquals(List.of("AA", "BBB"), objFoo.getStringVectorAttributeValue("sv"));
+    }
+
+    @Test
+    void jsonOversizedMatrixTest() throws IOException {
+        String json = new String(getClass().getResourceAsStream("/studyCase.json").readAllBytes(), StandardCharsets.UTF_8)
+                .replace("\"rowCount\" : 2", "\"rowCount\" : 2147483647");
+        PowerFactoryException e = assertThrows(PowerFactoryException.class, () -> StudyCase.parseJson(new StringReader(json)));
+        assertTrue(e.getMessage().contains("less than the declared"));
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Security fix


**What is the current behavior?**

The PowerFactory readers size a `BlockRealMatrix` from a row/column count taken from the input before checking that the input actually carries that many values. In `DgsParser.ElementDataMatrix.read` the `SIZEROW` field of a matrix data row flows straight into `new BlockRealMatrix(actualRows, actualCols)`. The vector reader validates its length and the matrix column count is validated too, but the row count is only logged on mismatch, so a small `.dgs` declaring a huge `SIZEROW` allocates (and overflows) an arbitrarily large matrix. `DataObject.parseMatrixJson` (study-case JSON, reachable from `StudyCase.readJson` / `Project.parseJson`) and `DataObjectBuilder.setDoubleMatrixAttributeValue` (native DB reader) have the same gap.


**What is the new behavior (if this is a feature change)?**

Each of the three sites checks the declared `rows * cols` against the values actually present before allocating, mirroring the length check the vector reader already performs. Valid files behave exactly as before; a matrix declaring more cells than it carries is skipped (DGS, consistent with the reader's existing empty-on-missing-cell handling) or rejected (JSON/DB) instead of driving the allocation. Regression tests cover the DGS and JSON paths.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
