### PR TITLE
Fix action-ial and psse builds on a fresh clone

### DIFF
--- a/action-ial/action-ial-dsl-spi/pom.xml
+++ b/action-ial/action-ial-dsl-spi/pom.xml
@@ -35,6 +35,14 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- This is addressing https://github.com/apache/maven-surefire/issues/2795 -->
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/psse/psse-model-test/pom.xml
+++ b/psse/psse-model-test/pom.xml
@@ -33,6 +33,14 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- This is addressing https://github.com/apache/maven-surefire/issues/2795 -->
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**

No.



**What kind of change does this PR introduce?**

Deactivate tests on 2 modules that have no tests and will probably never have.



**What is the current behavior?**

On a fresh clone, getting this error for `powsybl-action-ial-dsl-spi` and `psse-model-test`:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.5:test (default-test) on project powsybl-action-ial-dsl-spi: groups/excludedGroups require TestNG, JUnit48+ or JUnit 5 (a specific engine required on classpath) on project test classpath -> [Help 1]
```

**What is the new behavior (if this is a feature change)?**

No error, the build passes.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


** Possible alternative **

The downside of the current approach is that if a test is added in the module later, it will be ignored by the build. This would happen if the contributor is not paying attention to the maven output and do not realize the tests have been skipped.

A possible alternative is to manually add the test engine dependency in those 2 modules. This is quieting surefire, and if we add a test later, it will be picked up by the build. But this would add a dependency that is literally not used today. If and when a test would be added, people would need to be careful to realize they have to cleanup the dependencies.

I went with the proposed solution as the semantics seems more aligned with the problem and less surprising.