### PR TITLE
Fix dependency convergence error caused by commons-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <autoservice.version>1.1.1</autoservice.version>
         <awaitility.version>4.3.0</awaitility.version>
         <commonscli.version>1.11.0</commonscli.version>
+        <commonscodec.version>1.20.0</commonscodec.version>
         <commonscompress.version>1.28.0</commonscompress.version>
         <commons-configuration2.version>2.15.1</commons-configuration2.version>
         <commons-csv.version>1.14.1</commons-csv.version>
@@ -765,6 +766,11 @@
                 <groupId>org.tukaani</groupId>
                 <artifactId>xz</artifactId>
                 <version>${xz.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commonscodec.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #1747 


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Dependency stability


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When building the project, there's a dependency convergence error for "commons-codec" (the only divergence remaining).


**What is the new behavior (if this is a feature change)?**
No more dependency convergence error when building the project.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

Before this PR, the detected versions for `commons-codec:commons-codec` are:
- 1.20.0, via `org.apache.poi:poi`
- 1.19.0, via `org.apache.commons:commons-compress`, `org.apache.commons:commons-csv`
- 1.15, via `org.eclipse.rdf4j:rdf4j-rio-rdfxml` and `org.eclipse.rdf4j:rdf4j-repository-sail`
- 1.11, via `org.eclipse.rdf4j:rdf4j-repository-sail`

<details>
<summary>Full details</summary>

```
Dependency convergence error for commons-codec:commons-codec:jar:1.19.0. Paths to dependency are:
+-com.powsybl:powsybl-distribution-core:pom:7.4.0-SNAPSHOT
  +-com.powsybl:powsybl-commons:jar:7.4.0-SNAPSHOT:compile
    +-org.apache.commons:commons-compress:jar:1.28.0:compile
      +-commons-codec:commons-codec:jar:1.19.0:compile
and
+-com.powsybl:powsybl-distribution-core:pom:7.4.0-SNAPSHOT
  +-com.powsybl:powsybl-commons:jar:7.4.0-SNAPSHOT:compile
    +-org.apache.commons:commons-csv:jar:1.14.1:compile
      +-commons-codec:commons-codec:jar:1.19.0:compile
and
+-com.powsybl:powsybl-distribution-core:pom:7.4.0-SNAPSHOT
  +-com.powsybl:powsybl-entsoe-util:jar:7.4.0-SNAPSHOT:compile
    +-org.apache.poi:poi-ooxml:jar:5.5.1:compile
      +-org.apache.poi:poi:jar:5.5.1:compile
        +-commons-codec:commons-codec:jar:1.20.0:compile
and
+-com.powsybl:powsybl-distribution-core:pom:7.4.0-SNAPSHOT
  +-com.powsybl:powsybl-triple-store-impl-rdf4j:jar:7.4.0-SNAPSHOT:runtime
    +-org.eclipse.rdf4j:rdf4j-rio-rdfxml:jar:5.3.1:runtime
      +-org.eclipse.rdf4j:rdf4j-rio-api:jar:5.3.1:runtime
        +-commons-codec:commons-codec:jar:1.15:runtime
and
+-com.powsybl:powsybl-distribution-core:pom:7.4.0-SNAPSHOT
  +-com.powsybl:powsybl-triple-store-impl-rdf4j:jar:7.4.0-SNAPSHOT:runtime
    +-org.eclipse.rdf4j:rdf4j-repository-sail:jar:5.3.1:runtime
      +-org.eclipse.rdf4j:rdf4j-http-client:jar:5.3.1:runtime
        +-org.apache.httpcomponents:httpclient:jar:4.5.14:runtime
          +-commons-codec:commons-codec:jar:1.11:runtime
and
+-com.powsybl:powsybl-distribution-core:pom:7.4.0-SNAPSHOT
  +-com.powsybl:powsybl-triple-store-impl-rdf4j:jar:7.4.0-SNAPSHOT:runtime
    +-org.eclipse.rdf4j:rdf4j-repository-sail:jar:5.3.1:runtime
      +-org.eclipse.rdf4j:rdf4j-http-client:jar:5.3.1:runtime
        +-commons-codec:commons-codec:jar:1.15:runtime
```
</details>

The version that was copied in the distribution directory (`distribution-core/target/powsybl/share/java/`) was the **1.19.0**.
This PR sets the version to **1.20.0**.

> [!IMPORTANT]
> With this PR, the whole release train builds and all the unit tests succeed.
