### PR TITLE
Deprecate and add a remplacement function to get country name

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Country.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Country.java
@@ -274,7 +274,7 @@ public enum Country {
      * @deprecated This method is deprecated because not explicit enough as function name() exists.
      * Use {@link #getFullName()} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval=false)
     public String getName() {
         return name;
     }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Country.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Country.java
@@ -270,8 +270,16 @@ public enum Country {
         this.name = name;
     }
 
+    /**
+     * @deprecated This method is deprecated because not explicit enough as function name() exists.
+     * Use {@link #getFullName()} instead.
+     */
+    @Deprecated
     public String getName() {
         return name;
     }
 
+    public String getFullName() {
+        return name;
+    }
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Country.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Country.java
@@ -274,7 +274,7 @@ public enum Country {
      * @deprecated This method is deprecated because not explicit enough as function name() exists.
      * Use {@link #getFullName()} instead.
      */
-    @Deprecated(forRemoval=false)
+    @Deprecated(forRemoval = false)
     public String getName() {
         return name;
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/NetworkImpl.java
@@ -323,7 +323,7 @@ public class NetworkImpl extends AbstractNetwork implements VariantManagerHolder
 
     @Override
     public Iterable<Substation> getSubstations(Country country, String tsoId, String... geographicalTags) {
-        return getSubstations(Optional.ofNullable(country).map(Country::getName).orElse(null), tsoId, geographicalTags);
+        return getSubstations(Optional.ofNullable(country).map(Country::getFullName).orElse(null), tsoId, geographicalTags);
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/Substations.java
@@ -28,7 +28,7 @@ final class Substations {
                                        final String tso,
                                        final String... geographicalTags) {
         return StreamSupport.stream(substations.spliterator(), false).filter(substation -> {
-            if (country != null && !country.equals(substation.getCountry().map(Country::getName).orElse(""))) {
+            if (country != null && !country.equals(substation.getCountry().map(Country::getFullName).orElse(""))) {
                 return false;
             }
             if (tso != null && !tso.equals(substation.getTso())) {

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksExplorationTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractSubnetworksExplorationTest.java
@@ -378,11 +378,11 @@ public abstract class AbstractSubnetworksExplorationTest {
         assertIds(List.of(n1Substation1, n2Substation1), merged.getSubstations(Country.FR, null));
         assertIds(List.of(n1Substation1), subnetwork1.getSubstations(Country.FR, null));
         assertIds(List.of(n2Substation1), subnetwork2.getSubstations(Country.FR, null));
-        var countryName = Country.ES.getName();
+        var countryName = Country.ES.getFullName();
         assertIds(List.of(n1Substation2), merged.getSubstations(countryName, null));
         assertIds(List.of(n1Substation2), subnetwork1.getSubstations(countryName, null));
         assertFalse(subnetwork2.getSubstations(countryName, null).iterator().hasNext());
-        countryName = Country.BE.getName();
+        countryName = Country.BE.getFullName();
         assertIds(List.of(n2Substation2), merged.getSubstations(countryName, null));
         assertFalse(subnetwork1.getSubstations(countryName, null).iterator().hasNext());
         assertIds(List.of(n2Substation2), subnetwork2.getSubstations(countryName, null));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #3571 


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Deprecate the function getName() as a function called name() already exist which lead to confusion. Added a new function with the same behaviour and whose name is more explicit : getFullName().



**What is the current behavior?**
<!-- You can also link to an open issue here -->
#3571


**What is the new behavior (if this is a feature change)?**
Deprecated a function and add a remplacement function with the same behaviour.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Change call to function `Country::getName()` to `Country::getFullName()` as `Country::getName()` is now deprecated and will later be removed.  
Both functions have the same behaviour, hence no more change is required.