### PR TITLE
Fix performance issue for copy of network in XML

### DIFF
--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
@@ -1295,14 +1295,18 @@ public final class NetworkSerDe {
         try {
             Pipe pipe = Pipe.open();
             executor.execute(() -> {
-                try (Pipe.SinkChannel sinkChannel = pipe.sink()) {
-                    write(network, new ExportOptions().setFormat(format), Channels.newOutputStream(sinkChannel));
+                try (OutputStream tmp = Channels.newOutputStream(pipe.sink());
+                     //using buffered stream is about 20 times more effective for xml and json formats
+                     OutputStream os = format == TreeDataFormat.BIN ? tmp : new BufferedOutputStream(tmp)) {
+                    write(network, new ExportOptions().setFormat(format), os);
                 } catch (Exception t) {
                     LOGGER.error(t.toString(), t);
                 }
             });
-            try (Pipe.SourceChannel sourceChannel = pipe.source()) {
-                return read(Channels.newInputStream(sourceChannel),
+            try (InputStream tmp = Channels.newInputStream(pipe.source());
+                 //using buffered stream for read has little impact, but it mimics the write behavior
+                 InputStream is = format == TreeDataFormat.BIN ? tmp : new BufferedInputStream(tmp)) {
+                return read(is,
                         new ImportOptions().setFormat(format), null, networkFactory, ReportNode.NO_OP);
             }
         } catch (IOException e) {

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
@@ -1296,7 +1296,7 @@ public final class NetworkSerDe {
             Pipe pipe = Pipe.open();
             executor.execute(() -> {
                 try (OutputStream tmp = Channels.newOutputStream(pipe.sink());
-                     //using buffered stream is about 20 times more effective for xml and json formats
+                     //using buffered stream is about 20 times more effective for xml
                      OutputStream os = format == TreeDataFormat.BIN ? tmp : new BufferedOutputStream(tmp)) {
                     write(network, new ExportOptions().setFormat(format), os);
                 } catch (Exception t) {

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
@@ -1297,7 +1297,7 @@ public final class NetworkSerDe {
             executor.execute(() -> {
                 try (OutputStream tmp = Channels.newOutputStream(pipe.sink());
                      //using buffered stream is about 20 times more effective for xml
-                     OutputStream os = format == TreeDataFormat.BIN ? tmp : new BufferedOutputStream(tmp)) {
+                     OutputStream os = format == TreeDataFormat.XML ? new BufferedOutputStream(tmp) : tmp) {
                     write(network, new ExportOptions().setFormat(format), os);
                 } catch (Exception t) {
                     LOGGER.error(t.toString(), t);
@@ -1305,7 +1305,7 @@ public final class NetworkSerDe {
             });
             try (InputStream tmp = Channels.newInputStream(pipe.source());
                  //using buffered stream for read has little impact, but it mimics the write behavior
-                 InputStream is = format == TreeDataFormat.BIN ? tmp : new BufferedInputStream(tmp)) {
+                 InputStream is = format == TreeDataFormat.XML ? new BufferedInputStream(tmp) : tmp) {
                 return read(is,
                         new ImportOptions().setFormat(format), null, networkFactory, ReportNode.NO_OP);
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

None

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Performance

**What is the current behavior?**
<!-- You can also link to an open issue here -->

Following bump of core version in powsybl-benchmark from 7.2.1 to 7.3.0 leads to degraded copy performance when using XML (about 10 times slower):

Core 7.2.1
```
| Network name | XML (XIIDM) | JSON (JIIDM) | Binary (BIIDM) |
|--------------|-------------|--------------|----------------|
| IEEE 14      | 0,61        | 0,47         | 0,31           |
| IEEE 118     | 4,93        | 3,85         | 2,61           |
| IEEE 300     | 10,98       | 8,52         | 5,76           |
| RTE 1888     | 124,44      | 81,32        | 53,53          |
| RTE 6515     | 348,57      | 251,73       | 178,85         |
| RealGrid     | 1381,19     | 873,97       | 539,26         |
```
Core 7.3.0
```
| Network name | XML (XIIDM) | JSON (JIIDM) | Binary (BIIDM) |
|--------------|-------------|--------------|----------------|
| IEEE 14      | 6,13        | 0,27         | 0,32           |
| IEEE 118     | 59,61       | 1,83         | 2,01           |
| IEEE 300     | 129,55      | 3,92         | 4,53           |
| RTE 1888     | 1650,76     | 37,60        | 39,45          |
| RTE 6515     | 4085,79     | 131,93       | 137,54         |
| RealGrid     | 20910,20    | 381,44       | 326,14         |
```

**What is the new behavior (if this is a feature change)?**

Added use of buffered channel for formats other than binary, here is the resulting benchmark:
```
| Network name | XML (XIIDM) | JSON (JIIDM) | Binary (BIIDM) |
|--------------|-------------|--------------|----------------|
| IEEE 14      | 0,44        | 0,32         | 0,32           |
| IEEE 118     | 3,05        | 1,80         | 1,99           |
| IEEE 300     | 6,68        | 4,04         | 4,34           |
| RTE 1888     | 76,39       | 37,09        | 39,21          |
| RTE 6515     | 220,80      | 130,42       | 135,88         |
| RealGrid     | 821,72      | 364,11       | 314,06         |
```
It's about 40% faster than core 7.2.1 and about 25 times faster than core 7.3.0. It's still slower than JSON and IIDM which both got their performance improved by a factor 2 when going from core 7.2.1 to core 7.3.0

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

I investigated a bit the cause of this slow down.
#3919 introduced use of channels for binary, and using buffered channel for json and xml, which is where we see the improvement (result similar to after this fix)
```
| Network name | XML (XIIDM) | JSON (JIIDM) | Binary (BIIDM) |
|--------------|-------------|--------------|----------------|
| IEEE 14      | 0,42        | 0,32         | 0,22           |
| IEEE 118     | 3,01        | 1,85         | 1,79           |
| IEEE 300     | 6,64        | 4,11         | 4,01           |
| RTE 1888     | 74,59       | 37,60        | 37,50          |
| RTE 6515     | 214,57      | 129,65       | 133,84         |
| RealGrid     | 814,54      | 371,41       | 301,48         |
```

The PR #3968 cleans up the code and uses a non buffered channel sink for all formats, which is where the slow down happens (results similar to bumping to core 7.3.0)
```
| Network name | XML (XIIDM) | JSON (JIIDM) | Binary (BIIDM) |
|--------------|-------------|--------------|----------------|
| IEEE 14      | 0,42        | 0,32         | 0,22           |
| IEEE 118     | 3,01        | 1,85         | 1,79           |
| IEEE 300     | 6,64        | 4,11         | 4,01           |
| RTE 1888     | 74,59       | 37,60        | 37,50          |
| RTE 6515     | 214,57      | 129,65       | 133,84         |
| RealGrid     | 814,54      | 371,41       | 301,48         |
```

So the fix of this PR is to use buffered channel or sink depending on the format (but still keeping the clean code of #3968)

The main speedup comes from the write, below is a benchmark where only the write part of the copy uses buffered channel:
```
| Network name | XML (XIIDM) | JSON (JIIDM) | Binary (BIIDM) |
|--------------|-------------|--------------|----------------|
| IEEE 14      | 0,43        | 0,32         | 0,32           |
| IEEE 118     | 2,94        | 1,82         | 1,97           |
| IEEE 300     | 6,51        | 4,03         | 4,36           |
| RTE 1888     | 75,05       | 37,59        | 38,91          |
| RTE 6515     | 213,62      | 127,07       | 136,14         |
| RealGrid     | 832,32      | 358,27       | 325,87         |
```
And here is the current fix, where both write and read use buffered channels for XML:
```
| Network name | XML (XIIDM) | JSON (JIIDM) | Binary (BIIDM) |
|--------------|-------------|--------------|----------------|
| IEEE 14      | 0,44        | 0,32         | 0,32           |
| IEEE 118     | 3,05        | 1,80         | 1,99           |
| IEEE 300     | 6,68        | 4,04         | 4,34           |
| RTE 1888     | 76,39       | 37,09        | 39,21          |
| RTE 6515     | 220,80      | 130,42       | 135,88         |
| RealGrid     | 821,72      | 364,11       | 314,06         |
```
As we can see, the results are similar, so we could choose to not use buffered channel for read, but it was done this way here to have a symmetric behavior.