### PR TITLE
Cgmes update. Issue 4028. Allow zero active power setpoint for HVDC links

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/dc/DCLinkUpdate.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/dc/DCLinkUpdate.java
@@ -54,9 +54,9 @@ public class DCLinkUpdate {
             mode = SIDE_1_RECTIFIER_SIDE_2_INVERTER;
         } else if (isInverter(mode1) && isRectifier(mode2)) {
             mode = SIDE_1_INVERTER_SIDE_2_RECTIFIER;
-        } else if (targetPpcc1() > 0.0 || targetPpcc2() < 0.0) {
+        } else if (isTargetPpccDefined(targetPpcc1()) && targetPpcc1() > 0.0 || isTargetPpccDefined(targetPpcc2()) && targetPpcc2() < 0.0) {
             mode = SIDE_1_RECTIFIER_SIDE_2_INVERTER;
-        } else if (targetPpcc1() < 0.0 || targetPpcc2() > 0.0) {
+        } else if (isTargetPpccDefined(targetPpcc1()) && targetPpcc1() < 0.0 || isTargetPpccDefined(targetPpcc2()) && targetPpcc2() > 0.0) {
             mode = SIDE_1_INVERTER_SIDE_2_RECTIFIER;
         } else {
             mode = defaultData.mode();
@@ -74,13 +74,15 @@ public class DCLinkUpdate {
     }
 
     private double targetPpcc1() {
-        double targetPpcc = converter1.asDouble(TARGET_PPCC);
-        return Double.isNaN(targetPpcc) ? 0.0 : targetPpcc;
+        return converter1.asDouble(TARGET_PPCC);
     }
 
     private double targetPpcc2() {
-        double targetPpcc = converter2.asDouble(TARGET_PPCC);
-        return Double.isNaN(targetPpcc) ? 0.0 : targetPpcc;
+        return converter2.asDouble(TARGET_PPCC);
+    }
+
+    private boolean isTargetPpccDefined(double targetPpcc) {
+        return Double.isFinite(targetPpcc);
     }
 
     private PoleLosses pole1Losses() {
@@ -133,12 +135,20 @@ public class DCLinkUpdate {
 
     private void computeActivePowers() {
         // targetP is AC active power on rectifier side.
-        if (getTargetPpccRectifier() != 0.0) {
-            targetP = getTargetPpccRectifier();
-        } else if (getTargetPpccInverter() != 0.0) {
-            double pDcInverter = -1 * (Math.abs(getTargetPpccInverter()) + getPoleLossesInverter().value());
+
+        double targetPpccRectifier = getTargetPpccRectifier();
+        boolean isTargetPpccRectifierDefined = isTargetPpccDefined(targetPpccRectifier);
+        double targetPpccInverter = getTargetPpccInverter();
+        boolean isTargetPpccInverterDefined = isTargetPpccDefined(targetPpccInverter);
+
+        if (isTargetPpccRectifierDefined && targetPpccRectifier != 0.0) {
+            targetP = targetPpccRectifier;
+        } else if (isTargetPpccInverterDefined && targetPpccInverter != 0.0) {
+            double pDcInverter = -1 * (Math.abs(targetPpccInverter) + getPoleLossesInverter().value());
             double pDcRectifier = Math.abs(pDcInverter) + resistiveLossesFromPdcInverter(pDcInverter);
             targetP = pDcRectifier + getPoleLossesRectifier().value();
+        } else if (isTargetPpccRectifierDefined || isTargetPpccInverterDefined) {
+            targetP = 0.0;
         } else {
             targetP = defaultData.targetP();
         }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcUpdateTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/HvdcUpdateTest.java
@@ -7,9 +7,15 @@
  */
 package com.powsybl.cgmes.conversion.test;
 
+import com.powsybl.cgmes.conversion.CgmesExport;
+import com.powsybl.commons.datasource.GenericReadOnlyDataSource;
 import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Properties;
 
 import static com.powsybl.cgmes.conversion.test.ConversionUtil.readCgmesResources;
@@ -95,6 +101,29 @@ class HvdcUpdateTest {
         properties.put("iidm.import.cgmes.remove-properties-and-aliases-after-import", "true");
         network = readCgmesResources(properties, DIR, "hvdc_EQ.xml", "hvdc_SSH.xml");
         assertPropertiesAndAliasesEmpty(network, true);
+    }
+
+    @Test
+    void hvdcZeroActivePowerSetpointTest() throws IOException {
+        Network network = readCgmesResources("/update/hvdc/", "hvdc_EQ.xml", "hvdc_SSH.xml");
+
+        assertEquals(300.0, network.getHvdcLine("DCLineSegment-Lcc").getActivePowerSetpoint());
+
+        // we export 0.0
+        network.getHvdcLine("DCLineSegment-Lcc").setActivePowerSetpoint(0.0);
+        Path dir = Files.createTempDirectory("hvdc-zero");
+        Properties exportParameters = new Properties();
+        exportParameters.put(CgmesExport.PROFILES, List.of("SSH"));
+        network.write("CGMES", exportParameters, dir.resolve("rt"));
+
+        // we restore the initial active power setpoint before the update
+        network.getHvdcLine("DCLineSegment-Lcc").setActivePowerSetpoint(300.0);
+
+        Properties importParameters = new Properties();
+        importParameters.put("iidm.import.cgmes.use-previous-values-during-update", "true");
+        network.update(new GenericReadOnlyDataSource(dir, "rt"), importParameters);
+
+        assertEquals(0.0, network.getHvdcLine("DCLineSegment-Lcc").getActivePowerSetpoint());
     }
 
     private static void assertPropertiesAndAliasesEmpty(Network network, boolean expected) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

Fixes #4028

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->

Zero is not allowed as an active power setpoint for HVDC link.

**What is the new behavior (if this is a feature change)?**

Zero is allowed as an active power setpoint for HVDC links.
Zero losses are assumed when targetP is 0.0, in both the rectifier and inverter cases.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
