### PR TITLE
Remove redundant read buffering from NetworkSerDe.copy

### DIFF
--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/NetworkSerDe.java
@@ -1303,9 +1303,7 @@ public final class NetworkSerDe {
                     LOGGER.error(t.toString(), t);
                 }
             });
-            try (InputStream tmp = Channels.newInputStream(pipe.source());
-                 //using buffered stream for read has little impact, but it mimics the write behavior
-                 InputStream is = format == TreeDataFormat.BIN ? tmp : new BufferedInputStream(tmp)) {
+            try (InputStream is = Channels.newInputStream(pipe.source())) {
                 return read(is,
                         new ImportOptions().setFormat(format), null, networkFactory, ReportNode.NO_OP);
             }

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/NetworkSerDeTest.java
@@ -326,6 +326,18 @@ class NetworkSerDeTest extends AbstractIidmSerDeTest {
         assertTxtEquals(file1, file3);
     }
 
+    @ParameterizedTest
+    @EnumSource(TreeDataFormat.class)
+    void testCopyAllFormats(TreeDataFormat format) {
+        Network network = createEurostagTutorialExample1();
+        Path file1 = tmpDir.resolve("n.xml");
+        NetworkSerDe.write(network, file1);
+        Network copiedNetwork = NetworkSerDe.copy(network, format);
+        Path file2 = tmpDir.resolve("n-" + format + ".xml");
+        NetworkSerDe.write(copiedNetwork, file2);
+        assertTxtEquals(file1, file2);
+    }
+
     static Network writeAndRead(Network network, ExportOptions options) throws IOException {
         try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             NetworkSerDe.write(network, options, os);


### PR DESCRIPTION
This is a one-commit JAIPilot Cloud follow-up on the exact current head of [powsybl/powsybl-core#4056](https://github.com/powsybl/powsybl-core/pull/4056). It targets that PR branch directly.

### Change

Keep the material write-side buffering from #4056 and remove the read-side BufferedInputStream wrapper. BIN already used the channel stream directly, and the wrapper was documented as having little impact.

### Proof

- Exact parent: fc86ce540bb6fe8716ebbddf917cfd54e7a34a24, the current #4056 head.
- The same 37 focused tests passed before and after; BIN, XML, and JSON copies remain byte-identical.
- Thirty warmups plus 40 measured iterations, repeated three times per format, found no reproducible throughput regression from removing the read wrapper.
- The iidm-serde module suite with dependencies passed.
- One wrapper and its 8 KB buffer allocation are removed per copy.

### Boundary and disclosure

The write buffer remains the important XML improvement and is untouched. This is a small resource cleanup; no throughput improvement is claimed.

JAIPilot Cloud generated and validated the patch in [skrcode/powsybl-core#2](https://github.com/skrcode/powsybl-core/pull/2). I reviewed the exact ancestry, complete two-file diff, format-equivalence evidence, repeated timing boundary, and limitation before offering it here.