### PR TITLE
Change P_PCC_DROOP control mode to DC_DROOP for AcDcConverter

### DIFF
--- a/docs/grid_model/network_subnetwork.md
+++ b/docs/grid_model/network_subnetwork.md
@@ -1009,7 +1009,7 @@ LCC and VSC share the following characteristics.
 | $SwitchingLoss$ | MW / A   | Switching losses                                                      |
 | $ResistiveLoss$ | $\Omega$ | Resistive losses                                                      |
 | $PccTerminal$   |          | Point of common coupling (PCC) AC terminal                            |
-| $ControlMode$   |          | The converter's control mode: P_PCC, V_DC or P_PCC_DROOP              |
+| $ControlMode$   |          | The converter's control mode: P_PCC, V_DC or DC_DROOP                 |
 | $TargetP$       | MW       | Active power target at point of common coupling, load sign convention |
 | $TargetVdc$     | kV       | DC voltage target                                                     |
 | $MinP$          | MW       | Minimum active power at point of common coupling, load sign convention |
@@ -1027,6 +1027,7 @@ The Point of Common Coupling (PCC) Terminal defines where the AC/DC converter in
 The control mode defines whether the converter:
 - controls active power at Point of Common Coupling
 - or, controls DC voltage at its DC terminals
+- or, controls the relation between DC voltage and active power through a droop curve
 
 When the `ControlMode` of the converter is set to `P_PCC`, the converter controls active power flow at the (AC) Point of common coupling terminal.
 `TargetP` is the desired active power flow at PCC, in passive sign convention, i.e.:
@@ -1058,20 +1059,21 @@ between the converter DC Node 1 and the DC Node 2 to be equal to `TargetVdc`
   - `+TargetVdc / 2` at the converter DC Node 1
   - `-TargetVdc / 2` at the converter DC Node 2
 
-When the `ControlMode` of the converter is set to `P_PCC_DROOP`, the converter controls active power as in the `P_PCC` control mode
-for normal load flow, but when a security analysis in run, the converter controls the relation between DC Voltage and DC Power:
-$P_{DC} - P_{REF} = -k * (V_{DC} - V_{REF})$
+When the `ControlMode` of the converter is set to `DC_DROOP`, the converter controls the relation between DC voltage and active
+power through a piecewise linear droop curve, anchored in the $(P_{AC}, V_{DC})$ plane at the point $(TargetP, TargetVdc)$:
+$V_{DC} - V_i = k_i \cdot (P_{AC} - P_i)$
 Where:
-- $k$ is the droop coefficient of the actual droop segment.
-- $P_{REF}$ is the power which was calculated during the base loadflow, at DC side, so it is not equal to targetP which is the AC setpoint.
-It represents the operating point before the security analysis starts.
-- $V_{REF}$ is the DC voltage which was calculated during the base loadflow. The droop control is only used for P controlled converters, so they should not have a targetVdc.
-- $P_{DC}$ is the actual power at DC side during the security analysis, which is determined by Newton Raphson.
-- $V_{DC}$ is the actual DC voltage during the security analysis, which is determined by Newton Raphson.
+- $V_{DC} = V_1 - V_2$ is the DC voltage of the converter, between DC Node 1 and DC Node 2.
+- $P_{AC}$ is the active power of the converter, using the same load sign convention as `TargetP`.
+- $k_i$ is the droop coefficient of the segment containing the operating point, and $(P_i, V_i)$ is that segment's lower bound on the curve.
 
-Each droop segment in the `DroopCurve` is defined with minimal and maximal voltage, and a droop coefficient. The actual
-droop segment should be the one which verifies:
-$V_{DC} \in [V_{min}, V_{max}]$ where $V_{DC}$ is the DC Voltage at converter's Terminals.
+Only the segment containing the anchor point has a directly known $(P_i, V_i)$, namely $(TargetP, TargetVdc)$. The $(P_i, V_i)$
+of every other segment is derived by walking the curve from the anchor, segment by segment: crossing a segment with droop
+coefficient $k$ between voltages $V_{min}$ and $V_{max}$ shifts $P$ by $(V_{max} - V_{min}) / k$.
+
+Each segment in the `DroopCurve` is defined with a minimal and maximal voltage, and a droop coefficient. The segment used
+at a given DC voltage is the one which verifies:
+$V_{DC} \in [V_{min}, V_{max})$ where $V_{DC}$ is the DC Voltage at converter's Terminals.
 
 `MinP` and `MaxP` define the operational active power limits of the converter at the Point of Common Coupling, using the
 same load sign convention as `TargetP`.

--- a/docs/grid_model/network_subnetwork.md
+++ b/docs/grid_model/network_subnetwork.md
@@ -1071,9 +1071,10 @@ Only the segment containing the anchor point has a directly known $(P_i, V_i)$, 
 of every other segment is derived by walking the curve from the anchor, segment by segment: crossing a segment with droop
 coefficient $k$ between voltages $V_{min}$ and $V_{max}$ shifts $P$ by $(V_{max} - V_{min}) / k$.
 
-Each segment in the `DroopCurve` is defined with a minimal and maximal voltage, and a droop coefficient. The segment used
+Each segment in the `DroopCurve` is defined with a minimal and maximal voltage $V_{min}$ and $V_{max}$, and a droop coefficient $k$. The segment used
 at a given DC voltage is the one which verifies:
 $V_{DC} \in [V_{min}, V_{max})$ where $V_{DC}$ is the DC Voltage at converter's Terminals.
+A droop curve must be invertible. This implies that all the droop coefficients $k$ must be non-zero and with the same sign.
 
 `MinP` and `MaxP` define the operational active power limits of the converter at the Point of Common Coupling, using the
 same load sign convention as `TargetP`.

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
@@ -82,7 +82,7 @@ import java.util.Optional;
  *             <td style="border: 1px solid black"> - </td>
  *             <td style="border: 1px solid black">yes</td>
  *             <td style="border: 1px solid black"> - </td>
- *             <td style="border: 1px solid black">The converter's control mode: P_PCC or V_DC</td>
+ *             <td style="border: 1px solid black">The converter's control mode: P_PCC, V_DC or DC_DROOP</td>
  *         </tr>
  *         <tr>
  *             <td style="border: 1px solid black">TargetP</td>
@@ -143,9 +143,9 @@ public interface AcDcConverter<I extends AcDcConverter<I>> extends Connectable<I
          */
         V_DC,
         /**
-         * Controlling DC Voltage with Droop Control
+         * Controlling the relation between DC voltage and AC power through a droop curve
          */
-        P_PCC_DROOP
+        DC_DROOP
     }
 
     /**

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DroopCurve.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DroopCurve.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 /**
  * A droop curve to define droop function of a <code>AcDcConverter</code>
- * in <code>P_PCC_DROOP</code> mode.
+ * in <code>DC_DROOP</code> mode.
  * <p>
  * This curve is made of <code>Segment</code> and each segment is defined by its minimum
  * and maximum voltage associated with a droop coefficient.

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DroopCurveAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DroopCurveAdderImpl.java
@@ -53,6 +53,9 @@ class DroopCurveAdderImpl<O extends Validable & AcDcConverter<?>> implements Dro
             if (Double.isNaN(k)) {
                 throw new ValidationException(owner, "k is not set");
             }
+            if (k == 0.0) {
+                throw new ValidationException(owner, "k is zero");
+            }
             if (Double.isNaN(minV)) {
                 throw new ValidationException(owner, "min V is not set");
             }
@@ -76,6 +79,11 @@ class DroopCurveAdderImpl<O extends Validable & AcDcConverter<?>> implements Dro
 
     @Override
     public DroopCurve add() {
+        boolean hasPositiveK = segments.stream().anyMatch(s -> s.getK() > 0.0);
+        boolean hasNegativeK = segments.stream().anyMatch(s -> s.getK() < 0.0);
+        if (hasPositiveK && hasNegativeK) {
+            throw new ValidationException(owner, "k have inconsistent signs");
+        }
         segments.sort(Comparator.comparingDouble(DroopCurve.Segment::getMinV));
         for (int i = 0; i < segments.size() - 1; i++) {
 

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
@@ -11,7 +11,10 @@ import com.powsybl.iidm.network.AcDcConverter;
 import com.powsybl.iidm.network.AcDcConverterAdder;
 import com.powsybl.iidm.network.DcTerminal;
 import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.serde.util.IidmSerDeUtil;
 import org.apache.commons.lang3.NotImplementedException;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.powsybl.iidm.serde.ConnectableSerDeUtil.*;
 
@@ -19,6 +22,34 @@ import static com.powsybl.iidm.serde.ConnectableSerDeUtil.*;
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
  */
 abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends AcDcConverterAdder<T, A>> extends AbstractSimpleIdentifiableSerDe<T, A, VoltageLevel> {
+
+    private static final String ATTR_CONTROL_MODE = "controlMode";
+
+    /**
+     * Serialized shape of {@link AcDcConverter.ControlMode} for IIDM versions up to V1_17, where the droop
+     * control mode was still named <code>P_PCC_DROOP</code>.
+     */
+    private enum ControlModeSerDe {
+        P_PCC,
+        V_DC,
+        P_PCC_DROOP;
+
+        static ControlModeSerDe from(AcDcConverter.ControlMode controlMode) {
+            return switch (controlMode) {
+                case P_PCC -> P_PCC;
+                case V_DC -> V_DC;
+                case DC_DROOP -> P_PCC_DROOP;
+            };
+        }
+
+        AcDcConverter.ControlMode toControlMode() {
+            return switch (this) {
+                case P_PCC -> AcDcConverter.ControlMode.P_PCC;
+                case V_DC -> AcDcConverter.ControlMode.V_DC;
+                case P_PCC_DROOP -> AcDcConverter.ControlMode.DC_DROOP;
+            };
+        }
+    }
 
     protected void readRootElementPqiAttributes(T converter, NetworkDeserializerContext context) {
         readPQ(1, converter.getTerminal1(), context.getReader());
@@ -38,7 +69,10 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
         context.getWriter().writeDoubleAttribute("idleLoss", converter.getIdleLoss());
         context.getWriter().writeDoubleAttribute("switchingLoss", converter.getSwitchingLoss());
         context.getWriter().writeDoubleAttribute("resistiveLoss", converter.getResistiveLoss());
-        context.getWriter().writeEnumAttribute("controlMode", converter.getControlMode());
+        IidmSerDeUtil.runUntilMaximumVersion(IidmVersion.V_1_17, context, () ->
+            context.getWriter().writeEnumAttribute(ATTR_CONTROL_MODE, ControlModeSerDe.from(converter.getControlMode())));
+        IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_18, context, () ->
+            context.getWriter().writeEnumAttribute(ATTR_CONTROL_MODE, converter.getControlMode()));
         context.getWriter().writeDoubleAttribute("targetP", converter.getTargetP());
         context.getWriter().writeDoubleAttribute("targetVdc", converter.getTargetVdc());
         if (converter.getMinP() != -Double.MAX_VALUE && !context.getOptions().isForceExportNetworkWithBetaFeatures()) {
@@ -77,7 +111,11 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
         double idleLoss = context.getReader().readDoubleAttribute("idleLoss");
         double switchingLoss = context.getReader().readDoubleAttribute("switchingLoss");
         double resistiveLoss = context.getReader().readDoubleAttribute("resistiveLoss");
-        AcDcConverter.ControlMode controlMode = context.getReader().readEnumAttribute("controlMode", AcDcConverter.ControlMode.class);
+        AtomicReference<AcDcConverter.ControlMode> controlMode = new AtomicReference<>();
+        IidmSerDeUtil.runUntilMaximumVersion(IidmVersion.V_1_17, context, () ->
+            controlMode.set(context.getReader().readEnumAttribute(ATTR_CONTROL_MODE, ControlModeSerDe.class).toControlMode()));
+        IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_18, context, () ->
+            controlMode.set(context.getReader().readEnumAttribute(ATTR_CONTROL_MODE, AcDcConverter.ControlMode.class)));
         double targetP = context.getReader().readDoubleAttribute("targetP");
         double targetVdc = context.getReader().readDoubleAttribute("targetVdc");
         adder
@@ -85,7 +123,7 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
             .setDcConnected1(dcConnected1)
             .setDcNode2(dcNode2Id)
             .setDcConnected2(dcConnected2)
-            .setControlMode(controlMode)
+            .setControlMode(controlMode.get())
             .setTargetP(targetP)
             .setTargetVdc(targetVdc)
             .setIdleLoss(idleLoss)

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_18.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_18.xsd
@@ -559,7 +559,7 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="P_PCC"/>
             <xs:enumeration value="V_DC"/>
-            <xs:enumeration value="P_PCC_DROOP"/>
+            <xs:enumeration value="DC_DROOP"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="DroopCurve">

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_18.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_18.xsd
@@ -559,7 +559,7 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="P_PCC"/>
             <xs:enumeration value="V_DC"/>
-            <xs:enumeration value="P_PCC_DROOP"/>
+            <xs:enumeration value="DC_DROOP"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="DroopCurve">

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
@@ -147,7 +147,7 @@ class LineCommutatedConverterSerDeTest extends AbstractIidmSerDeTest {
                 .setBus2(bus2.getId())
                 .setReactiveModel(LineCommutatedConverter.ReactiveModel.CALCULATED_POWER_FACTOR)
                 .setPowerFactor(0.92)
-                .setControlMode(AcDcConverter.ControlMode.P_PCC_DROOP)
+                .setControlMode(AcDcConverter.ControlMode.DC_DROOP)
                 .setTargetVdc(502.)
                 .setTargetP(301.)
                 .setPccTerminal(lineBb.getTerminal1())

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
@@ -145,7 +145,7 @@ class VoltageSourceConverterSerDeTest extends AbstractIidmSerDeTest {
                 .setDcConnected2(true)
                 .setBus1(bus1.getId())
                 .setBus2(bus2.getId())
-                .setControlMode(AcDcConverter.ControlMode.P_PCC_DROOP)
+                .setControlMode(AcDcConverter.ControlMode.DC_DROOP)
                 .setTargetVdc(502.)
                 .setTargetP(301.)
                 .setPccTerminal(lineBb.getTerminal1())

--- a/iidm/iidm-serde/src/test/resources/V1_18/lineCommutatedConverterRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_18/lineCommutatedConverterRoundTripRef.xml
@@ -13,7 +13,7 @@
                 <iidm:property name="prop name" value="prop value"/>
                 <iidm:pccTerminal id="lccBb1ACWithoutSolvedV" number="ONE"/>
             </iidm:lineCommutatedConverter>
-            <iidm:lineCommutatedConverter id="lccBb2ACWithSolvedV" name="LCC in Bus/Breaker with two AC Terminals with solved values and droop curve" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="2.0" switchingLoss="0.2" resistiveLoss="2.0E-6" controlMode="P_PCC_DROOP" targetP="301.0" targetVdc="502.0" bus1="bus1" connectableBus1="bus1" bus2="bus2" connectableBus2="bus2" reactiveModel="CALCULATED_POWER_FACTOR" powerFactor="0.92" p1="-100.0" q1="-200.0" p2="-100.1" q2="-200.2" dcP1="-100.0" dcI1="-200.0" dcP2="0.4" dcI2="200.0">
+            <iidm:lineCommutatedConverter id="lccBb2ACWithSolvedV" name="LCC in Bus/Breaker with two AC Terminals with solved values and droop curve" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="2.0" switchingLoss="0.2" resistiveLoss="2.0E-6" controlMode="DC_DROOP" targetP="301.0" targetVdc="502.0" bus1="bus1" connectableBus1="bus1" bus2="bus2" connectableBus2="bus2" reactiveModel="CALCULATED_POWER_FACTOR" powerFactor="0.92" p1="-100.0" q1="-200.0" p2="-100.1" q2="-200.2" dcP1="-100.0" dcI1="-200.0" dcP2="0.4" dcI2="200.0">
                 <iidm:pccTerminal id="lineBb" side="ONE"/>
                 <iidm:droopCurve>
                     <iidm:segment minV="-500.0" maxV="-100.0" k="-10.0"/>

--- a/iidm/iidm-serde/src/test/resources/V1_18/voltageSourceConverterRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_18/voltageSourceConverterRoundTripRef.xml
@@ -14,7 +14,7 @@
                 <iidm:pccTerminal id="vscBb1ACWithoutSolvedV" number="ONE"/>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
             </iidm:voltageSourceConverter>
-            <iidm:voltageSourceConverter id="vscBb2ACWithSolvedV" name="VSC in Bus/Breaker with two AC Terminals with solved values and droop curve" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="2.0" switchingLoss="0.2" resistiveLoss="2.0E-6" controlMode="P_PCC_DROOP" targetP="301.0" targetVdc="502.0" bus1="bus1" connectableBus1="bus1" bus2="bus2" connectableBus2="bus2" voltageRegulatorOn="true" voltageSetpoint="387.0" reactivePowerSetpoint="12.3" p1="-100.0" q1="-200.0" p2="-100.1" q2="-200.2" dcP1="-100.0" dcI1="-200.0" dcP2="0.4" dcI2="200.0">
+            <iidm:voltageSourceConverter id="vscBb2ACWithSolvedV" name="VSC in Bus/Breaker with two AC Terminals with solved values and droop curve" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="2.0" switchingLoss="0.2" resistiveLoss="2.0E-6" controlMode="DC_DROOP" targetP="301.0" targetVdc="502.0" bus1="bus1" connectableBus1="bus1" bus2="bus2" connectableBus2="bus2" voltageRegulatorOn="true" voltageSetpoint="387.0" reactivePowerSetpoint="12.3" p1="-100.0" q1="-200.0" p2="-100.1" q2="-200.2" dcP1="-100.0" dcI1="-200.0" dcP2="0.4" dcI2="200.0">
                 <iidm:pccTerminal id="lineBb" side="ONE"/>
                 <iidm:droopCurve>
                     <iidm:segment minV="-500.0" maxV="-100.0" k="-10.0"/>

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractAcDcConverterTest.java
@@ -734,7 +734,7 @@ public abstract class AbstractAcDcConverterTest {
 
     @Test
     public void testDroopCurve() {
-        AcDcConverter<?> vsc = createVscA(vla).setControlMode(AcDcConverter.ControlMode.P_PCC_DROOP);
+        AcDcConverter<?> vsc = createVscA(vla).setControlMode(AcDcConverter.ControlMode.DC_DROOP);
 
         assertEquals(DroopCurve.EMPTY, vsc.getDroopCurve());
         assertEquals(0., vsc.getDroopCurve().getSegments().size());

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractDroopCurveTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractDroopCurveTest.java
@@ -51,13 +51,35 @@ public abstract class AbstractDroopCurveTest {
 
     @Test
     public void invalidK() {
-        DroopCurveAdder.SegmentAdder segmentAdder = converter.newDroopCurve()
+        DroopCurveAdder.SegmentAdder segmentAdder1 = converter.newDroopCurve()
                 .beginSegment()
                 .setK(Double.NaN)
                 .setMaxV(500.0)
                 .setMinV(100.0);
-        ValidationException e = assertThrows(ValidationException.class, segmentAdder::endSegment);
-        assertTrue(e.getMessage().contains("k is not set"));
+        ValidationException e1 = assertThrows(ValidationException.class, segmentAdder1::endSegment);
+        assertTrue(e1.getMessage().contains("k is not set"));
+
+        DroopCurveAdder.SegmentAdder segmentAdder2 = converter.newDroopCurve()
+                .beginSegment()
+                .setK(0.0)
+                .setMaxV(500.0)
+                .setMinV(100.0);
+        ValidationException e2 = assertThrows(ValidationException.class, segmentAdder2::endSegment);
+        assertTrue(e2.getMessage().contains("k is zero"));
+
+        DroopCurveAdder droopCurveAdder3 = converter.newDroopCurve()
+                .beginSegment()
+                .setK(1.0)
+                .setMaxV(500.0)
+                .setMinV(0.0)
+                .endSegment()
+                .beginSegment()
+                .setK(-1.0)
+                .setMaxV(100.0)
+                .setMinV(-500.0)
+                .endSegment();
+        ValidationException e3 = assertThrows(ValidationException.class, droopCurveAdder3::add);
+        assertTrue(e3.getMessage().contains("k have inconsistent signs"));
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
#3956

The changes are deeper, however.

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Change the name of droop control for AcDcConverter from P_PCC_DROOP to DC_DROOP (see issue). There is an associated change of behavior. Behavior no longer depends on computation mode (security vs load flow). The control mode has to be changed explicitly.

Furthermore this was the opportunity to change the meaning of the droop curve to make it more consistent with standards from recent research projects. It also fixes a major flaw in the definition of droop control.

Finally, a validation of the droop curve is added to prevent its slope crossing zero, i.e. only all-positive or all-negative values of the slopes of the piecewise linear curve are allowed.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The droop curve is defined as a set of droop coefficients k that depend on the voltage level of converters. These droop coefficients define slopes of the DC power vs DC voltage. The current formula makes the droop curve discontinuous.

The behavior also relates the current problem to the result of a previous computation, and to the type of computation (security vs load flow). This control mode is called P_PCC_DROOP because is switches to P_PCC or droop control depending on context.

**What is the new behavior (if this is a feature change)?**
Droop coefficients now relate DC voltages to AC powers in AcDcConverter. The formula makes the curve continuous and in line with current research.

Furthermore the problem definition is simplified and it no longer depends on a previous result or on a mode of computation. Switching to droop control must now be explicit. The control mode is renamed to DC_DROOP for this reason.

The following IIDM validations are added:
- the droop curve must not contain any zero droop value
- all segments of the the droop curve must have a droop of same sign

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

Existing uses of `AcDcConverter.ControlMode.P_PCC_DROOP` enum constant must be renamed to `AcDcConverter.ControlMode.DC_DROOP`. Where relevant, the load flow formula must be changed, as the definition of DC_DROOP and of the droop curve is modified.

Custom IIDM implementations maintainers must:

- ensure that all their implementations of `DroopCurveAdder` check that the droop curve has no zero droop value (on `endSegment())`) and that all droop values are of the same sign (on `add()`).

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Open Load Flow and PyPowSyBl are directly impacted by this change.

I decided to allow loading and writing of previous versions of serialized IIDM, by converting P_PCC_DROOP to DC_DROOP automatically. It is questionable, as the behavior has changed. Consequences are small since to my knowledge this was not implemented and used outside PowSyBl Core.