### PR TITLE
Update UcteCountryCode to include Ireland

### DIFF
--- a/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/UcteCountryCode.java
+++ b/ucte/ucte-network/src/main/java/com/powsybl/ucte/network/UcteCountryCode.java
@@ -34,6 +34,7 @@ public enum UcteCountryCode {
     GR('G', "Greece"),
     HU('M', "Hungary"),
     HR('H', "Croatia"),
+    IE('4', "Ireland"),
     IT('I', "Italy"),
     LU('1', "Luxemburg"),
     LT('6', "Lithuania"),
@@ -45,7 +46,6 @@ public enum UcteCountryCode {
     PT('P', "Portugal"),
     PL('Z', "Poland"),
     RO('R', "Romania"),
-    RU('4', "Russia"),
     SE('8', "Sweden"),
     SK('Q', "Slovakia"),
     SI('L', "Slovenia"),
@@ -91,6 +91,7 @@ public enum UcteCountryCode {
             case 'G' -> GR;
             case 'M' -> HU;
             case 'H' -> HR;
+            case '4' -> IE;
             case 'I' -> IT;
             case '1' -> LU;
             case '6' -> LT;
@@ -102,7 +103,6 @@ public enum UcteCountryCode {
             case 'P' -> PT;
             case 'Z' -> PL;
             case 'R' -> RO;
-            case '4' -> RU;
             case '8' -> SE;
             case 'Q' -> SK;
             case 'L' -> SI;

--- a/ucte/ucte-network/src/test/java/com/powsybl/ucte/network/UcteCountryCodeTest.java
+++ b/ucte/ucte-network/src/test/java/com/powsybl/ucte/network/UcteCountryCodeTest.java
@@ -22,16 +22,16 @@ class UcteCountryCodeTest {
     void test() {
         final char[] countryCodeNodes = {
             'O', 'A', 'B', 'V', 'W', '3', 'S', 'C', 'D',
-            'K', 'E', 'F', '5', 'G', 'M', 'H', 'I', '1',
-            '6', '2', '7', 'Y', '9', 'N', 'P', 'Z', 'R',
-            '4', '8', 'Q', 'L', 'T', 'U', '0', 'J', '_', 'X',
+            'K', 'E', 'F', '5', 'G', 'M', 'H', '4', 'I',
+            '1', '6', '2', '7', 'Y', '9', 'N', 'P', 'Z',
+            'R', '8', 'Q', 'L', 'T', 'U', '0', 'J', '_', 'X',
         };
 
         final String[] prettyNames = {
             "Austria", "Albania", "Belgium", "Bulgaria", "Bosnia and Herzegovina", "Belarus", "Switzerland", "Czech Republic", "Germany",
-            "Denmark", "Spain", "France", "Great Britain", "Greece", "Hungary", "Croatia", "Italy", "Luxemburg",
-            "Lithuania", "Morocco", "Moldavia", "FYROM", "Norway", "Netherlands", "Portugal", "Poland", "Romania",
-            "Russia", "Sweden", "Slovakia", "Slovenia", "Turkey", "Ukraine", "Montenegro", "Serbia", "Kosovo", "Fictitious border node"
+            "Denmark", "Spain", "France", "Great Britain", "Greece", "Hungary", "Croatia", "Ireland", "Italy",
+            "Luxemburg", "Lithuania", "Morocco", "Moldavia", "FYROM", "Norway", "Netherlands", "Portugal", "Poland",
+            "Romania", "Sweden", "Slovakia", "Slovenia", "Turkey", "Ukraine", "Montenegro", "Serbia", "Kosovo", "Fictitious border node"
         };
 
         assertEquals(37, UcteCountryCode.values().length);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

No

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Code update

**What is the current behavior?**
<!-- You can also link to an open issue here -->

The UcteCountryCode '4' represents Russia.

**What is the new behavior (if this is a feature change)?**

The UcteCountryCode '4' represents Ireland. This update is important in particular because Ireland is going to be represented in GridCapa based on PowSyBl, after the commissionning of Celtic interconnector between France and Ireland. 

Source: [UCTE-def](https://eepublicdownloads.entsoe.eu/clean-documents/pre2015/publications/ce/otherreports/UCTE-format.pdf).

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
