### PR TITLE
Add limits to detailed DC components

### DIFF
--- a/docs/grid_model/additional.md
+++ b/docs/grid_model/additional.md
@@ -112,8 +112,9 @@ Some equipment has operational limits regarding the current, active power or app
 
 Loading limits can be declined into active power limits (in MW), apparent power limits (in kVA) and current limits (in A).
 They may be set for [lines](./network_subnetwork.md#line), [boundary lines](./network_subnetwork.md#boundary-line),
-[tie lines](./network_subnetwork.md#tie-line) (via their boundary lines), [two-winding transformers](./network_subnetwork.md#two-winding-transformer)
-and [three-winding transformers](./network_subnetwork.md#three-winding-transformer). The active power limits are in absolute value.
+[tie lines](./network_subnetwork.md#tie-line) (via their boundary lines), [two-winding transformers](./network_subnetwork.md#two-winding-transformer),
+[three-winding transformers](./network_subnetwork.md#three-winding-transformer) and [DC lines](./network_subnetwork.md#dc-line).
+The active power limits are in absolute value.
 
 ### High loading limits
 

--- a/docs/grid_model/network_subnetwork.md
+++ b/docs/grid_model/network_subnetwork.md
@@ -916,12 +916,19 @@ DC nodes are points where DC terminals of DC conducting equipment are connected 
 
 **Characteristics**
 
-| Attribute  | Unit | Description                          |
-|------------|------|--------------------------------------|
-| $NominalV$ | kV   | The nominal voltage, always positive |
+| Attribute           | Unit | Description                          |
+|---------------------|------|--------------------------------------|
+| $NominalV$          | kV   | The nominal voltage, always positive |
+| $LowVoltageLimit$   | kV   | The low voltage limit, optional      |
+| $HighVoltageLimit$  | kV   | The high voltage limit, optional     |
 
 Although the nominal voltage of DC nodes must always be specified as a positive value,
 the solved voltages can be negative - for example, in the case of an LCC monopole operating in reverse polarity.
+
+The voltage limits describe the operating band of the DC node. Like the solved voltage, they are signed: they bound
+the voltage itself and not its magnitude, so both limits are negative on a DC node operating at negative polarity,
+and a DC node that may operate at either polarity has a band spanning both signs. Only the ordering of the two
+limits is checked: $LowVoltageLimit$ must not be greater than $HighVoltageLimit$.
 
 **Available extensions**
 - [Dynamic Model Info](extensions.md#dynamic-model-info)

--- a/docs/grid_model/network_subnetwork.md
+++ b/docs/grid_model/network_subnetwork.md
@@ -947,6 +947,12 @@ A DC Line has two DC Terminals.
 |-----------|----------|----------------------------------------|
 | $R$       | $\Omega$ | The series resistance, always positive |
 
+**Metadata**
+
+- A DC Line can have [loading limits](./additional.md#loading-limits), in a single collection for the whole line
+rather than one per side: a DC Line has no shunt admittance, so the current entering one DC Terminal is the current
+leaving the other. Current limits are the meaningful kind here; apparent power limits have no meaning on DC.
+
 **Available extensions**
 - [Dynamic Model Info](extensions.md#dynamic-model-info)
 

--- a/docs/grid_model/network_subnetwork.md
+++ b/docs/grid_model/network_subnetwork.md
@@ -949,9 +949,10 @@ A DC Line has two DC Terminals.
 
 **Metadata**
 
-- A DC Line can have [loading limits](./additional.md#loading-limits), in a single collection for the whole line
-rather than one per side: a DC Line has no shunt admittance, so the current entering one DC Terminal is the current
-leaving the other. Current limits are the meaningful kind here; apparent power limits have no meaning on DC.
+- A DC Line can have [loading limits](./additional.md#loading-limits), in which case they are stored in a single
+collection for the whole line rather than one per side: a DC Line has no shunt admittance, so the current entering
+one DC Terminal is the current leaving the other. Only current limits are accepted. Active and apparent power limits
+are refused, because a DC Line carries no reactive power and its two DC Terminals carry different active power.
 
 **Available extensions**
 - [Dynamic Model Info](extensions.md#dynamic-model-info)

--- a/docs/grid_model/network_subnetwork.md
+++ b/docs/grid_model/network_subnetwork.md
@@ -1066,7 +1066,8 @@ same load sign convention as `TargetP`.
 
 `MinP` must be less than or equal to `MaxP`. Both attributes are optional; if not set, the converter is considered with unlimited active power capability.
 
-`MinP` and `MaxP` are not serializable as of today. Trying to serialize AC-DC converters with non-default values of `MinP` or `MaxP` will raise an error.
+`MinP` and `MaxP` are serialized from IIDM version 1.18 onwards, and are omitted from the serialized file when left unset.
+Exporting a converter with a non-default `MinP` or `MaxP` to an earlier IIDM version raises an error.
 
 **Available extensions**
 - [Dynamic Model Info](extensions.md#dynamic-model-info)

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverter.java
@@ -196,9 +196,6 @@ public interface AcDcConverter<I extends AcDcConverter<I>> extends Connectable<I
 
     /**
      * Set the minimal active power in MW.
-     * <p><b>Note:</b> IIDM serialization is not yet supported for non-default values.
-     * Setting a value other than -{@link Double#MAX_VALUE} will cause
-     * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
      */
     I setMinP(double minP);
 
@@ -210,9 +207,6 @@ public interface AcDcConverter<I extends AcDcConverter<I>> extends Connectable<I
 
     /**
      * Set the maximal active power in MW.
-     * <p><b>Note:</b> IIDM serialization is not yet supported for non-default values.
-     * Setting a value other than {@link Double#MAX_VALUE} will cause
-     * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
      */
     I setMaxP(double maxP);
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverterAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/AcDcConverterAdder.java
@@ -34,17 +34,11 @@ public interface AcDcConverterAdder<T extends AcDcConverter<T> & Connectable<T> 
 
     /**
      * Set the minimal active power in MW.
-     * <p><b>Note:</b> IIDM serialization is not yet supported for non-default values.
-     * Setting a value other than -{@link Double#MAX_VALUE} will cause
-     * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
      */
     A setMinP(double minP);
 
     /**
      * Set the maximal active power in MW.
-     * <p><b>Note:</b> IIDM serialization is not yet supported for non-default values.
-     * Setting a value other than {@link Double#MAX_VALUE} will cause
-     * {@link com.powsybl.iidm.serde.NetworkSerDe#write} to throw a {@link com.powsybl.commons.PowsyblException}.
      */
     A setMaxP(double maxP);
 

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcLine.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcLine.java
@@ -20,13 +20,14 @@ package com.powsybl.iidm.network;
  * than one collection per side as a {@link Branch} does. A DC Line has no shunt admittance, so the current
  * entering one DC Terminal is the current leaving the other, and one limit describes both.
  *
- * <p>{@link CurrentLimits} is the meaningful limit on a DC Line: it is the rating of the conductor, and it
- * is unambiguous because both DC Terminals carry the same current.
+ * <p>{@link CurrentLimits} is the only kind of limit a DC Line accepts: it is the rating of the conductor,
+ * and it is unambiguous because both DC Terminals carry the same current.
  *
- * <p>The other two kinds come with {@link FlowsLimitsHolder} and should not be relied on here.
- * {@link ApparentPowerLimits} has no meaning on DC. An {@link ActivePowerLimits} is ambiguous: the two DC
- * Terminals carry different active power, since the series resistance consumes some of it, and a single
- * limit does not say which of the two it bounds.
+ * <p>The other two kinds come with {@link FlowsLimitsHolder}, but a DC Line refuses them, because neither
+ * describes anything physical on DC. An {@link ApparentPowerLimits} has no meaning where there is no
+ * reactive power. An {@link ActivePowerLimits} would not say which DC Terminal it bounds, since the series
+ * resistance makes the two carry different active power. Setting either one fails with a
+ * {@link ValidationException}, and so does importing a network that contains one.
  *
  * <p>
  *  Characteristics

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcLine.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcLine.java
@@ -13,6 +13,22 @@ package com.powsybl.iidm.network;
  * <p> To create a DcLine, see {@link DcLineAdder}
  *
  * <p>
+ *  Operational limits
+ * </p>
+ *
+ * <p>A DC Line carries a single collection of {@link OperationalLimitsGroup} for the whole line, rather
+ * than one collection per side as a {@link Branch} does. A DC Line has no shunt admittance, so the current
+ * entering one DC Terminal is the current leaving the other, and one limit describes both.
+ *
+ * <p>{@link CurrentLimits} is the meaningful limit on a DC Line: it is the rating of the conductor, and it
+ * is unambiguous because both DC Terminals carry the same current.
+ *
+ * <p>The other two kinds come with {@link FlowsLimitsHolder} and should not be relied on here.
+ * {@link ApparentPowerLimits} has no meaning on DC. An {@link ActivePowerLimits} is ambiguous: the two DC
+ * Terminals carry different active power, since the series resistance consumes some of it, and a single
+ * limit does not say which of the two it bounds.
+ *
+ * <p>
  *  Characteristics
  * </p>
  *
@@ -57,7 +73,7 @@ package com.powsybl.iidm.network;
  *
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
  */
-public interface DcLine extends DcConnectable<DcLine> {
+public interface DcLine extends DcConnectable<DcLine>, FlowsLimitsHolder {
 
     @Override
     default IdentifiableType getType() {

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcNode.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcNode.java
@@ -52,8 +52,30 @@ package com.powsybl.iidm.network;
  *             <td style="border: 1px solid black"> - </td>
  *             <td style="border: 1px solid black">The nominal voltage, always positive</td>
  *         </tr>
+ *         <tr>
+ *             <td style="border: 1px solid black">LowVoltageLimit</td>
+ *             <td style="border: 1px solid black">double</td>
+ *             <td style="border: 1px solid black">kV</td>
+ *             <td style="border: 1px solid black">no</td>
+ *             <td style="border: 1px solid black"> - </td>
+ *             <td style="border: 1px solid black">The low voltage limit, may be negative</td>
+ *         </tr>
+ *         <tr>
+ *             <td style="border: 1px solid black">HighVoltageLimit</td>
+ *             <td style="border: 1px solid black">double</td>
+ *             <td style="border: 1px solid black">kV</td>
+ *             <td style="border: 1px solid black">no</td>
+ *             <td style="border: 1px solid black"> - </td>
+ *             <td style="border: 1px solid black">The high voltage limit, may be negative</td>
+ *         </tr>
  *     </tbody>
  * </table>
+ *
+ * <p>
+ * The voltage limits bound the <b>signed</b> voltage {@link #getV()}, not its magnitude, so that the operating band
+ * of a DC node on the negative pole can be expressed. On such a node both limits are negative and crossing the low
+ * voltage limit means that the voltage <i>magnitude</i> is too large.
+ * </p>
  *
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
  */
@@ -74,6 +96,36 @@ public interface DcNode extends Identifiable<DcNode>, DcTopologyVisitable {
      * @return self for method chaining
      */
     DcNode setNominalV(double nominalV);
+
+    /**
+     * Get the low voltage limit in kV. The limit bounds the signed voltage {@link #getV()} and may be negative.
+     *
+     * @return the low voltage limit or NaN if undefined
+     */
+    double getLowVoltageLimit();
+
+    /**
+     * Set the low voltage limit in kV. The limit bounds the signed voltage {@link #getV()} and may be negative.
+     *
+     * @param lowVoltageLimit new low voltage limit in kV
+     * @return self for method chaining
+     */
+    DcNode setLowVoltageLimit(double lowVoltageLimit);
+
+    /**
+     * Get the high voltage limit in kV. The limit bounds the signed voltage {@link #getV()} and may be negative.
+     *
+     * @return the high voltage limit or NaN if undefined
+     */
+    double getHighVoltageLimit();
+
+    /**
+     * Set the high voltage limit in kV. The limit bounds the signed voltage {@link #getV()} and may be negative.
+     *
+     * @param highVoltageLimit new high voltage limit in kV
+     * @return self for method chaining
+     */
+    DcNode setHighVoltageLimit(double highVoltageLimit);
 
     /**
      * Get the voltage of the DC node in kV.

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcNode.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcNode.java
@@ -72,9 +72,10 @@ package com.powsybl.iidm.network;
  * </table>
  *
  * <p>
- * The voltage limits bound the <b>signed</b> voltage {@link #getV()}, not its magnitude, so that the operating band
- * of a DC node on the negative pole can be expressed. On such a node both limits are negative and crossing the low
- * voltage limit means that the voltage <i>magnitude</i> is too large.
+ * The voltage limits bound the <b>signed</b> voltage {@link #getV()}, not its magnitude. The rule is always
+ * {@code LowVoltageLimit <= V <= HighVoltageLimit}: a DC Node at a positive potential has a band such as
+ * {@code [480, 520]}, and one at a negative potential has {@code [-520, -480]}, with both limits negative. On the
+ * latter, crossing the low voltage limit means the voltage <i>magnitude</i> is too large.
  * </p>
  *
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcNode.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcNode.java
@@ -72,10 +72,38 @@ package com.powsybl.iidm.network;
  * </table>
  *
  * <p>
- * The voltage limits bound the <b>signed</b> voltage {@link #getV()}, not its magnitude. The rule is always
- * {@code LowVoltageLimit <= V <= HighVoltageLimit}: a DC Node at a positive potential has a band such as
- * {@code [480, 520]}, and one at a negative potential has {@code [-520, -480]}, with both limits negative. On the
- * latter, crossing the low voltage limit means the voltage <i>magnitude</i> is too large.
+ * These limits apply to the signed value returned by {@link #getV()}, not to how big that number is once you
+ * ignore its sign. The rule is always {@code LowVoltageLimit <= V <= HighVoltageLimit}. This matters because
+ * the same check already written for {@link VoltageLevel} can be reused as is: a healthy DC Node on the
+ * negative side reads something like {@code -500}. If the limits were stored ignoring the sign, as
+ * {@code [480, 520]}, that check would see {@code -500 <= 480} and wrongly say the voltage is too low. Stored
+ * signed instead, as {@code [-520, -480]}, the same check sees {@code -500} sits between them and reports
+ * nothing, which is correct.
+ * </p>
+ *
+ * <p>
+ * A DC Node on the positive side has a band such as {@code [480, 520]}. One on the negative side has a band
+ * such as {@code [-520, -480]}. On the negative side, going below {@code -520} (the low limit) means the
+ * voltage is too big once you ignore the sign, and going above {@code -480} (the high limit) means it is too
+ * small: the opposite of the positive side. So "low" always means the smaller number and "high" always means
+ * the bigger number, but which one is "too big" and which one is "too little" flips depending on which side of
+ * zero the band is on.
+ * </p>
+ *
+ * <p>
+ * A band can even sit around zero, such as {@code [-10, 10]}. There, {@code V = -15} crosses the low limit and
+ * {@code V = 15} crosses the high limit, but both are the same problem: the voltage moved too far from zero, in
+ * one direction or the other. Neither crossing means "too little", because every value close to zero is inside
+ * the band and allowed. So code that wants to report "voltage too high" or "voltage too low" cannot decide it
+ * from which field, low or high, was crossed. It first has to check where zero falls relative to the band.
+ * </p>
+ *
+ * <p>
+ * There are too many different bands for one meaning of "low" and "high" to fit them all: a positive-side node,
+ * a negative-side node, and a node centered on zero each need a different answer. So this class does not try
+ * to pick one. It only checks that {@code LowVoltageLimit <= HighVoltageLimit}
+ * ({@link ValidationUtil#checkDcVoltageLimits}), the one rule that holds in every case, and leaves it to
+ * whoever reads {@code V} and the band to decide what "too high" or "too low" means for that particular node.
  * </p>
  *
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcNodeAdder.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/DcNodeAdder.java
@@ -14,6 +14,16 @@ public interface DcNodeAdder extends IdentifiableAdder<DcNode, DcNodeAdder> {
 
     DcNodeAdder setNominalV(double nominalV);
 
+    /**
+     * @param lowVoltageLimit low voltage limit in kV, bounding the signed voltage, may be negative
+     */
+    DcNodeAdder setLowVoltageLimit(double lowVoltageLimit);
+
+    /**
+     * @param highVoltageLimit high voltage limit in kV, bounding the signed voltage, may be negative
+     */
+    DcNodeAdder setHighVoltageLimit(double highVoltageLimit);
+
     @Override
     DcNode add();
 }

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java
@@ -379,6 +379,18 @@ public final class ValidationUtil {
         }
     }
 
+    /**
+     * Check the voltage limits of a DC node. Contrary to {@link #checkVoltageLimits(Validable, double, double)},
+     * negative limits are valid for a DC node on the negative pole. The limits bound the signed voltage {@link DcNode#getV()}.
+     * Only the ordering of the two bounds is checked. An undefined ({@link Double#NaN}) bound passes, since all comparisons with NaN are false.
+     */
+    public static void checkDcVoltageLimits(Validable validable, double lowVoltageLimit, double highVoltageLimit) {
+        if (lowVoltageLimit > highVoltageLimit) {
+            throw new ValidationException(validable, "Inconsistent voltage limit range ["
+                    + lowVoltageLimit + ", " + highVoltageLimit + "]");
+        }
+    }
+
     public static void checkTopologyKind(Validable validable, TopologyKind topologyKind) {
         if (topologyKind == null) {
             throw new ValidationException(validable, "topology kind is invalid");

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcLineImpl.java
@@ -104,6 +104,7 @@ public class DcLineImpl extends AbstractDcConnectable<DcLine> implements DcLine 
         return this;
     }
 
+    // A removed DcLine's limits cannot be accessed, like r above and like DcNodeImpl does for its voltage limits.
     private void checkAccess() {
         ValidationUtil.checkAccessOfRemovedEquipment(this.id, this.removed, LIMITS_ATTRIBUTE);
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcLineImpl.java
@@ -13,12 +13,14 @@ import com.powsybl.iidm.network.ApparentPowerLimitsAdder;
 import com.powsybl.iidm.network.CurrentLimitsAdder;
 import com.powsybl.iidm.network.DcLine;
 import com.powsybl.iidm.network.DcTerminal;
+import com.powsybl.iidm.network.LimitType;
 import com.powsybl.iidm.network.OperationalLimitsGroup;
 import com.powsybl.iidm.network.TwoSides;
 import com.powsybl.iidm.network.ValidationUtil;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -31,6 +33,10 @@ public class DcLineImpl extends AbstractDcConnectable<DcLine> implements DcLine 
 
     private static final String LIMITS_ATTRIBUTE = "limits";
 
+    private static final Map<LimitType, String> UNSUPPORTED_LIMITS = Map.of(
+            LimitType.ACTIVE_POWER, "active power limits are not supported: the two DC terminals carry different active power",
+            LimitType.APPARENT_POWER, "apparent power limits are not supported: a DC line carries no reactive power");
+
     private double r;
 
     private final OperationalLimitsGroupsImpl operationalLimitsGroups;
@@ -38,7 +44,7 @@ public class DcLineImpl extends AbstractDcConnectable<DcLine> implements DcLine 
     DcLineImpl(Ref<NetworkImpl> ref, Ref<SubnetworkImpl> subnetworkRef, String id, String name, boolean fictitious, double r) {
         super(ref, subnetworkRef, id, name, fictitious);
         this.r = r;
-        this.operationalLimitsGroups = new OperationalLimitsGroupsImpl(this, LIMITS_ATTRIBUTE);
+        this.operationalLimitsGroups = new OperationalLimitsGroupsImpl(this, LIMITS_ATTRIBUTE, UNSUPPORTED_LIMITS);
     }
 
     @Override
@@ -212,6 +218,8 @@ public class DcLineImpl extends AbstractDcConnectable<DcLine> implements DcLine 
     @Override
     public ActivePowerLimitsAdder newActivePowerLimits() {
         checkModification();
+        // before getOrCreate, or a refusal leaves an empty group behind
+        operationalLimitsGroups.checkSupported(LimitType.ACTIVE_POWER);
         return operationalLimitsGroups.getOrCreateSelectedOperationalLimitsGroup().newActivePowerLimits();
     }
 
@@ -222,6 +230,7 @@ public class DcLineImpl extends AbstractDcConnectable<DcLine> implements DcLine 
     @Override
     public ApparentPowerLimitsAdder newApparentPowerLimits() {
         checkModification();
+        operationalLimitsGroups.checkSupported(LimitType.APPARENT_POWER);
         return operationalLimitsGroups.getOrCreateSelectedOperationalLimitsGroup().newApparentPowerLimits();
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcLineImpl.java
@@ -104,11 +104,6 @@ public class DcLineImpl extends AbstractDcConnectable<DcLine> implements DcLine 
         return this;
     }
 
-    /**
-     * A removed DC equipment must refuse access, like the {@code r} and terminal accessors above and like
-     * {@code DcNodeImpl} does for its voltage limits. {@code BoundaryLineImpl}, whose delegations this class
-     * otherwise copies, has no such rule and delegates bare; ours add one of these two calls.
-     */
     private void checkAccess() {
         ValidationUtil.checkAccessOfRemovedEquipment(this.id, this.removed, LIMITS_ATTRIBUTE);
     }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcLineImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcLineImpl.java
@@ -8,12 +8,19 @@
 package com.powsybl.iidm.network.impl;
 
 import com.powsybl.commons.ref.Ref;
+import com.powsybl.iidm.network.ActivePowerLimitsAdder;
+import com.powsybl.iidm.network.ApparentPowerLimitsAdder;
+import com.powsybl.iidm.network.CurrentLimitsAdder;
 import com.powsybl.iidm.network.DcLine;
 import com.powsybl.iidm.network.DcTerminal;
+import com.powsybl.iidm.network.OperationalLimitsGroup;
 import com.powsybl.iidm.network.TwoSides;
 import com.powsybl.iidm.network.ValidationUtil;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
@@ -22,11 +29,16 @@ public class DcLineImpl extends AbstractDcConnectable<DcLine> implements DcLine 
 
     public static final String R_ATTRIBUTE = "r";
 
+    private static final String LIMITS_ATTRIBUTE = "limits";
+
     private double r;
+
+    private final OperationalLimitsGroupsImpl operationalLimitsGroups;
 
     DcLineImpl(Ref<NetworkImpl> ref, Ref<SubnetworkImpl> subnetworkRef, String id, String name, boolean fictitious, double r) {
         super(ref, subnetworkRef, id, name, fictitious);
         this.r = r;
+        this.operationalLimitsGroups = new OperationalLimitsGroupsImpl(this, LIMITS_ATTRIBUTE);
     }
 
     @Override
@@ -84,5 +96,132 @@ public class DcLineImpl extends AbstractDcConnectable<DcLine> implements DcLine 
         this.r = r;
         getNetwork().getListeners().notifyUpdate(this, R_ATTRIBUTE, oldValue, r);
         return this;
+    }
+
+    /**
+     * A removed DC equipment must refuse access, like the {@code r} and terminal accessors above and like
+     * {@code DcNodeImpl} does for its voltage limits. {@code BoundaryLineImpl}, whose delegations this class
+     * otherwise copies, has no such rule and delegates bare; ours add one of these two calls.
+     */
+    private void checkAccess() {
+        ValidationUtil.checkAccessOfRemovedEquipment(this.id, this.removed, LIMITS_ATTRIBUTE);
+    }
+
+    private void checkModification() {
+        ValidationUtil.checkModifyOfRemovedEquipment(this.id, this.removed, LIMITS_ATTRIBUTE);
+    }
+
+    @Override
+    public Collection<OperationalLimitsGroup> getOperationalLimitsGroups() {
+        checkAccess();
+        return operationalLimitsGroups.getOperationalLimitsGroups();
+    }
+
+    @Override
+    public Optional<String> getSelectedOperationalLimitsGroupId() {
+        checkAccess();
+        return operationalLimitsGroups.getSelectedOperationalLimitsGroupId();
+    }
+
+    @Override
+    public Collection<String> getAllSelectedOperationalLimitsGroupIds() {
+        checkAccess();
+        return operationalLimitsGroups.getAllSelectedOperationalLimitsGroupIds();
+    }
+
+    @Override
+    public List<String> getAllSelectedOperationalLimitsGroupIdsOrdered() {
+        checkAccess();
+        return operationalLimitsGroups.getAllSelectedOperationalLimitsGroupIdsOrdered();
+    }
+
+    @Override
+    public Optional<OperationalLimitsGroup> getOperationalLimitsGroup(String id) {
+        checkAccess();
+        return operationalLimitsGroups.getOperationalLimitsGroup(id);
+    }
+
+    @Override
+    public Optional<OperationalLimitsGroup> getSelectedOperationalLimitsGroup() {
+        checkAccess();
+        return operationalLimitsGroups.getSelectedOperationalLimitsGroup();
+    }
+
+    @Override
+    public List<OperationalLimitsGroup> getAllSelectedOperationalLimitsGroups() {
+        checkAccess();
+        return operationalLimitsGroups.getAllSelectedOperationalLimitsGroups();
+    }
+
+    @Override
+    public OperationalLimitsGroup newOperationalLimitsGroup(String id) {
+        checkModification();
+        return operationalLimitsGroups.newOperationalLimitsGroup(id);
+    }
+
+    @Override
+    public void setSelectedOperationalLimitsGroup(String id) {
+        checkModification();
+        operationalLimitsGroups.setSelectedOperationalLimitsGroup(id);
+    }
+
+    @Override
+    public void addSelectedOperationalLimitsGroups(String... ids) {
+        checkModification();
+        operationalLimitsGroups.addSelectedOperationalLimitsGroups(ids);
+    }
+
+    @Override
+    public void removeOperationalLimitsGroup(String id) {
+        checkModification();
+        operationalLimitsGroups.removeOperationalLimitsGroup(id);
+    }
+
+    @Override
+    public void cancelSelectedOperationalLimitsGroup() {
+        checkModification();
+        operationalLimitsGroups.cancelSelectedOperationalLimitsGroup();
+    }
+
+    @Override
+    public void deselectOperationalLimitsGroups(String... ids) {
+        checkModification();
+        operationalLimitsGroups.deselectOperationalLimitsGroups(ids);
+    }
+
+    @Override
+    public OperationalLimitsGroup getOrCreateSelectedOperationalLimitsGroup() {
+        checkModification();
+        return operationalLimitsGroups.getOrCreateSelectedOperationalLimitsGroup();
+    }
+
+    /**
+     * @deprecated Use {@link OperationalLimitsGroup#newCurrentLimits()} instead.
+     */
+    @Deprecated(since = "6.8.0")
+    @Override
+    public CurrentLimitsAdder newCurrentLimits() {
+        checkModification();
+        return operationalLimitsGroups.getOrCreateSelectedOperationalLimitsGroup().newCurrentLimits();
+    }
+
+    /**
+     * @deprecated Use {@link OperationalLimitsGroup#newActivePowerLimits()} instead.
+     */
+    @Deprecated(since = "6.8.0")
+    @Override
+    public ActivePowerLimitsAdder newActivePowerLimits() {
+        checkModification();
+        return operationalLimitsGroups.getOrCreateSelectedOperationalLimitsGroup().newActivePowerLimits();
+    }
+
+    /**
+     * @deprecated Use {@link OperationalLimitsGroup#newApparentPowerLimits()} instead.
+     */
+    @Deprecated(since = "6.8.0")
+    @Override
+    public ApparentPowerLimitsAdder newApparentPowerLimits() {
+        checkModification();
+        return operationalLimitsGroups.getOrCreateSelectedOperationalLimitsGroup().newApparentPowerLimits();
     }
 }

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcNodeAdderImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcNodeAdderImpl.java
@@ -22,6 +22,8 @@ public class DcNodeAdderImpl extends AbstractIdentifiableAdder<DcNodeAdderImpl> 
     private final Ref<NetworkImpl> networkRef;
     private final Ref<SubnetworkImpl> subnetworkRef;
     private double nominalV = Double.NaN;
+    private double lowVoltageLimit = Double.NaN;
+    private double highVoltageLimit = Double.NaN;
 
     DcNodeAdderImpl(Ref<NetworkImpl> ref, Ref<SubnetworkImpl> subnetworkRef) {
         this.networkRef = ref;
@@ -35,11 +37,24 @@ public class DcNodeAdderImpl extends AbstractIdentifiableAdder<DcNodeAdderImpl> 
     }
 
     @Override
+    public DcNodeAdder setLowVoltageLimit(double lowVoltageLimit) {
+        this.lowVoltageLimit = lowVoltageLimit;
+        return this;
+    }
+
+    @Override
+    public DcNodeAdder setHighVoltageLimit(double highVoltageLimit) {
+        this.highVoltageLimit = highVoltageLimit;
+        return this;
+    }
+
+    @Override
     public DcNode add() {
         String id = checkAndGetUniqueId();
         ValidationUtil.checkNominalV(this, nominalV);
+        ValidationUtil.checkDcVoltageLimits(this, lowVoltageLimit, highVoltageLimit);
 
-        DcNodeImpl dcNode = new DcNodeImpl(networkRef, subnetworkRef, id, getName(), isFictitious(), nominalV);
+        DcNodeImpl dcNode = new DcNodeImpl(networkRef, subnetworkRef, id, getName(), isFictitious(), nominalV, lowVoltageLimit, highVoltageLimit);
         NetworkImpl network = networkRef.get();
         network.getIndex().checkAndAdd(dcNode);
         network.getListeners().notifyCreation(dcNode);

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcNodeImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/DcNodeImpl.java
@@ -25,11 +25,15 @@ import java.util.stream.Stream;
 public class DcNodeImpl extends AbstractDcTopologyVisitable<DcNode> implements DcNode, MultiVariantObject {
 
     public static final String NOMINAL_V_ATTRIBUTE = "nominalV";
+    public static final String LOW_VOLTAGE_LIMIT_ATTRIBUTE = "lowVoltageLimit";
+    public static final String HIGH_VOLTAGE_LIMIT_ATTRIBUTE = "highVoltageLimit";
 
     private final Ref<NetworkImpl> networkRef;
     private final Ref<SubnetworkImpl> subnetworkRef;
     protected boolean removed = false;
     private double nominalV;
+    private double lowVoltageLimit;
+    private double highVoltageLimit;
 
     private final List<DcTerminal> dcTerminals;
 
@@ -39,11 +43,14 @@ public class DcNodeImpl extends AbstractDcTopologyVisitable<DcNode> implements D
 
     private final TIntArrayList dcComponentNumber;
 
-    DcNodeImpl(Ref<NetworkImpl> ref, Ref<SubnetworkImpl> subnetworkRef, String id, String name, boolean fictitious, double nominalV) {
+    DcNodeImpl(Ref<NetworkImpl> ref, Ref<SubnetworkImpl> subnetworkRef, String id, String name, boolean fictitious, double nominalV,
+               double lowVoltageLimit, double highVoltageLimit) {
         super(id, name, fictitious);
         this.networkRef = Objects.requireNonNull(ref);
         this.subnetworkRef = subnetworkRef;
         this.nominalV = nominalV;
+        this.lowVoltageLimit = lowVoltageLimit;
+        this.highVoltageLimit = highVoltageLimit;
         int variantArraySize = ref.get().getVariantManager().getVariantArraySize();
         dcTerminals = new ArrayList<>();
         v = new TDoubleArrayList(variantArraySize);
@@ -86,6 +93,38 @@ public class DcNodeImpl extends AbstractDcTopologyVisitable<DcNode> implements D
         double oldValue = this.nominalV;
         this.nominalV = nominalV;
         getNetwork().getListeners().notifyUpdate(this, NOMINAL_V_ATTRIBUTE, oldValue, nominalV);
+        return this;
+    }
+
+    @Override
+    public double getLowVoltageLimit() {
+        ValidationUtil.checkAccessOfRemovedEquipment(this.id, this.removed, LOW_VOLTAGE_LIMIT_ATTRIBUTE);
+        return this.lowVoltageLimit;
+    }
+
+    @Override
+    public DcNode setLowVoltageLimit(double lowVoltageLimit) {
+        ValidationUtil.checkModifyOfRemovedEquipment(this.id, this.removed, LOW_VOLTAGE_LIMIT_ATTRIBUTE);
+        ValidationUtil.checkDcVoltageLimits(this, lowVoltageLimit, this.highVoltageLimit);
+        double oldValue = this.lowVoltageLimit;
+        this.lowVoltageLimit = lowVoltageLimit;
+        getNetwork().getListeners().notifyUpdate(this, LOW_VOLTAGE_LIMIT_ATTRIBUTE, oldValue, lowVoltageLimit);
+        return this;
+    }
+
+    @Override
+    public double getHighVoltageLimit() {
+        ValidationUtil.checkAccessOfRemovedEquipment(this.id, this.removed, HIGH_VOLTAGE_LIMIT_ATTRIBUTE);
+        return this.highVoltageLimit;
+    }
+
+    @Override
+    public DcNode setHighVoltageLimit(double highVoltageLimit) {
+        ValidationUtil.checkModifyOfRemovedEquipment(this.id, this.removed, HIGH_VOLTAGE_LIMIT_ATTRIBUTE);
+        ValidationUtil.checkDcVoltageLimits(this, this.lowVoltageLimit, highVoltageLimit);
+        double oldValue = this.highVoltageLimit;
+        this.highVoltageLimit = highVoltageLimit;
+        getNetwork().getListeners().notifyUpdate(this, HIGH_VOLTAGE_LIMIT_ATTRIBUTE, oldValue, highVoltageLimit);
         return this;
     }
 

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OperationalLimitsGroupImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OperationalLimitsGroupImpl.java
@@ -9,6 +9,7 @@ package com.powsybl.iidm.network.impl;
 
 import com.powsybl.iidm.network.*;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -27,6 +28,7 @@ public class OperationalLimitsGroupImpl extends AbstractPropertiesHolder impleme
     private final Validable validable;
     private final String attributeName;
     private final Predicate<String> isSelected;
+    private final Map<LimitType, String> unsupportedLimitTypes;
 
     /**
      * @param id the ID of the group we want to create
@@ -35,8 +37,20 @@ public class OperationalLimitsGroupImpl extends AbstractPropertiesHolder impleme
      * @param isSelected a predicate telling this group if it is part of the selected groups
      */
     OperationalLimitsGroupImpl(String id, AbstractIdentifiable<?> identifiable, String attributeName, Predicate<String> isSelected) {
+        this(id, identifiable, attributeName, isSelected, Map.of());
+    }
+
+    /**
+     * @param id the ID of the group we want to create
+     * @param identifiable on what to create the group
+     * @param attributeName prefix used for referencing the limits (used when notifying listeners)
+     * @param isSelected a predicate telling this group if it is part of the selected groups
+     * @param unsupportedLimitTypes limit types this group refuses, each with the message to throw
+     */
+    OperationalLimitsGroupImpl(String id, AbstractIdentifiable<?> identifiable, String attributeName, Predicate<String> isSelected,
+                               Map<LimitType, String> unsupportedLimitTypes) {
         this(id, Objects.requireNonNull(identifiable), identifiable.getNetwork().getListeners(),
-                identifiable, attributeName, Objects.requireNonNull(isSelected));
+                identifiable, attributeName, Objects.requireNonNull(isSelected), unsupportedLimitTypes);
     }
 
     /**
@@ -49,12 +63,28 @@ public class OperationalLimitsGroupImpl extends AbstractPropertiesHolder impleme
      */
     public OperationalLimitsGroupImpl(String id, Identifiable<?> identifiable, NetworkListenerList listeners,
                                       Validable validable, String attributeName, Predicate<String> isSelected) {
+        this(id, identifiable, listeners, validable, attributeName, isSelected, Map.of());
+    }
+
+    /**
+     * @param id the ID of the group we want to create
+     * @param identifiable on what to create the group
+     * @param listeners the listeners on the changes of this group
+     * @param validable used for exception mechanism when validating the network, provides a label for the error
+     * @param attributeName prefix used for referencing the limits (used when notifying listeners)
+     * @param isSelected a predicate telling this group if it is selected or not
+     * @param unsupportedLimitTypes limit types this group refuses, each with the message to throw
+     */
+    public OperationalLimitsGroupImpl(String id, Identifiable<?> identifiable, NetworkListenerList listeners,
+                                      Validable validable, String attributeName, Predicate<String> isSelected,
+                                      Map<LimitType, String> unsupportedLimitTypes) {
         this.id = Objects.requireNonNull(id);
         this.identifiable = Objects.requireNonNull(identifiable);
         this.listeners = listeners;
         this.validable = Objects.requireNonNull(validable);
         this.attributeName = Objects.requireNonNull(attributeName);
         this.isSelected = isSelected;
+        this.unsupportedLimitTypes = Objects.requireNonNull(unsupportedLimitTypes);
     }
 
     @Override
@@ -79,17 +109,27 @@ public class OperationalLimitsGroupImpl extends AbstractPropertiesHolder impleme
 
     @Override
     public CurrentLimitsAdder newCurrentLimits() {
+        checkSupported(LimitType.CURRENT);
         return new CurrentLimitsAdderImpl(() -> this, validable, identifiable.getId(), id, getNetwork());
     }
 
     @Override
     public ActivePowerLimitsAdder newActivePowerLimits() {
+        checkSupported(LimitType.ACTIVE_POWER);
         return new ActivePowerLimitsAdderImpl(() -> this, validable, identifiable.getId(), id, getNetwork());
     }
 
     @Override
     public ApparentPowerLimitsAdder newApparentPowerLimits() {
+        checkSupported(LimitType.APPARENT_POWER);
         return new ApparentPowerLimitsAdderImpl(() -> this, validable, identifiable.getId(), id, getNetwork());
+    }
+
+    private void checkSupported(LimitType limitType) {
+        String message = unsupportedLimitTypes.get(limitType);
+        if (message != null) {
+            throw new ValidationException(validable, message);
+        }
     }
 
     @Override

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OperationalLimitsGroupsImpl.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/OperationalLimitsGroupsImpl.java
@@ -30,16 +30,35 @@ class OperationalLimitsGroupsImpl implements FlowsLimitsHolder {
 
     private final Map<String, OperationalLimitsGroupImpl> operationalLimitsGroupById = new LinkedHashMap<>();
     private final AbstractIdentifiable<?> identifiable;
+    private final Map<LimitType, String> unsupportedLimitTypes;
 
     OperationalLimitsGroupsImpl(AbstractIdentifiable<?> identifiable, String attributeName) {
+        this(identifiable, attributeName, Map.of());
+    }
+
+    /**
+     * @param identifiable the equipment these groups belong to
+     * @param attributeName prefix used for referencing the limits (used when notifying listeners)
+     * @param unsupportedLimitTypes limit types the groups created here refuse, each with the message to throw
+     */
+    OperationalLimitsGroupsImpl(AbstractIdentifiable<?> identifiable, String attributeName, Map<LimitType, String> unsupportedLimitTypes) {
         this.identifiable = Objects.requireNonNull(identifiable);
         this.attributeName = attributeName;
+        this.unsupportedLimitTypes = Objects.requireNonNull(unsupportedLimitTypes);
+    }
+
+    /** Called before a group is created, so a refused add leaves no empty group behind. */
+    void checkSupported(LimitType limitType) {
+        String message = unsupportedLimitTypes.get(limitType);
+        if (message != null) {
+            throw new ValidationException(identifiable, message);
+        }
     }
 
     @Override
     public OperationalLimitsGroupImpl newOperationalLimitsGroup(String id) {
         Objects.requireNonNull(id);
-        OperationalLimitsGroupImpl newLimits = new OperationalLimitsGroupImpl(id, identifiable, attributeName, selectedLimitsIds::contains);
+        OperationalLimitsGroupImpl newLimits = new OperationalLimitsGroupImpl(id, identifiable, attributeName, selectedLimitsIds::contains, unsupportedLimitTypes);
         OperationalLimitsGroup oldLimits = operationalLimitsGroupById.put(id, newLimits);
         if (selectedLimitsIds.contains(id)) {
             notifyUpdate(oldLimits, newLimits);

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
@@ -82,12 +82,12 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
         double targetVdc = context.getReader().readDoubleAttribute("targetVdc");
 
         // unbounded active power as default value for IIDM version < 1.18 and for converters declaring no limit
-        double[] minP = {-Double.MAX_VALUE};
-        double[] maxP = {Double.MAX_VALUE};
-        IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_18, context, () -> {
-            minP[0] = context.getReader().readDoubleAttribute(MIN_P, -Double.MAX_VALUE);
-            maxP[0] = context.getReader().readDoubleAttribute(MAX_P, Double.MAX_VALUE);
-        });
+        double minP = -Double.MAX_VALUE;
+        double maxP = Double.MAX_VALUE;
+        if (context.getVersion().compareTo(IidmVersion.V_1_18) >= 0) {
+            minP = context.getReader().readDoubleAttribute(MIN_P, -Double.MAX_VALUE);
+            maxP = context.getReader().readDoubleAttribute(MAX_P, Double.MAX_VALUE);
+        }
         adder
             .setDcNode1(dcNode1Id)
             .setDcConnected1(dcConnected1)
@@ -99,8 +99,8 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
             .setIdleLoss(idleLoss)
             .setSwitchingLoss(switchingLoss)
             .setResistiveLoss(resistiveLoss)
-            .setMinP(minP[0])
-            .setMaxP(maxP[0]);
+            .setMinP(minP)
+            .setMaxP(maxP);
         readNodeOrBus(adder, voltageLevel.getTopologyKind(), context);
     }
 

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/AbstractAcDcConverterSerDe.java
@@ -11,7 +11,7 @@ import com.powsybl.iidm.network.AcDcConverter;
 import com.powsybl.iidm.network.AcDcConverterAdder;
 import com.powsybl.iidm.network.DcTerminal;
 import com.powsybl.iidm.network.VoltageLevel;
-import org.apache.commons.lang3.NotImplementedException;
+import com.powsybl.iidm.serde.util.IidmSerDeUtil;
 
 import static com.powsybl.iidm.serde.ConnectableSerDeUtil.*;
 
@@ -19,6 +19,9 @@ import static com.powsybl.iidm.serde.ConnectableSerDeUtil.*;
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
  */
 abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends AcDcConverterAdder<T, A>> extends AbstractSimpleIdentifiableSerDe<T, A, VoltageLevel> {
+
+    private static final String MIN_P = "minP";
+    private static final String MAX_P = "maxP";
 
     protected void readRootElementPqiAttributes(T converter, NetworkDeserializerContext context) {
         readPQ(1, converter.getTerminal1(), context.getReader());
@@ -41,16 +44,13 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
         context.getWriter().writeEnumAttribute("controlMode", converter.getControlMode());
         context.getWriter().writeDoubleAttribute("targetP", converter.getTargetP());
         context.getWriter().writeDoubleAttribute("targetVdc", converter.getTargetVdc());
-        if (converter.getMinP() != -Double.MAX_VALUE && !context.getOptions().isForceExportNetworkWithBetaFeatures()) {
-            throw new NotImplementedException(getRootElementName() + " '" + converter.getId() + "': minP serialization is not yet supported. " +
-                "To force the export of the network and ignore this value, either use the config parameter iidm.export.xml.force-export-network-with-beta-features, " +
-                "or ExportOptions.setForceExportNetworkWithBetaFeatures");
-        }
-        if (converter.getMaxP() != Double.MAX_VALUE && !context.getOptions().isForceExportNetworkWithBetaFeatures()) {
-            throw new NotImplementedException(getRootElementName() + " '" + converter.getId() + "': maxP serialization is not yet supported. " +
-                "To force the export of the network and ignore this value, either use the config parameter iidm.export.xml.force-export-network-with-beta-features, " +
-                "or ExportOptions.setForceExportNetworkWithBetaFeatures");
-        }
+
+        IidmSerDeUtil.assertMinimumVersionAndRunIfNotDefault(converter.getMinP() != -Double.MAX_VALUE, getRootElementName(), MIN_P,
+                IidmSerDeUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmVersion.V_1_18, context,
+                () -> context.getWriter().writeDoubleAttribute(MIN_P, converter.getMinP()));
+        IidmSerDeUtil.assertMinimumVersionAndRunIfNotDefault(converter.getMaxP() != Double.MAX_VALUE, getRootElementName(), MAX_P,
+                IidmSerDeUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmVersion.V_1_18, context,
+                () -> context.getWriter().writeDoubleAttribute(MAX_P, converter.getMaxP()));
 
         writeNodeOrBus(converter, context);
     }
@@ -80,6 +80,14 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
         AcDcConverter.ControlMode controlMode = context.getReader().readEnumAttribute("controlMode", AcDcConverter.ControlMode.class);
         double targetP = context.getReader().readDoubleAttribute("targetP");
         double targetVdc = context.getReader().readDoubleAttribute("targetVdc");
+
+        // unbounded active power as default value for IIDM version < 1.18 and for converters declaring no limit
+        double[] minP = {-Double.MAX_VALUE};
+        double[] maxP = {Double.MAX_VALUE};
+        IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_18, context, () -> {
+            minP[0] = context.getReader().readDoubleAttribute(MIN_P, -Double.MAX_VALUE);
+            maxP[0] = context.getReader().readDoubleAttribute(MAX_P, Double.MAX_VALUE);
+        });
         adder
             .setDcNode1(dcNode1Id)
             .setDcConnected1(dcConnected1)
@@ -90,7 +98,9 @@ abstract class AbstractAcDcConverterSerDe<T extends AcDcConverter<T>, A extends 
             .setTargetVdc(targetVdc)
             .setIdleLoss(idleLoss)
             .setSwitchingLoss(switchingLoss)
-            .setResistiveLoss(resistiveLoss);
+            .setResistiveLoss(resistiveLoss)
+            .setMinP(minP[0])
+            .setMaxP(maxP[0]);
         readNodeOrBus(adder, voltageLevel.getTopologyKind(), context);
     }
 

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/BoundaryLineSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/BoundaryLineSerDe.java
@@ -126,7 +126,7 @@ class BoundaryLineSerDe extends AbstractSimpleIdentifiableSerDe<BoundaryLine, Bo
         IidmSerDeUtil.runInBetweenTwoVersions(IidmVersion.V_1_12, IidmVersion.V_1_15, context, () ->
             readSelectedGroupId(null, bl::setSelectedOperationalLimitsGroup, context));
         IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_16, context, () ->
-            readAllSelectedGroupIds(bl, context));
+            readAllSelectedGroupIds(bl, bl.getId(), context));
         return bl;
     }
 

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ConnectableSerDeUtil.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/ConnectableSerDeUtil.java
@@ -486,18 +486,20 @@ public final class ConnectableSerDeUtil {
     }
 
     /**
-     * Read all the ids of the selected {@link OperationalLimitsGroup} to be added on the boundary line
-     * @param boundaryLine the {@link BoundaryLine} on which to add the selected groups
+     * Read all the ids of the selected {@link OperationalLimitsGroup} to be added on a holder carrying a single
+     * collection of groups, such as a {@link BoundaryLine} or a {@link DcLine}
+     * @param holder the {@link FlowsLimitsHolder} on which to add the selected groups
+     * @param identifiableId the id of the identifiable owning the <code>holder</code>
      * @param context to deserialize the data
      */
-    static void readAllSelectedGroupIds(BoundaryLine boundaryLine, NetworkDeserializerContext context) {
+    static void readAllSelectedGroupIds(FlowsLimitsHolder holder, String identifiableId, NetworkDeserializerContext context) {
         Collection<String> selectedIds = readAndGetAllSelectedGroupIds(
             null,
-            c -> boundaryLine.addSelectedOperationalLimitsGroups(c.toArray(String[]::new)),
+            c -> holder.addSelectedOperationalLimitsGroups(c.toArray(String[]::new)),
             context
         );
         context.addSelectedGroupIds(
-            boundaryLine.getId(),
+            identifiableId,
             ThreeSides.ONE,
             selectedIds
         );

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/DcLineSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/DcLineSerDe.java
@@ -11,8 +11,18 @@ import com.powsybl.iidm.network.DcLine;
 import com.powsybl.iidm.network.DcLineAdder;
 import com.powsybl.iidm.network.DcTerminal;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.OperationalLimitsGroup;
+import com.powsybl.iidm.network.ThreeSides;
+import com.powsybl.iidm.serde.util.IidmSerDeUtil;
 
+import java.util.Collection;
+
+import static com.powsybl.iidm.serde.ConnectableSerDeUtil.LIMITS_GROUP;
+import static com.powsybl.iidm.serde.ConnectableSerDeUtil.readAllSelectedGroupIds;
+import static com.powsybl.iidm.serde.ConnectableSerDeUtil.readLoadingLimitsGroups;
 import static com.powsybl.iidm.serde.ConnectableSerDeUtil.readPI;
+import static com.powsybl.iidm.serde.ConnectableSerDeUtil.writeAllSelectedGroupIds;
+import static com.powsybl.iidm.serde.ConnectableSerDeUtil.writeLimits;
 import static com.powsybl.iidm.serde.ConnectableSerDeUtil.writePI;
 
 /**
@@ -40,6 +50,22 @@ public class DcLineSerDe extends AbstractSimpleIdentifiableSerDe<DcLine, DcLineA
         context.getWriter().writeBooleanAttribute("connected2", dcTerminal2.isConnected());
         writePI(dcTerminal1, context.getWriter());
         writePI(dcTerminal2, context.getWriter());
+        // this attribute only names groups, so it is empty whenever there are none to name; the error for
+        // writing limits to a file older than 1.18 is raised on the groups themselves, in writeSubElements
+        IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_18, context, () ->
+                writeAllSelectedGroupIds(null, dcLine.getAllSelectedOperationalLimitsGroupIdsOrdered(), context.getWriter()));
+    }
+
+    @Override
+    protected void writeSubElements(final DcLine dcLine, final Network parent, final NetworkSerializerContext context) {
+        Collection<OperationalLimitsGroup> groupsToWrite = context.getOptions().isOnlySelectedOperationalLimitsGroups()
+                ? dcLine.getAllSelectedOperationalLimitsGroups()
+                : dcLine.getOperationalLimitsGroups();
+        IidmSerDeUtil.assertMinimumVersionAndRunIfNotDefault(!groupsToWrite.isEmpty(),
+                getRootElementName(), LIMITS_GROUP, IidmSerDeUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED,
+                IidmVersion.V_1_18, context,
+                () -> writeLimits(context, null, getRootElementName(),
+                        dcLine.getSelectedOperationalLimitsGroup().orElse(null), groupsToWrite));
     }
 
     @Override
@@ -63,11 +89,24 @@ public class DcLineSerDe extends AbstractSimpleIdentifiableSerDe<DcLine, DcLineA
                 .add();
         readPI(dcLine.getDcTerminal1(), context.getReader());
         readPI(dcLine.getDcTerminal2(), context.getReader());
+        IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_18, context, () ->
+                readAllSelectedGroupIds(dcLine, dcLine.getId(), context));
         return dcLine;
     }
 
     @Override
     protected void readSubElements(final DcLine dcLine, final NetworkDeserializerContext context) {
         context.getReader().readChildNodes(elementName -> readSubElement(elementName, dcLine, context));
+    }
+
+    @Override
+    protected void readSubElement(final String elementName, final DcLine dcLine, final NetworkDeserializerContext context) {
+        if (LIMITS_GROUP.equals(elementName)) {
+            IidmSerDeUtil.assertMinimumVersion(getRootElementName(), LIMITS_GROUP,
+                    IidmSerDeUtil.ErrorMessage.NOT_SUPPORTED, IidmVersion.V_1_18, context);
+            readLoadingLimitsGroups(dcLine, dcLine.getId(), ThreeSides.ONE, LIMITS_GROUP, context);
+        } else {
+            super.readSubElement(elementName, dcLine, context);
+        }
     }
 }

--- a/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/DcNodeSerDe.java
+++ b/iidm/iidm-serde/src/main/java/com/powsybl/iidm/serde/DcNodeSerDe.java
@@ -8,6 +8,7 @@
 package com.powsybl.iidm.serde;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.serde.util.IidmSerDeUtil;
 
 /**
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
@@ -17,6 +18,10 @@ public class DcNodeSerDe extends AbstractSimpleIdentifiableSerDe<DcNode, DcNodeA
     static final DcNodeSerDe INSTANCE = new DcNodeSerDe();
     static final String ROOT_ELEMENT_NAME = "dcNode";
     static final String ARRAY_ELEMENT_NAME = "dcNodes";
+    private static final String NOMINAL_V = "nominalV";
+    private static final String LOW_VOLTAGE_LIMIT = "lowVoltageLimit";
+    private static final String HIGH_VOLTAGE_LIMIT = "highVoltageLimit";
+    private static final String V = "v";
 
     @Override
     protected String getRootElementName() {
@@ -25,8 +30,12 @@ public class DcNodeSerDe extends AbstractSimpleIdentifiableSerDe<DcNode, DcNodeA
 
     @Override
     protected void writeRootElementAttributes(final DcNode dcNode, final Network parent, final NetworkSerializerContext context) {
-        context.getWriter().writeDoubleAttribute("nominalV", dcNode.getNominalV());
-        context.getWriter().writeDoubleAttribute("v", dcNode.getV());
+        context.getWriter().writeDoubleAttribute(NOMINAL_V, dcNode.getNominalV());
+        IidmSerDeUtil.writeDoubleAttributeFromMinimumVersion(getRootElementName(), LOW_VOLTAGE_LIMIT, dcNode.getLowVoltageLimit(),
+                IidmSerDeUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmVersion.V_1_18, context);
+        IidmSerDeUtil.writeDoubleAttributeFromMinimumVersion(getRootElementName(), HIGH_VOLTAGE_LIMIT, dcNode.getHighVoltageLimit(),
+                IidmSerDeUtil.ErrorMessage.NOT_DEFAULT_NOT_SUPPORTED, IidmVersion.V_1_18, context);
+        context.getWriter().writeDoubleAttribute(V, dcNode.getV());
     }
 
     @Override
@@ -36,10 +45,19 @@ public class DcNodeSerDe extends AbstractSimpleIdentifiableSerDe<DcNode, DcNodeA
 
     @Override
     protected DcNode readRootElementAttributes(final DcNodeAdder adder, final Network parent, final NetworkDeserializerContext context) {
-        double nominalV = context.getReader().readDoubleAttribute("nominalV");
-        double v = context.getReader().readDoubleAttribute("v");
+        double nominalV = context.getReader().readDoubleAttribute(NOMINAL_V);
+        // undefined voltage limits as default value for IIDM version < 1.18 and for DC nodes declaring no limit
+        double[] lowVoltageLimit = {Double.NaN};
+        double[] highVoltageLimit = {Double.NaN};
+        IidmSerDeUtil.runFromMinimumVersion(IidmVersion.V_1_18, context, () -> {
+            lowVoltageLimit[0] = context.getReader().readDoubleAttribute(LOW_VOLTAGE_LIMIT);
+            highVoltageLimit[0] = context.getReader().readDoubleAttribute(HIGH_VOLTAGE_LIMIT);
+        });
+        double v = context.getReader().readDoubleAttribute(V);
         DcNode dcNode = adder
                 .setNominalV(nominalV)
+                .setLowVoltageLimit(lowVoltageLimit[0])
+                .setHighVoltageLimit(highVoltageLimit[0])
                 .add();
         dcNode.setV(v);
         return dcNode;

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_18.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_18.xsd
@@ -872,6 +872,8 @@
         <xs:complexContent>
             <xs:extension base="iidm:Identifiable">
                 <xs:attribute name="nominalV" use="required" type="xs:double"/>
+                <xs:attribute name="lowVoltageLimit" use="optional" type="xs:double"/>
+                <xs:attribute name="highVoltageLimit" use="optional" type="xs:double"/>
                 <xs:attribute name="v" use="optional" type="xs:double"/>
             </xs:extension>
         </xs:complexContent>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_18.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_18.xsd
@@ -892,6 +892,10 @@
     <xs:complexType name="DcLine">
         <xs:complexContent>
             <xs:extension base="iidm:Identifiable">
+                <xs:sequence>
+                    <xs:element name="operationalLimitsGroup" type="iidm:OperationalLimitsGroup" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attribute name="selectedOperationalLimitsGroupIds" use="optional" type="iidm:selectedOperationalLimitsGroupIds"/>
                 <xs:attribute name="dcNode1" use="required" type="iidm:nonEmptyString"/>
                 <xs:attribute name="dcNode2" use="required" type="iidm:nonEmptyString"/>
                 <xs:attribute name="r" use="required" type="xs:double"/>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_18.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_V1_18.xsd
@@ -589,6 +589,8 @@
                 <xs:attribute name="controlMode" use="required" type="iidm:AcDcConverterControlMode"/>
                 <xs:attribute name="targetP" use="optional" type="xs:double"/>
                 <xs:attribute name="targetVdc" use="optional" type="xs:double"/>
+                <xs:attribute name="minP" use="optional" type="xs:double"/>
+                <xs:attribute name="maxP" use="optional" type="xs:double"/>
                 <xs:attribute name="node1" use="optional" type="xs:int"/>
                 <xs:attribute name="bus1" use="optional" type="iidm:nonEmptyString"/>
                 <xs:attribute name="connectableBus1" use="optional" type="iidm:nonEmptyString"/>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_18.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_18.xsd
@@ -872,6 +872,8 @@
         <xs:complexContent>
             <xs:extension base="iidm:Identifiable">
                 <xs:attribute name="nominalV" use="required" type="xs:double"/>
+                <xs:attribute name="lowVoltageLimit" use="optional" type="xs:double"/>
+                <xs:attribute name="highVoltageLimit" use="optional" type="xs:double"/>
                 <xs:attribute name="v" use="optional" type="xs:double"/>
             </xs:extension>
         </xs:complexContent>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_18.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_18.xsd
@@ -892,6 +892,10 @@
     <xs:complexType name="DcLine">
         <xs:complexContent>
             <xs:extension base="iidm:Identifiable">
+                <xs:sequence>
+                    <xs:element name="operationalLimitsGroup" type="iidm:OperationalLimitsGroup" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attribute name="selectedOperationalLimitsGroupIds" use="optional" type="iidm:selectedOperationalLimitsGroupIds"/>
                 <xs:attribute name="dcNode1" use="required" type="iidm:nonEmptyString"/>
                 <xs:attribute name="dcNode2" use="required" type="iidm:nonEmptyString"/>
                 <xs:attribute name="r" use="required" type="xs:double"/>

--- a/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_18.xsd
+++ b/iidm/iidm-serde/src/main/resources/xsd/iidm_equipment_V1_18.xsd
@@ -589,6 +589,8 @@
                 <xs:attribute name="controlMode" use="required" type="iidm:AcDcConverterControlMode"/>
                 <xs:attribute name="targetP" use="optional" type="xs:double"/>
                 <xs:attribute name="targetVdc" use="optional" type="xs:double"/>
+                <xs:attribute name="minP" use="optional" type="xs:double"/>
+                <xs:attribute name="maxP" use="optional" type="xs:double"/>
                 <xs:attribute name="node1" use="optional" type="xs:int"/>
                 <xs:attribute name="bus1" use="optional" type="iidm:nonEmptyString"/>
                 <xs:attribute name="connectableBus1" use="optional" type="iidm:nonEmptyString"/>

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcLineSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcLineSerDeTest.java
@@ -10,6 +10,7 @@ package com.powsybl.iidm.serde;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.DcLine;
 import com.powsybl.iidm.network.DcNode;
+import com.powsybl.iidm.network.LoadingLimits;
 import com.powsybl.iidm.network.Network;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +18,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -52,29 +55,38 @@ class DcLineSerDeTest extends AbstractIidmSerDeTest {
     }
 
     @Test
-    void testExportOnlySelectedGroups() throws IOException {
+    void testExportOnlySelectedGroups() {
         Network network = createBaseNetwork();
 
-        Network read = allFormatsRoundTripTest(network, "/dcLineOnlySelectedGroupsRef.xml", CURRENT_IIDM_VERSION,
-                new ExportOptions().setOnlySelectedOperationalLimitsGroups(true));
+        // testing only the current version would stop covering 1.18 the day a 1.19 is added
+        testForAllVersionsSince(IidmVersion.V_1_18, version -> {
+            Network read = assertDoesNotThrow(() -> allFormatsRoundTripTest(network, "/dcLineOnlySelectedGroupsRef.xml", version,
+                    new ExportOptions().setOnlySelectedOperationalLimitsGroups(true)));
 
-        DcLine dcLine = read.getDcLine("dcLineWithSolvedV");
-        assertEquals(1, dcLine.getOperationalLimitsGroups().size());
-        assertEquals("summer", dcLine.getSelectedOperationalLimitsGroupId().orElseThrow());
-        assertEquals(2106.0, dcLine.getCurrentLimits().orElseThrow().getPermanentLimit());
+            DcLine dcLine = read.getDcLine("dcLineWithSolvedV");
+            assertEquals(1, dcLine.getOperationalLimitsGroups().size());
+            assertEquals("summer", dcLine.getSelectedOperationalLimitsGroupId().orElseThrow());
+            assertEquals(2106.0, dcLine.getCurrentLimits().orElseThrow().getPermanentLimit());
+        });
     }
 
     @Test
-    void testMultipleSelectedGroups() throws IOException {
+    void testMultipleSelectedGroups() {
         Network network = createBaseNetwork();
         network.getDcLine("dcLineWithSolvedV").addSelectedOperationalLimitsGroups("winter");
 
-        Network read = allFormatsRoundTripTest(network, "/dcLineMultipleSelectedGroupsRef.xml", CURRENT_IIDM_VERSION);
+        testForAllVersionsSince(IidmVersion.V_1_18, version -> {
+            Network read = assertDoesNotThrow(() -> allFormatsRoundTripTest(network, "/dcLineMultipleSelectedGroupsRef.xml", version));
 
-        DcLine dcLine = read.getDcLine("dcLineWithSolvedV");
-        assertEquals(List.of("summer", "winter"), dcLine.getAllSelectedOperationalLimitsGroupIdsOrdered());
-        assertEquals(2, dcLine.getAllSelectedCurrentLimits().size());
-        assertEquals(2400.0, dcLine.getCurrentLimits().orElseThrow().getPermanentLimit());
+            DcLine dcLine = read.getDcLine("dcLineWithSolvedV");
+            assertEquals(List.of("summer", "winter"), dcLine.getAllSelectedOperationalLimitsGroupIdsOrdered());
+
+            // getCurrentLimits() alone only reads the last selected group, so both must be checked explicitly
+            Set<Double> permanentLimits = dcLine.getAllSelectedCurrentLimits().stream()
+                    .map(LoadingLimits::getPermanentLimit)
+                    .collect(Collectors.toSet());
+            assertEquals(Set.of(2106.0, 2400.0), permanentLimits);
+        });
     }
 
     @Test

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcLineSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcLineSerDeTest.java
@@ -65,6 +65,15 @@ class DcLineSerDeTest extends AbstractIidmSerDeTest {
     }
 
     @Test
+    void testOnlyCurrentLimitsCanBeRead() {
+        // a DcLine refuses the other kinds, so such a file can only be hand-written; reading must refuse it too
+        PowsyblException e = assertThrows(PowsyblException.class,
+                () -> NetworkSerDe.read(getVersionedNetworkAsStream("dcLineApparentPowerLimits.xml", CURRENT_IIDM_VERSION)));
+        assertEquals("DC Line 'dcLineWithSolvedV': apparent power limits are not supported: a DC line carries no reactive power",
+                e.getMessage());
+    }
+
+    @Test
     void testLimitsNotSupported() {
         Network network = createBaseNetwork();
 

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcLineSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcLineSerDeTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -51,17 +52,29 @@ class DcLineSerDeTest extends AbstractIidmSerDeTest {
     }
 
     @Test
-    void testExportOnlySelectedGroups() {
+    void testExportOnlySelectedGroups() throws IOException {
         Network network = createBaseNetwork();
 
-        ExportOptions options = new ExportOptions().setOnlySelectedOperationalLimitsGroups(true);
-        Path path = tmpDir.resolve("onlySelectedGroups.xml");
-        NetworkSerDe.write(network, options, path);
-        DcLine dcLine = NetworkSerDe.read(path).getDcLine("dcLineWithSolvedV");
+        Network read = allFormatsRoundTripTest(network, "/dcLineOnlySelectedGroupsRef.xml", CURRENT_IIDM_VERSION,
+                new ExportOptions().setOnlySelectedOperationalLimitsGroups(true));
 
+        DcLine dcLine = read.getDcLine("dcLineWithSolvedV");
         assertEquals(1, dcLine.getOperationalLimitsGroups().size());
         assertEquals("summer", dcLine.getSelectedOperationalLimitsGroupId().orElseThrow());
         assertEquals(2106.0, dcLine.getCurrentLimits().orElseThrow().getPermanentLimit());
+    }
+
+    @Test
+    void testMultipleSelectedGroups() throws IOException {
+        Network network = createBaseNetwork();
+        network.getDcLine("dcLineWithSolvedV").addSelectedOperationalLimitsGroups("winter");
+
+        Network read = allFormatsRoundTripTest(network, "/dcLineMultipleSelectedGroupsRef.xml", CURRENT_IIDM_VERSION);
+
+        DcLine dcLine = read.getDcLine("dcLineWithSolvedV");
+        assertEquals(List.of("summer", "winter"), dcLine.getAllSelectedOperationalLimitsGroupIdsOrdered());
+        assertEquals(2, dcLine.getAllSelectedCurrentLimits().size());
+        assertEquals(2400.0, dcLine.getCurrentLimits().orElseThrow().getPermanentLimit());
     }
 
     @Test
@@ -79,18 +92,18 @@ class DcLineSerDeTest extends AbstractIidmSerDeTest {
 
         // versions 1.15 to 1.17 support the DC line but not its operational limits, so exporting a DC line
         // that declares limits must fail rather than silently drop them
-        testForAllPreviousVersions(IidmVersion.V_1_18, version -> {
-            if (version.compareTo(IidmVersion.V_1_15) < 0) {
-                return;
-            }
+        testForAllVersionsBetween(IidmVersion.V_1_15, IidmVersion.V_1_17, version -> {
             ExportOptions options = new ExportOptions().setVersion(version.toString("."));
             Path path = tmpDir.resolve("fail");
             PowsyblException e = assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, options, path));
             assertEquals("dcLine.operationalLimitsGroup is not defined as default and not supported for IIDM version "
                     + version.toString(".") + ". IIDM version should be >= 1.18", e.getMessage());
         });
+    }
 
-        // the same export must succeed with no limits to drop or the assertions above prove nothing
+    @Test
+    void testExportToOlderVersionSucceedsWithNoLimitToDrop() {
+        // with no limits at all there is nothing to lose, so the version error must not fire
         Network noLimits = Network.create("dcLineTest", "code");
         noLimits.setCaseDate(ZonedDateTime.parse("2025-01-02T03:04:05.000+01:00"));
         noLimits.newDcNode().setId("dcNode1").setNominalV(500.).add();
@@ -99,8 +112,8 @@ class DcLineSerDeTest extends AbstractIidmSerDeTest {
         ExportOptions options = new ExportOptions().setVersion(IidmVersion.V_1_17.toString("."));
         assertDoesNotThrow(() -> NetworkSerDe.write(noLimits, options, tmpDir.resolve("noLimits.xml")));
 
-        // exporting only the selected groups leaves nothing to write when none is selected, so the
-        // version error must not fire either
+        // same when exporting only the selected groups and none is selected
+        Network network = createBaseNetwork();
         network.getDcLine("dcLineWithSolvedV").cancelSelectedOperationalLimitsGroup();
         ExportOptions selectedOnly = new ExportOptions()
                 .setVersion(IidmVersion.V_1_17.toString("."))
@@ -149,6 +162,11 @@ class DcLineSerDeTest extends AbstractIidmSerDeTest {
                 .setName("20'")
                 .setAcceptableDuration(20 * 60)
                 .setValue(2350.0)
+                .endTemporaryLimit()
+                .beginTemporaryLimit()
+                .setName("5'")
+                .setAcceptableDuration(5 * 60)
+                .setValue(2600.0)
                 .endTemporaryLimit()
                 .add();
         dcLine2.newOperationalLimitsGroup("winter")

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcLineSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcLineSerDeTest.java
@@ -51,6 +51,20 @@ class DcLineSerDeTest extends AbstractIidmSerDeTest {
     }
 
     @Test
+    void testExportOnlySelectedGroups() {
+        Network network = createBaseNetwork();
+
+        ExportOptions options = new ExportOptions().setOnlySelectedOperationalLimitsGroups(true);
+        Path path = tmpDir.resolve("onlySelectedGroups.xml");
+        NetworkSerDe.write(network, options, path);
+        DcLine dcLine = NetworkSerDe.read(path).getDcLine("dcLineWithSolvedV");
+
+        assertEquals(1, dcLine.getOperationalLimitsGroups().size());
+        assertEquals("summer", dcLine.getSelectedOperationalLimitsGroupId().orElseThrow());
+        assertEquals(2106.0, dcLine.getCurrentLimits().orElseThrow().getPermanentLimit());
+    }
+
+    @Test
     void testLimitsNotSupported() {
         Network network = createBaseNetwork();
 
@@ -75,6 +89,14 @@ class DcLineSerDeTest extends AbstractIidmSerDeTest {
         noLimits.newDcLine().setId("dcLine").setDcNode1("dcNode1").setDcNode2("dcNode2").setR(1.0).add();
         ExportOptions options = new ExportOptions().setVersion(IidmVersion.V_1_17.toString("."));
         assertDoesNotThrow(() -> NetworkSerDe.write(noLimits, options, tmpDir.resolve("noLimits.xml")));
+
+        // exporting only the selected groups leaves nothing to write when none is selected, so the
+        // version error must not fire either
+        network.getDcLine("dcLineWithSolvedV").cancelSelectedOperationalLimitsGroup();
+        ExportOptions selectedOnly = new ExportOptions()
+                .setVersion(IidmVersion.V_1_17.toString("."))
+                .setOnlySelectedOperationalLimitsGroups(true);
+        assertDoesNotThrow(() -> NetworkSerDe.write(network, selectedOnly, tmpDir.resolve("noSelected.xml")));
     }
 
     private static Network createBaseNetwork() {

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcLineSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcLineSerDeTest.java
@@ -7,15 +7,20 @@
  */
 package com.powsybl.iidm.serde;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.DcLine;
 import com.powsybl.iidm.network.DcNode;
 import com.powsybl.iidm.network.Network;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.ZonedDateTime;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
@@ -43,6 +48,33 @@ class DcLineSerDeTest extends AbstractIidmSerDeTest {
         // check it doesn't fail for version 1.14 if IidmVersionIncompatibilityBehavior is to log error
         var options = new ExportOptions().setIidmVersionIncompatibilityBehavior(ExportOptions.IidmVersionIncompatibilityBehavior.LOG_ERROR);
         testWriteVersionedXml(network, options, "dcLineNotSupported.xml", IidmVersion.V_1_14);
+    }
+
+    @Test
+    void testLimitsNotSupported() {
+        Network network = createBaseNetwork();
+
+        // versions 1.15 to 1.17 support the DC line but not its operational limits, so exporting a DC line
+        // that declares limits must fail rather than silently drop them
+        testForAllPreviousVersions(IidmVersion.V_1_18, version -> {
+            if (version.compareTo(IidmVersion.V_1_15) < 0) {
+                return;
+            }
+            ExportOptions options = new ExportOptions().setVersion(version.toString("."));
+            Path path = tmpDir.resolve("fail");
+            PowsyblException e = assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, options, path));
+            assertEquals("dcLine.operationalLimitsGroup is not defined as default and not supported for IIDM version "
+                    + version.toString(".") + ". IIDM version should be >= 1.18", e.getMessage());
+        });
+
+        // the same export must succeed with no limits to drop or the assertions above prove nothing
+        Network noLimits = Network.create("dcLineTest", "code");
+        noLimits.setCaseDate(ZonedDateTime.parse("2025-01-02T03:04:05.000+01:00"));
+        noLimits.newDcNode().setId("dcNode1").setNominalV(500.).add();
+        noLimits.newDcNode().setId("dcNode2").setNominalV(500.).add();
+        noLimits.newDcLine().setId("dcLine").setDcNode1("dcNode1").setDcNode2("dcNode2").setR(1.0).add();
+        ExportOptions options = new ExportOptions().setVersion(IidmVersion.V_1_17.toString("."));
+        assertDoesNotThrow(() -> NetworkSerDe.write(noLimits, options, tmpDir.resolve("noLimits.xml")));
     }
 
     private static Network createBaseNetwork() {
@@ -79,6 +111,20 @@ class DcLineSerDeTest extends AbstractIidmSerDeTest {
                 .add();
         dcLine2.getDcTerminal1().setP(100.).setI(200.);
         dcLine2.getDcTerminal2().setP(-98.).setI(-195.);
+        dcLine2.newOperationalLimitsGroup("summer")
+                .newCurrentLimits()
+                .setPermanentLimit(2106.0)
+                .beginTemporaryLimit()
+                .setName("20'")
+                .setAcceptableDuration(20 * 60)
+                .setValue(2350.0)
+                .endTemporaryLimit()
+                .add();
+        dcLine2.newOperationalLimitsGroup("winter")
+                .newCurrentLimits()
+                .setPermanentLimit(2400.0)
+                .add();
+        dcLine2.setSelectedOperationalLimitsGroup("summer");
         return network;
     }
 

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcNodeSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/DcNodeSerDeTest.java
@@ -51,6 +51,31 @@ class DcNodeSerDeTest extends AbstractIidmSerDeTest {
         testWriteVersionedXml(network, options, "dcNodeNotSupported.xml", IidmVersion.V_1_14);
     }
 
+    @Test
+    void testVoltageLimitsNotSupported() {
+        Network network = createBaseNetwork();
+
+        // versions 1.15 to 1.17 support the DC node but not its voltage limits, so exporting a DC node that
+        // declares limits must fail rather than silently drop them
+        testForAllPreviousVersions(IidmVersion.V_1_18, version -> {
+            if (version.compareTo(IidmVersion.V_1_15) < 0) {
+                return;
+            }
+            ExportOptions options = new ExportOptions().setVersion(version.toString("."));
+            Path path = tmpDir.resolve("fail");
+            PowsyblException e = assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, options, path));
+            assertEquals("dcNode.lowVoltageLimit is not defined as default and not supported for IIDM version "
+                    + version.toString(".") + ". IIDM version should be >= 1.18", e.getMessage());
+        });
+
+        // a DC node declaring no limit is unaffected
+        Network noLimits = Network.create("dcNodeTest", "code");
+        noLimits.setCaseDate(ZonedDateTime.parse("2025-01-02T03:04:05.000+01:00"));
+        noLimits.newDcNode().setId("dcNode").setNominalV(500.).add();
+        ExportOptions options = new ExportOptions().setVersion(IidmVersion.V_1_17.toString("."));
+        assertDoesNotThrow(() -> NetworkSerDe.write(noLimits, options, tmpDir.resolve("noLimits.xml")));
+    }
+
     private static Network createBaseNetwork() {
         Network network = Network.create("dcNodeTest", "code");
         network.setCaseDate(ZonedDateTime.parse("2025-01-02T03:04:05.000+01:00"));
@@ -66,8 +91,18 @@ class DcNodeSerDeTest extends AbstractIidmSerDeTest {
                 .setId("dcNodeWithSolvedV")
                 .setName("A DC Node with solved V")
                 .setNominalV(500.)
+                .setLowVoltageLimit(480.)
+                .setHighVoltageLimit(520.)
                 .add()
                 .setV(498.);
+        network.newDcNode()
+                .setId("dcNodeWithNegativeLimits")
+                .setName("A DC Node with negative voltage limits")
+                .setNominalV(500.)
+                .setLowVoltageLimit(-520.)
+                .setHighVoltageLimit(-480.)
+                .add()
+                .setV(-502.);
         return network;
     }
 

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/LineCommutatedConverterSerDeTest.java
@@ -7,8 +7,8 @@
  */
 package com.powsybl.iidm.serde;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
-import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -16,7 +16,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -25,31 +25,62 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class LineCommutatedConverterSerDeTest extends AbstractIidmSerDeTest {
 
     @Test
-    void testMinPNotSupported() {
-        Network network = createNetworkWithNonDefaultMinP();
-        Path filename = tmpDir.resolve("fail");
-        assertThrows(NotImplementedException.class, () -> NetworkSerDe.write(network, filename));
-    }
-
-    @Test
-    void testMinPWithForceExport() {
-        Network network = createNetworkWithNonDefaultMinP();
-        Path filename = tmpDir.resolve("lcc-minP-force-export");
-        assertDoesNotThrow(() -> NetworkSerDe.write(network, new ExportOptions().setForceExportNetworkWithBetaFeatures(true), filename));
-    }
-
-    @Test
     void testNetworkLineCommutatedConverter() throws IOException {
         Network network = createBaseNetwork();
 
         // Test for the current version
-        allFormatsRoundTripTest(network, "/lineCommutatedConverterRoundTripRef.xml", CURRENT_IIDM_VERSION);
+        Network readNetwork = allFormatsRoundTripTest(network, "/lineCommutatedConverterRoundTripRef.xml", CURRENT_IIDM_VERSION);
+
+        // active power limits survive the round trip, and are left unbounded where they were not set
+        LineCommutatedConverter lccWithoutLimits = readNetwork.getLineCommutatedConverter("lccBb1ACWithoutSolvedV");
+        assertEquals(-Double.MAX_VALUE, lccWithoutLimits.getMinP());
+        assertEquals(Double.MAX_VALUE, lccWithoutLimits.getMaxP());
+        LineCommutatedConverter lccWithBothLimits = readNetwork.getLineCommutatedConverter("lccBb2ACWithSolvedV");
+        assertEquals(-400., lccWithBothLimits.getMinP());
+        assertEquals(400., lccWithBothLimits.getMaxP());
+        LineCommutatedConverter lccWithMaxPOnly = readNetwork.getLineCommutatedConverter("lccNb2ACWithPartiallySolvedV");
+        assertEquals(-Double.MAX_VALUE, lccWithMaxPOnly.getMinP());
+        assertEquals(350., lccWithMaxPOnly.getMaxP());
 
         // backward compatibility - checks from version 1.15
         allFormatsRoundTripFromVersionedXmlFromMinToCurrentVersionTest("/lineCommutatedConverterRoundTripRef.xml", IidmVersion.V_1_15);
 
         // Note: we do not test here failing for all versions < 1.15: LineCommutatedConverter cannot exist without DcNode,
         // hence the DcNode SerDe test is sufficient.
+    }
+
+    @Test
+    void testMinPNotSupportedBeforeIidm118() {
+        Network network = createBaseNetwork(); // contains a LineCommutatedConverter with minP = -400.
+
+        // minP and maxP are only supported from IIDM 1.18; versions 1.15 to 1.17 support LineCommutatedConverter
+        // but not its active power limits. An Exception should be thrown when they are set in this case.
+        testForAllVersionsBetween(IidmVersion.V_1_15, IidmVersion.V_1_17, version -> {
+            ExportOptions options = new ExportOptions().setVersion(version.toString("."));
+            Path path = tmpDir.resolve("fail");
+            PowsyblException e = assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, options, path));
+            assertEquals("lineCommutatedConverter.minP is not defined as default and not supported for IIDM version "
+                    + version.toString(".") + ". IIDM version should be >= 1.18", e.getMessage());
+        });
+    }
+
+    @Test
+    void testActivePowerLimitsDroppedWhenExportingToIidm117() {
+        Network network = createBaseNetwork();
+
+        // with LOG_ERROR, exporting to an IIDM version that does not support the active power limits succeeds
+        // and silently drops them: the resulting file is a valid file of that version.
+        ExportOptions options = new ExportOptions()
+                .setVersion(IidmVersion.V_1_17.toString("."))
+                .setIidmVersionIncompatibilityBehavior(ExportOptions.IidmVersionIncompatibilityBehavior.LOG_ERROR);
+        Path path = tmpDir.resolve("lcc-iidm-1-17.xiidm");
+        NetworkSerDe.write(network, options, path);
+
+        Network readNetwork = NetworkSerDe.validateAndRead(path);
+        for (LineCommutatedConverter lcc : readNetwork.getLineCommutatedConverters()) {
+            assertEquals(-Double.MAX_VALUE, lcc.getMinP());
+            assertEquals(Double.MAX_VALUE, lcc.getMaxP());
+        }
     }
 
     private static Network createBaseNetwork() {
@@ -154,6 +185,8 @@ class LineCommutatedConverterSerDeTest extends AbstractIidmSerDeTest {
                 .setIdleLoss(2.0)
                 .setSwitchingLoss(0.2)
                 .setResistiveLoss(2e-6)
+                .setMinP(-400.)
+                .setMaxP(400.)
                 .add();
         lcc2.getDcTerminal1().setP(-100.).setI(-200.);
         lcc2.getDcTerminal2().setP(0.4).setI(200.);
@@ -184,6 +217,7 @@ class LineCommutatedConverterSerDeTest extends AbstractIidmSerDeTest {
                 .setIdleLoss(3.0)
                 .setSwitchingLoss(0.3)
                 .setResistiveLoss(3e-6)
+                .setMaxP(350.) // minP left unbounded
                 .add();
 
         lcc3.getTerminal1().getBusView().getBus().setV(402.).setAngle(12.3);
@@ -192,28 +226,6 @@ class LineCommutatedConverterSerDeTest extends AbstractIidmSerDeTest {
         lcc3.getTerminal1().setP(-105.); // no Q
         lcc3.getTerminal2().orElseThrow().setQ(-200.8); // no P
 
-        return network;
-    }
-
-    private static Network createNetworkWithNonDefaultMinP() {
-        Network network = Network.create("lineCommutatedConverterTest", "code");
-        network.setCaseDate(ZonedDateTime.parse("2025-01-02T03:04:05.000+01:00"));
-        DcNode dcNode1 = network.newDcNode().setId("dcNode1").setNominalV(500.).add();
-        DcNode dcNode2 = network.newDcNode().setId("dcNode2").setNominalV(500.).add();
-        Substation s = network.newSubstation().setId("S").add();
-        VoltageLevel vl = s.newVoltageLevel().setId("vl").setTopologyKind(TopologyKind.BUS_BREAKER).setNominalV(400.).add();
-        vl.getBusBreakerView().newBus().setId("bus").add();
-        vl.newLineCommutatedConverter()
-                .setId("lcc")
-                .setDcNode1(dcNode1.getId()).setDcConnected1(false)
-                .setDcNode2(dcNode2.getId()).setDcConnected2(false)
-                .setConnectableBus1("bus")
-                .setReactiveModel(LineCommutatedConverter.ReactiveModel.FIXED_POWER_FACTOR)
-                .setPowerFactor(0.92)
-                .setControlMode(AcDcConverter.ControlMode.V_DC)
-                .setTargetVdc(500.)
-                .setMinP(-100.)
-                .add();
         return network;
     }
 

--- a/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
+++ b/iidm/iidm-serde/src/test/java/com/powsybl/iidm/serde/VoltageSourceConverterSerDeTest.java
@@ -7,8 +7,8 @@
  */
 package com.powsybl.iidm.serde;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
-import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -16,7 +16,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 
 import static com.powsybl.iidm.serde.IidmSerDeConstants.CURRENT_IIDM_VERSION;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -25,31 +25,43 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class VoltageSourceConverterSerDeTest extends AbstractIidmSerDeTest {
 
     @Test
-    void testMaxPNotSupported() {
-        Network network = createNetworkWithNonDefaultMaxP();
-        Path filename = tmpDir.resolve("fail");
-        assertThrows(NotImplementedException.class, () -> NetworkSerDe.write(network, filename));
-    }
-
-    @Test
-    void testMaxPWithForceExport() {
-        Network network = createNetworkWithNonDefaultMaxP();
-        Path filename = tmpDir.resolve("vsc-maxP-force-export");
-        assertDoesNotThrow(() -> NetworkSerDe.write(network, new ExportOptions().setForceExportNetworkWithBetaFeatures(true), filename));
-    }
-
-    @Test
     void testNetworkVoltageSourceConverter() throws IOException {
         Network network = createBaseNetwork();
 
         // Test for the current version
-        allFormatsRoundTripTest(network, "/voltageSourceConverterRoundTripRef.xml", CURRENT_IIDM_VERSION);
+        Network readNetwork = allFormatsRoundTripTest(network, "/voltageSourceConverterRoundTripRef.xml", CURRENT_IIDM_VERSION);
+
+        // active power limits survive the round trip, and are left unbounded where they were not set
+        VoltageSourceConverter vscWithoutLimits = readNetwork.getVoltageSourceConverter("vscBb1ACWithoutSolvedV");
+        assertEquals(-Double.MAX_VALUE, vscWithoutLimits.getMinP());
+        assertEquals(Double.MAX_VALUE, vscWithoutLimits.getMaxP());
+        VoltageSourceConverter vscWithMaxPOnly = readNetwork.getVoltageSourceConverter("vscBb2ACWithSolvedV");
+        assertEquals(-Double.MAX_VALUE, vscWithMaxPOnly.getMinP());
+        assertEquals(400., vscWithMaxPOnly.getMaxP());
+        VoltageSourceConverter vscWithMinPOnly = readNetwork.getVoltageSourceConverter("vscNb2ACWithPartiallySolvedV");
+        assertEquals(-380., vscWithMinPOnly.getMinP());
+        assertEquals(Double.MAX_VALUE, vscWithMinPOnly.getMaxP());
 
         // backward compatibility - checks from version 1.15
         allFormatsRoundTripFromVersionedXmlFromMinToCurrentVersionTest("/voltageSourceConverterRoundTripRef.xml", IidmVersion.V_1_15);
 
         // Note: we do not test here failing for all versions < 1.15: VoltageSourceConverter cannot exist without DcNode,
         // hence the DcNode SerDe test is sufficient.
+    }
+
+    @Test
+    void testMaxPNotSupportedBeforeIidm118() {
+        Network network = createBaseNetwork(); // contains a VoltageSourceConverter with maxP = 400.
+
+        // minP and maxP are only supported from IIDM 1.18; versions 1.15 to 1.17 support VoltageSourceConverter
+        // but not its active power limits. An Exception should be thrown when they are set in this case.
+        testForAllVersionsBetween(IidmVersion.V_1_15, IidmVersion.V_1_17, version -> {
+            ExportOptions options = new ExportOptions().setVersion(version.toString("."));
+            Path path = tmpDir.resolve("fail");
+            PowsyblException e = assertThrows(PowsyblException.class, () -> NetworkSerDe.write(network, options, path));
+            assertEquals("voltageSourceConverter.maxP is not defined as default and not supported for IIDM version "
+                    + version.toString(".") + ". IIDM version should be >= 1.18", e.getMessage());
+        });
     }
 
     private static Network createBaseNetwork() {
@@ -155,6 +167,7 @@ class VoltageSourceConverterSerDeTest extends AbstractIidmSerDeTest {
                 .setVoltageRegulatorOn(true)
                 .setReactivePowerSetpoint(12.3)
                 .setVoltageSetpoint(387.)
+                .setMaxP(400.) // minP left unbounded
                 .add();
         vsc2.newMinMaxReactiveLimits().setMinQ(-200.).setMaxQ(+210.).add();
         vsc2.getDcTerminal1().setP(-100.).setI(-200.);
@@ -186,6 +199,7 @@ class VoltageSourceConverterSerDeTest extends AbstractIidmSerDeTest {
                 .setResistiveLoss(3e-6)
                 .setVoltageRegulatorOn(true)
                 .setVoltageSetpoint(397.)
+                .setMinP(-380.) // maxP left unbounded
                 .add();
         vsc3.newReactiveCapabilityCurve()
                 .beginPoint().setP(-200.).setMinQ(-190.).setMaxQ(192.).endPoint()
@@ -199,28 +213,6 @@ class VoltageSourceConverterSerDeTest extends AbstractIidmSerDeTest {
         vsc3.getTerminal1().setP(-105.); // no Q
         vsc3.getTerminal2().orElseThrow().setQ(-200.8); // no P
 
-        return network;
-    }
-
-    private static Network createNetworkWithNonDefaultMaxP() {
-        Network network = Network.create("voltageSourceConverterTest", "code");
-        network.setCaseDate(ZonedDateTime.parse("2025-01-02T03:04:05.000+01:00"));
-        DcNode dcNode1 = network.newDcNode().setId("dcNode1").setNominalV(500.).add();
-        DcNode dcNode2 = network.newDcNode().setId("dcNode2").setNominalV(500.).add();
-        Substation s = network.newSubstation().setId("S").add();
-        VoltageLevel vl = s.newVoltageLevel().setId("vl").setTopologyKind(TopologyKind.BUS_BREAKER).setNominalV(400.).add();
-        vl.getBusBreakerView().newBus().setId("bus").add();
-        vl.newVoltageSourceConverter()
-                .setId("vsc")
-                .setDcNode1(dcNode1.getId()).setDcConnected1(false)
-                .setDcNode2(dcNode2.getId()).setDcConnected2(false)
-                .setConnectableBus1("bus")
-                .setControlMode(AcDcConverter.ControlMode.V_DC)
-                .setTargetVdc(500.)
-                .setVoltageRegulatorOn(false)
-                .setReactivePowerSetpoint(0.)
-                .setMaxP(500.)
-                .add();
         return network;
     }
 

--- a/iidm/iidm-serde/src/test/resources/V1_14/dcNodeNotSupported.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_14/dcNodeNotSupported.xml
@@ -5,4 +5,5 @@
         <iidm:property name="prop name" value="prop value"/>
     </iidm:dcNode>
     <iidm:dcNode id="dcNodeWithSolvedV" name="A DC Node with solved V" nominalV="500.0" v="498.0"/>
+    <iidm:dcNode id="dcNodeWithNegativeLimits" name="A DC Node with negative voltage limits" nominalV="500.0" v="-502.0"/>
 </iidm:network>

--- a/iidm/iidm-serde/src/test/resources/V1_18/dcLineApparentPowerLimits.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_18/dcLineApparentPowerLimits.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_18" id="dcLineTest" caseDate="2025-01-02T03:04:05.000+01:00" forecastDistance="0" sourceFormat="code" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:dcNode id="dcNode1" nominalV="500.0"/>
+    <iidm:dcNode id="dcNode2" nominalV="500.0"/>
+    <iidm:dcLine id="dcLineWithoutSolvedV" name="A DC Line without solved values" fictitious="true" dcNode1="dcNode1" dcNode2="dcNode2" r="3.0" connected1="false" connected2="false">
+        <iidm:alias>someAlias</iidm:alias>
+        <iidm:property name="prop name" value="prop value"/>
+    </iidm:dcLine>
+    <iidm:dcLine id="dcLineWithSolvedV" name="A DC Line with solved values" dcNode1="dcNode1" dcNode2="dcNode2" r="4.0" connected1="true" connected2="true" dcP1="100.0" dcI1="200.0" dcP2="-98.0" dcI2="-195.0" selectedOperationalLimitsGroupIds="summer">
+        <iidm:operationalLimitsGroup id="summer">
+            <iidm:currentLimits permanentLimit="2106.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="2350.0"/>
+            </iidm:currentLimits>
+        </iidm:operationalLimitsGroup>
+        <iidm:operationalLimitsGroup id="winter">
+            <iidm:apparentPowerLimits permanentLimit="2400.0"/>
+        </iidm:operationalLimitsGroup>
+    </iidm:dcLine>
+</iidm:network>

--- a/iidm/iidm-serde/src/test/resources/V1_18/dcLineMultipleSelectedGroupsRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_18/dcLineMultipleSelectedGroupsRef.xml
@@ -6,7 +6,7 @@
         <iidm:alias>someAlias</iidm:alias>
         <iidm:property name="prop name" value="prop value"/>
     </iidm:dcLine>
-    <iidm:dcLine id="dcLineWithSolvedV" name="A DC Line with solved values" dcNode1="dcNode1" dcNode2="dcNode2" r="4.0" connected1="true" connected2="true" dcP1="100.0" dcI1="200.0" dcP2="-98.0" dcI2="-195.0" selectedOperationalLimitsGroupIds="summer">
+    <iidm:dcLine id="dcLineWithSolvedV" name="A DC Line with solved values" dcNode1="dcNode1" dcNode2="dcNode2" r="4.0" connected1="true" connected2="true" dcP1="100.0" dcI1="200.0" dcP2="-98.0" dcI2="-195.0" selectedOperationalLimitsGroupIds="summer,winter">
         <iidm:operationalLimitsGroup id="summer">
             <iidm:currentLimits permanentLimit="2106.0">
                 <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="2350.0"/>
@@ -14,7 +14,7 @@
             </iidm:currentLimits>
         </iidm:operationalLimitsGroup>
         <iidm:operationalLimitsGroup id="winter">
-            <iidm:apparentPowerLimits permanentLimit="2400.0"/>
+            <iidm:currentLimits permanentLimit="2400.0"/>
         </iidm:operationalLimitsGroup>
     </iidm:dcLine>
 </iidm:network>

--- a/iidm/iidm-serde/src/test/resources/V1_18/dcLineOnlySelectedGroupsRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_18/dcLineOnlySelectedGroupsRef.xml
@@ -13,8 +13,5 @@
                 <iidm:temporaryLimit name="5'" acceptableDuration="300" value="2600.0"/>
             </iidm:currentLimits>
         </iidm:operationalLimitsGroup>
-        <iidm:operationalLimitsGroup id="winter">
-            <iidm:apparentPowerLimits permanentLimit="2400.0"/>
-        </iidm:operationalLimitsGroup>
     </iidm:dcLine>
 </iidm:network>

--- a/iidm/iidm-serde/src/test/resources/V1_18/dcLineRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_18/dcLineRoundTripRef.xml
@@ -10,6 +10,7 @@
         <iidm:operationalLimitsGroup id="summer">
             <iidm:currentLimits permanentLimit="2106.0">
                 <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="2350.0"/>
+                <iidm:temporaryLimit name="5'" acceptableDuration="300" value="2600.0"/>
             </iidm:currentLimits>
         </iidm:operationalLimitsGroup>
         <iidm:operationalLimitsGroup id="winter">

--- a/iidm/iidm-serde/src/test/resources/V1_18/dcLineRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_18/dcLineRoundTripRef.xml
@@ -6,5 +6,14 @@
         <iidm:alias>someAlias</iidm:alias>
         <iidm:property name="prop name" value="prop value"/>
     </iidm:dcLine>
-    <iidm:dcLine id="dcLineWithSolvedV" name="A DC Line with solved values" dcNode1="dcNode1" dcNode2="dcNode2" r="4.0" connected1="true" connected2="true" dcP1="100.0" dcI1="200.0" dcP2="-98.0" dcI2="-195.0"/>
+    <iidm:dcLine id="dcLineWithSolvedV" name="A DC Line with solved values" dcNode1="dcNode1" dcNode2="dcNode2" r="4.0" connected1="true" connected2="true" dcP1="100.0" dcI1="200.0" dcP2="-98.0" dcI2="-195.0" selectedOperationalLimitsGroupIds="summer">
+        <iidm:operationalLimitsGroup id="summer">
+            <iidm:currentLimits permanentLimit="2106.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="2350.0"/>
+            </iidm:currentLimits>
+        </iidm:operationalLimitsGroup>
+        <iidm:operationalLimitsGroup id="winter">
+            <iidm:currentLimits permanentLimit="2400.0"/>
+        </iidm:operationalLimitsGroup>
+    </iidm:dcLine>
 </iidm:network>

--- a/iidm/iidm-serde/src/test/resources/V1_18/dcNodeRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_18/dcNodeRoundTripRef.xml
@@ -4,5 +4,6 @@
         <iidm:alias>someAlias</iidm:alias>
         <iidm:property name="prop name" value="prop value"/>
     </iidm:dcNode>
-    <iidm:dcNode id="dcNodeWithSolvedV" name="A DC Node with solved V" nominalV="500.0" v="498.0"/>
+    <iidm:dcNode id="dcNodeWithSolvedV" name="A DC Node with solved V" nominalV="500.0" lowVoltageLimit="480.0" highVoltageLimit="520.0" v="498.0"/>
+    <iidm:dcNode id="dcNodeWithNegativeLimits" name="A DC Node with negative voltage limits" nominalV="500.0" lowVoltageLimit="-520.0" highVoltageLimit="-480.0" v="-502.0"/>
 </iidm:network>

--- a/iidm/iidm-serde/src/test/resources/V1_18/lineCommutatedConverterRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_18/lineCommutatedConverterRoundTripRef.xml
@@ -13,7 +13,7 @@
                 <iidm:property name="prop name" value="prop value"/>
                 <iidm:pccTerminal id="lccBb1ACWithoutSolvedV" number="ONE"/>
             </iidm:lineCommutatedConverter>
-            <iidm:lineCommutatedConverter id="lccBb2ACWithSolvedV" name="LCC in Bus/Breaker with two AC Terminals with solved values and droop curve" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="2.0" switchingLoss="0.2" resistiveLoss="2.0E-6" controlMode="P_PCC_DROOP" targetP="301.0" targetVdc="502.0" bus1="bus1" connectableBus1="bus1" bus2="bus2" connectableBus2="bus2" reactiveModel="CALCULATED_POWER_FACTOR" powerFactor="0.92" p1="-100.0" q1="-200.0" p2="-100.1" q2="-200.2" dcP1="-100.0" dcI1="-200.0" dcP2="0.4" dcI2="200.0">
+            <iidm:lineCommutatedConverter id="lccBb2ACWithSolvedV" name="LCC in Bus/Breaker with two AC Terminals with solved values and droop curve" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="2.0" switchingLoss="0.2" resistiveLoss="2.0E-6" controlMode="P_PCC_DROOP" targetP="301.0" targetVdc="502.0" minP="-400.0" maxP="400.0" bus1="bus1" connectableBus1="bus1" bus2="bus2" connectableBus2="bus2" reactiveModel="CALCULATED_POWER_FACTOR" powerFactor="0.92" p1="-100.0" q1="-200.0" p2="-100.1" q2="-200.2" dcP1="-100.0" dcI1="-200.0" dcP2="0.4" dcI2="200.0">
                 <iidm:pccTerminal id="lineBb" side="ONE"/>
                 <iidm:droopCurve>
                     <iidm:segment minV="-500.0" maxV="-100.0" k="-10.0"/>
@@ -32,7 +32,7 @@
                 <iidm:internalConnection node1="3" node2="5"/>
                 <iidm:bus v="402.0" angle="12.3" nodes="0,2,4"/>
             </iidm:nodeBreakerTopology>
-            <iidm:lineCommutatedConverter id="lccNb2ACWithPartiallySolvedV" name="LCC in Node/Breaker with two AC Terminals with some solved values missing" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="3.0" switchingLoss="0.3" resistiveLoss="3.0E-6" controlMode="P_PCC" targetP="302.0" targetVdc="503.0" node1="4" node2="5" reactiveModel="FIXED_POWER_FACTOR" powerFactor="0.94" p1="-105.0" q2="-200.8" dcP1="-102.0" dcI2="202.0">
+            <iidm:lineCommutatedConverter id="lccNb2ACWithPartiallySolvedV" name="LCC in Node/Breaker with two AC Terminals with some solved values missing" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="3.0" switchingLoss="0.3" resistiveLoss="3.0E-6" controlMode="P_PCC" targetP="302.0" targetVdc="503.0" maxP="350.0" node1="4" node2="5" reactiveModel="FIXED_POWER_FACTOR" powerFactor="0.94" p1="-105.0" q2="-200.8" dcP1="-102.0" dcI2="202.0">
                 <iidm:pccTerminal id="lineNb" side="TWO"/>
             </iidm:lineCommutatedConverter>
         </iidm:voltageLevel>

--- a/iidm/iidm-serde/src/test/resources/V1_18/voltageSourceConverterRoundTripRef.xml
+++ b/iidm/iidm-serde/src/test/resources/V1_18/voltageSourceConverterRoundTripRef.xml
@@ -14,7 +14,7 @@
                 <iidm:pccTerminal id="vscBb1ACWithoutSolvedV" number="ONE"/>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
             </iidm:voltageSourceConverter>
-            <iidm:voltageSourceConverter id="vscBb2ACWithSolvedV" name="VSC in Bus/Breaker with two AC Terminals with solved values and droop curve" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="2.0" switchingLoss="0.2" resistiveLoss="2.0E-6" controlMode="P_PCC_DROOP" targetP="301.0" targetVdc="502.0" bus1="bus1" connectableBus1="bus1" bus2="bus2" connectableBus2="bus2" voltageRegulatorOn="true" voltageSetpoint="387.0" reactivePowerSetpoint="12.3" p1="-100.0" q1="-200.0" p2="-100.1" q2="-200.2" dcP1="-100.0" dcI1="-200.0" dcP2="0.4" dcI2="200.0">
+            <iidm:voltageSourceConverter id="vscBb2ACWithSolvedV" name="VSC in Bus/Breaker with two AC Terminals with solved values and droop curve" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="2.0" switchingLoss="0.2" resistiveLoss="2.0E-6" controlMode="P_PCC_DROOP" targetP="301.0" targetVdc="502.0" maxP="400.0" bus1="bus1" connectableBus1="bus1" bus2="bus2" connectableBus2="bus2" voltageRegulatorOn="true" voltageSetpoint="387.0" reactivePowerSetpoint="12.3" p1="-100.0" q1="-200.0" p2="-100.1" q2="-200.2" dcP1="-100.0" dcI1="-200.0" dcP2="0.4" dcI2="200.0">
                 <iidm:pccTerminal id="lineBb" side="ONE"/>
                 <iidm:droopCurve>
                     <iidm:segment minV="-500.0" maxV="-100.0" k="-10.0"/>
@@ -34,7 +34,7 @@
                 <iidm:internalConnection node1="3" node2="5"/>
                 <iidm:bus v="402.0" angle="12.3" nodes="0,2,4"/>
             </iidm:nodeBreakerTopology>
-            <iidm:voltageSourceConverter id="vscNb2ACWithPartiallySolvedV" name="VSC in Node/Breaker with two AC Terminals with some solved values missing" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="3.0" switchingLoss="0.3" resistiveLoss="3.0E-6" controlMode="P_PCC" targetP="302.0" targetVdc="503.0" node1="4" node2="5" voltageRegulatorOn="true" voltageSetpoint="397.0" p1="-105.0" q2="-200.8" dcP1="-102.0" dcI2="202.0">
+            <iidm:voltageSourceConverter id="vscNb2ACWithPartiallySolvedV" name="VSC in Node/Breaker with two AC Terminals with some solved values missing" dcNode1="dcNode1" dcConnected1="true" dcNode2="dcNode2" dcConnected2="true" idleLoss="3.0" switchingLoss="0.3" resistiveLoss="3.0E-6" controlMode="P_PCC" targetP="302.0" targetVdc="503.0" minP="-380.0" node1="4" node2="5" voltageRegulatorOn="true" voltageSetpoint="397.0" p1="-105.0" q2="-200.8" dcP1="-102.0" dcI2="202.0">
                 <iidm:pccTerminal id="lineNb" side="TWO"/>
                 <iidm:reactiveCapabilityCurve>
                     <iidm:point p="-200.0" minQ="-190.0" maxQ="192.0"/>

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractDcLineTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractDcLineTest.java
@@ -120,6 +120,77 @@ public abstract class AbstractDcLineTest {
     }
 
     @Test
+    public void testCurrentLimits() {
+        DcLine dcLine = createDcLine("dcLine");
+
+        assertTrue(dcLine.getOperationalLimitsGroups().isEmpty());
+        assertTrue(dcLine.getSelectedOperationalLimitsGroupId().isEmpty());
+        assertTrue(dcLine.getSelectedOperationalLimitsGroup().isEmpty());
+        assertTrue(dcLine.getCurrentLimits().isEmpty());
+        assertNull(dcLine.getNullableCurrentLimits());
+
+        OperationalLimitsGroup group = dcLine.newOperationalLimitsGroup("summer");
+        group.newCurrentLimits()
+                .setPermanentLimit(2106.0)
+                .beginTemporaryLimit()
+                .setName("20'")
+                .setAcceptableDuration(20 * 60)
+                .setValue(2350.0)
+                .endTemporaryLimit()
+                .add();
+        dcLine.setSelectedOperationalLimitsGroup("summer");
+
+        assertEquals(1, dcLine.getOperationalLimitsGroups().size());
+        assertEquals("summer", dcLine.getSelectedOperationalLimitsGroupId().orElseThrow());
+        assertSame(group, dcLine.getSelectedOperationalLimitsGroup().orElseThrow());
+        assertSame(group, dcLine.getOperationalLimitsGroup("summer").orElseThrow());
+        assertTrue(dcLine.getOperationalLimitsGroup("winter").isEmpty());
+
+        CurrentLimits limits = dcLine.getCurrentLimits().orElseThrow();
+        assertEquals(2106.0, limits.getPermanentLimit());
+        assertEquals(2350.0, limits.getTemporaryLimitValue(20 * 60));
+        assertSame(limits, dcLine.getNullableCurrentLimits());
+
+        assertTrue(dcLine.getActivePowerLimits().isEmpty());
+        assertTrue(dcLine.getApparentPowerLimits().isEmpty());
+
+        dcLine.cancelSelectedOperationalLimitsGroup();
+        assertTrue(dcLine.getSelectedOperationalLimitsGroup().isEmpty());
+        assertTrue(dcLine.getCurrentLimits().isEmpty());
+        assertEquals(1, dcLine.getOperationalLimitsGroups().size());
+
+        dcLine.removeOperationalLimitsGroup("summer");
+        assertTrue(dcLine.getOperationalLimitsGroups().isEmpty());
+    }
+
+    @Test
+    public void testMultipleLimitsGroups() {
+        DcLine dcLine = createDcLine("dcLine");
+
+        dcLine.newOperationalLimitsGroup("summer").newCurrentLimits().setPermanentLimit(2106.0).add();
+        dcLine.newOperationalLimitsGroup("winter").newCurrentLimits().setPermanentLimit(2400.0).add();
+        assertEquals(2, dcLine.getOperationalLimitsGroups().size());
+
+        dcLine.addSelectedOperationalLimitsGroups("summer", "winter");
+        assertEquals(2, dcLine.getAllSelectedOperationalLimitsGroups().size());
+        assertEquals(2, dcLine.getAllSelectedOperationalLimitsGroupIds().size());
+        assertEquals(List.of("summer", "winter"), dcLine.getAllSelectedOperationalLimitsGroupIdsOrdered());
+        assertEquals(2, dcLine.getAllSelectedCurrentLimits().size());
+
+        dcLine.deselectOperationalLimitsGroups("winter");
+        assertEquals(List.of("summer"), dcLine.getAllSelectedOperationalLimitsGroupIdsOrdered());
+        assertEquals(2106.0, dcLine.getCurrentLimits().orElseThrow().getPermanentLimit());
+
+        // setSelected replaces the whole selection, addSelected extends it
+        dcLine.setSelectedOperationalLimitsGroup("winter");
+        assertEquals(List.of("winter"), dcLine.getAllSelectedOperationalLimitsGroupIdsOrdered());
+        assertEquals(2400.0, dcLine.getCurrentLimits().orElseThrow().getPermanentLimit());
+
+        OperationalLimitsGroup created = dcLine.getOrCreateSelectedOperationalLimitsGroup();
+        assertSame(created, dcLine.getSelectedOperationalLimitsGroup().orElseThrow());
+    }
+
+    @Test
     public void testCreateDuplicate() {
         network.newDcLine()
                 .setId("dcLine1")
@@ -183,6 +254,18 @@ public abstract class AbstractDcLineTest {
 
         PowsyblException e6 = assertThrows(PowsyblException.class, () -> t2.traverse(Mockito.mock(DcTerminal.TopologyTraverser.class)));
         assertEquals("Associated equipment dcLine1 is removed", e6.getMessage());
+
+        PowsyblException e7 = assertThrows(PowsyblException.class, dcLine1::getOperationalLimitsGroups);
+        assertEquals("Cannot access limits of removed equipment dcLine1", e7.getMessage());
+
+        PowsyblException e8 = assertThrows(PowsyblException.class, dcLine1::getCurrentLimits);
+        assertEquals("Cannot access limits of removed equipment dcLine1", e8.getMessage());
+
+        PowsyblException e9 = assertThrows(PowsyblException.class, () -> dcLine1.newOperationalLimitsGroup("summer"));
+        assertEquals("Cannot modify limits of removed equipment dcLine1", e9.getMessage());
+
+        PowsyblException e10 = assertThrows(PowsyblException.class, () -> dcLine1.setSelectedOperationalLimitsGroup("summer"));
+        assertEquals("Cannot modify limits of removed equipment dcLine1", e10.getMessage());
     }
 
     @Test
@@ -314,5 +397,16 @@ public abstract class AbstractDcLineTest {
         adder.setDcNode2(dcNodeRootNetwork.getId());
         PowsyblException e3 = assertThrows(PowsyblException.class, adder::add);
         assertEquals("DC Line 'dcLineAcrossSubnets': DC Nodes 'dcNode1Subnetwork1' and 'dcNodeRootNetwork' are in different networks 'subnetwork1' and 'test'", e3.getMessage());
+    }
+
+    private DcLine createDcLine(String id) {
+        return network.newDcLine()
+                .setId(id)
+                .setDcNode1(dcNode1.getId())
+                .setConnected1(true)
+                .setDcNode2(dcNode2.getId())
+                .setConnected2(true)
+                .setR(1.1)
+                .add();
     }
 }

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractDcLineTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractDcLineTest.java
@@ -164,6 +164,28 @@ public abstract class AbstractDcLineTest {
     }
 
     @Test
+    public void testOnlyCurrentLimitsAreAccepted() {
+        DcLine dcLine = createDcLine("dcLine");
+        OperationalLimitsGroup group = dcLine.newOperationalLimitsGroup("summer");
+
+        ValidationException e1 = assertThrows(ValidationException.class, group::newActivePowerLimits);
+        assertEquals("DC Line 'dcLine': active power limits are not supported: the two DC terminals carry different active power",
+                e1.getMessage());
+        ValidationException e2 = assertThrows(ValidationException.class, group::newApparentPowerLimits);
+        assertEquals("DC Line 'dcLine': apparent power limits are not supported: a DC line carries no reactive power",
+                e2.getMessage());
+
+        assertDoesNotThrow(() -> group.newCurrentLimits().setPermanentLimit(2106.0).add());
+        assertEquals(2106.0, group.getCurrentLimits().orElseThrow().getPermanentLimit());
+
+        // the deprecated adders refuse before creating the group they would have used
+        DcLine bare = createDcLine("bareDcLine");
+        assertThrows(ValidationException.class, bare::newActivePowerLimits);
+        assertThrows(ValidationException.class, bare::newApparentPowerLimits);
+        assertTrue(bare.getOperationalLimitsGroups().isEmpty());
+    }
+
+    @Test
     public void testMultipleLimitsGroups() {
         DcLine dcLine = createDcLine("dcLine");
 

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractDcNodeTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractDcNodeTest.java
@@ -69,6 +69,70 @@ public abstract class AbstractDcNodeTest {
     }
 
     @Test
+    public void testVoltageLimits() {
+        Network network = Network.create("test", "test");
+
+        DcNode noLimits = network.newDcNode().setId("noLimits").setNominalV(500.).add();
+        assertTrue(Double.isNaN(noLimits.getLowVoltageLimit()));
+        assertTrue(Double.isNaN(noLimits.getHighVoltageLimit()));
+
+        DcNode positiveLimits = network.newDcNode().setId("positiveLimits").setNominalV(500.)
+                .setLowVoltageLimit(480.).setHighVoltageLimit(520.).add();
+        assertEquals(480., positiveLimits.getLowVoltageLimit());
+        assertEquals(520., positiveLimits.getHighVoltageLimit());
+
+        DcNode negativeLimits = network.newDcNode().setId("negativeLimits").setNominalV(500.)
+                .setLowVoltageLimit(-520.).setHighVoltageLimit(-480.).add();
+        assertEquals(-520., negativeLimits.getLowVoltageLimit());
+        assertEquals(-480., negativeLimits.getHighVoltageLimit());
+
+        DcNode spanningLimits = network.newDcNode().setId("spanningLimits").setNominalV(500.)
+                .setLowVoltageLimit(-520.).setHighVoltageLimit(520.).add();
+        assertEquals(-520., spanningLimits.getLowVoltageLimit());
+        assertEquals(520., spanningLimits.getHighVoltageLimit());
+
+        // an undefined bound leaves the other one unconstrained, since all comparisons with NaN are false
+        DcNode highLimitOnly = network.newDcNode().setId("highLimitOnly").setNominalV(500.)
+                .setHighVoltageLimit(520.).add();
+        assertTrue(Double.isNaN(highLimitOnly.getLowVoltageLimit()));
+        assertEquals(520., highLimitOnly.getHighVoltageLimit());
+
+        // the widest band, so that each new bound stays consistent with the stored value of the other one
+        assertSame(spanningLimits, spanningLimits.setLowVoltageLimit(-510.));
+        assertEquals(-510., spanningLimits.getLowVoltageLimit());
+        assertSame(spanningLimits, spanningLimits.setHighVoltageLimit(510.));
+        assertEquals(510., spanningLimits.getHighVoltageLimit());
+        spanningLimits.setLowVoltageLimit(Double.NaN);
+        assertTrue(Double.isNaN(spanningLimits.getLowVoltageLimit()));
+    }
+
+    @Test
+    public void testVoltageLimitsError() {
+        Network network = Network.create("test", "test");
+
+        DcNodeAdder adder = network.newDcNode().setId("dcNode").setNominalV(500.)
+                .setLowVoltageLimit(520.).setHighVoltageLimit(480.);
+        PowsyblException e1 = assertThrows(PowsyblException.class, adder::add);
+        assertEquals("DC Node 'dcNode': Inconsistent voltage limit range [520.0, 480.0]", e1.getMessage());
+
+        // only the ordering is checked, so a negative pair is rejected on the same rule
+        DcNodeAdder negativeAdder = network.newDcNode().setId("negativeDcNode").setNominalV(500.)
+                .setLowVoltageLimit(-480.).setHighVoltageLimit(-520.);
+        PowsyblException e2 = assertThrows(PowsyblException.class, negativeAdder::add);
+        assertEquals("DC Node 'negativeDcNode': Inconsistent voltage limit range [-480.0, -520.0]", e2.getMessage());
+
+        DcNode dcNode = network.newDcNode().setId("dcNode").setNominalV(500.)
+                .setLowVoltageLimit(-520.).setHighVoltageLimit(-480.).add();
+        PowsyblException e3 = assertThrows(PowsyblException.class, () -> dcNode.setLowVoltageLimit(-470.));
+        assertEquals("DC Node 'dcNode': Inconsistent voltage limit range [-470.0, -480.0]", e3.getMessage());
+        PowsyblException e4 = assertThrows(PowsyblException.class, () -> dcNode.setHighVoltageLimit(-530.));
+        assertEquals("DC Node 'dcNode': Inconsistent voltage limit range [-520.0, -530.0]", e4.getMessage());
+
+        assertEquals(-520., dcNode.getLowVoltageLimit());
+        assertEquals(-480., dcNode.getHighVoltageLimit());
+    }
+
+    @Test
     public void testRemove() {
         Network network = Network.create("test", "test");
         String dcNode1Id = "dcNode1";
@@ -88,6 +152,18 @@ public abstract class AbstractDcNodeTest {
 
         PowsyblException e2 = assertThrows(PowsyblException.class, dcNode1::getNominalV);
         assertEquals("Cannot access nominalV of removed equipment dcNode1", e2.getMessage());
+
+        PowsyblException e3 = assertThrows(PowsyblException.class, () -> dcNode1.setLowVoltageLimit(480.));
+        assertEquals("Cannot modify lowVoltageLimit of removed equipment dcNode1", e3.getMessage());
+
+        PowsyblException e4 = assertThrows(PowsyblException.class, dcNode1::getLowVoltageLimit);
+        assertEquals("Cannot access lowVoltageLimit of removed equipment dcNode1", e4.getMessage());
+
+        PowsyblException e5 = assertThrows(PowsyblException.class, () -> dcNode1.setHighVoltageLimit(520.));
+        assertEquals("Cannot modify highVoltageLimit of removed equipment dcNode1", e5.getMessage());
+
+        PowsyblException e6 = assertThrows(PowsyblException.class, dcNode1::getHighVoltageLimit);
+        assertEquals("Cannot access highVoltageLimit of removed equipment dcNode1", e6.getMessage());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any): powsybl/powsybl-network-store#675


**Does this PR already have an issue describing the problem?**

Fixes [#4024](https://github.com/powsybl/powsybl-core/issues/4024).

It also completes part of [#3954](https://github.com/powsybl/powsybl-core/issues/3954) (open, assigned to
[@SGI-Landry](https://github.com/SGI-Landry)): the IIDM serialization of the AC/DC converter active power
limits, which [#3940](https://github.com/powsybl/powsybl-core/pull/3940) deliberately left out
(*"intended to be implemented in IIDM 1.18, in the 2026.2 release"*). The CGMES and DGS half of
[#3954](https://github.com/powsybl/powsybl-core/issues/3954) is not touched here.

Depends on [#3984](https://github.com/powsybl/powsybl-core/pull/3984) (Bump IIDM to 1.18) and is based on
`bump_iidm_18` rather than `main`, so the diff shows only this work. Draft until
[#3984](https://github.com/powsybl/powsybl-core/pull/3984) merges.


**What kind of change does this PR introduce?**

Feature.


**What is the current behavior?**

The detailed DC model has no limits:

- `AcDcConverter.getMinP()` / `getMaxP()` exist but cannot be written or read: `AbstractAcDcConverterSerDe`
  throws `NotImplementedException`.
- `DcNode` has no voltage limits.
- `DcLine` has no current limits, so a DC cable has nowhere to record its rating.


**What is the new behavior (if this is a feature change)?**

Three additions, all gated on IIDM 1.18.

1. **`AcDcConverter` `minP`/`maxP` are serialized**, as two optional attributes.

2. **`DcNode` gains `lowVoltageLimit` and `highVoltageLimit`**, both optional, `NaN` when unset.

3. **`DcLine` becomes a [`FlowsLimitsHolder`](https://github.com/powsybl/powsybl-core/blob/main/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/FlowsLimitsHolder.java)**,
   so it carries operational limits groups the same way
   [`BoundaryLine`](https://github.com/powsybl/powsybl-core/blob/main/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/BoundaryLine.java)
   does:

```java
dcLine.newOperationalLimitsGroup("summer").newCurrentLimits().setPermanentLimit(2106.).add();
dcLine.setSelectedOperationalLimitsGroup("summer");
```

No DC-specific limits type is introduced; `OperationalLimitsGroup` and `CurrentLimits` are reused
unchanged.

**Design choices**

The rest of the diff follows existing AC or DC patterns.

*1. A `DcLine` has one set of limits for the whole line, not one set per side.*

An AC branch has two current limits because its shunt admittance (`g1/b1/g2/b2`) makes the currents at its
two terminals differ. A `DcLine`'s only electrical attribute is `r`, so the current entering one terminal
is the current leaving the other, and one limit describes both.

Two sets per side would mean writing the same rating twice:

```java
dcLine.newOperationalLimitsGroup1("summer").newCurrentLimits().setPermanentLimit(2106.).add();
dcLine.newOperationalLimitsGroup2("summer").newCurrentLimits().setPermanentLimit(2106.).add();
```

Nothing would stop 2106 on side 1 and 2400 on side 2, leaving the model claiming that one physical current
must stay under both. 

So `DcLine` follows
[`BoundaryLine`](https://github.com/powsybl/powsybl-core/blob/main/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/BoundaryLine.java),
which has a single set of limits, rather than `Branch`, which has one per side. `FlowsLimitsHolderBranchAdapter` in
[`MatpowerExporter`](https://github.com/powsybl/powsybl-core/blob/main/matpower/matpower-converter/src/main/java/com/powsybl/matpower/converter/MatpowerExporter.java)
already wraps one side of a branch into a single `FlowsLimitsHolder`, so the interface describes one set of
limits and not one terminal.

*2. A `DcNode`'s voltage limits are signed, and only their ordering is validated.*

A `DcNode`'s `v` is a signed potential, not an RMS magnitude: a node at negative polarity sits near
−500 kV and needs a band like [−520, −480].
[`ValidationUtil.checkVoltageLimits`](https://github.com/powsybl/powsybl-core/blob/main/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/ValidationUtil.java)
rejects limits below zero, so a new `checkDcVoltageLimits` validates only `low <= high`.

Signed rather than magnitude because of what a detector will do with it:
[`LimitViolationDetection.checkVoltage`](https://github.com/powsybl/powsybl-core/blob/main/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/LimitViolationDetection.java)
compares `value <= lowVoltageLimit` and `value >= highVoltageLimit`. A DC detector copying those lines
works with signed limits; with magnitude limits `-500 <= 480` is true, so it would report `LOW_VOLTAGE` on
a healthy node.
[`VoltageAngleLimit`](https://github.com/powsybl/powsybl-core/blob/main/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/VoltageAngleLimit.java)
was used as a precedent for a signed low/high pair validated for ordering only.

*3. Violation detection is deliberately out of scope.*

Limits are reachable through `OperationalLimitsGroup` / `LoadingLimits`, so adding detection later is a
matter of new cases. `LimitViolationType` already has `CURRENT`, `LOW_VOLTAGE` and `HIGH_VOLTAGE`, so it
likely needs no new entries.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section


**What changes might users need to make in their application due to this PR? (migration steps)**

Action is needed only if you **implement** `DcLine`, `DcNode` or `DcNodeAdder` yourself, as
[powsybl-network-store](https://github.com/powsybl/powsybl-network-store) does. This is tracked in
powsybl/powsybl-network-store#675. Those implementations will stop compiling, because the interfaces
gain abstract methods:

- **`DcLine`** now extends `FlowsLimitsHolder`: 17 methods. Hold one `OperationalLimitsGroupsImpl` and
  delegate to it, as
  [`BoundaryLineImpl`](https://github.com/powsybl/powsybl-core/blob/main/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/BoundaryLineImpl.java)
  does.
- **`DcNode`**: `getLowVoltageLimit`, `setLowVoltageLimit`, `getHighVoltageLimit`, `setHighVoltageLimit`.
- **`DcNodeAdder`**: `setLowVoltageLimit`, `setHighVoltageLimit`.

`DcLineImpl` and `DcNodeImpl` in this repository are updated accordingly and can be used as the reference.


Two further points, neither of which affects code that only *uses* these interfaces:

- **A `DcLine` now refuses active and apparent power limits.** Both fail with a `ValidationException`, and
  a file carrying one is rejected on import. The rule is asserted in the TCK, so an implementation of
  `DcLine` has to enforce it as well: hold the group collection with the two kinds marked unsupported, as
  `DcLineImpl` does.
- **Exporting `AcDcConverter.minP`/`maxP` to IIDM 1.17 or earlier now fails.** Until now these values had
  no serialization at all, and 7.3.0 shipped [#3954](https://github.com/powsybl/powsybl-core/issues/3954) let a network carrying them be exported by ignoring the values, either with the `iidm.export.xml.force-export-network-with-beta-features` config parameter or `ExportOptions.setForceExportNetworkWithBetaFeatures`. That escape pattern is removed: from 1.18 the values are written properly, and exporting them to an older version follows the normal `IidmVersionIncompatibilityBehavior`, so it raises an error by default or logs and drops them on request. Anyone on 7.3.0 who was relying on the force flag to export converters with `minP`/`maxP` to 1.17 should target 1.18 or set the incompatibility behaviour to `LOG_ERROR`.

**Other information**:

- The two sentinel conventions differ on purpose. `AcDcConverter.minP`/`maxP` use `∓Double.MAX_VALUE`, per
  the reasoning in [#3954](https://github.com/powsybl/powsybl-core/issues/3954) (*"ideally we would use
  -inf and inf for default values but this pattern is not used elsewhere. Non-finite real values are also
  unsupported in JSON."*), while the `DcNode` limits follow `VoltageLevel` and use `NaN`. This is why the
  two serializations use different version-gating helpers.
- One change reaches AC code: `ConnectableSerDeUtil.readAllSelectedGroupIds` is widened from
  `BoundaryLine` to `FlowsLimitsHolder` plus an id, and its single `BoundaryLineSerDe` call site is
  updated.
- Writing the new data to a pre-1.18 file raises an error, or logs and drops it, per
  `IidmVersionIncompatibilityBehavior`. Each piece has a test asserting that, and that an element
  *without* the new data still exports cleanly at those versions.
