### PR TITLE
CGMES: CGM with subnetworks multithreaded import

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -229,6 +229,10 @@ public class CgmesImport implements Importer {
                 futures.add(executor.submit(() -> importData2(dsList.get(idx), networkFactory, p, tripleStoreReportNodes.get(idx), conversionReportNodes.get(idx))));
             }
             Network[] networks = new Network[dsList.size()];
+            // It is fine to retrieve the result sequentially.
+            // Futures already run in parallel on the executor, so blocking on them in submission order costs nothing.
+            // An ExecutorCompletionService would only save time here if collecting a finished result were expensive,
+            // which it isn't (we are only putting network objects in the list, this is a cheap operation).
             for (int i = 0; i < futures.size(); i++) {
                 networks[i] = futures.get(i).get();
             }
@@ -885,7 +889,8 @@ public class CgmesImport implements Importer {
     private static final Parameter IMPORT_CGM_WITH_SUBNETWORKS_THREAD_COUNT_PARAMETER = new Parameter(
             IMPORT_CGM_WITH_SUBNETWORKS_THREAD_COUNT,
             ParameterType.INTEGER,
-            "Number of threads used to import subnetworks of a CGM concurrently (1 = sequential import)",
+            "Number of threads used to import subnetworks of a CGM concurrently (1 = sequential import). " +
+                    "Applicable only if iidm.import.cgmes.cgm-with-subnetworks parameter is set to true.",
             1);
 
     public static final Parameter MISSING_PERMANENT_LIMIT_PERCENTAGE_PARAMETER = new Parameter(

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -19,6 +19,7 @@ import com.powsybl.cgmes.model.CgmesOnDataSource;
 import com.powsybl.cgmes.model.CgmesSubset;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.compress.SafeZipInputStream;
+import com.powsybl.commons.concurrent.CleanableExecutors;
 import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.commons.datasource.CompressionFormat;
 import com.powsybl.commons.datasource.DataSource;
@@ -65,6 +66,9 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.zip.ZipInputStream;
@@ -181,17 +185,64 @@ public class CgmesImport implements Importer {
                             p, IMPORT_CGM_WITH_SUBNETWORKS_DEFINED_BY_PARAMETER, defaultValueConfig));
             Set<ReadOnlyDataSource> dss = new MultipleGridModelChecker(ds).separate(separatingBy);
             if (dss.size() > 1) {
-                return Network.merge(dss.stream()
-                        .map(ds1 -> importData1(ds1, networkFactory, p, reportNode))
-                        .toArray(Network[]::new));
+                int threadCount = Parameter.readInteger(getFormat(), p, IMPORT_CGM_WITH_SUBNETWORKS_THREAD_COUNT_PARAMETER, defaultValueConfig);
+                return Network.merge(importSubnetworks(dss, networkFactory, p, reportNode, threadCount));
             }
         }
         return importData1(ds, networkFactory, p, reportNode);
     }
 
     private Network importData1(ReadOnlyDataSource ds, NetworkFactory networkFactory, Properties p, ReportNode reportNode) {
-        CgmesModel cgmes = readCgmes(ds, p, reportNode);
+        ReportNode tripleStoreReportNode = CgmesReports.readingCgmesTriplestoreReport(reportNode);
         ReportNode conversionReportNode = CgmesReports.importingCgmesFileReport(reportNode, ds.getBaseName());
+        return importData2(ds, networkFactory, p, tripleStoreReportNode, conversionReportNode);
+    }
+
+    /**
+     * Imports every subnetwork data source into its own {@link Network}, optionally concurrently.
+     * <p>{@link ReportNode} is not safe for concurrent mutation of the same parent, so every child report node
+     * used by the subnetwork imports is created here, sequentially, before any parallel work is dispatched.
+     */
+    private Network[] importSubnetworks(Set<ReadOnlyDataSource> dss, NetworkFactory networkFactory, Properties p, ReportNode reportNode, int threadCount) {
+        // dss is sorted deterministically by MultipleGridModelChecker, so import order (and therefore the
+        // produced report) does not depend on the thread count used.
+        List<ReadOnlyDataSource> dsList = new ArrayList<>(dss);
+        List<ReportNode> tripleStoreReportNodes = new ArrayList<>(dsList.size());
+        List<ReportNode> conversionReportNodes = new ArrayList<>(dsList.size());
+        for (ReadOnlyDataSource ds : dsList) {
+            tripleStoreReportNodes.add(CgmesReports.readingCgmesTriplestoreReport(reportNode));
+            conversionReportNodes.add(CgmesReports.importingCgmesFileReport(reportNode, ds.getBaseName()));
+        }
+
+        if (threadCount <= 1) {
+            Network[] networks = new Network[dsList.size()];
+            for (int i = 0; i < dsList.size(); i++) {
+                networks[i] = importData2(dsList.get(i), networkFactory, p, tripleStoreReportNodes.get(i), conversionReportNodes.get(i));
+            }
+            return networks;
+        }
+
+        try (ExecutorService executor = CleanableExecutors.newFixedThreadPool("cgmes-cgm-import", Math.min(threadCount, dsList.size()))) {
+            List<Future<Network>> futures = new ArrayList<>(dsList.size());
+            for (int i = 0; i < dsList.size(); i++) {
+                int idx = i;
+                futures.add(executor.submit(() -> importData2(dsList.get(idx), networkFactory, p, tripleStoreReportNodes.get(idx), conversionReportNodes.get(idx))));
+            }
+            Network[] networks = new Network[dsList.size()];
+            for (int i = 0; i < futures.size(); i++) {
+                networks[i] = futures.get(i).get();
+            }
+            return networks;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PowsyblException("Interrupted while importing CGMES subnetworks", e);
+        } catch (ExecutionException e) {
+            throw new PowsyblException("Failed to import CGMES subnetwork", e.getCause() != null ? e.getCause() : e);
+        }
+    }
+
+    private Network importData2(ReadOnlyDataSource ds, NetworkFactory networkFactory, Properties p, ReportNode tripleStoreReportNode, ReportNode conversionReportNode) {
+        CgmesModel cgmes = createCgmesModel(ds, p, tripleStoreReportNode);
         return new Conversion(cgmes, config(p), activatedPreProcessors(p), activatedPostProcessors(p), networkFactory).convert(conversionReportNode);
     }
 
@@ -467,6 +518,11 @@ public class CgmesImport implements Importer {
     }
 
     public CgmesModel readCgmes(ReadOnlyDataSource ds, Properties p, ReportNode reportNode) {
+        ReportNode tripleStoreReportNode = CgmesReports.readingCgmesTriplestoreReport(reportNode);
+        return createCgmesModel(ds, p, tripleStoreReportNode);
+    }
+
+    private CgmesModel createCgmesModel(ReadOnlyDataSource ds, Properties p, ReportNode tripleStoreReportNode) {
         TripleStoreOptions options = new TripleStoreOptions();
         String sourceForIidmIds = Parameter.readString(getFormat(), p, SOURCE_FOR_IIDM_ID_PARAMETER, defaultValueConfig);
         if (sourceForIidmIds.equalsIgnoreCase(SOURCE_FOR_IIDM_ID_MRID)) {
@@ -475,7 +531,6 @@ public class CgmesImport implements Importer {
             options.setRemoveInitialUnderscoreForIdentifiers(false);
         }
         options.decodeEscapedIdentifiers(Parameter.readBoolean(getFormat(), p, DECODE_ESCAPED_IDENTIFIERS_PARAMETER, defaultValueConfig));
-        ReportNode tripleStoreReportNode = CgmesReports.readingCgmesTriplestoreReport(reportNode);
         return CgmesModelFactory.create(ds, boundary(p), tripleStore(p), tripleStoreReportNode, options);
     }
 
@@ -722,6 +777,7 @@ public class CgmesImport implements Importer {
     public static final String MISSING_PERMANENT_LIMIT_PERCENTAGE = "iidm.import.cgmes.missing-permanent-limit-percentage";
     public static final String IMPORT_CGM_WITH_SUBNETWORKS = "iidm.import.cgmes.cgm-with-subnetworks";
     public static final String IMPORT_CGM_WITH_SUBNETWORKS_DEFINED_BY = "iidm.import.cgmes.cgm-with-subnetworks-defined-by";
+    public static final String IMPORT_CGM_WITH_SUBNETWORKS_THREAD_COUNT = "iidm.import.cgmes.cgm-with-subnetworks-thread-count";
     public static final String CREATE_FICTITIOUS_VOLTAGE_LEVEL_FOR_EVERY_NODE = "iidm.import.cgmes.create-fictitious-voltage-level-for-every-node";
     public static final String USE_PREVIOUS_VALUES_DURING_UPDATE = "iidm.import.cgmes.use-previous-values-during-update";
     public static final String REMOVE_PROPERTIES_AND_ALIASES_AFTER_IMPORT = "iidm.import.cgmes.remove-properties-and-aliases-after-import";
@@ -826,6 +882,11 @@ public class CgmesImport implements Importer {
             "Choose how subnetworks from CGM must be imported: defined by filenames or by modeling authority",
             SubnetworkDefinedBy.MODELING_AUTHORITY.name(),
             Arrays.stream(SubnetworkDefinedBy.values()).map(Enum::name).collect(Collectors.toList()));
+    private static final Parameter IMPORT_CGM_WITH_SUBNETWORKS_THREAD_COUNT_PARAMETER = new Parameter(
+            IMPORT_CGM_WITH_SUBNETWORKS_THREAD_COUNT,
+            ParameterType.INTEGER,
+            "Number of threads used to import subnetworks of a CGM concurrently (1 = sequential import)",
+            1);
 
     public static final Parameter MISSING_PERMANENT_LIMIT_PERCENTAGE_PARAMETER = new Parameter(
             MISSING_PERMANENT_LIMIT_PERCENTAGE,
@@ -882,6 +943,7 @@ public class CgmesImport implements Importer {
             DISCONNECT_BOUNDARY_LINE_IF_BOUNDARY_SIDE_IS_DISCONNECTED_PARAMETER,
             IMPORT_CGM_WITH_SUBNETWORKS_PARAMETER,
             IMPORT_CGM_WITH_SUBNETWORKS_DEFINED_BY_PARAMETER,
+            IMPORT_CGM_WITH_SUBNETWORKS_THREAD_COUNT_PARAMETER,
             MISSING_PERMANENT_LIMIT_PERCENTAGE_PARAMETER,
             CREATE_FICTITIOUS_VOLTAGE_LEVEL_FOR_EVERY_NODE_PARAMETER,
             USE_PREVIOUS_VALUES_DURING_UPDATE_PARAMETER,

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java
@@ -203,7 +203,7 @@ public class CgmesImport implements Importer {
      * <p>{@link ReportNode} is not safe for concurrent mutation of the same parent, so every child report node
      * used by the subnetwork imports is created here, sequentially, before any parallel work is dispatched.
      */
-    private Network[] importSubnetworks(Set<ReadOnlyDataSource> dss, NetworkFactory networkFactory, Properties p, ReportNode reportNode, int threadCount) {
+    Network[] importSubnetworks(Set<ReadOnlyDataSource> dss, NetworkFactory networkFactory, Properties p, ReportNode reportNode, int threadCount) {
         // dss is sorted deterministically by MultipleGridModelChecker, so import order (and therefore the
         // produced report) does not depend on the thread count used.
         List<ReadOnlyDataSource> dsList = new ArrayList<>(dss);
@@ -222,11 +222,12 @@ public class CgmesImport implements Importer {
             return networks;
         }
 
-        try (ExecutorService executor = CleanableExecutors.newFixedThreadPool("cgmes-cgm-import", Math.min(threadCount, dsList.size()))) {
+        try (StoppableExecutorService executor = new StoppableExecutorService(
+                CleanableExecutors.newFixedThreadPool("cgmes-cgm-import", Math.min(threadCount, dsList.size())))) {
             List<Future<Network>> futures = new ArrayList<>(dsList.size());
             for (int i = 0; i < dsList.size(); i++) {
                 int idx = i;
-                futures.add(executor.submit(() -> importData2(dsList.get(idx), networkFactory, p, tripleStoreReportNodes.get(idx), conversionReportNodes.get(idx))));
+                futures.add(executor.get().submit(() -> importData2(dsList.get(idx), networkFactory, p, tripleStoreReportNodes.get(idx), conversionReportNodes.get(idx))));
             }
             Network[] networks = new Network[dsList.size()];
             // It is fine to retrieve the result sequentially.
@@ -245,7 +246,21 @@ public class CgmesImport implements Importer {
         }
     }
 
+    private record StoppableExecutorService(ExecutorService delegate) implements AutoCloseable {
+        ExecutorService get() {
+            return delegate;
+        }
+
+        @Override
+        public void close() {
+            delegate.shutdownNow();
+        }
+    }
+
     private Network importData2(ReadOnlyDataSource ds, NetworkFactory networkFactory, Properties p, ReportNode tripleStoreReportNode, ReportNode conversionReportNode) {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new PowsyblException("Interrupted while importing CGMES subnetwork " + ds.getBaseName());
+        }
         CgmesModel cgmes = createCgmesModel(ds, p, tripleStoreReportNode);
         return new Conversion(cgmes, config(p), activatedPreProcessors(p), activatedPostProcessors(p), networkFactory).convert(conversionReportNode);
     }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/CgmWithSubnetworksMultithreadedImportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/CgmWithSubnetworksMultithreadedImportTest.java
@@ -5,25 +5,31 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * SPDX-License-Identifier: MPL-2.0
  */
-package com.powsybl.cgmes.conversion.test;
+package com.powsybl.cgmes.conversion;
 
 import com.powsybl.cgmes.conformity.CgmesConformity3Catalog;
-import com.powsybl.cgmes.conversion.CgmesImport;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.report.PowsyblCoreReportResourceBundle;
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.commons.test.PowsyblTestReportResourceBundle;
 import com.powsybl.commons.test.TestUtil;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.NetworkFactory;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
@@ -167,6 +173,82 @@ class CgmWithSubnetworksMultithreadedImportTest {
         assertEquals(EXPECTED_REPORT, print(sequentialReport));
         assertEquals(EXPECTED_REPORT, print(parallelReport));
         assertEquals(EXPECTED_REPORT, print(overSubscribedReport));
+    }
+
+    @Test
+    void callingThreadInterruptedDuringParallelImportThrowsPowsyblException() {
+        ReadOnlyDataSource ds = CgmesConformity3Catalog.microGridBaseCaseAssembled().dataSource();
+        Thread.currentThread().interrupt();
+        try {
+            PowsyblException e = assertThrows(PowsyblException.class, () -> importWithThreadCount(ds, 2, ReportNode.NO_OP));
+            assertEquals("Interrupted while importing CGMES subnetworks", e.getMessage());
+        } finally {
+            assertTrue(Thread.interrupted(), "interrupt status should still be set");
+        }
+    }
+
+    @Test
+    void callingThreadInterruptedDuringSequentialImportThrowsPowsyblException() {
+        ReadOnlyDataSource ds = CgmesConformity3Catalog.microGridBaseCaseAssembled().dataSource();
+        Thread.currentThread().interrupt();
+        try {
+            assertThrows(PowsyblException.class, () -> importWithThreadCount(ds, 1, ReportNode.NO_OP));
+        } finally {
+            assertTrue(Thread.interrupted(), "interrupt status should still be set");
+        }
+    }
+
+    @Test
+    void oneSubnetworkImportFailureThrowsPowsyblException() {
+        ReadOnlyDataSource validSubnetworkDs = CgmesConformity3Catalog.microGridBaseCaseAssembled().dataSource();
+        Set<ReadOnlyDataSource> dss = Set.of(new BrokenReadOnlyDataSource(), validSubnetworkDs);
+        CgmesImport cgmesImport = new CgmesImport();
+        NetworkFactory networkFactory = NetworkFactory.findDefault();
+        Properties importParams = new Properties();
+        PowsyblException e = assertThrows(PowsyblException.class,
+                () -> cgmesImport.importSubnetworks(dss, networkFactory, importParams, ReportNode.NO_OP, 2));
+        assertEquals("Failed to import CGMES subnetwork", e.getMessage());
+        assertEquals("CIM Namespace not found", e.getCause().getMessage());
+    }
+
+    /**
+     * A data source that always fails to read, simulating a subnetwork import failure.
+     */
+    private static final class BrokenReadOnlyDataSource implements ReadOnlyDataSource {
+        @Override
+        public String getBaseName() {
+            return "broken";
+        }
+
+        @Override
+        public boolean exists(String suffix, String ext) {
+            return false;
+        }
+
+        @Override
+        public boolean exists(String fileName) {
+            return false;
+        }
+
+        @Override
+        public boolean isDataExtension(String ext) {
+            return false;
+        }
+
+        @Override
+        public InputStream newInputStream(String suffix, String ext) throws IOException {
+            throw new IOException("Simulated failure reading subnetwork data");
+        }
+
+        @Override
+        public InputStream newInputStream(String fileName) throws IOException {
+            throw new IOException("Simulated failure reading subnetwork data");
+        }
+
+        @Override
+        public Set<String> listNames(String regex) {
+            return new HashSet<>();
+        }
     }
 
     private static ReportNode newReportNode() {

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/CgmWithSubnetworksMultithreadedImportTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/CgmWithSubnetworksMultithreadedImportTest.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) 2026, Artelys (https://www.artelys.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.cgmes.conversion.test;
+
+import com.powsybl.cgmes.conformity.CgmesConformity3Catalog;
+import com.powsybl.cgmes.conversion.CgmesImport;
+import com.powsybl.commons.datasource.ReadOnlyDataSource;
+import com.powsybl.commons.report.PowsyblCoreReportResourceBundle;
+import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.test.PowsyblTestReportResourceBundle;
+import com.powsybl.commons.test.TestUtil;
+import com.powsybl.iidm.network.Network;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Damien Jeandemange {@literal <damien.jeandemange at artelys.com>}
+ */
+class CgmWithSubnetworksMultithreadedImportTest {
+
+    private static final String EXPECTED_REPORT = """
+            + Test reports
+               + Reading CGMES Triplestore
+                  Instance file 20210325T1530Z_1D_ASSEMBLED_TP_001.xml
+                  Instance file 20210325T1530Z_1D_BE_EQ_001.xml
+                  Instance file 20210325T1530Z_1D_BE_SSH_001.xml
+                  Instance file 20171002T0930Z_ENTSO-E_EQ_BD_2.xml
+                  Instance file 20210325T1530Z_1D_ASSEMBLED_SV_001.xml
+               + Importing CGMES file(s) with basename '20210325T1530Z_1D_BE'
+                  Applying preprocessors.
+                  Building mappings.
+                  Converting Substation.
+                  Converting VoltageLevel.
+                  Converting ConnectivityNode.
+                  Converting BusbarSection.
+                  Converting Ground.
+                  Converting EnergyConsumer.
+                  Converting EnergySource.
+                  Converting EquivalentInjection.
+                  Converting ExternalNetworkInjection.
+                  Converting ShuntCompensator.
+                  Converting EquivalentShunt.
+                  Converting StaticVarCompensator.
+                  Converting AsynchronousMachine.
+                  Converting SynchronousMachine.
+                  Converting Switch.
+                  Converting ACLineSegment.
+                  Converting EquivalentBranch.
+                  Converting SeriesCompensator.
+                  Converting PowerTransformer.
+                  Converting equipments at boundaries.
+                  Converting DC network.
+                  Converting OperationalLimit.
+                  Converting ControlArea.
+                  Converting TieFlow.
+                  Converting RegulatingControl.
+                  Applying postprocessors.
+                  CGMES network urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d is imported.
+                  Converting during update Terminal.
+                  Converting during update TIE_LINE.
+                  Converting during update SvInjection.
+                  Updating SWITCH.
+                  Updating LOAD.
+                  Updating GENERATOR.
+                  Updating LINE.
+                  Updating TWO_WINDINGS_TRANSFORMER.
+                  Updating THREE_WINDINGS_TRANSFORMER.
+                  Updating STATIC_VAR_COMPENSATOR.
+                  Updating SHUNT_COMPENSATOR.
+                  Updating HVDC_LINE.
+                  Updating BOUNDARY_LINE.
+                  Fixing issues with boundary lines.
+                  Updating VOLTAGE_LEVEL.
+                  Updating GROUND.
+                  Updating AREA.
+                  Setting voltages and angles.
+                  Running validation checks on IIDM network urn:uuid:095c6b30-255d-40d5-85fe-2c9fe6c9846d
+               + Reading CGMES Triplestore
+                  Instance file 20210325T1530Z_1D_NL_SSH_001.xml
+                  Instance file 20210325T1530Z_1D_NL_EQ_001.xml
+                  Instance file 20171002T0930Z_ENTSO-E_EQ_BD_2.xml
+               + Importing CGMES file(s) with basename '20210325T1530Z_1D_BE'
+                  Applying preprocessors.
+                  Building mappings.
+                  Converting Substation.
+                  Converting VoltageLevel.
+                  Converting ConnectivityNode.
+                  Converting BusbarSection.
+                  Converting Ground.
+                  Converting EnergyConsumer.
+                  Converting EnergySource.
+                  Converting EquivalentInjection.
+                  Converting ExternalNetworkInjection.
+                  Converting ShuntCompensator.
+                  Converting EquivalentShunt.
+                  Converting StaticVarCompensator.
+                  Converting AsynchronousMachine.
+                  Converting SynchronousMachine.
+                  Converting Switch.
+                  Converting ACLineSegment.
+                  Converting EquivalentBranch.
+                  Converting SeriesCompensator.
+                  Converting PowerTransformer.
+                  Converting equipments at boundaries.
+                  Converting DC network.
+                  Converting OperationalLimit.
+                  Converting ControlArea.
+                  Converting TieFlow.
+                  Converting RegulatingControl.
+                  Applying postprocessors.
+                  CGMES network urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61 is imported.
+                  Converting during update Terminal.
+                  Converting during update TIE_LINE.
+                  Converting during update SvInjection.
+                  Updating SWITCH.
+                  Updating LOAD.
+                  Updating GENERATOR.
+                  Updating LINE.
+                  Updating TWO_WINDINGS_TRANSFORMER.
+                  Updating THREE_WINDINGS_TRANSFORMER.
+                  Updating STATIC_VAR_COMPENSATOR.
+                  Updating SHUNT_COMPENSATOR.
+                  Updating HVDC_LINE.
+                  Updating BOUNDARY_LINE.
+                  Fixing issues with boundary lines.
+                  Updating VOLTAGE_LEVEL.
+                  Updating GROUND.
+                  Updating AREA.
+                  Setting voltages and angles.
+                  Running validation checks on IIDM network urn:uuid:87da6373-3b6c-47a2-9493-1918a8d9df61
+            """;
+
+    @Test
+    void concurrentSubnetworkImportMatchesSequentialImport() {
+        ReadOnlyDataSource ds = CgmesConformity3Catalog.microGridBaseCaseAssembled().dataSource();
+
+        ReportNode sequentialReport = newReportNode();
+        ReportNode parallelReport = newReportNode();
+        // More threads than subnetworks must be clamped, not fail
+        ReportNode overSubscribedReport = newReportNode();
+        Network sequential = importWithThreadCount(ds, 1, sequentialReport);
+        Network parallel = importWithThreadCount(ds, 2, parallelReport);
+        Network overSubscribed = importWithThreadCount(ds, 8, overSubscribedReport);
+
+        assertEquals(subnetworkIds(sequential), subnetworkIds(parallel));
+        assertEquals(subnetworkIds(sequential), subnetworkIds(overSubscribed));
+        for (String subnetworkId : subnetworkIds(sequential)) {
+            assertEquals(sequential.getSubnetwork(subnetworkId).getIdentifiables().size(),
+                    parallel.getSubnetwork(subnetworkId).getIdentifiables().size());
+            assertEquals(sequential.getSubnetwork(subnetworkId).getIdentifiables().size(),
+                    overSubscribed.getSubnetwork(subnetworkId).getIdentifiables().size());
+        }
+
+        // The report content (including per-subnetwork child ordering) must not depend on the thread count.
+        assertEquals(EXPECTED_REPORT, print(sequentialReport));
+        assertEquals(EXPECTED_REPORT, print(parallelReport));
+        assertEquals(EXPECTED_REPORT, print(overSubscribedReport));
+    }
+
+    private static ReportNode newReportNode() {
+        return ReportNode.newRootReportNode()
+                .withResourceBundles(PowsyblTestReportResourceBundle.TEST_BASE_NAME, PowsyblCoreReportResourceBundle.BASE_NAME)
+                .withMessageTemplate("test")
+                .build();
+    }
+
+    private static Network importWithThreadCount(ReadOnlyDataSource ds, int threadCount, ReportNode reportNode) {
+        Properties importParams = new Properties();
+        importParams.put(CgmesImport.IMPORT_CGM_WITH_SUBNETWORKS_THREAD_COUNT, String.valueOf(threadCount));
+        return Network.read(ds, importParams, reportNode);
+    }
+
+    private static List<String> subnetworkIds(Network network) {
+        return network.getSubnetworks().stream().map(Network::getId).sorted().toList();
+    }
+
+    private static String print(ReportNode reportNode) {
+        StringWriter sw = new StringWriter();
+        try {
+            reportNode.print(sw);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return TestUtil.normalizeLineSeparator(sw.toString());
+    }
+}

--- a/docs/grid_exchange_formats/cgmes/import.md
+++ b/docs/grid_exchange_formats/cgmes/import.md
@@ -875,7 +875,9 @@ If `iidm.import.cgmes.cgm-with-subnetworks` is set to `true`, use this property 
 Its default value is `MODELING_AUTHORITY`.
 
 **iidm.import.cgmes.cgm-with-subnetworks-thread-count**<br>
-If `iidm.import.cgmes.cgm-with-subnetworks` is set to `true`, use this property to define the number of threads used to import the IGMs of a CGM concurrently. Its default value is `1`, meaning IGMs are imported sequentially. Values above the number of IGMs are clamped to that number.
+If `iidm.import.cgmes.cgm-with-subnetworks` is set to `true`, use this property to define the number of threads used to import the IGMs of a CGM concurrently.
+Its default value is `1`, meaning IGMs are imported sequentially.
+If there are less IGMs than the number of configured threads, the importer will only use as many threads as there are IGMs.
 
 **iidm.import.cgmes.create-fictitious-voltage-level-for-every-node**<br>
 Optional property that defines the fictitious voltage levels created by line container. If it is set to `true`, a fictitious voltage level is created for each connectivity node inside the line container.

--- a/docs/grid_exchange_formats/cgmes/import.md
+++ b/docs/grid_exchange_formats/cgmes/import.md
@@ -874,6 +874,9 @@ Optional property to define if subnetworks must be added to the network when imp
 If `iidm.import.cgmes.cgm-with-subnetworks` is set to `true`, use this property to specify how the set of input files should be split by IGM: based on their filenames (use the value `FILENAME`) or by its modeling authority, read from the header (use the value `MODELING_AUTHORITY`).
 Its default value is `MODELING_AUTHORITY`.
 
+**iidm.import.cgmes.cgm-with-subnetworks-thread-count**<br>
+If `iidm.import.cgmes.cgm-with-subnetworks` is set to `true`, use this property to define the number of threads used to import the IGMs of a CGM concurrently. Its default value is `1`, meaning IGMs are imported sequentially. Values above the number of IGMs are clamped to that number.
+
 **iidm.import.cgmes.create-fictitious-voltage-level-for-every-node**<br>
 Optional property that defines the fictitious voltage levels created by line container. If it is set to `true`, a fictitious voltage level is created for each connectivity node inside the line container.
 If it is set to `false`, only one fictitious voltage level is created for each line container.


### PR DESCRIPTION
Draft: because to merge after / needs #4080 

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature / performance


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Sequential IGM import.


**What is the new behavior (if this is a feature change)?**
Concurrent IGM import, with configurable number of threads. Default 1 thread means sequential.

Test on a 29 IGMs CGM (without SV):
- sequential: 90 s
- 2 threads: 38 s
- 4 threads: 27 s
- more thread do not bring further improvement (probably because I/O bound and/or my laptop)

Note that more threads require more RAM

**Does this PR introduce a breaking change or deprecate an API?**
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
