### PR TITLE
Reject null DataSource in Importers.importData (#1990)

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Importers.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/Importers.java
@@ -57,6 +57,7 @@ public final class Importers {
      */
     public static Network importData(ImportersLoader loader, String format, ReadOnlyDataSource dataSource, Properties parameters,
                                      ComputationManager computationManager, ImportConfig config, ReportNode reportNode) {
+        Objects.requireNonNull(dataSource);
         Importer importer = Importer.find(loader, format, computationManager, config);
         if (importer == null) {
             throw new PowsyblException("Import format " + format + " not supported");

--- a/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/ImportersTest.java
+++ b/iidm/iidm-api/src/test/java/com/powsybl/iidm/network/ImportersTest.java
@@ -151,8 +151,14 @@ class ImportersTest extends AbstractConvertersTest {
 
     @Test
     void importBadData() {
-        PowsyblException e = assertThrows(PowsyblException.class, () -> Importers.importData(loader, UNSUPPORTED_FORMAT, null, null, computationManager, importConfigMock));
+        ReadOnlyDataSource dataSource = new DirectoryDataSource(fileSystem.getPath(WORK_DIR), "foo");
+        PowsyblException e = assertThrows(PowsyblException.class, () -> Importers.importData(loader, UNSUPPORTED_FORMAT, dataSource, null, computationManager, importConfigMock));
         assertEquals("Import format " + UNSUPPORTED_FORMAT + " not supported", e.getMessage());
+    }
+
+    @Test
+    void importDataNullDataSource() {
+        assertThrows(NullPointerException.class, () -> Importers.importData(loader, TEST_FORMAT, null, null, computationManager, importConfigMock));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1990

`Importers.importData` now rejects a null `DataSource` with NPE instead of passing it into the importer. The unsupported-format test uses a real datasource so it still checks the format error, not the null.
