### PR TITLE
Create fictitious switch for disconnected terminal in node-breaker

### DIFF
--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/Conversion.java
@@ -287,7 +287,6 @@ public class Conversion {
         Context updateContext = createUpdateContext(network, reportNode);
 
         // add processes to create new equipment using update data (ssh and sv data)
-        createFictitiousSwitchesForDisconnectedTerminalsDuringUpdate(network, cgmes, updateContext);
         createTieLinesWhenThereAreMoreThanTwoBoundaryLinesAtBoundaryNodeDuringUpdate(network, updateContext);
         createFictitiousLoadsForSvInjectionsDuringUpdate(network, cgmes, updateContext);
 
@@ -355,6 +354,7 @@ public class Conversion {
         // Switches are updated first because the subsequent update of the terminals
         // is configurable and, if activated, may modify their state.
         // Then, the update of the terminals can overwrite the state of the switches
+        createFictitiousSwitchesForDisconnectedTerminalsDuringUpdate(network, cgmes, updateContext);
         updateSwitches(network, updateContext);
 
         updateLoads(network, cgmes, updateContext);
@@ -1061,10 +1061,6 @@ public class Conversion {
             return disconnectNetworkSideOfBoundaryLinesIfBoundaryIsDisconnected;
         }
 
-        public boolean updateTerminalConnectionInNodeBreakerVoltageLevel() {
-            return UPDATE_TERMINAL_CONNECTION_IN_NODE_BREAKER_VOLTAGE_LEVEL;
-        }
-
         public List<DefaultValue> updateDefaultValuesPriority() {
             return usePreviousValuesDuringUpdate
                     ? List.of(DefaultValue.PREVIOUS, DefaultValue.EQ, DefaultValue.DEFAULT, DefaultValue.EMPTY)
@@ -1140,7 +1136,6 @@ public class Conversion {
 
         private double missingPermanentLimitPercentage = 100;
         private boolean createFictitiousVoltageLevelsForEveryNode = true;
-        private static final boolean UPDATE_TERMINAL_CONNECTION_IN_NODE_BREAKER_VOLTAGE_LEVEL = false;
         private boolean usePreviousValuesDuringUpdate = false;
         private boolean removePropertiesAndAliasesAfterImport = false;
         private boolean useDetailedDcModel = false;

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
@@ -529,8 +529,8 @@ public abstract class AbstractConductingEquipmentConversion extends AbstractIden
     }
 
     private static void updateTerminal(PropertyBag cgmesTerminal, Terminal terminal, Context context) {
-        if (updateConnect(terminal, context)) {
-            boolean connectedInUpdate = cgmesTerminal.asBoolean(CgmesNames.CONNECTED, true);
+        boolean connectedInUpdate = cgmesTerminal.asBoolean(CgmesNames.CONNECTED, true);
+        if (terminal.getVoltageLevel().getTopologyKind().equals(TopologyKind.BUS_BREAKER)) {
             if (!terminal.isConnected() && connectedInUpdate) {
                 terminal.connect();
             } else if (terminal.isConnected() && !connectedInUpdate) {
@@ -544,14 +544,6 @@ public abstract class AbstractConductingEquipmentConversion extends AbstractIden
             } else {
                 terminal.setP(Double.NaN).setQ(Double.NaN);
             }
-        }
-    }
-
-    private static boolean updateConnect(Terminal terminal, Context context) {
-        if (terminal.getVoltageLevel().getTopologyKind().equals(TopologyKind.NODE_BREAKER)) {
-            return context.config().updateTerminalConnectionInNodeBreakerVoltageLevel();
-        } else {
-            return true;
         }
     }
 

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/AbstractConductingEquipmentConversion.java
@@ -524,11 +524,11 @@ public abstract class AbstractConductingEquipmentConversion extends AbstractIden
     public static void updateTerminals(Connectable<?> connectable, Context context, Terminal... ts) {
         PropertyBags cgmesTerminals = getCgmesTerminals(connectable, context, ts.length);
         for (int k = 0; k < ts.length; k++) {
-            updateTerminal(cgmesTerminals.get(k), ts[k], context);
+            updateTerminal(cgmesTerminals.get(k), ts[k]);
         }
     }
 
-    private static void updateTerminal(PropertyBag cgmesTerminal, Terminal terminal, Context context) {
+    private static void updateTerminal(PropertyBag cgmesTerminal, Terminal terminal) {
         boolean connectedInUpdate = cgmesTerminal.asBoolean(CgmesNames.CONNECTED, true);
         if (terminal.getVoltageLevel().getTopologyKind().equals(TopologyKind.BUS_BREAKER)) {
             if (!terminal.isConnected() && connectedInUpdate) {

--- a/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/TerminalConversion.java
+++ b/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/TerminalConversion.java
@@ -33,50 +33,47 @@ public final class TerminalConversion {
     public static void create(Network network, PropertyBag cgmesTerminal, Context context) {
         String cgmesTerminalId = cgmesTerminal.getId(CgmesNames.TERMINAL);
         boolean connected = cgmesTerminal.asBoolean(CgmesNames.CONNECTED, true);
-        if (createFictitiousSwitch(network, cgmesTerminalId, connected)) {
+        if (createFictitiousSwitch(network, cgmesTerminalId, connected, context)) {
             create(network, cgmesTerminalId, context);
         }
     }
 
-    private static boolean createFictitiousSwitch(Network network, String cgmesTerminalId, boolean connected) {
-        if (cgmesTerminalId == null || connected) {
+    private static boolean createFictitiousSwitch(Network network, String cgmesTerminalId, boolean connected, Context context) {
+        // Only create if it's a disconnected terminal of a connectable that's not a busbar section.
+        Identifiable<?> identifiable = network.getIdentifiable(cgmesTerminalId);
+        if (cgmesTerminalId == null || connected || identifiable == null || identifiable.getType() == IdentifiableType.BUSBAR_SECTION) {
             return false;
         }
-        // Do not create a switch if the terminal is associated with a busbar section
-        Identifiable<?> identifiable = network.getIdentifiable(cgmesTerminalId);
-        return identifiable == null || identifiable.getType() != IdentifiableType.BUSBAR_SECTION;
+
+        // Check if a fictitious switch has already been created (from a previous update).
+        Optional<Switch> sw = context.network().getSwitchStream()
+            .filter(s -> "true".equals(s.getProperty(PROPERTY_IS_CREATED_FOR_DISCONNECTED_TERMINAL))
+                && cgmesTerminalId.equals(s.getProperty(PROPERTY_TERMINAL)))
+            .findFirst();
+        if (sw.isPresent()) {
+            return false;
+        }
+
+        // Check if configuration allows fictitious switch creation.
+        return switch (context.config().getCreateFictitiousSwitchesForDisconnectedTerminalsMode()) {
+            case NEVER -> false;
+            case ALWAYS -> true;
+            case ALWAYS_EXCEPT_SWITCHES -> identifiable.getType() != IdentifiableType.SWITCH;
+        };
     }
 
     private static void create(Network network, String cgmesTerminalId, Context context) {
         Identifiable<?> identifiable = network.getIdentifiable(cgmesTerminalId);
-        if (createFictitiousSwitch(identifiable, context)) {
-            if (identifiable instanceof Switch sw) {
-                if (createFictitiousSwitch(sw)) {
-                    createSwitchForSwitch(sw, getNode(sw, cgmesTerminalId), cgmesTerminalId, context);
-                }
-            } else if (identifiable instanceof Connectable<?> connectable) {
-                Terminal terminal = getTerminal(connectable, cgmesTerminalId);
-                if (createFictitiousSwitch(terminal)) {
-                    createSwitchForTerminal(terminal, cgmesTerminalId, context);
-                }
+        if (identifiable instanceof Switch sw) {
+            if (sw.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER) {
+                createSwitchForSwitch(sw, getNode(sw, cgmesTerminalId), cgmesTerminalId, context);
+            }
+        } else if (identifiable instanceof Connectable<?> connectable) {
+            Terminal terminal = getTerminal(connectable, cgmesTerminalId);
+            if (terminal != null && terminal.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER) {
+                createSwitchForTerminal(terminal, cgmesTerminalId, context);
             }
         }
-    }
-
-    private static boolean createFictitiousSwitch(Identifiable<?> identifiable, Context context) {
-        return switch (context.config().getCreateFictitiousSwitchesForDisconnectedTerminalsMode()) {
-            case NEVER -> false;
-            case ALWAYS -> identifiable != null;
-            case ALWAYS_EXCEPT_SWITCHES -> identifiable != null && identifiable.getType() != IdentifiableType.SWITCH;
-        };
-    }
-
-    private static boolean createFictitiousSwitch(Switch sw) {
-        return sw.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER;
-    }
-
-    private static boolean createFictitiousSwitch(Terminal terminal) {
-        return terminal != null && terminal.getVoltageLevel().getTopologyKind() == TopologyKind.NODE_BREAKER;
     }
 
     private static int getNode(Switch sw, String terminalId) {
@@ -149,16 +146,18 @@ public final class TerminalConversion {
     // In some cases, it may have already been recorded as an alias associated with other equipment
     private static void createSwitch(VoltageLevel voltageLevel, String cgmesTerminalId, int node1, int node2, Context context) {
         String switchId = cgmesTerminalId + "_SW_fict";
+        // The switch is closed for all variants but the current one.
         Switch sw = voltageLevel.getNodeBreakerView().newSwitch()
                 .setFictitious(true)
                 .setId(switchId)
                 .setName(cgmesTerminalId)
                 .setNode1(node1)
                 .setNode2(node2)
-                .setOpen(true)
+                .setOpen(false)
                 .setKind(SwitchKind.BREAKER)
                 .setEnsureIdUnicity(context.config().isEnsureIdAliasUnicity())
                 .add();
+        sw.setOpen(true);
         sw.setProperty(PROPERTY_IS_CREATED_FOR_DISCONNECTED_TERMINAL, "true");
         sw.setProperty(PROPERTY_TERMINAL, cgmesTerminalId);
     }

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/GroundUpdateTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/GroundUpdateTest.java
@@ -46,23 +46,23 @@ class GroundUpdateTest {
         Network network = readCgmesResources(DIR, "ground_EQ.xml");
         assertEq(network);
 
-        // Import a SSH where the ground is connected
+        // Import a SSH where the ground is connected. No fictitious switch needed.
         readCgmesResources(network, DIR, "ground_SSH.xml");
         assertFictSwitch(network, false);
         assertGroundConnected(network, true);
 
-        // Import a SSH where the ground is disconnected
+        // Import a SSH where the ground is disconnected. A fictitious switch is created.
         readCgmesResources(network, DIR, "ground_SSH_1.xml");
         assertFictSwitch(network, true);
         assertGroundConnected(network, false);
 
-        // Check that a second import does'nt create a new fictitious switch
+        // Check that a second import doesn't create a new fictitious switch.
         readCgmesResources(network, DIR, "ground_SSH_1.xml");
         assertFictSwitch(network, true);
         assertGroundConnected(network, false);
 
         // When importing a situation where the ground is reconnected,
-        // the fictitious switch remains but is now closed
+        // the fictitious switch remains and is now closed.
         readCgmesResources(network, DIR, "ground_SSH.xml");
         assertFictSwitch(network, true);
         assertGroundConnected(network, true);
@@ -70,6 +70,7 @@ class GroundUpdateTest {
 
     @Test
     void completeUpdateUsingDifferentVariantsTest() {
+        // Basically the same test as above except the different situations are imported in different variants.
         Network network = readCgmesResources(DIR, "ground_EQ.xml", "ground_SSH.xml");
 
         network.getVariantManager().cloneVariant(network.getVariantManager().getWorkingVariantId(), "update-08");

--- a/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/GroundUpdateTest.java
+++ b/cgmes/cgmes-conversion/src/test/java/com/powsybl/cgmes/conversion/test/GroundUpdateTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
+import static com.powsybl.cgmes.conversion.Conversion.PROPERTY_IS_CREATED_FOR_DISCONNECTED_TERMINAL;
+import static com.powsybl.cgmes.conversion.Conversion.PROPERTY_TERMINAL;
 import static com.powsybl.cgmes.conversion.test.ConversionUtil.readCgmesResources;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -26,47 +28,88 @@ class GroundUpdateTest {
     @Test
     void importEqTest() {
         Network network = readCgmesResources(DIR, "ground_EQ.xml");
-        assertEquals(1, network.getGroundCount());
-
-        assertEq(network.getGround("Ground"));
+        assertEq(network);
+        assertFictSwitch(network, false);
+        assertGroundConnected(network, true);
     }
 
     @Test
     void importEqAndSshTogetherTest() {
         Network network = readCgmesResources(DIR, "ground_EQ.xml", "ground_SSH.xml");
-        assertEquals(1, network.getGroundCount());
-
-        assertSsh(network.getGround("Ground"));
+        assertEq(network);
+        assertFictSwitch(network, false);
+        assertGroundConnected(network, true);
     }
 
     @Test
     void importEqAndTwoSshsTest() {
         Network network = readCgmesResources(DIR, "ground_EQ.xml");
-        assertEquals(1, network.getGroundCount());
+        assertEq(network);
 
-        assertEq(network.getGround("Ground"));
-
+        // Import a SSH where the ground is connected
         readCgmesResources(network, DIR, "ground_SSH.xml");
-        assertSsh(network.getGround("Ground"));
+        assertFictSwitch(network, false);
+        assertGroundConnected(network, true);
 
+        // Import a SSH where the ground is disconnected
         readCgmesResources(network, DIR, "ground_SSH_1.xml");
-        // For grounds, only the terminals are updated.
-        // We are using a nodeBreaker model, and the configuration attribute
-        // UPDATE_TERMINAL_CONNECTION_IN_NODE_BREAKER_VOLTAGE_LEVEL is set to false.
-        // Then, changing the terminal status to disconnected will not actually disconnect the ground.
-        assertSsh(network.getGround("Ground"));
+        assertFictSwitch(network, true);
+        assertGroundConnected(network, false);
+
+        // Check that a second import does'nt create a new fictitious switch
+        readCgmesResources(network, DIR, "ground_SSH_1.xml");
+        assertFictSwitch(network, true);
+        assertGroundConnected(network, false);
+
+        // When importing a situation where the ground is reconnected,
+        // the fictitious switch remains but is now closed
+        readCgmesResources(network, DIR, "ground_SSH.xml");
+        assertFictSwitch(network, true);
+        assertGroundConnected(network, true);
+    }
+
+    @Test
+    void completeUpdateUsingDifferentVariantsTest() {
+        Network network = readCgmesResources(DIR, "ground_EQ.xml", "ground_SSH.xml");
+
+        network.getVariantManager().cloneVariant(network.getVariantManager().getWorkingVariantId(), "update-08");
+        network.getVariantManager().setWorkingVariant("update-08");
+        readCgmesResources(network, DIR, "ground_SSH_1.xml");
+
+        network.getVariantManager().cloneVariant(network.getVariantManager().getWorkingVariantId(), "update-16");
+        network.getVariantManager().setWorkingVariant("update-16");
+        readCgmesResources(network, DIR, "ground_SSH_1.xml");
+
+        network.getVariantManager().cloneVariant(network.getVariantManager().getWorkingVariantId(), "update-24");
+        network.getVariantManager().setWorkingVariant("update-24");
+        readCgmesResources(network, DIR, "ground_SSH.xml");
+
+        assertEq(network);
+        assertFictSwitch(network, true);
+
+        network.getVariantManager().setWorkingVariant("InitialState");
+        assertGroundConnected(network, true);
+
+        network.getVariantManager().setWorkingVariant("update-08");
+        assertGroundConnected(network, false);
+
+        network.getVariantManager().setWorkingVariant("update-16");
+        assertGroundConnected(network, false);
+
+        network.getVariantManager().setWorkingVariant("update-24");
+        assertGroundConnected(network, true);
     }
 
     @Test
     void usePreviousValuesTest() {
         Network network = readCgmesResources(DIR, "ground_EQ.xml", "ground_SSH.xml");
         assertEquals(1, network.getGroundCount());
-        assertSsh(network.getGround("Ground"));
+        assertGroundConnected(network, true);
 
         Properties properties = new Properties();
         properties.put("iidm.import.cgmes.use-previous-values-during-update", "true");
         readCgmesResources(network, properties, DIR, "../empty_SSH.xml", "../empty_SV.xml");
-        assertSsh(network.getGround("Ground"));
+        assertGroundConnected(network, true);
     }
 
     @Test
@@ -88,14 +131,25 @@ class GroundUpdateTest {
         assertEquals(expected, network.getGroundStream().allMatch(ground -> ground.getAliases().isEmpty()));
     }
 
-    private static void assertEq(Ground ground) {
+    private static void assertEq(Network network) {
+        Ground ground = network.getGround("Ground");
         assertNotNull(ground);
         assertNotNull(ground.getTerminal());
-        assertTrue(ground.getTerminal().isConnected());
     }
 
-    private static void assertSsh(Ground ground) {
-        assertNotNull(ground);
-        assertTrue(ground.getTerminal().isConnected());
+    private static void assertFictSwitch(Network network, boolean fictitiousSwitch) {
+        if (!fictitiousSwitch) {
+            assertEquals(0, network.getSwitchCount());
+        } else {
+            assertEquals(1, network.getSwitchCount());
+            Switch fictSwitch = network.getSwitch("Ground-T_SW_fict");
+            assertEquals("true", fictSwitch.getProperty(PROPERTY_IS_CREATED_FOR_DISCONNECTED_TERMINAL));
+            assertEquals("Ground-T", fictSwitch.getProperty(PROPERTY_TERMINAL));
+        }
+    }
+
+    private static void assertGroundConnected(Network network, boolean connected) {
+        Ground ground = network.getGround("Ground");
+        assertEquals(connected, ground.getTerminal().isConnected());
     }
 }

--- a/cgmes/cgmes-conversion/src/test/resources/functional-logs/microGridBaseCaseBE-invalid-voltage-bus.txt
+++ b/cgmes/cgmes-conversion/src/test/resources/functional-logs/microGridBaseCaseBE-invalid-voltage-bus.txt
@@ -36,9 +36,9 @@
       Converting RegulatingControl.
       Applying postprocessors.
       CGMES network urn:uuid:d400c631-75a0-4c30-8aed-832b0d282e73 is imported.
-      Converting during update Terminal.
       Converting during update TIE_LINE.
       Converting during update SvInjection.
+      Converting during update Terminal.
       Updating SWITCH.
       Updating LOAD.
       Updating GENERATOR.

--- a/cgmes/cgmes-conversion/src/test/resources/functional-logs/microGridBaseCaseBE-target-deadband.txt
+++ b/cgmes/cgmes-conversion/src/test/resources/functional-logs/microGridBaseCaseBE-target-deadband.txt
@@ -35,9 +35,9 @@
       Converting RegulatingControl.
       Applying postprocessors.
       CGMES network urn:uuid:d400c631-75a0-4c30-8aed-832b0d282e73 is imported.
-      Converting during update Terminal.
       Converting during update TIE_LINE.
       Converting during update SvInjection.
+      Converting during update Terminal.
       Updating SWITCH.
       Updating LOAD.
       Updating GENERATOR.

--- a/cgmes/cgmes-conversion/src/test/resources/functional-logs/microGridBaseCaseBE.txt
+++ b/cgmes/cgmes-conversion/src/test/resources/functional-logs/microGridBaseCaseBE.txt
@@ -39,9 +39,9 @@
       Converting RegulatingControl.
       Applying postprocessors.
       CGMES network urn:uuid:d400c631-75a0-4c30-8aed-832b0d282e73 is imported.
-      Converting during update Terminal.
       Converting during update TIE_LINE.
       Converting during update SvInjection.
+      Converting during update Terminal.
       Updating SWITCH.
       Updating LOAD.
       Updating GENERATOR.

--- a/cgmes/cgmes-conversion/src/test/resources/functional-logs/miniGridNodeBreaker.txt
+++ b/cgmes/cgmes-conversion/src/test/resources/functional-logs/miniGridNodeBreaker.txt
@@ -36,9 +36,9 @@
       Converting RegulatingControl.
       Applying postprocessors.
       CGMES network urn:uuid:239ecbd2-9a39-11e0-aa80-0800200c9a66 is imported.
-      Converting during update Terminal.
       Converting during update TIE_LINE.
       Converting during update SvInjection.
+      Converting during update Terminal.
       Updating SWITCH.
       Updating LOAD.
       Updating GENERATOR.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #4059 


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In node-breaker voltage levels, disconnected terminals from SSH were ignored.


**What is the new behavior (if this is a feature change)?**
<!--  -->
If allowed by config, an open fictitious switch is created during update to represent the disconnected terminal from SSH. In case of multiple variants, it is open only for the current one and closed for all the other ones. This is a way to keep the same structure for all variants while having situational changes.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
