### PR TITLE
refactor: return List instead of Collection in LoadingLimits (#4097)

### DIFF
--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/LoadingLimits.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/LoadingLimits.java
@@ -7,7 +7,7 @@
  */
 package com.powsybl.iidm.network;
 
-import java.util.Collection;
+import java.util.List;
 
 /**
  * @author Miora Ralambotiana {@literal <miora.ralambotiana at rte-france.com>}
@@ -91,7 +91,7 @@ public interface LoadingLimits extends OperationalLimits {
      * Get a list of temporary limits ordered by descending duration.
      * @return a list of temporary limits ordered by descending duration
      */
-    Collection<TemporaryLimit> getTemporaryLimits();
+    List<TemporaryLimit> getTemporaryLimits();
 
     /**
      * Get a temporary limit from its acceptable duration. Return null if there is non temporary limit with this

--- a/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/LimitViolationUtils.java
+++ b/iidm/iidm-api/src/main/java/com/powsybl/iidm/network/util/LimitViolationUtils.java
@@ -246,7 +246,7 @@ public final class LimitViolationUtils {
         if (Double.isNaN(i) || Double.isNaN(permanentLimit)) {
             return null;
         }
-        Collection<LoadingLimits.TemporaryLimit> temporaryLimits = limitsContainer.getLimits().getTemporaryLimits();
+        List<LoadingLimits.TemporaryLimit> temporaryLimits = limitsContainer.getLimits().getTemporaryLimits();
         String previousLimitName = limitsContainer.getLimits().getPermanentLimitName();
         double previousLimit = permanentLimit;
         int previousAcceptableDuration = 0; // never mind initialisation it will be overridden with first loop
@@ -269,7 +269,7 @@ public final class LimitViolationUtils {
     }
 
     private static OverloadImpl getOverloadLow(LimitsContainer<LoadingLimits> limitsContainer, double i, double limitReductionValue) {
-        Collection<LoadingLimits.TemporaryLimit> temporaryLimits = limitsContainer.getLimits().getTemporaryLimits();
+        List<LoadingLimits.TemporaryLimit> temporaryLimits = limitsContainer.getLimits().getTemporaryLimits();
         LoadingLimits.TemporaryLimit previousTemporaryLimit = null;
         //iterate on ascending values until i is not above a temporary limit
         for (LoadingLimits.TemporaryLimit tl : temporaryLimits) {

--- a/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractLoadingLimits.java
+++ b/iidm/iidm-impl/src/main/java/com/powsybl/iidm/network/impl/AbstractLoadingLimits.java
@@ -198,8 +198,8 @@ abstract class AbstractLoadingLimits<L extends AbstractLoadingLimits<L>> extends
     }
 
     @Override
-    public Collection<TemporaryLimit> getTemporaryLimits() {
-        return temporaryLimits.values();
+    public List<TemporaryLimit> getTemporaryLimits() {
+        return Collections.unmodifiableList(new ArrayList<>(temporaryLimits.values()));
     }
 
     @Override

--- a/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/SecurityAnalysisTestNetworkFactoryTest.java
+++ b/iidm/iidm-impl/src/test/java/com/powsybl/iidm/network/impl/SecurityAnalysisTestNetworkFactoryTest.java
@@ -11,7 +11,6 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.SecurityAnalysisTestNetworkFactory;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -103,7 +102,7 @@ class SecurityAnalysisTestNetworkFactoryTest {
         assertTrue(network.getLine(lineS1S2V11Str).getCurrentLimits1().isPresent());
         assertEquals(75, network.getLine(lineS1S2V11Str).getCurrentLimits1().get().getPermanentLimit(), threshold);
         assertEquals(3, network.getLine(lineS1S2V11Str).getCurrentLimits1().get().getTemporaryLimits().size(), threshold);
-        List<LoadingLimits.TemporaryLimit> temporaryLimits = new ArrayList<>(network.getLine(lineS1S2V11Str).getCurrentLimits1().get().getTemporaryLimits());
+        List<LoadingLimits.TemporaryLimit> temporaryLimits = network.getLine(lineS1S2V11Str).getCurrentLimits1().get().getTemporaryLimits();
         assertEquals("10'", temporaryLimits.get(0).getName());
         assertEquals(600, temporaryLimits.get(0).getAcceptableDuration(), threshold);
         assertEquals(80, temporaryLimits.get(0).getValue(), threshold);
@@ -120,7 +119,7 @@ class SecurityAnalysisTestNetworkFactoryTest {
         assertTrue(network.getLine(lineS1S2V12Str).getCurrentLimits1().isPresent());
         assertEquals(75, network.getLine(lineS1S2V12Str).getCurrentLimits1().get().getPermanentLimit(), threshold);
         assertEquals(3, network.getLine(lineS1S2V12Str).getCurrentLimits1().get().getTemporaryLimits().size(), threshold);
-        temporaryLimits = new ArrayList<>(network.getLine(lineS1S2V12Str).getCurrentLimits1().get().getTemporaryLimits());
+        temporaryLimits = network.getLine(lineS1S2V12Str).getCurrentLimits1().get().getTemporaryLimits();
         assertEquals("10'", temporaryLimits.get(0).getName());
         assertEquals(600, temporaryLimits.get(0).getAcceptableDuration(), threshold);
         assertEquals(80, temporaryLimits.get(0).getValue(), threshold);
@@ -137,7 +136,7 @@ class SecurityAnalysisTestNetworkFactoryTest {
         assertTrue(network.getLine(lineS1S2V2Str).getCurrentLimits1().isPresent());
         assertEquals(60, network.getLine(lineS1S2V2Str).getCurrentLimits1().get().getPermanentLimit(), threshold);
         assertEquals(1, network.getLine(lineS1S2V2Str).getCurrentLimits1().get().getTemporaryLimits().size(), threshold);
-        temporaryLimits = new ArrayList<>(network.getLine(lineS1S2V2Str).getCurrentLimits1().get().getTemporaryLimits());
+        temporaryLimits = network.getLine(lineS1S2V2Str).getCurrentLimits1().get().getTemporaryLimits();
         assertEquals("10'", temporaryLimits.get(0).getName());
         assertEquals(600, temporaryLimits.get(0).getAcceptableDuration(), threshold);
         assertEquals(80, temporaryLimits.get(0).getValue(), threshold);
@@ -145,7 +144,7 @@ class SecurityAnalysisTestNetworkFactoryTest {
         assertTrue(network.getTwoWindingsTransformer(twtStr).getCurrentLimits1().isPresent());
         assertEquals(92, network.getTwoWindingsTransformer(twtStr).getCurrentLimits1().get().getPermanentLimit(), threshold);
         assertEquals(2, network.getTwoWindingsTransformer(twtStr).getCurrentLimits1().get().getTemporaryLimits().size(), threshold);
-        temporaryLimits = new ArrayList<>(network.getTwoWindingsTransformer(twtStr).getCurrentLimits1().get().getTemporaryLimits());
+        temporaryLimits = network.getTwoWindingsTransformer(twtStr).getCurrentLimits1().get().getTemporaryLimits();
         assertEquals("10'", temporaryLimits.get(0).getName());
         assertEquals(600, temporaryLimits.get(0).getAcceptableDuration(), threshold);
         assertEquals(100, temporaryLimits.get(0).getValue(), threshold);
@@ -156,7 +155,7 @@ class SecurityAnalysisTestNetworkFactoryTest {
         assertTrue(network.getTwoWindingsTransformer(twt2Str).getCurrentLimits1().isPresent());
         assertEquals(90, network.getTwoWindingsTransformer(twt2Str).getCurrentLimits1().get().getPermanentLimit(), threshold);
         assertEquals(2, network.getTwoWindingsTransformer(twt2Str).getCurrentLimits1().get().getTemporaryLimits().size(), threshold);
-        temporaryLimits = new ArrayList<>(network.getTwoWindingsTransformer(twt2Str).getCurrentLimits1().get().getTemporaryLimits());
+        temporaryLimits = network.getTwoWindingsTransformer(twt2Str).getCurrentLimits1().get().getTemporaryLimits();
         assertEquals("10'", temporaryLimits.get(0).getName());
         assertEquals(600, temporaryLimits.get(0).getAcceptableDuration(), threshold);
         assertEquals(100, temporaryLimits.get(0).getValue(), threshold);

--- a/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractIdenticalLimitsTest.java
+++ b/iidm/iidm-tck/src/test/java/com/powsybl/iidm/network/tck/AbstractIdenticalLimitsTest.java
@@ -8,8 +8,8 @@ public abstract class AbstractIdenticalLimitsTest {
     public boolean areLimitsIdentical(LoadingLimits limits1, LoadingLimits limits2) {
         boolean areIdentical = limits1.getPermanentLimit() == limits2.getPermanentLimit();
 
-        List<LoadingLimits.TemporaryLimit> tempLimits1 = limits1.getTemporaryLimits().stream().toList();
-        List<LoadingLimits.TemporaryLimit> tempLimits2 = limits2.getTemporaryLimits().stream().toList();
+        List<LoadingLimits.TemporaryLimit> tempLimits1 = limits1.getTemporaryLimits();
+        List<LoadingLimits.TemporaryLimit> tempLimits2 = limits2.getTemporaryLimits();
 
         if (areIdentical && tempLimits1.size() == tempLimits2.size()) {
             for (int i = 0; i < tempLimits1.size(); i++) {

--- a/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/limitreduction/result/AbstractReducedLoadingLimits.java
+++ b/security-analysis/security-analysis-api/src/main/java/com/powsybl/security/limitreduction/result/AbstractReducedLoadingLimits.java
@@ -13,7 +13,9 @@ import com.powsybl.iidm.network.LoadingLimits;
 import com.powsybl.iidm.network.util.LoadingLimitsUtil;
 import com.powsybl.iidm.network.util.UnsupportedPropertiesHolder;
 
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -141,8 +143,8 @@ public abstract class AbstractReducedLoadingLimits extends UnsupportedProperties
     }
 
     @Override
-    public Collection<TemporaryLimit> getTemporaryLimits() {
-        return temporaryLimits.values();
+    public List<TemporaryLimit> getTemporaryLimits() {
+        return Collections.unmodifiableList(new ArrayList<>(temporaryLimits.values()));
     }
 
     @Override


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)

**Does this PR already have an issue describing the problem?**
Fixes #4097

**What kind of change does this PR introduce?**
Refactoring / Breaking Change

**What is the current behavior?**
`LoadingLimits.getTemporaryLimits()` returns a `Collection<TemporaryLimit>`, which does not preserve the order guarantee in the type signature despite the Javadoc specifying descending duration order.

**What is the new behavior (if this is a feature change)?**
- `LoadingLimits.getTemporaryLimits()` now returns `List<TemporaryLimit>`.
- `AbstractLoadingLimits` and `AbstractReducedLoadingLimits` return unmodifiable lists.
- Simplified callers and test assertions where collections were manually converted.

**Other information**:
- `mvn clean test-compile` passed across all modules.
- `mvn test -pl iidm/iidm-api,iidm/iidm-impl,iidm/iidm-tck,security-analysis/security-analysis-api -am` passed (289 tests, 0 failures).
- `mvn validate` passed with 0 Checkstyle violations.